### PR TITLE
made forecasting optional

### DIFF
--- a/hisim/components/occupancy.py
+++ b/hisim/components/occupancy.py
@@ -66,7 +66,7 @@ class Occupancy(cp.Component):
     def __init__( self,
                   my_simulation_parameters: SimulationParameters,
                   profile="CH01"):
-        super().__init__(name="Occupancy", my_simulation_parameters=my_simulation_parameters)
+        super().__init__( name="Occupancy", my_simulation_parameters = my_simulation_parameters )
 
         self.build( profile = profile )
 
@@ -184,8 +184,9 @@ class Occupancy(cp.Component):
         stsv.set_output_value(self.electricity_outputC, self.electricity_consumption[timestep])
         stsv.set_output_value(self.water_consumptionC, self.water_consumption[timestep])
         
-        demandforecast = self.electricity_consumption[ timestep : int( timestep + 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep ) ]
-        self.simulation_repository.set_entry( self.Electricity_Demand_Forecast_24h, demandforecast )
+        if self.my_simulation_parameters.system_config.predictive == True:
+            demandforecast = self.electricity_consumption[ timestep : int( timestep + 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep ) ]
+            self.simulation_repository.set_entry( self.Electricity_Demand_Forecast_24h, demandforecast )
 
     def build( self, profile ):
         self.profile = profile

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -90,12 +90,11 @@ class Weather(Component):
 
     @utils.measure_execution_time
     def __init__(self,
-                 my_simulation_parameters: SimulationParameters, location="Aachen", generate_forecast: bool = False):
+                 my_simulation_parameters: SimulationParameters, location="Aachen" ):
         super().__init__(name="Weather", my_simulation_parameters=my_simulation_parameters)
         if(my_simulation_parameters is None):
             raise Exception("Simparameters was none")
         self.weatherConfig = WeatherConfig(my_simulation_parameters,location)
-        self.generate_forecasts: bool = generate_forecast
         self.build(location,my_simulation_parameters)
 
         self.t_outC : ComponentOutput = self.add_output(self.ComponentName,
@@ -162,6 +161,7 @@ class Weather(Component):
         pass
 
     def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_conversion: bool):
+
         stsv.set_output_value(self.t_outC, self.temperature_list[timestep])
         stsv.set_output_value(self.DNIC, self.DNI_list[timestep])
         stsv.set_output_value(self.DNIextraC, self.DNIextra_list[timestep])
@@ -173,7 +173,7 @@ class Weather(Component):
         stsv.set_output_value(self.apparent_zenithC, self.apparent_zenith_list[timestep])
 
         # set the temperature forecast
-        if(self.generate_forecasts):
+        if self.my_simulation_parameters.system_config.predictive:
             timesteps_24h = 24*3600 / self.my_simulation_parameters.seconds_per_timestep
             last_forecast_timestep = int(timestep+ timesteps_24h)
             if(last_forecast_timestep > len(self.temperature_list)):

--- a/hisim/simulationparameters.py
+++ b/hisim/simulationparameters.py
@@ -8,10 +8,12 @@ from hisim.utils import PostProcessingOptions
 @dataclass()
 class SystemConfig:
     def __init__( self,
+                 predictive : bool = False,
                  pv_included : bool = True,
                  smart_devices_included : bool = True,
                  boiler_included : Union[ bool, str ] = 'electricity',
                  heating_device_included : Union[ bool, str ] = 'heat_pump' ):
+        self.predictive = predictive
         self.pv_included = pv_included
         self.smart_devices_included = smart_devices_included
         self.boiler_included = boiler_included
@@ -54,8 +56,10 @@ class SimulationParameters:
     def get_unique_key(self):
         return str(self.start_date) + "###" + str(self.end_date) + "###"  + str(self.seconds_per_timestep) + "###" + str(self.year) + "###" + str(self.timesteps)
     
