### PR TITLE
Clean up 15 min time resolution

### DIFF
--- a/examples/basic_household_Districtheating.py
+++ b/examples/basic_household_Districtheating.py
@@ -128,8 +128,7 @@ def basic_household_Districtheating_explicit( my_sim, my_simulation_parameters )
     my_building = building.Building( building_code=building_code,
                                         bClass=building_class,
                                         initial_temperature=initial_temperature,
-                                        sim_params=my_sim_params,
-                                        seconds_per_timestep=seconds_per_timestep )
+                                        sim_params=my_sim_params )
     my_building.connect_input(my_building.Altitude,
                               my_weather.ComponentName,
                               my_building.Altitude)

--- a/examples/basic_household_Oilheater.py
+++ b/examples/basic_household_Oilheater.py
@@ -35,12 +35,17 @@ def basic_household_Oilheater_explicit(my_sim, my_simulation_parameters):
         - Building
         - Oil heater
     """
+    
+    ####delete all files in cache:
+    dir = '..//hisim//inputs//cache'
+    for file in os.listdir( dir ):
+        os.remove( os.path.join( dir, file ) )
 
     ##### System Parameters #####
 
     # Set simulation parameters
     year = 2021
-    seconds_per_timestep = 60
+    seconds_per_timestep = 60*15
 
     # Set weather
     location = "Aachen"
@@ -75,17 +80,17 @@ def basic_household_Oilheater_explicit(my_sim, my_simulation_parameters):
     # Build system parameters
     if my_simulation_parameters is None:
         my_sim_params: sim.SimulationParameters = sim.SimulationParameters.full_year(year=year,
-                                                                                     seconds_per_timestep=seconds_per_timestep)
+                                                                                     seconds_per_timestep=seconds_per_timestep )
     else:
         my_sim_params = my_simulation_parameters
     my_sim.set_parameters(my_sim_params)
 
     # Build occupancy
-    my_occupancy = occupancy.Occupancy( profile = occupancy_profile )
+    my_occupancy = occupancy.Occupancy( profile = occupancy_profile, seconds_per_timestep = seconds_per_timestep )
     my_sim.add_component( my_occupancy )
 
     # Build Weather
-    my_weather = weather.Weather( location=location, my_simulation_parameters=my_sim_params )
+    my_weather = weather.Weather( location=location, my_simulation_parameters = my_sim_params )
     my_sim.add_component( my_weather )
 
     my_photovoltaic_system = pvs.PVSystem( time=time,
@@ -122,11 +127,10 @@ def basic_household_Oilheater_explicit(my_sim, my_simulation_parameters):
                                          my_weather.WindSpeed )
     my_sim.add_component( my_photovoltaic_system )
 
-    my_building = building.Building( building_code=building_code,
-                                        bClass=building_class,
-                                        initial_temperature=initial_temperature,
-                                        sim_params=my_sim_params )
-                                        #seconds_per_timestep=seconds_per_timestep)
+    my_building = building.Building( building_code = building_code,
+                                        bClass = building_class,
+                                        initial_temperature = initial_temperature,
+                                        sim_params = my_sim_params )
     my_building.connect_input(my_building.Altitude,
                               my_weather.ComponentName,
                               my_building.Altitude)

--- a/hisim/components/occupancy.py
+++ b/hisim/components/occupancy.py
@@ -228,7 +228,7 @@ class Occupancy(cp.Component):
                                                 sep=";", decimal=",", encoding = "cp1252")
             
             #convert electricity consumption and water consumption to desired format and unit
-            self.electricity_consumption = pd.to_numeric(pre_electricity_consumption["Sum [kWh]"] * 1000).tolist()
+            self.electricity_consumption = pd.to_numeric(pre_electricity_consumption["Sum [kWh]"] * 1000 *60 ).tolist() #1 kWh/min == 60W / min
             self.water_consumption = pd.to_numeric(pre_water_consumption["Sum [L]"]).tolist()  
             
             #process data when time resolution of inputs matches timeresolution of simulation
@@ -249,8 +249,8 @@ class Occupancy(cp.Component):
                         self.number_of_residents[ timestep ] += np.round( number_of_residents_av )
                         self.heating_by_residents[ timestep ] = self.heating_by_residents[timestep] + \
                                                                 gain_per_person[mode] * number_of_residents_av
-                                                                
-                self.electricity_consumption = [ sum( self.electricity_consumption[ n : n + steps_ratio ] ) for n in range( 0, steps_original, steps_ratio ) ]
+                #power needs averaging, not sum                                                
+                self.electricity_consumption = [ sum( self.electricity_consumption[ n : n + steps_ratio ] ) / steps_ratio for n in range( 0, steps_original, steps_ratio ) ]
                 self.water_consumption = [ sum( self.water_consumption[ n : n + steps_ratio ] ) for n in range( 0, steps_original, steps_ratio ) ]
 
             else:

--- a/hisim/postprocessing/charts.py
+++ b/hisim/postprocessing/charts.py
@@ -76,9 +76,9 @@ class Carpet(Chart):
                          directorypath=directorypath,
                          time_correction_factor=time_correction_factor)
     def plot(self):
-        # if( len( self.data.index ) != 365*24 ):
-        #     logging.error("Carpet plot can only deal with data for 365 days in 1h resolution")
-        #     return
+        if( len( self.data.index ) != 365*24 ):
+            logging.error("Carpet plot can only deal with data for 365 days in 1h resolution")
+            return
         xdims = 365 #number of days
         ydims = int( len( self.data ) / 365 ) #number of calculated timesteps per day
         y_steps_per_hour = int( ydims / 24 )

--- a/hisim/postprocessing/charts.py
+++ b/hisim/postprocessing/charts.py
@@ -76,9 +76,9 @@ class Carpet(Chart):
                          directorypath=directorypath,
                          time_correction_factor=time_correction_factor)
     def plot(self):
-        if(len(self.data.index) != 365*24):
-            logging.error("Carpet plot can only deal with data for 365 days in 1h resolution")
-            return
+        # if( len( self.data.index ) != 365*24 ):
+        #     logging.error("Carpet plot can only deal with data for 365 days in 1h resolution")
+        #     return
         xdims = 365 #number of days
         ydims = int( len( self.data ) / 365 ) #number of calculated timesteps per day
         y_steps_per_hour = int( ydims / 24 )
@@ -175,8 +175,9 @@ class Day(Chart):
         self.get_day_data()
 
     def get_day_data(self):
-        firstindex = (self.month * 30 + self.day) * 24 * int(1 / self.time_correction_factor)
-        lastindex = firstindex + 24 * int(1 / self.time_correction_factor)
+        #time_correction_factor was adopted, transformation updated here
+        firstindex = (self.month * 30 + self.day) * 24 * int( 3600 * self.time_correction_factor)
+        lastindex = firstindex + 24 * int( 3600 * self.time_correction_factor)
         day_number = self.day + 1
         if day_number == 1:
             ordinal = "st"

--- a/hisim/postprocessing/postprocessing_main.py
+++ b/hisim/postprocessing/postprocessing_main.py
@@ -153,6 +153,8 @@ class PostProcessor:
             my_sankey.plot_building()
 
     def run(self):
+        
+        print( len(self.ppdt.results) )
         # Define the directory name
         ##
         warnings.filterwarnings("ignore")
@@ -308,7 +310,7 @@ class PostProcessor:
         if solar_gain_through_windows is not None:
             self.write_to_report(["Absolute Solar Gains [kWh]: {:.0f}".format(1E-3*solar_gain_through_windows)])
             if building_area is not None:
-                self.write_to_report(["Relative Solar Gains [Wh/m2]: {:.0f} ".format(1E-3*solar_gain_through_windows/building_area)])
+                self.write_to_report(["Relative Solar Gains [kWh/m2]: {:.0f} ".format(1E-3*solar_gain_through_windows/building_area)])
 
         # Writes building internal gains
         if internal_gains is not None:
@@ -387,12 +389,12 @@ class PostProcessor:
 
 # if __name__ == "__main__":
 #     flags = {"plot_line": True,
-#              "plot_carpet": False,
-#              "plot_sankey": False,
-#              "plot_day": False,
-#              "plot_bar": False,
-#              "open_dir": True,
-#              "export_results_to_CSV": True}
+#               "plot_carpet": False,
+#               "plot_sankey": False,
+#               "plot_day": False,
+#               "plot_bar": False,
+#               "open_dir": True,
+#               "export_results_to_CSV": True}
 #     my_post_processing = PostProcessor(**flags)
 #     #my_post_processing.set_dir_results()
 #     my_post_processing.run()

--- a/hisim/simulator.py
+++ b/hisim/simulator.py
@@ -358,7 +358,8 @@ class Simulator:
 
         self.get_std_results()
 
-        time_correction_factor = 1/self.SimulationParameters.seconds_per_timestep
+        #Johanna Ganglbauer: time correction factor is applied in postprocessing to sum over power values and convert them to energy
+        time_correction_factor = self.SimulationParameters.seconds_per_timestep / 3600
         ppdt = pp.PostProcessingDataTransfer(
             time_correction_factor = time_correction_factor,
             directory_path = self.dirpath,

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -23,7 +23,7 @@ def test_building():
     my_weather = weather.Weather(weather_location, my_simulation_parameters)
 
     # Set Residence
-    my_residence = building.Building(building_code=building_code, bClass=bClass, seconds_per_timestep=60)
+    my_residence = building.Building(building_code=building_code, bClass=bClass, sim_params = my_simulation_parameters )
 
     # Fake energy delivered
     thermal_energy_delivered_output = component.ComponentOutput("FakeThermalDeliveryMachine",

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -5,6 +5,8 @@ from hisim.components import building
 from hisim.loadtypes import LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters
 
+import os
+
 def test_building():
     # Sets inputs
     weather_location = "Aachen"
@@ -56,20 +58,31 @@ def test_building():
 
     my_residence.t_mC.GlobalIndex = 11
     thermal_energy_delivered_output.GlobalIndex = 12
-
-    # Simulates
-    stsv.values[11] = 23
-    print(stsv.values)
-    my_weather.i_simulate(0, stsv, seconds_per_timestep, False)
-    print(stsv.values)
-    my_occupancy.i_simulate(0, stsv, seconds_per_timestep, False)
-    print(stsv.values)
-    my_residence.i_simulate(0, stsv, seconds_per_timestep, False)
-    print(stsv.values)
-
-    print("Occupancy: {}\n".format(stsv.values[:4]))
-    print("Weather: {}\n".format(stsv.values[4:10]))
-    print("Residence: {}\n".format(stsv.values[10:]))
-    # #assert False
-    print(stsv.values[11])
-    assert (stsv.values[11] - 22.98) <0.01
+    
+    
+    #test building models for various time resolutions
+    for seconds_per_timestep in [ 60, 60 * 15, 60 * 60 ]:
+        
+        print( seconds_per_timestep )
+        my_residence.seconds_per_timestep = seconds_per_timestep
+        
+        # Simulates
+        stsv.values[11] = 23
+        print(stsv.values)
+        my_weather.i_simulate(0, stsv, seconds_per_timestep, False)
+        print(stsv.values)
+        my_occupancy.i_simulate(0, stsv, seconds_per_timestep, False)
+        print(stsv.values)
+        my_residence.i_simulate(0, stsv, seconds_per_timestep, False)
+        print(stsv.values)
+    
+        print("Occupancy: {}\n".format(stsv.values[:4]))
+        print("Weather: {}\n".format(stsv.values[4:10]))
+        print("Residence: {}\n".format(stsv.values[10:]))
+        # #assert False
+        print(stsv.values[11])
+        assert (stsv.values[11] - 23.0 ) < - 0.01 * ( seconds_per_timestep / 60 )
+    
+    """test different time resolutions and compare heat loss within January"""
+    
+    


### PR DESCRIPTION
(1) cleaned up building models by (a) removing time correction factor (all heat transmission coefficients are given in W and are time independent) (b) defining all gains and losses in W, (c) adding timestep size into calc_temperature_next_step() to account for different time resolutions.
(2) added automated test of building models for different time resolutions : 1 min, 15 min and 60 min
(3) corrected energy/power misunderstanding in electricity demand of occupancy class -> please crosscheck