### PR TITLE
Add default connection excluding variable inputs

### DIFF
--- a/examples/basic_household.py
+++ b/examples/basic_household.py
@@ -7,6 +7,9 @@ from hisim.components import building
 from hisim.components import heat_pump
 from hisim.components import sumbuilder
 from hisim import utils
+
+import os
+
 __authors__ = "Vitor Hugo Bellotto Zago"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
 __credits__ = ["Noah Pflugradt"]
@@ -205,6 +208,11 @@ def basic_household_with_default_connections(my_sim, my_simulation_parameters: O
         - Heat Pump
     """
 
+    ##### delete all files in cache:
+    dir = '..//hisim//inputs//cache'
+    for file in os.listdir( dir ):
+        os.remove( os.path.join( dir, file ) )
+
     ##### System Parameters #####
 
     # Set simulation parameters
@@ -277,34 +285,36 @@ def basic_household_with_default_connections(my_sim, my_simulation_parameters: O
                                         bClass=building_class,
                                         initial_temperature=initial_temperature,
                                         my_simulation_parameters=my_simulation_parameters)
-    my_building.connect_input(my_building.Altitude,
-                              my_weather.ComponentName,
-                              my_building.Altitude)
-    my_building.connect_input(my_building.Azimuth,
-                              my_weather.ComponentName,
-                              my_building.Azimuth)
-    my_building.connect_input(my_building.DirectNormalIrradiance,
-                              my_weather.ComponentName,
-                              my_building.DirectNormalIrradiance)
-    my_building.connect_input(my_building.DiffuseHorizontalIrradiance,
-                              my_weather.ComponentName,
-                              my_building.DiffuseHorizontalIrradiance)
-    my_building.connect_input(my_building.GlobalHorizontalIrradiance,
-                              my_weather.ComponentName,
-                              my_building.GlobalHorizontalIrradiance)
-    my_building.connect_input(my_building.DirectNormalIrradianceExtra,
-                              my_weather.ComponentName,
-                              my_building.DirectNormalIrradianceExtra)
-    my_building.connect_input(my_building.ApparentZenith,
-                             my_weather.ComponentName,
-                             my_building.ApparentZenith)
-    my_building.connect_input(my_building.TemperatureOutside,
-                              my_weather.ComponentName,
-                              my_weather.TemperatureOutside)
-    my_building.connect_input(my_building.HeatingByResidents,
-                              my_occupancy.ComponentName,
-                              my_occupancy.HeatingByResidents)
+    my_building.connect_only_predefined_connections( my_weather )   
+    my_building.connect_only_predefined_connections( my_occupancy )
     my_sim.add_component(my_building)
+    # my_building.connect_input(my_building.Altitude,
+    #                           my_weather.ComponentName,
+    #                           my_building.Altitude)
+    # my_building.connect_input(my_building.Azimuth,
+    #                           my_weather.ComponentName,
+    #                           my_building.Azimuth)
+    # my_building.connect_input(my_building.DirectNormalIrradiance,
+    #                           my_weather.ComponentName,
+    #                           my_building.DirectNormalIrradiance)
+    # my_building.connect_input(my_building.DiffuseHorizontalIrradiance,
+    #                           my_weather.ComponentName,
+    #                           my_building.DiffuseHorizontalIrradiance)
+    # my_building.connect_input(my_building.GlobalHorizontalIrradiance,
+    #                           my_weather.ComponentName,
+    #                           my_building.GlobalHorizontalIrradiance)
+    # my_building.connect_input(my_building.DirectNormalIrradianceExtra,
+    #                           my_weather.ComponentName,
+    #                           my_building.DirectNormalIrradianceExtra)
+    # my_building.connect_input(my_building.ApparentZenith,
+    #                          my_weather.ComponentName,
+    #                          my_building.ApparentZenith)
+    # my_building.connect_input(my_building.TemperatureOutside,
+    #                           my_weather.ComponentName,
+    #                           my_weather.TemperatureOutside)
+    # my_building.connect_input(my_building.HeatingByResidents,
+    #                           my_occupancy.ComponentName,
+    #                           my_occupancy.HeatingByResidents)
 
     my_heat_pump_controller = heat_pump.HeatPumpController(t_air_heating=t_air_heating,
                                                            t_air_cooling=t_air_cooling,

--- a/examples/basic_household.py
+++ b/examples/basic_household.py
@@ -285,45 +285,18 @@ def basic_household_with_default_connections(my_sim, my_simulation_parameters: O
                                         bClass=building_class,
                                         initial_temperature=initial_temperature,
                                         my_simulation_parameters=my_simulation_parameters)
-    my_building.connect_only_predefined_connections( my_weather )   
-    my_building.connect_only_predefined_connections( my_occupancy )
+    my_building.connect_only_predefined_connections( my_weather, my_occupancy )   
     my_sim.add_component(my_building)
-    # my_building.connect_input(my_building.Altitude,
-    #                           my_weather.ComponentName,
-    #                           my_building.Altitude)
-    # my_building.connect_input(my_building.Azimuth,
-    #                           my_weather.ComponentName,
-    #                           my_building.Azimuth)
-    # my_building.connect_input(my_building.DirectNormalIrradiance,
-    #                           my_weather.ComponentName,
-    #                           my_building.DirectNormalIrradiance)
-    # my_building.connect_input(my_building.DiffuseHorizontalIrradiance,
-    #                           my_weather.ComponentName,
-    #                           my_building.DiffuseHorizontalIrradiance)
-    # my_building.connect_input(my_building.GlobalHorizontalIrradiance,
-    #                           my_weather.ComponentName,
-    #                           my_building.GlobalHorizontalIrradiance)
-    # my_building.connect_input(my_building.DirectNormalIrradianceExtra,
-    #                           my_weather.ComponentName,
-    #                           my_building.DirectNormalIrradianceExtra)
-    # my_building.connect_input(my_building.ApparentZenith,
-    #                          my_weather.ComponentName,
-    #                          my_building.ApparentZenith)
-    # my_building.connect_input(my_building.TemperatureOutside,
-    #                           my_weather.ComponentName,
-    #                           my_weather.TemperatureOutside)
-    # my_building.connect_input(my_building.HeatingByResidents,
-    #                           my_occupancy.ComponentName,
-    #                           my_occupancy.HeatingByResidents)
 
     my_heat_pump_controller = heat_pump.HeatPumpController(t_air_heating=t_air_heating,
                                                            t_air_cooling=t_air_cooling,
                                                            offset=offset,
                                                            mode=hp_mode,
                                                            my_simulation_parameters=my_simulation_parameters)
-    my_heat_pump_controller.connect_input(my_heat_pump_controller.TemperatureMean,
-                                          my_building.ComponentName,
-                                          my_building.TemperatureMean)
+    my_heat_pump_controller.connect_only_predefined_connections( my_building )
+    # my_heat_pump_controller.connect_input(my_heat_pump_controller.TemperatureMean,
+    #                                       my_building.ComponentName,
+    #                                       my_building.TemperatureMean)
     my_heat_pump_controller.connect_input(my_heat_pump_controller.ElectricityInput,
                                           my_base_electricity_load_profile.ComponentName,
                                           my_base_electricity_load_profile.ElectricityOutput)
@@ -334,12 +307,13 @@ def basic_household_with_default_connections(my_sim, my_simulation_parameters: O
                                           min_operation_time=hp_min_operation_time,
                                           min_idle_time=hp_min_idle_time,
                                       my_simulation_parameters=my_simulation_parameters)
-    my_heat_pump.connect_input(my_heat_pump.State,
-                               my_heat_pump_controller.ComponentName,
-                               my_heat_pump_controller.State)
-    my_heat_pump.connect_input(my_heat_pump.TemperatureOutside,
-                               my_weather.ComponentName,
-                               my_weather.TemperatureOutside)
+    # my_heat_pump.connect_input(my_heat_pump.State,
+    #                            my_heat_pump_controller.ComponentName,
+    #                            my_heat_pump_controller.State)
+    # my_heat_pump.connect_input(my_heat_pump.TemperatureOutside,
+    #                            my_weather.ComponentName,
+    #                            my_weather.TemperatureOutside)
+    my_heat_pump.connect_only_predefined_connections( my_weather, my_heat_pump_controller )
 
     my_sim.add_component(my_heat_pump)
 

--- a/examples/basic_household.py
+++ b/examples/basic_household.py
@@ -294,9 +294,8 @@ def basic_household_with_default_connections(my_sim, my_simulation_parameters: O
                                                            mode=hp_mode,
                                                            my_simulation_parameters=my_simulation_parameters)
     my_heat_pump_controller.connect_only_predefined_connections( my_building )
-    # my_heat_pump_controller.connect_input(my_heat_pump_controller.TemperatureMean,
-    #                                       my_building.ComponentName,
-    #                                       my_building.TemperatureMean)
+    
+    #depending on previous loads, hard to define default connections
     my_heat_pump_controller.connect_input(my_heat_pump_controller.ElectricityInput,
                                           my_base_electricity_load_profile.ComponentName,
                                           my_base_electricity_load_profile.ElectricityOutput)
@@ -307,16 +306,11 @@ def basic_household_with_default_connections(my_sim, my_simulation_parameters: O
                                           min_operation_time=hp_min_operation_time,
                                           min_idle_time=hp_min_idle_time,
                                       my_simulation_parameters=my_simulation_parameters)
-    # my_heat_pump.connect_input(my_heat_pump.State,
-    #                            my_heat_pump_controller.ComponentName,
-    #                            my_heat_pump_controller.State)
-    # my_heat_pump.connect_input(my_heat_pump.TemperatureOutside,
-    #                            my_weather.ComponentName,
-    #                            my_weather.TemperatureOutside)
     my_heat_pump.connect_only_predefined_connections( my_weather, my_heat_pump_controller )
 
     my_sim.add_component(my_heat_pump)
 
+    #depending on type of heating device, hard to define default connections
     my_building.connect_input(my_building.ThermalEnergyDelivered,
                               my_heat_pump.ComponentName,
                               my_heat_pump.ThermalEnergyDelivered)

--- a/examples/basic_household_Districtheating.py
+++ b/examples/basic_household_Districtheating.py
@@ -11,6 +11,7 @@ from hisim.components import building
 from hisim.components import district_heating
 from hisim.components import sumbuilder
 from hisim.simulationparameters import SimulationParameters
+
 __authors__ = "Johanna Ganglbauer - johanna.ganglbauer@4wardenergy.at"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
 __credits__ = ["Noah Pflugradt"]

--- a/examples/modular_household.py
+++ b/examples/modular_household.py
@@ -1,0 +1,240 @@
+from typing import Optional
+from hisim.simulator import SimulationParameters
+from hisim.components import occupancy
+from hisim.components import weather
+from hisim.components import pvs
+from hisim.components import building
+from hisim.components import heat_pump
+from hisim.components import simple_bucket_boiler
+from hisim.components import oil_heater
+from hisim.components import district_heating
+from hisim.components import sumbuilder
+from hisim import utils
+
+import os
+
+__authors__ = "Johanna Ganglbauer - johanna.ganglbauer@4wardenergy.at"
+__copyright__ = "Copyright 2021, the House Infrastructure Project"
+__credits__ = ["Noah Pflugradt"]
+__license__ = "MIT"
+__version__ = "0.1"
+__maintainer__ = "Vitor Hugo Bellotto Zago"
+__email__ = "vitor.zago@rwth-aachen.de"
+__status__ = "development"
+
+def modular_household_explicit( my_sim, my_simulation_parameters: Optional[SimulationParameters] = None ):
+    """
+    This setup function emulates an household including
+    the basic components "building", "occupancy" and "weather". Here it can be freely chosen if a PV system or a boiler are included or not.
+    The heating system can be either a heat pump, an Oilheater or Districtheating
+
+    - Simulation Parameters
+    - Components
+        - Occupancy (Residents' Demands)
+        - Weather
+        - Photovoltaic System
+        - Building
+        - Heat Pump
+    """
+
+    ##### delete all files in cache:
+    dir = '..//hisim//inputs//cache'
+    for file in os.listdir( dir ):
+        os.remove( os.path.join( dir, file ) )
+
+    ##### System Parameters #####
+
+    # Set simulation parameters
+    year = 2021
+    seconds_per_timestep = 60 * 15
+    
+    # Set building
+    building_code = "DE.N.SFH.05.Gen.ReEx.001.002"
+    building_class = "medium"
+    initial_temperature = 23
+
+    # Set weather
+    location = "Aachen"
+    
+    # Set occupancy
+    occupancy_profile = "CH01"
+
+    # Set photovoltaic system
+    pv_included = False #True or False
+    time = 2019
+    power = 10E3
+    load_module_data = False
+    module_name = "Hanwha_HSL60P6_PA_4_250T__2013_"
+    integrateInverter = True
+    inverter_name = "ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_"
+    
+    # Set boiler
+    boiler_included = 'electricity' #Electricity, Hydrogen or False
+    
+    if boiler_included == 'electricity':
+        definition = '0815-boiler'
+        smart = 1
+    elif boiler_included == 'hydrogen':
+        definition = 'hydrogen'
+        smart = 0
+    elif boiler_included:
+        raise NameError( 'Boiler definition', boiler_included, 'not known. Choose electricity, hydrogen, or False.' )
+
+    #Set heating system
+    heating_device_included = 'district_heating'    
+
+    if heating_device_included == 'heat_pump':
+        # Set heat pump controller
+        t_air_heating = 16.0
+        t_air_cooling = 24.0
+        offset = 0.5
+        hp_mode = 2
+        # Set heat pump
+        hp_manufacturer = "Viessmann Werke GmbH & Co KG"
+        hp_name = "Vitocal 300-A AWO-AC 301.B07"
+        hp_min_operation_time = 60
+        hp_min_idle_time = 15      
+    elif heating_device_included == 'oil_heater':
+        # Set Oil heater controller
+        t_air_heating = 21.0
+        offset = 3.0
+        # Set Oil Heater
+        max_power = 5000
+        min_on_time = 60
+        min_off_time = 15
+    elif heating_device_included == 'district_heating':
+        t_air_heating = 21.0
+        tol = 1e-2 #tolerance of set point -> considered in control
+        max_power = 15000
+        min_power = 1000
+        efficiency = 0.85
+    
+    elif heating_device_included:
+        raise NameError( 'Heating Device definition', heating_device_included, 'not known. Choose heat_pump, oil_heater, district_heating, or False.' )
+
+    ##### Build Components #####
+
+    # Build system parameters
+    if my_simulation_parameters is None:
+        my_simulation_parameters = SimulationParameters.full_year_all_options( year= year,
+                                                                               seconds_per_timestep=seconds_per_timestep )
+    my_sim.SimulationParameters = my_simulation_parameters
+    
+    # Build occupancy
+    my_occupancy = occupancy.Occupancy( profile = occupancy_profile, my_simulation_parameters = my_simulation_parameters )
+    my_sim.add_component( my_occupancy )
+    
+    #initialize list of electricity profiles and operation counter
+    electricity_load_profiles = [ my_occupancy ]
+    operation_counter = 1
+
+    # Build Weather
+    my_weather = weather.Weather( location=location, my_simulation_parameters = my_simulation_parameters )
+    my_sim.add_component( my_weather )
+    
+    # Build building
+    my_building = building.Building( building_code = building_code,
+                                     bClass = building_class,
+                                     initial_temperature = initial_temperature,
+                                     my_simulation_parameters = my_simulation_parameters )
+    my_building.connect_only_predefined_connections( my_weather, my_occupancy )   
+    my_sim.add_component( my_building )
+
+    if pv_included:
+        my_photovoltaic_system = pvs.PVSystem( time = time,
+                                               location = location,
+                                               power = power,
+                                               load_module_data = load_module_data,
+                                               module_name = module_name,
+                                               integrateInverter = integrateInverter,
+                                               inverter_name = inverter_name,
+                                               my_simulation_parameters = my_simulation_parameters )
+        my_photovoltaic_system.connect_only_predefined_connections( my_weather )
+        my_sim.add_component( my_photovoltaic_system )
+    
+        electricity_load_profiles.append( sumbuilder.ElectricityGrid( name = "BaseLoad" + str( operation_counter ),
+                                                                      grid=[ electricity_load_profiles[ operation_counter - 1 ], "Subtract", my_photovoltaic_system ], 
+                                                                      my_simulation_parameters = my_simulation_parameters ) )
+        my_sim.add_component( electricity_load_profiles[ operation_counter ] )
+        operation_counter += 1
+    
+    if boiler_included:  
+        my_boiler = simple_bucket_boiler.Boiler( definition = definition, fuel = boiler_included, my_simulation_parameters = my_simulation_parameters )
+        # my_boiler.connect_input( my_boiler.WaterConsumption,
+        #                          my_occupancy.ComponentName, 
+        #                          my_occupancy.WaterConsumption )
+        my_boiler.connect_only_predefined_connections( my_occupancy )
+        my_sim.add_component( my_boiler )
+        
+        my_boiler_controller = simple_bucket_boiler.BoilerController( smart = smart, my_simulation_parameters = my_simulation_parameters )
+        # my_boiler_controller.connect_input( my_boiler_controller.StorageTemperature,
+        #                                     my_boiler.ComponentName,
+        #                                     my_boiler.StorageTemperature )
+        my_boiler_controller.connect_only_predefined_connections( my_boiler )
+        my_sim.add_component( my_boiler_controller )
+        
+        # my_boiler.connect_input( my_boiler.State,
+        #                          my_boiler_controller.ComponentName,
+        #                          my_boiler_controller.State )
+        my_boiler.connect_only_predefined_connections( my_boiler_controller )
+
+        if boiler_included == 'electricity':
+            my_boiler_controller.connect_input( my_boiler_controller.ElectricityInput,
+                                        electricity_load_profiles[ operation_counter - 1 ].ComponentName,
+                                        electricity_load_profiles[ operation_counter - 1 ].ElectricityOutput )
+            
+            electricity_load_profiles.append( sumbuilder.ElectricityGrid( name = "BaseLoad" + str( operation_counter ),
+                                                                      grid=[ electricity_load_profiles[ operation_counter - 1 ], "Sum", my_boiler ], 
+                                                                      my_simulation_parameters = my_simulation_parameters ) )
+            my_sim.add_component( electricity_load_profiles[ operation_counter ] )
+            operation_counter += 1
+            
+    if heating_device_included:
+        #initialize and connect controller
+        if heating_device_included == 'heat_pump':
+            my_heating_controller = heat_pump.HeatPumpController( t_air_heating = t_air_heating,
+                                                                  t_air_cooling = t_air_cooling,
+                                                                  offset = offset,
+                                                                  mode = hp_mode,
+                                                                  my_simulation_parameters = my_simulation_parameters )
+            my_heating_controller.connect_input( my_heating_controller.ElectricityInput,
+                                                 electricity_load_profiles[ operation_counter - 1 ].ComponentName,
+                                                 electricity_load_profiles[ operation_counter - 1 ].ElectricityOutput )    
+        elif heating_device_included == 'oil_heater':
+            my_heating_controller = oil_heater.OilHeaterController( t_air_heating = t_air_heating,
+                                                                    offset = offset, 
+                                                                    my_simulation_parameters = my_simulation_parameters ) 
+            my_heating_controller.connect_only_predefined_connections( my_weather )
+        elif heating_device_included == 'district_heating':
+            my_heating_controller = district_heating.DistrictHeatingController( max_power = max_power,
+                                                                                min_power = min_power,
+                                                                                t_air_heating = t_air_heating,
+                                                                                tol = tol,
+                                                                                my_simulation_parameters = my_simulation_parameters )
+        my_heating_controller.connect_only_predefined_connections( my_building )
+        my_sim.add_component( my_heating_controller)
+        
+        #initialize and connect heating device
+        if heating_device_included == 'heat_pump':
+            my_heating = heat_pump.HeatPump( manufacturer = hp_manufacturer,
+                                             name = hp_name,
+                                             min_operation_time = hp_min_operation_time,
+                                             min_idle_time = hp_min_idle_time,
+                                             my_simulation_parameters = my_simulation_parameters )
+            my_heating.connect_only_predefined_connections( my_weather )    
+        elif heating_device_included == 'oil_heater':
+            my_heating = oil_heater.OilHeater( max_power = max_power,
+                                               min_off_time = min_off_time,
+                                               min_on_time = min_on_time, 
+                                               my_simulation_parameters = my_simulation_parameters )      
+        elif heating_device_included == 'district_heating':
+            my_heating = district_heating.DistrictHeating( max_power = max_power,
+                                                           min_power = min_power,
+                                                           efficiency = efficiency,
+                                                           my_simulation_parameters = my_simulation_parameters )
+        my_heating.connect_only_predefined_connections( my_heating_controller ) 
+        my_sim.add_component( my_heating )
+
+        my_building.connect_input( my_building.ThermalEnergyDelivered,
+                                   my_heating.ComponentName,
+                                   my_heating.ThermalEnergyDelivered )

--- a/examples/modular_household.py
+++ b/examples/modular_household.py
@@ -75,7 +75,7 @@ def modular_household_explicit( my_sim, my_simulation_parameters: Optional[Simul
         definition = '0815-boiler'
         smart = 1
     elif boiler_included == 'hydrogen':
-        definition = 'hydrogen'
+        definition = 'hydrogen-boiler'
         smart = 0
     elif boiler_included:
         raise NameError( 'Boiler definition', boiler_included, 'not known. Choose electricity, hydrogen, or False.' )

--- a/hisim/component.py
+++ b/hisim/component.py
@@ -142,10 +142,12 @@ class Component:
             raise ValueError("The component " + self.ComponentName + " has no input with the name " + input_fieldname)
         input_to_set.src_object_name = src_object_name
         input_to_set.src_field_name = src_field_name
-
-    def connect_only_predefined_connections(self,source_component ):
-        connections = self.get_default_connections(source_component)
-        self.connect_with_connections_list(connections)
+        
+    #added variable input length and loop to be able to set default connections in one line in examples    
+    def connect_only_predefined_connections(self, *source_components ):
+        for source_component in source_components:
+            connections = self.get_default_connections(source_component)
+            self.connect_with_connections_list(connections)
 
     def connect_with_connections_list(self, connections: List[ComponentConnection]):
          for connection in connections:

--- a/hisim/components/heat_pump.py
+++ b/hisim/components/heat_pump.py
@@ -197,7 +197,7 @@ class HeatPump(cp.Component):
         print("setting weather default connections")
         connections = [ ]
         weather_classname = Weather.get_classname( )
-        connections.append( cp.ComponentConnection( HeatPump.TemperatureOutside, weather_classname, Building.TemperatureOutside ) )
+        connections.append( cp.ComponentConnection( HeatPump.TemperatureOutside, weather_classname, Weather.TemperatureOutside ) )
         return connections
     
     def get_controller_default_connections( self ):

--- a/hisim/components/heat_pump.py
+++ b/hisim/components/heat_pump.py
@@ -14,6 +14,8 @@ from hisim.simulationparameters import SimulationParameters
 from hisim.components.extended_storage import WaterSlice
 from hisim.components.configuration import WarmWaterStorageConfig
 from hisim.components.configuration import PhysicsConfig
+from hisim.components.building import Building
+from hisim.components.weather import Weather
 
 seaborn.set(style='ticks')
 font = {'family' : 'normal',
@@ -187,6 +189,23 @@ class HeatPump(cp.Component):
                                                                    self.NumberOfCycles,
                                                                    LoadTypes.Any,
                                                                    Units.Any)
+        
+        self.add_default_connections( Weather, self.get_weather_default_connections( ) )
+        self.add_default_connections( HeatPumpController, self.get_controller_default_connections( ) )
+        
+    def get_weather_default_connections( self ):
+        print("setting weather default connections")
+        connections = [ ]
+        weather_classname = Weather.get_classname( )
+        connections.append( cp.ComponentConnection( HeatPump.TemperatureOutside, weather_classname, Building.TemperatureOutside ) )
+        return connections
+    
+    def get_controller_default_connections( self ):
+        print("setting controller default connections")
+        connections = [ ]
+        controller_classname = HeatPumpController.get_classname( )
+        connections.append( cp.ComponentConnection( HeatPump.State, controller_classname, HeatPumpController.State ) )
+        return connections
 
     def build(self, manufacturer, name, min_operation_time, min_idle_time):
         # Simulation parameters
@@ -437,6 +456,15 @@ class HeatPumpController(cp.Component):
                                       self.State,
                                       LoadTypes.Any,
                                       Units.Any)
+        
+        self.add_default_connections( Building, self.get_building_default_connections( ) )
+        
+    def get_building_default_connections( self ):
+        print("setting building default connections")
+        connections = [ ]
+        building_classname = Building.get_classname( )
+        connections.append( cp.ComponentConnection( HeatPumpController.TemperatureMean, building_classname, Building.TemperatureMean ) )
+        return connections
 
     def build(self, t_air_heating, t_air_cooling, offset, mode):
         # Sth


### PR DESCRIPTION
Same as "added-default-connections" but modular_houshold has no additional inputs and hisim.main remains unchanged. 
Automated tests for modluar household cannot be included at this stage