-    def reset_system_config( self, pv_included : bool, smart_devices_included : bool, boiler_included : Union[ bool, str ], heating_device_included : Union[ bool, str ] ):
-        self.system_config = SystemConfig( pv_included = pv_included, 
+    def reset_system_config( self, predictive : bool = False, pv_included : bool = True, smart_devices_included : bool = True, 
+                                   boiler_included : Union[ bool, str ] = 'electricity', heating_device_included : Union[ bool, str ] = 'heat_pump' ):
+        self.system_config = SystemConfig( predictive = predictive,
+                                           pv_included = pv_included, 
                                            smart_devices_included = smart_devices_included,
                                            boiler_included = boiler_included,
                                            heating_device_included = heating_device_included )

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -23,21 +23,23 @@ def test_building():
     bClass="medium"
     seconds_per_timestep = 60
     my_simulation_parameters = SimulationParameters.full_year(year=2021, seconds_per_timestep=seconds_per_timestep)
+
     stsv : component.SingleTimeStepValues = component.SingleTimeStepValues(20)
-    repo = component.SimRepository()
+    #repo = component.SimRepository()
     t2 = time.perf_counter()
     log.profile("T2: " + str(t2-t1))
     # Set Occupancy
     my_occupancy = occupancy.Occupancy(profile=my_occupancy_profile, my_simulation_parameters=my_simulation_parameters)
-    my_occupancy.set_sim_repo( repo )
+    #my_occupancy.set_sim_repo( repo )
     t3 = time.perf_counter()
     log.profile("T2: " + str(t3 - t2))
 
     # Set Weather
     my_weather = weather.Weather(location=weather_location,my_simulation_parameters=my_simulation_parameters)
-    my_weather.set_sim_repo(repo)
+    #my_weather.set_sim_repo(repo)
     t4 = time.perf_counter()
     log.profile("T2: " + str(t4 - t3))
+
     # Set Residence
     my_residence = building.Building(building_code=building_code, bClass=bClass, my_simulation_parameters=my_simulation_parameters)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -75,16 +75,18 @@ def test_basic_household_with_all_resultfiles():
 def test_modular_household_configurations( ):
     path = "../examples/modular_household.py"
     func = "modular_household_explicit"
-    mysimpar = mysimpar = SimulationParameters.one_day_only( year = 2019, seconds_per_timestep = 60 ) 
+    mysimpar = SimulationParameters.one_day_only( year = 2019, seconds_per_timestep = 60 ) 
     # for pv_included in [ True, False ]:
     #     for smart_devices_included in [ True, False ]:
     #         for boiler_included in [ 'electricity', 'hydrogen', None ]:
     #             for heating_device_included in [ 'heat_pump', 'oil_heater', 'district_heating' ]:
+    predictive = True
     pv_included = random.choice( [ True, False ] )
     smart_devices_included = random.choice( [ True, False ] )
     boiler_included = random.choice( [ 'electricity', 'hydrogen', None ] )
     heating_device_included = random.choice( [ 'heat_pump', 'oil_heater', 'district_heating' ] )
-    mysimpar.reset_system_config( pv_included = pv_included, 
+    mysimpar.reset_system_config( predictive = predictive,
+                                  pv_included = pv_included, 
                                   smart_devices_included = smart_devices_included, 
                                   boiler_included = boiler_included, 
                                   heating_device_included = heating_device_included )

--- a/tests/test_occupancy.py
+++ b/tests/test_occupancy.py
@@ -8,14 +8,12 @@ def test_occupancy():
     Year heating generated: 1719 kWh
     """
     
-    repo = component.SimRepository()
     my_occupancy_profile = "CH01"
     seconds_per_timestep = 60
     number_of_outputs = 4
     my_simulation_parameters = SimulationParameters.one_day_only(2017, seconds_per_timestep)
     stsv = component.SingleTimeStepValues(number_of_outputs)
     my_occupancy = occupancy.Occupancy(profile=my_occupancy_profile, my_simulation_parameters=my_simulation_parameters)
-    my_occupancy.set_sim_repo( repo )
 
     # Needed to number globalindex to activate return of component outputs
     my_occupancy.number_of_residentsC.GlobalIndex = 0

--- a/tests/test_photovoltaic.py
+++ b/tests/test_photovoltaic.py
@@ -12,6 +12,7 @@ def test_photovoltaic():
 
     mysim: sim.SimulationParameters = sim.SimulationParameters.full_year(year=2021,
                                                                            seconds_per_timestep=seconds_per_timestep)
+    mysim.reset_system_config( predictive = True )
 
     stsv : component.SingleTimeStepValues = component.SingleTimeStepValues(11)
     # Weather: 6 outputs


### PR DESCRIPTION
introduced boolean variable predictive < SystemConfig < SimulationParameters

Did that a week ago and needed to resolve conflicts in component weather. A boolean variable "generate_forecast" was introduced, which I removed. The choice is now done in SimulationParameters.SystemConfig.predictive. Please see if that is ok before accepting the pull request ;-)