### PR TITLE
Include chp to modular household

### DIFF
--- a/examples/basic_dynamic_components.py
+++ b/examples/basic_dynamic_components.py
@@ -117,13 +117,13 @@ def basic_household_explicit(my_sim, my_simulation_parameters: Optional[Simulati
                                             source_component_output = my_advanced_battery_1.AcBatteryPower,
                                             source_load_type = lt.LoadTypes.Electricity,
                                             source_unit = lt.Units.Watt,
-                                            source_tags = [ lt.ComponentType.Battery ],
+                                            source_tags = [ lt.ComponentType.Battery, lt.InandOutputType.ElectricityReal ],
                                             source_weight = 1 )
     my_cl2.add_component_input_and_connect( source_component_class = my_advanced_battery_2,
                                             source_component_output = my_advanced_battery_2.AcBatteryPower,
                                             source_load_type = lt.LoadTypes.Electricity,
                                             source_unit = lt.Units.Watt,
-                                            source_tags = [ lt.ComponentType.Battery ],
+                                            source_tags = [ lt.ComponentType.Battery, lt.InandOutputType.ElectricityReal ],
                                             source_weight = 2 )
 
     electricity_to_or_from_battery_target_1 = my_cl2.add_component_output( source_output_name = lt.InandOutputType.ElectricityTarget,
@@ -148,13 +148,13 @@ def basic_household_explicit(my_sim, my_simulation_parameters: Optional[Simulati
                                             source_component_output = my_advanced_fuel_cell_1.ElectricityOutput,
                                             source_load_type = lt.LoadTypes.Electricity,
                                             source_unit = lt.Units.Watt,
-                                            source_tags = [ lt.ComponentType.FuelCell ],
+                                            source_tags = [ lt.ComponentType.FuelCell, lt.InandOutputType.ElectricityReal ],
                                             source_weight = 3 )
     my_cl2.add_component_input_and_connect( source_component_class = my_advanced_fuel_cell_2,
                                             source_component_output = my_advanced_fuel_cell_2.ElectricityOutput,
                                             source_load_type = lt.LoadTypes.Electricity,
                                             source_unit = lt.Units.Watt,
-                                            source_tags = [ lt.ComponentType.FuelCell ],
+                                            source_tags = [ lt.ComponentType.FuelCell, lt.InandOutputType.ElectricityReal ],
                                             source_weight = 4 )
 
     electricity_from_fuel_cell_target_1 = my_cl2.add_component_output( source_output_name = lt.InandOutputType.ElectricityTarget,

--- a/examples/basic_dynamic_components.py
+++ b/examples/basic_dynamic_components.py
@@ -47,6 +47,9 @@ def basic_household_explicit(my_sim, my_simulation_parameters: Optional[Simulati
     if my_simulation_parameters is None:
         my_simulation_parameters = SimulationParameters.full_year_all_options(year=year,
                                                                                  seconds_per_timestep=seconds_per_timestep)
+       # my_simulation_parameters = SimulationParameters.january_only(year=year, seconds_per_timestep=seconds_per_timestep)
+       # my_simulation_parameters.enable_all_options( )                                                                          
+       
     my_sim.SimulationParameters = my_simulation_parameters
 
     my_advanced_battery_config_1 = advanced_battery_bslib.BatteryConfig( system_id='SG1',
@@ -70,9 +73,9 @@ def basic_household_explicit(my_sim, my_simulation_parameters: Optional[Simulati
     my_advanced_fuel_cell_config_2.name= "CHP2"
 
     my_advanced_fuel_cell_1 = advanced_fuel_cell.CHP(my_simulation_parameters=my_simulation_parameters,
-                                                     config=my_advanced_fuel_cell_config_1)
+                                                      config=my_advanced_fuel_cell_config_1)
     my_advanced_fuel_cell_2 = advanced_fuel_cell.CHP(my_simulation_parameters=my_simulation_parameters,
-                                                     config=my_advanced_fuel_cell_config_2)
+                                                      config=my_advanced_fuel_cell_config_2)
     my_cl2 = cl2.ControllerElectricityGeneric(my_simulation_parameters=my_simulation_parameters)
 
     my_occupancy_config = loadprofilegenerator_connector.OccupancyConfig(profile_name="CH01")
@@ -110,72 +113,72 @@ def basic_household_explicit(my_sim, my_simulation_parameters: Optional[Simulati
                                              source_unit = lt.Units.Watt,
                                              source_tags = [ lt.InandOutputType.Production ],
                                              source_weight = 999 )
-    my_cl2.add_component_input_and_connect( source_component_class=my_advanced_battery_1,
-                                               source_component_output=my_advanced_battery_1.AcBatteryPower,
-                                               source_load_type= lt.LoadTypes.Electricity,
-                                               source_unit= lt.Units.Watt,
-                                               source_tags=[lt.ComponentType.Battery,lt.InandOutputType.ElectricityReal],
-                                               source_weight=1)
-    my_cl2.add_component_input_and_connect( source_component_class=my_advanced_battery_2,
-                                               source_component_output=my_advanced_battery_2.AcBatteryPower,
-                                               source_load_type= lt.LoadTypes.Electricity,
-                                               source_unit= lt.Units.Watt,
-                                               source_tags=[lt.ComponentType.Battery,lt.InandOutputType.ElectricityReal],
-                                               source_weight=2)
+    my_cl2.add_component_input_and_connect( source_component_class = my_advanced_battery_1,
+                                            source_component_output = my_advanced_battery_1.AcBatteryPower,
+                                            source_load_type = lt.LoadTypes.Electricity,
+                                            source_unit = lt.Units.Watt,
+                                            source_tags = [ lt.ComponentType.Battery ],
+                                            source_weight = 1 )
+    my_cl2.add_component_input_and_connect( source_component_class = my_advanced_battery_2,
+                                            source_component_output = my_advanced_battery_2.AcBatteryPower,
+                                            source_load_type = lt.LoadTypes.Electricity,
+                                            source_unit = lt.Units.Watt,
+                                            source_tags = [ lt.ComponentType.Battery ],
+                                            source_weight = 2 )
 
-    electricity_to_or_from_battery_target_1 = my_cl2.add_component_output(source_output_name=lt.InandOutputType.ElectricityTarget,
-                                               source_tags=[lt.ComponentType.Battery],
-                                               source_weight=my_advanced_battery_1.source_weight,
-                                               source_load_type= lt.LoadTypes.Electricity,
-                                               source_unit= lt.Units.Watt)
-    electricity_to_or_from_battery_target_2 = my_cl2.add_component_output(source_output_name=lt.InandOutputType.ElectricityTarget,
-                                               source_tags=[lt.ComponentType.Battery],
-                                               source_weight=my_advanced_battery_2.source_weight,
-                                               source_load_type= lt.LoadTypes.Electricity,
-                                               source_unit= lt.Units.Watt)
+    electricity_to_or_from_battery_target_1 = my_cl2.add_component_output( source_output_name = lt.InandOutputType.ElectricityTarget,
+                                                                           source_tags = [ lt.ComponentType.Battery, lt.InandOutputType.ElectricityTarget ],
+                                                                           source_weight = my_advanced_battery_1.source_weight,
+                                                                           source_load_type = lt.LoadTypes.Electricity,
+                                                                           source_unit = lt.Units.Watt )
+    electricity_to_or_from_battery_target_2 = my_cl2.add_component_output( source_output_name = lt.InandOutputType.ElectricityTarget,
+                                                                           source_tags = [ lt.ComponentType.Battery, lt.InandOutputType.ElectricityTarget ],
+                                                                           source_weight = my_advanced_battery_2.source_weight,
+                                                                           source_load_type = lt.LoadTypes.Electricity,
+                                                                           source_unit = lt.Units.Watt )
 
-    my_advanced_battery_1.connect_dynamic_input(input_fieldname=advanced_battery_bslib.Battery.LoadingPowerInput,
-                                        src_object=electricity_to_or_from_battery_target_1)
-    my_advanced_battery_2.connect_dynamic_input(input_fieldname=advanced_battery_bslib.Battery.LoadingPowerInput,
-                                        src_object=electricity_to_or_from_battery_target_2)
+    my_advanced_battery_1.connect_dynamic_input( input_fieldname = advanced_battery_bslib.Battery.LoadingPowerInput,
+                                                 src_object = electricity_to_or_from_battery_target_1 )
+    my_advanced_battery_2.connect_dynamic_input( input_fieldname = advanced_battery_bslib.Battery.LoadingPowerInput,
+                                                 src_object = electricity_to_or_from_battery_target_2 )
     
     print( type(my_advanced_fuel_cell_1.ElectricityOutput))
 
-    my_cl2.add_component_input_and_connect( source_component_class=my_advanced_fuel_cell_1,
-                                               source_component_output=my_advanced_fuel_cell_1.ElectricityOutput,
-                                               source_load_type= lt.LoadTypes.Electricity,
-                                               source_unit= lt.Units.Watt,
-                                               source_tags=[lt.ComponentType.FuelCell,lt.InandOutputType.ElectricityReal],
-                                               source_weight=3)
-    my_cl2.add_component_input_and_connect( source_component_class=my_advanced_fuel_cell_2,
-                                               source_component_output=my_advanced_fuel_cell_2.ElectricityOutput,
-                                               source_load_type= lt.LoadTypes.Electricity,
-                                               source_unit= lt.Units.Watt,
-                                               source_tags=[lt.ComponentType.FuelCell,lt.InandOutputType.ElectricityReal],
-                                               source_weight=4)
+    my_cl2.add_component_input_and_connect( source_component_class = my_advanced_fuel_cell_1,
+                                            source_component_output = my_advanced_fuel_cell_1.ElectricityOutput,
+                                            source_load_type = lt.LoadTypes.Electricity,
+                                            source_unit = lt.Units.Watt,
+                                            source_tags = [ lt.ComponentType.FuelCell ],
+                                            source_weight = 3 )
+    my_cl2.add_component_input_and_connect( source_component_class = my_advanced_fuel_cell_2,
+                                            source_component_output = my_advanced_fuel_cell_2.ElectricityOutput,
+                                            source_load_type = lt.LoadTypes.Electricity,
+                                            source_unit = lt.Units.Watt,
+                                            source_tags = [ lt.ComponentType.FuelCell ],
+                                            source_weight = 4 )
 
-    electricity_from_fuel_cell_target_1 = my_cl2.add_component_output(source_output_name=lt.InandOutputType.ElectricityTarget,
-                                               source_tags=[lt.ComponentType.FuelCell],
-                                               source_weight=3,
-                                               source_load_type= lt.LoadTypes.Electricity,
-                                               source_unit= lt.Units.Watt)
-    electricity_from_fuel_cell_target_2 = my_cl2.add_component_output(source_output_name=lt.InandOutputType.ElectricityTarget,
-                                               source_tags=[lt.ComponentType.FuelCell],
-                                               source_weight=4,
-                                               source_load_type= lt.LoadTypes.Electricity,
-                                               source_unit= lt.Units.Watt)
+    electricity_from_fuel_cell_target_1 = my_cl2.add_component_output( source_output_name = lt.InandOutputType.ElectricityTarget,
+                                                                        source_tags = [ lt.ComponentType.FuelCell, lt.InandOutputType.ElectricityTarget ],
+                                                                        source_weight = 3,
+                                                                        source_load_type = lt.LoadTypes.Electricity,
+                                                                        source_unit = lt.Units.Watt )
+    electricity_from_fuel_cell_target_2 = my_cl2.add_component_output( source_output_name=lt.InandOutputType.ElectricityTarget,
+                                                                        source_tags = [ lt.ComponentType.FuelCell, lt.InandOutputType.ElectricityTarget ],
+                                                                        source_weight = 4,
+                                                                        source_load_type = lt.LoadTypes.Electricity,
+                                                                        source_unit = lt.Units.Watt )
 
-    my_advanced_fuel_cell_1.connect_dynamic_input(input_fieldname=advanced_fuel_cell.CHP.ElectricityFromCHPTarget,
-                                        src_object=electricity_from_fuel_cell_target_1)
-    my_advanced_fuel_cell_2.connect_dynamic_input(input_fieldname=advanced_fuel_cell.CHP.ElectricityFromCHPTarget,
-                                        src_object=electricity_from_fuel_cell_target_2)
+    my_advanced_fuel_cell_1.connect_dynamic_input( input_fieldname=advanced_fuel_cell.CHP.ElectricityFromCHPTarget,
+                                                    src_object=electricity_from_fuel_cell_target_1 )
+    my_advanced_fuel_cell_2.connect_dynamic_input( input_fieldname=advanced_fuel_cell.CHP.ElectricityFromCHPTarget,
+                                                    src_object=electricity_from_fuel_cell_target_2 )
 
-    my_sim.add_component(my_advanced_battery_1)
-    my_sim.add_component(my_advanced_battery_2)
-    my_sim.add_component(my_advanced_fuel_cell_1)
-    my_sim.add_component(my_advanced_fuel_cell_2)
-    my_sim.add_component(my_cl2)
+    my_sim.add_component( my_advanced_battery_1 )
+    my_sim.add_component( my_advanced_battery_2 )
+    my_sim.add_component( my_advanced_fuel_cell_1 )
+    my_sim.add_component( my_advanced_fuel_cell_2 )
+    my_sim.add_component( my_cl2)
     my_sim.add_component( my_weather )
     my_sim.add_component( my_occupancy )
-    my_sim.add_component(my_photovoltaic_system)
+    my_sim.add_component( my_photovoltaic_system )
 

--- a/hisim/component.py
+++ b/hisim/component.py
@@ -373,14 +373,13 @@ class DynamicComponent(Component):
         return inputvalue
     
     def get_dynamic_inputs( self, stsv : SingleTimeStepValues,
-                                  tags : List[ Union[ lt.ComponentType, lt.InandOutputType ] ],
-                                  weight_counter : int ) -> List:
+                                  tags : List[ Union[ lt.ComponentType, lt.InandOutputType ] ] ) -> List:
         """returns input values from all dynamic inputs with component type and weight"""
         inputvalues = [ ]
     
         #check if component of component type is available
         for index, element in enumerate( self.MyComponentInputs ): #loop over all inputs
-            if all( tag in element.SourceTags for tag in tags ) and weight_counter == element.SourceWeight:
+            if all( tag in element.SourceTags for tag in tags ):
                 inputvalues.append( stsv.get_input_value( self.__getattribute__( element.SourceComponentClass ) ) )
             else:
                 continue

--- a/hisim/components/building.py
+++ b/hisim/components/building.py
@@ -448,7 +448,7 @@ class Building(cp.DynamicComponent):
             # the name thermal_energy_delivered might be misleading, because it is actually power in W
             thermal_energy_delivered = stsv.get_input_value(self.thermal_energy_deliveredC)  # W
         else:
-            thermal_energy_delivered = sum( self.get_dynamic_inputs( stsv = stsv, tags = [ lt.InandOutputType.HeatToBuilding ], weight_counter = 999 ) )
+            thermal_energy_delivered = sum( self.get_dynamic_inputs( stsv = stsv, tags = [ lt.InandOutputType.HeatToBuilding ] ) )
         t_m_prev = self.state.t_m
 
         # old_stored_energy = self.state.cal_stored_energy()

--- a/hisim/components/controller_l2_energy_management_system.py
+++ b/hisim/components/controller_l2_energy_management_system.py
@@ -536,8 +536,8 @@ class ControllerElectricityGeneric(cp.DynamicComponent):
     """
     #Inputs
 
-    ElectricityConsumptionBuilding="ElectricityConsumptionBuilding"
-    ElectricityDemandHeatPump= "ElectricityDemandHeatPump"
+    #ElectricityConsumptionBuilding="ElectricityConsumptionBuilding"
+    #ElectricityDemandHeatPump= "ElectricityDemandHeatPump"
     #ElectricityOutputPvs = "ElectricityOutputPvs"
     MyComponentInputs: List[cp.DynamicConnectionInput] = []
     ElectricityToElectrolyzerUnused = "ElectricityToElectrolyzerUnused"
@@ -683,9 +683,8 @@ class ControllerElectricityGeneric(cp.DynamicComponent):
                 continue
             break
         return demand
+    
     def optimize_own_consumption(self, delta_demand: float, stsv: cp.SingleTimeStepValues):
-
-
         electricity_to_or_from_grid:float = 0
         MyComponentInputs=self.MyComponentInputs
         MyComponentOutputs=self.MyComponentOutputs

--- a/hisim/components/controller_l2_generic_chp.py
+++ b/hisim/components/controller_l2_generic_chp.py
@@ -130,7 +130,7 @@ class L2_Controller( cp.Component ):
     def get_default_config():
         config = L2CHPConfig( name = 'L2CHP',
                               source_weight = 1,
-                              T_min = 18,
+                              T_min = 20,
                               T_max = 22 ) 
         return config
         

--- a/hisim/components/controller_l2_generic_chp.py
+++ b/hisim/components/controller_l2_generic_chp.py
@@ -9,7 +9,7 @@ from hisim import component as cp
 from hisim.loadtypes import LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters
 from hisim.components import controller_l3_generic_heatpump_modular
-from hisim.components.generic_dhw_boiler import Boiler
+from hisim.components.building import Building
 from hisim import log
 
 from dataclasses import dataclass
@@ -24,9 +24,30 @@ __maintainer__ = "Vitor Hugo Bellotto Zago"
 __email__ = "vitor.zago@rwth-aachen.de"
 __status__ = "development"
 
+@dataclass_json
+@dataclass
+class L2CHPConfig:
+    """
+    GCHP Config
+    """
+    name: str
+    source_weight: int
+    T_min : float       
+    T_max : float
+
+    def __init__( self,
+                  name : str,
+                  source_weight : int,
+                  T_min : float,
+                  T_max : float ):
+        self.name = name
+        self.source_weight = source_weight
+        self.T_min = T_min
+        self.T_max = T_max
+
 class L2_ControllerState:
     """
-    This data class saves the state of the heat pump.
+    This data class saves the state of the CHP.
     """
 
     def __init__( self, timestep_actual : int = -1, state : int = 0, compulsory : int = 0, count : int = 0 ):
@@ -80,27 +101,16 @@ class L2_Controller( cp.Component ):
     """
     # Inputs
     ReferenceTemperature = "ReferenceTemperature"
-    l3_DeviceSignal = "l3_DeviceSignal"
 
     # Outputs
     l2_DeviceSignal = "l2_DeviceSignal"
     
-    # #Forecasts
-    # HeatPumpLoadForecast = "HeatPumpLoadForecast"
-
-    # Similar components to connect to:
-    # 1. Building
-    # 2. HeatPump
-    
     @utils.measure_execution_time
     def __init__( self, 
-                  my_simulation_parameters : SimulationParameters,
-                  T_min : float = 45.0,
-                  T_max : float = 60.0,
-                  T_tolerance : float = 10.0,
-                  source_weight : int = 1 ):
-        super().__init__( "L2_Controller_Boiler" + str( source_weight ), my_simulation_parameters = my_simulation_parameters )
-        self.build( T_min, T_max, T_tolerance )
+                  config : L2CHPConfig,
+                  my_simulation_parameters : SimulationParameters ):
+        super().__init__( config.name + str( config.source_weight ), my_simulation_parameters = my_simulation_parameters )
+        self.build( config )
 
         #Component Inputs
         self.ReferenceTemperatureC: cp.ComponentInput = self.add_input(     self.ComponentName,
@@ -108,13 +118,7 @@ class L2_Controller( cp.Component ):
                                                                             LoadTypes.Temperature,
                                                                             Units.Celsius,
                                                                             mandatory = True )
-        self.add_default_connections( Boiler, self.get_boiler_default_connections( ) )
-        
-        self.l3_DeviceSignalC: cp.ComponentInput = self.add_input(  self.ComponentName,
-                                                                    self.l3_DeviceSignal,
-                                                                    LoadTypes.OnOff,
-                                                                    Units.binary,
-                                                                    mandatory = False )
+        self.add_default_connections( Building, self.get_building_default_connections( ) )
         
         #Component outputs
         self.l2_DeviceSignalC: cp.ComponentOutput = self.add_output( self.ComponentName,
@@ -122,18 +126,27 @@ class L2_Controller( cp.Component ):
                                                                      LoadTypes.OnOff,
                                                                      Units.binary )
         
-    def get_boiler_default_connections( self ):
-        log.information("setting boiler default connections in L2 Controller")
+    @staticmethod
+    def get_default_config():
+        config = L2CHPConfig( name = 'L2CHP',
+                              source_weight = 1,
+                              T_min = 18,
+                              T_max = 22 ) 
+        return config
+        
+    def get_building_default_connections( self ):
+        log.information( "setting building default connections in L2 CHP Controller" )
         connections = [ ]
-        boiler_classname = Boiler.get_classname( )
-        connections.append( cp.ComponentConnection( L2_Controller.ReferenceTemperature, boiler_classname, Boiler.TemperatureMean ) )
+        building_classname = Building.get_classname( )
+        connections.append( cp.ComponentConnection( L2_Controller.ReferenceTemperature, building_classname, Building.TemperatureMean ) )
         return connections
 
-    def build( self, T_min, T_max, T_tolerance ):
+    def build( self, config ):
         
-        self.T_min = T_min
-        self.T_max = T_max
-        self.T_tolerance = T_tolerance
+        self.name = config.name
+        self.source_weight = config.source_weight
+        self.T_min = config.T_min
+        self.T_max = config.T_max
         self.state = L2_ControllerState( )
         self.previous_state = L2_ControllerState( )
 
@@ -158,38 +171,17 @@ class L2_Controller( cp.Component ):
         #get temperature of building
         T_control = stsv.get_input_value( self.ReferenceTemperatureC )
 
-        #get l3 recommendation if available
-        l3state = 0
-        if self.l3_DeviceSignalC.SourceOutput is not None:
-            l3state = stsv.get_input_value( self.l3_DeviceSignalC )
-        
-            #reset temperature limits if recommended from l3
-            if l3state == 1 :
-                T_max = self.T_max + self.T_tolerance
-                T_min = self.T_min
-                self.state.is_compulsory( )
-                self.previous_state.is_compulsory( )
-            elif l3state == 0:
-                T_max = self.T_max
-                T_min = self.T_min - self.T_tolerance
-                self.state.is_compulsory( )
-                self.previous_state.is_compulsory( )
-        
-        else:
-            T_max = self.T_max
-            T_min = self.T_min
-
         #check if it is the first iteration and reset compulsory and timestep_of_last_activation in state and previous_state
         if self.state.is_first_iteration( timestep ):
             self.previous_state.is_first_iteration( timestep )
         
         #check out
-        if T_control > T_max:
+        if T_control > self.T_max:
             #stop heating if temperature exceeds upper limit
             self.state.deactivate( )
             self.previous_state.deactivate( )
 
-        elif T_control < T_min:
+        elif T_control < self.T_min:
             #start heating if temperature goes below lower limit
             self.state.activate( )
             self.previous_state.activate( )
@@ -197,9 +189,6 @@ class L2_Controller( cp.Component ):
             if self.state.compulsory == 1:
                 #use previous state if it compulsory
                 pass
-            elif self.l3_DeviceSignalC.SourceOutput is not None:
-                #use recommendation from l3 if available and not compulsory
-                self.state.state = l3state
             else:
                 #use revious state if l3 was not available
                 self.state = self.previous_state.clone( )

--- a/hisim/components/generic_CHP.py
+++ b/hisim/components/generic_CHP.py
@@ -292,7 +292,7 @@ class L1_Controller( cp.Component ):
         
     @staticmethod
     def get_default_config():
-        config = L1CHPConfig( name = 'CHP',
+        config = L1CHPConfig( name = 'L1CHP',
                               source_weight =  1,
                               min_operation_time = 14400,
                               min_idle_time = 7200 )

--- a/hisim/components/generic_CHP.py
+++ b/hisim/components/generic_CHP.py
@@ -76,11 +76,11 @@ class GCHP( cp.Component ):
         self.build( config )
 
         #Inputs
-        self.l1_DeviceSignalC: ComponentInput = self.add_input( self.ComponentName, 
-                                                               self.l1_DeviceSignal, 
-                                                               lt.LoadTypes.OnOff, 
-                                                               lt.Units.binary,
-                                                               mandatory = True )
+        self.l1_DeviceSignalC: cp.ComponentInput = self.add_input( self.ComponentName, 
+                                                                self.l1_DeviceSignal, 
+                                                                lt.LoadTypes.OnOff, 
+                                                                lt.Units.binary,
+                                                                mandatory = True )
         
         #Component outputs
         self.ThermalEnergyDeliveredC: cp.ComponentOutput = self.add_output( self.ComponentName,

--- a/hisim/components/generic_CHP.py
+++ b/hisim/components/generic_CHP.py
@@ -1,0 +1,305 @@
+from hisim import component as cp
+from hisim import loadtypes as lt
+from hisim.components.configuration import PhysicsConfig
+from hisim import utils
+#from math import pi
+#from math import floor
+from hisim.simulationparameters import SimulationParameters
+from hisim.components import controller_l2_generic_chp
+import hisim.log as log
+import pandas as pd
+import os
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json
+
+import math
+
+__authors__ = "Frank Burkrad, Maximilian Hillen,"
+__copyright__ = "Copyright 2021, the House Infrastructure Project"
+__credits__ = ["Noah Pflugradt"]
+__license__ = ""
+__version__ = ""
+__maintainer__ = "Johanna Ganglbauer"
+__email__ = "johanna.ganglbauer@4wardenergy.at"
+__status__ = "development"
+
+@dataclass_json
+@dataclass
+class GCHPConfig:
+    """
+    GCHP Config
+    """
+    name: str
+    source_weight: int
+    p_el : float       
+    p_th : float
+    p_fuel : float
+
+    def __init__( self,
+                  name : str,
+                  source_weight : int,
+                  p_el : float,
+                  p_th : float,
+                  p_fuel : float ):
+        self.name = name
+        self.source_weight = source_weight
+        self.p_el = p_el
+        self.p_th = p_th
+        self.p_fuel = p_fuel
+            
+class CHPState:
+    """
+    This data class saves the state of the CHP.
+    """
+
+    def __init__( self, state : int = 0 ):
+        self.state = state
+        
+    def clone( self ):
+        return CHPState( state = self.state )
+            
+class GCHP( cp.Component ):
+    """
+    Simulates CHP operation with constant electical and thermal power as well as constant fuel consumption.
+    """
+    # Inputs
+    l1_DeviceSignal = "l1_DeviceSignal"
+
+    # Outputs
+    ThermalEnergyDelivered = "ThermalEnergyDelivered"
+    ElectricityOutput = "ElectricityOutput"
+    FuelDelivered = "FuelDelivered"
+    
+    
+    def __init__( self, my_simulation_parameters: SimulationParameters, config: GCHPConfig ):
+        super().__init__( name = config.name + str( config.source_weight ), my_simulation_parameters=my_simulation_parameters )
+        self.build( config )
+
+        #Inputs
+        self.l1_DeviceSignalC: ComponentInput = self.add_input( self.ComponentName, 
+                                                               self.l1_DeviceSignal, 
+                                                               lt.LoadTypes.OnOff, 
+                                                               lt.Units.binary,
+                                                               mandatory = True )
+        
+        #Component outputs
+        self.ThermalEnergyDeliveredC: cp.ComponentOutput = self.add_output( self.ComponentName,
+                                                                            self.ThermalEnergyDelivered,
+                                                                            lt.LoadTypes.Heating,
+                                                                            lt.Units.Watt )
+        self.ElectricityOutputC: cp.ComponentOutput = self.add_output( self.ComponentName,
+                                                                       self.ElectricityOutput,
+                                                                       lt.LoadTypes.Electricity,
+                                                                       lt.Units.Watt )
+        self.FuelDeliveredC: cp.ComponentOutput = self.add_output( self.ComponentName,
+                                                                   self.FuelDelivered,
+                                                                   lt.LoadTypes.Hydrogen,
+                                                                   lt.Units.kg_per_sec )
+        self.add_default_connections( L1_Controller, self.get_l1_controller_default_connections( ) )
+
+    @staticmethod
+    def get_default_config():
+        config=GCHPConfig( name = 'CHP',
+                          source_weight =  1,
+                          p_el = 2000,
+                          p_th = 3000,
+                          p_fuel = 6000 ) 
+        return config
+    
+    def build( self, config ):
+        self.state = CHPState( )
+        self.previous_state = CHPState( )
+        self.p_th = config.p_th
+        self.p_el = config.p_el
+        self.p_fuel = config.p_fuel
+    
+    def i_save_state(self):
+        self.previous_state = self.state.clone( )
+
+    def i_restore_state(self):
+        self.state = self.previous_state.clone( )
+
+    def i_doublecheck(self, timestep: int, stsv: cp.SingleTimeStepValues):
+         pass
+
+    def i_simulate( self, timestep: int, stsv: cp.SingleTimeStepValues,  force_convergence: bool ):
+
+        # Inputs
+        self.state.state = stsv.get_input_value( self.l1_DeviceSignalC )
+       
+        # Outputs
+        stsv.set_output_value( self.ThermalEnergyDeliveredC, self.state.state * self.p_th )
+        stsv.set_output_value( self.ElectricityOutputC, self.state.state * self.p_el )
+        
+        #heat of combustion hydrogen: 141.8 MJ / kg; conversion W = J/s to kg / s
+        stsv.set_output_value( self.FuelDeliveredC, ( self.state.state * self.p_fuel / 1.418 ) * 1e-8  )
+        
+    def get_l1_controller_default_connections( self ):
+        log.information("setting l1 default connections in generic CHP" )
+        connections = [ ]
+        controller_classname = L1_Controller.get_classname( )
+        connections.append( cp.ComponentConnection( GCHP.l1_DeviceSignal, controller_classname, L1_Controller.l1_DeviceSignal ) )
+        return connections
+        
+@dataclass_json
+@dataclass
+class L1CHPConfig:
+    """
+    L1CHP Config
+    """
+    name : str
+    source_weight : int
+    min_operation_time : int
+    min_idle_time : int
+
+    def __init__( self,
+                  name : str,
+                  source_weight : int,
+                  min_operation_time : int,
+                  min_idle_time : int ):
+        self.name = name
+        self.source_weight = source_weight
+        self.min_operation_time = min_operation_time
+        self.min_idle_time = min_idle_time
+        
+class L1_ControllerState:
+    """
+    This data class saves the state of the controller.
+    """
+
+    def __init__( self, timestep_actual : int = -1, state : int = 0, timestep_of_last_action : int = 0 ):
+        self.timestep_actual = timestep_actual
+        self.state = state
+        self.timestep_of_last_action = timestep_of_last_action
+        
+    def clone( self ):
+        return L1_ControllerState( timestep_actual = self.timestep_actual, state = self.state, timestep_of_last_action = self.timestep_of_last_action )
+    
+    def is_first_iteration( self, timestep ):
+        if self.timestep_actual + 1 == timestep:
+            self.timestep_actual += 1
+            return True
+        else:
+            return False
+        
+    def activation( self, timestep ):
+        self.state = 1
+        self.timestep_of_last_action = timestep
+        
+    def deactivation( self, timestep ):
+        self.state = 0
+        self.timestep_of_last_action = timestep 
+
+class L1_Controller( cp.Component ):
+    
+    """
+    L1 CHP Controller. It takes care of the operation of the CHP only in terms of running times.
+
+    Parameters
+    --------------
+    min_running_time: int, optional
+        Minimal running time of device, in seconds. The default is 3600 seconds.
+    min_idle_time : int, optional
+        Minimal off time of device, in seconds. The default is 900 seconds.
+    source_weight : int, optional
+        Weight of component, relevant if there is more than one component of same type, defines hierachy in control. The default is 1.
+    component type : str, optional
+        Name of component to be controlled
+    """
+    # Inputs
+    l2_DeviceSignal = "l2_DeviceSignal"
+
+    # Outputs
+    l1_DeviceSignal = "l1_DeviceSignal"
+
+    # Similar components to connect to:
+    # 1. Building
+    @utils.measure_execution_time
+    def __init__( self, 
+                  my_simulation_parameters : SimulationParameters,
+                  config : L1CHPConfig ):
+        
+        super().__init__( config.name + str( config.source_weight ), my_simulation_parameters = my_simulation_parameters )
+        self.build( config )
+        
+        #add inputs
+        self.l2_DeviceSignalC: cp.ComponentInput = self.add_input( self.ComponentName,
+                                                                   self.l2_DeviceSignal,
+                                                                   lt.LoadTypes.OnOff,
+                                                                   lt.Units.binary,
+                                                                   mandatory = True )
+        self.add_default_connections( controller_l2_generic_chp.L2_Controller, self.get_l2_controller_default_connections( ) )
+        
+        
+        #add outputs
+        self.l1_DeviceSignalC: cp.ComponentOutput = self.add_output(    self.ComponentName,
+                                                                        self.l1_DeviceSignal,
+                                                                        lt.LoadTypes.OnOff,
+                                                                        lt.Units.binary )
+        
+    def get_l2_controller_default_connections( self ):
+        log.information("setting l2 default connections in l1")
+        connections = [ ]
+        controller_classname = controller_l2_generic_chp.L2_Controller.get_classname( )
+        connections.append( cp.ComponentConnection( L1_Controller.l2_DeviceSignal, controller_classname,controller_l2_generic_chp.L2_Controller.l2_DeviceSignal ) )
+        return connections
+
+    def build( self, config ):
+        
+        self.on_time = int( config.min_operation_time / self.my_simulation_parameters.seconds_per_timestep )
+        self.off_time = int( config.min_idle_time / self.my_simulation_parameters.seconds_per_timestep )
+        self.name = config.name
+        self.source_weight = config.source_weight
+        
+        self.state0 = L1_ControllerState( )
+        self.state = L1_ControllerState( )
+        self.previous_state = L1_ControllerState( )
+
+    def i_save_state(self):
+        self.previous_state = self.state.clone( )
+
+    def i_restore_state(self):
+        self.state = self.previous_state.clone( )
+
+    def i_doublecheck(self, timestep: int, stsv: cp.SingleTimeStepValues):
+        pass
+
+    def i_simulate( self, timestep: int, stsv: cp.SingleTimeStepValues,  force_convergence: bool ):
+        # check demand, and change state of self.has_heating_demand, and self._has_cooling_demand
+        if force_convergence:
+            pass
+        
+        l2_devicesignal = stsv.get_input_value( self.l2_DeviceSignalC )
+        
+        #save reference state state0 in first iteration
+        if self.state.is_first_iteration( timestep ):
+            self.state0 = self.state.clone( )
+        
+        #return device on if minimum operation time is not fulfilled and device was on in previous state
+        if ( self.state0.state == 1 and self.state0.timestep_of_last_action + self.on_time >= timestep ):
+            self.state.state = 1
+        #return device off if minimum idle time is not fulfilled and device was off in previous state
+        elif ( self.state0.state == 0 and self.state0.timestep_of_last_action + self.off_time >= timestep ):
+            self.state.state = 0
+        #check signal from l2 and turn on or off if it is necesary
+        else:
+            if l2_devicesignal == 0 and self.state0.state == 1:
+                self.state.deactivation( timestep )
+            elif l2_devicesignal == 1 and self.state0.state == 0:
+                self.state.activation( timestep )
+        
+        stsv.set_output_value( self.l1_DeviceSignalC, self.state.state )
+        
+    @staticmethod
+    def get_default_config():
+        config = L1CHPConfig( name = 'CHP',
+                              source_weight =  1,
+                              min_operation_time = 14400,
+                              min_idle_time = 7200 )
+        return config
+
+    def prin1t_outpu1t(self, t_m, state):
+        log.information("==========================================")
+        log.information("T m: {}".format(t_m))
+        log.information("State: {}".format(state))
+        

--- a/hisim/components/generic_dhw_boiler.py
+++ b/hisim/components/generic_dhw_boiler.py
@@ -35,7 +35,7 @@ __status__ = "development"
 @dataclass
 class BoilerConfig:
     name : str
-    source_weight : str
+    source_weight : int
     parameter_string: str
     volume : float
     surface : float
@@ -48,7 +48,7 @@ class BoilerConfig:
 
     def __init__( self,
                   name : str,
-                  source_weight : str,
+                  source_weight : int,
                   volume : float,
                   surface : float,
                   u_value : float,

--- a/hisim/components/generic_dhw_boiler.py
+++ b/hisim/components/generic_dhw_boiler.py
@@ -34,6 +34,8 @@ __status__ = "development"
 @dataclass_json
 @dataclass
 class BoilerConfig:
+    name : str
+    source_weight : str
     parameter_string: str
     volume : float
     surface : float
@@ -45,7 +47,8 @@ class BoilerConfig:
     fuel : str
 
     def __init__( self,
-                  my_simulation_parameters: SimulationParameters,
+                  name : str,
+                  source_weight : str,
                   volume : float,
                   surface : float,
                   u_value : float,
@@ -54,7 +57,8 @@ class BoilerConfig:
                   power : float, 
                   efficiency : float,
                   fuel : str ) :
-        self.parameter_string = my_simulation_parameters.get_unique_key()
+        self.name = name
+        self.source_weight = source_weight
         self.volume = volume
         self.surface = surface
         self.u = u_value
@@ -139,30 +143,11 @@ class Boiler( cp.Component ):
     ElectricityOutput = "ElectricityOutput"
     HydrogenOutput = "HydrogenOutput"
     
-    def __init__( self, my_simulation_parameters: SimulationParameters, 
-                        volume : float = 200, 
-                        surface : float = 1.2,
-                        u_value : float = 0.36,
-                        T_warmwater : float = 50,
-                        T_drainwater : float = 10,
-                        power : float = 2400,
-                        efficiency : float = 1,
-                        fuel : str = 'electricity',
-                        source_weight : int = 1,
-                        name : str = 'Boiler' ) :
+    def __init__( self, my_simulation_parameters: SimulationParameters, config : BoilerConfig ):
 
-        super().__init__( name + str( source_weight ), my_simulation_parameters = my_simulation_parameters )
+        super().__init__( config.name + str( config.source_weight ), my_simulation_parameters = my_simulation_parameters )
         
-        self.config = BoilerConfig( my_simulation_parameters = my_simulation_parameters,
-                                    volume = volume,
-                                    surface = surface,
-                                    u_value = u_value,
-                                    T_warmwater = T_warmwater, 
-                                    T_drainwater = T_drainwater, 
-                                    power = power, 
-                                    efficiency = efficiency,
-                                    fuel = fuel )
-        self.build( source_weight )
+        self.build( config )
         
         #inputs
         self.WaterConsumptionC : cp.ComponentInput = self.add_input( self.ComponentName,
@@ -188,19 +173,19 @@ class Boiler( cp.Component ):
                                                                          lt.LoadTypes.Temperature,
                                                                          lt.Units.Celsius )
         
-        if self.config.fuel == 'electricity':
+        if self.fuel == 'electricity':
             self.ElectricityOutputC = self.add_output( self.ComponentName,
                                                          self.ElectricityOutput,
                                                          lt.LoadTypes.Electricity,
                                                          lt.Units.Watt )
         
-        elif self.config.fuel == 'hydrogen':
+        elif self.fuel == 'hydrogen':
             self.hydrogen_output_c = self.add_output( self.ComponentName,
                                                       self.HydrogenOutput,
                                                       lt.LoadTypes.Hydrogen,
                                                       lt.Units.kg_per_sec )
         else:
-            raise Exception(" The fuel ", str( self.config.fuel ), " is not available. Choose either 'electricity' or 'hydrogen'. " )
+            raise Exception(" The fuel ", str( self.fuel ), " is not available. Choose either 'electricity' or 'hydrogen'. " )
             
         self.add_default_connections( Occupancy, self.get_occupancy_default_connections( ) )
         self.add_default_connections( controller_l1_generic_runtime.L1_Controller, self.get_l1_controller_default_connections( ) )
@@ -220,12 +205,35 @@ class Boiler( cp.Component ):
         connections.append( cp.ComponentConnection( Boiler.l1_RunTimeSignal, controller_classname, controller_l1_generic_runtime.L1_Controller.l1_RunTimeSignal ) )
         return connections
     
-    def build( self, source_weight ):
+    @staticmethod
+    def get_default_config():
+        config = BoilerConfig( name = 'Boiler',
+                               source_weight = 1, 
+                               volume = 200,
+                               surface = 1.2,
+                               u_value = 0.36,
+                               T_warmwater = 50,
+                               T_drainwater = 10,
+                               power = 2400,
+                               efficiency = 1,
+                               fuel  = 'electricity' )
+        return config
+    
+    def build( self, config : BoilerConfig ):
         
-        self.source_weight = source_weight
+        self.source_weight = config.source_weight
+        self.power = config.power
+        self.volume = config.volume
+        self.surface = config.surface
+        self.u = config.u
+        self.efficiency = config.efficiency
+        self.T_drainwater = config.T_drainwater
+        self.T_warmwater = config.T_warmwater
+        self.fuel = config.fuel
+        
         
         #initialize Boiler State
-        self.state = BoilerState( volume_in_l = self.config.volume, temperature_in_K = 273 + 50 )
+        self.state = BoilerState( volume_in_l = config.volume, temperature_in_K = 273 + 50 )
         self.previous_state = self.state.clone()
             
         self.write_to_report( )
@@ -233,8 +241,8 @@ class Boiler( cp.Component ):
     def write_to_report(self):
         lines = []
         lines.append("Name: {}".format("electric Boiler"))
-        lines.append("Power: {:4.0f} kW".format( ( self.config.power ) * 1E-3 ) )
-        lines.append( "Volume: {:4.0f} l".format( self.config.volume ) )
+        lines.append("Power: {:4.0f} kW".format( ( self.power ) * 1E-3 ) )
+        lines.append( "Volume: {:4.0f} l".format( self.volume ) )
         return lines
 
     def i_save_state( self ):
@@ -259,9 +267,9 @@ class Boiler( cp.Component ):
         #4.182 specific heat of water in kJ K^(-1) kg^(-1)
         #1e-3 conversion J to kJ
         energy = self.state.energy_from_temperature()
-        new_energy = energy - ( self.state.temperature_in_K - 293 ) * self.config.surface * self.config.u * self.my_simulation_parameters.seconds_per_timestep * 1e-3 \
-                                              - WW_consumption * ( self.config.T_warmwater - self.config.T_drainwater ) * 0.977 * 4.182 \
-                                              + signal * self.config.power * self.config.efficiency * self.my_simulation_parameters.seconds_per_timestep * 1e-3
+        new_energy = energy - ( self.state.temperature_in_K - 293 ) * self.surface * self.u * self.my_simulation_parameters.seconds_per_timestep * 1e-3 \
+                                              - WW_consumption * ( self.T_warmwater - self.T_drainwater ) * 0.977 * 4.182 \
+                                              + signal * self.power * self.efficiency * self.my_simulation_parameters.seconds_per_timestep * 1e-3
                                               
         #convert new energy to new temperature
         self.state.set_temperature_from_energy( new_energy )
@@ -269,8 +277,8 @@ class Boiler( cp.Component ):
         #save outputs
         stsv.set_output_value( self.TemperatureMeanC, self.state.temperature_in_K - 273.15 )
         
-        if self.config.fuel == 'electricity':
-            stsv.set_output_value( self.ElectricityOutputC, self.config.power * signal )
+        if self.fuel == 'electricity':
+            stsv.set_output_value( self.ElectricityOutputC, self.power * signal )
               
             #put forecast into dictionary
             if self.my_simulation_parameters.system_config.predictive:
@@ -279,188 +287,7 @@ class Boiler( cp.Component ):
                     self.state.timestep += 1
                     self.previous_state.timestep += 1
                     runtime = stsv.get_input_value( self.l1_RunTimeSignalC )
-                    self.simulation_repository.set_dynamic_entry( component_type = lt.ComponentType.Boiler, source_weight = self.source_weight, entry = [ self.config.power ] * runtime )
+                    self.simulation_repository.set_dynamic_entry( component_type = lt.ComponentType.Boiler, source_weight = self.source_weight, entry = [ self.power ] * runtime )
         else:
             #heat of combustion hydrogen: 141.8 MJ / kg; conversion W = J/s to kg / s
-            stsv.set_output_value( self.hydrogen_output_c, ( self.config.power * signal / 1.418 ) * 1e-8 )
-
-# class ControllerState:
-#     """
-#     This data class saves the state of the controller.
-#     """
-
-#     def __init__( self, state : int = 0, timestep_of_last_action : int = -999 ):
-#         self.state = state
-#         self.timestep_of_last_action = timestep_of_last_action
-        
-#     def clone( self ):
-#         return ControllerState( state = self.state, timestep_of_last_action = self.timestep_of_last_action )
-
-# class BoilerController(cp.Component):
-#     """
-#     Boiler on/off controller. It activates boiler, when temperature falls below
-#     certain threshold and deactivates it if temperature exceeds limit.
-
-#     Parameters
-#     --------------
-#     t_water_min: float
-#         Minimum temperature of water in hot water storage -> in Kelvin
-#     t_water_max: float
-#         Maximum temperature of water in hot water storage -> in Kelvin
-#     P_on : float
-#         Power of boiler -> in Watt
-#     smart : bool
-#         One if boiler enforces heating in case of surplus from PV and 0 if it does not react to the situaltion.
-#     """
-#     # Inputs
-#     TemperatureMean = "Storage Temperature"
-#     BoilerSignal = "BoilerSignal"
-
-#     # Outputs
-#     BoilerControllerState = "BoilerControllerState"
-    
-#     #Forecasts
-#     BoilerLoadForecast = "BoilerLoadForecast"
-
-    # # Similar components to connect to:
-    # # 1. Building
-
-    # def __init__( self, my_simulation_parameters: SimulationParameters,
-    #                     t_water_min : float = 273.0 + 40.0,
-    #                     t_water_max : float = 273.0 + 80.0,
-    #                     P_on :        int =   2400,
-    #                     on_time :   int = 2700,
-    #                     off_time :  int = 1800 ):
-        
-    #     super().__init__( name="BoilerController", my_simulation_parameters = my_simulation_parameters )
-        
-    #     self.build( t_water_min = t_water_min,
-    #                 t_water_max = t_water_max,
-    #                 P_on = P_on,
-    #                 on_time = on_time,
-    #                 off_time = off_time )
-
-    #     #input
-    #     self.TemperatureMeanC: cp.ComponentInput = self.add_input( self.ComponentName,
-    #                                                                   self.TemperatureMean,
-    #                                                                   lt.LoadTypes.Temperature,
-    #                                                                   lt.Units.Kelvin,
-    #                                                                   mandatory = True )
-    #     if self.my_simulation_parameters.system_config.predictive and self.my_simulation_parameters.system_config.boiler_included == 'electricity':
-    #         self.BoilerSignalC: cp.ComponentInput = self.add_input( self.ComponentName,
-    #                                                                 self.BoilerSignal,
-    #                                                                 lt.LoadTypes.Any,
-    #                                                                 lt.Units.Any,
-    #                                                                 mandatory = False )
-    #         self.add_default_connections( controller_l3_predictive.PredictiveController, self.get_predictive_controller_default_connections( ) )
-        
-        
-    #     #output
-    #     self.BoilerControllerStateC = self.add_output( self.ComponentName,
-    #                                                     self.BoilerControllerState,
-    #                                                     lt.LoadTypes.Any,
-    #                                                     lt.Units.Any )
-        
-    #     self.add_default_connections( Boiler, self.get_boiler_default_connections( ) )
-    
-    # def get_boiler_default_connections( self ):
-    #     log.information("setting boiler default connections")
-    #     connections = [ ]
-    #     boiler_classname = Boiler.get_classname( )
-    #     connections.append( cp.ComponentConnection( BoilerController.TemperatureMean, boiler_classname, Boiler.TemperatureMean ) )
-    #     return connections
-    
-    # def get_predictive_controller_default_connections( self ):
-    #     log.information( "setting predictive controller default connections") 
-    #     connections = [ ]
-    #     predictive_controller_classname = controller_l3_predictive.PredictiveController.get_classname( )
-    #     connections.append( cp.ComponentConnection( BoilerController.BoilerSignal, predictive_controller_classname, 
-    #                                                 controller_l3_predictive.PredictiveController.BoilerSignal ) )
-    #     return connections
-
-    # def build( self, t_water_min, t_water_max, P_on, on_time, off_time ):
-        
-    #     # state
-    #     self.state = ControllerState( )
-    #     self.previous_state = ControllerState( )
-
-    #     # Configuration
-    #     self.t_water_min = t_water_min
-    #     self.t_water_max = t_water_max
-    #     self.P_on = P_on
-    #     self.on_time = int( on_time / self.my_simulation_parameters.seconds_per_timestep )
-    #     self.off_time = int( off_time / self.my_simulation_parameters.seconds_per_timestep )
-        
-    # def activation( self, timestep ):
-    #     self.state.state = 2
-    #     self.state.timestep_of_last_action = timestep
-    #     #violently access previous timestep to avoid oscillation between 0 and 1 (decision is based on decision of previous time step)
-    #     self.previous_state = self.state.clone( )
-
-    # def deactivation( self, timestep ):
-    #     self.state.state = -2
-    #     self.state.timestep_of_last_action = timestep 
-    #     #violently access previous timestep to avoid oscillation between 0 and 1 (decision is based on decision of previous time step)
-    #     self.previous_state = self.state.clone( )
-
-    # def i_save_state(self):
-    #     self.previous_state = self.state.clone( )
-
-    # def i_restore_state(self):
-    #     self.state = self.previous_state.clone( )
-
-    # def i_doublecheck(self, timestep: int, stsv: cp.SingleTimeStepValues):
-    #     pass
-
-    # def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues,  force_convergence: bool):
-
-    #     if force_convergence: # please stop oscillating!
-    #         return
-        
-    #     if ( self.state.state == 2 and timestep < self.state.timestep_of_last_action + self.on_time ) or \
-    #           ( self.state.state == -2 and timestep < self.state.timestep_of_last_action + self.off_time ):
-    #         pass
-    #     else:
-    #         # Retrieves inputs
-    #         T_control = stsv.get_input_value( self.TemperatureMeanC )
-    
-    #         #on off control based on temperature limits
-    #         if T_control > self.t_water_max:
-    #             #stop heating if temperature exceeds upper limit
-    #             if self.state.state >= 0:
-    #                 self.deactivation( timestep )
-
-    #         elif T_control < self.t_water_min:
-    #             #start heating if temperature goes below lower limit
-    #             if self.state.state <= 0:
-    #                 self.activation( timestep )
-             
-    #         #continue working if other is not defined    
-    #         else:
-    #             if self.state.state > 0:
-    #                 self.state.state = 1
-    #             if self.state.state < 0:
-    #                 self.state.state = -1
-        
-    #         if self.my_simulation_parameters.system_config.predictive and self.my_simulation_parameters.system_config.boiler_included == 'electricity':
-    #             #put forecast into dictionary
-    #             if self.state.state > 0:
-    #                 self.simulation_repository.set_entry( self.BoilerLoadForecast, [ self.P_on ] * max( 1, self.on_time - timestep + self.state.timestep_of_last_action ) )
-    #             else:
-    #                 self.simulation_repository.set_entry( self.BoilerLoadForecast, [ self.P_on ] * self.on_time )
-                    
-    #             #read in signal and modify state if recommended
-    #             devicesignal = stsv.get_input_value( self.BoilerSignalC )
-    #             if self.state.state == 1 and devicesignal == -1:
-    #                 self.deactivation( timestep )
-                    
-    #             elif self.state.state == -1 and devicesignal == 1:
-    #                 self.activation( timestep )
-                 
-    #     stsv.set_output_value( self.BoilerControllerStateC, self.state.state )     
-
-    # # def log_output(self, t_m, state):
-    # #     log.information("==========================================")
-    # #     log.information("T m: {}".format(t_m))
-    # #     log.information("State: {}".format(state))
-
+            stsv.set_output_value( self.hydrogen_output_c, ( self.power * signal / 1.418 ) * 1e-8 )

--- a/hisim/components/generic_electrolyzer.py
+++ b/hisim/components/generic_electrolyzer.py
@@ -1,0 +1,329 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul  5 12:39:29 2022
+
+@author: Johanna
+"""
+
+# Owned
+from hisim.simulationparameters import SimulationParameters
+
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json
+from hisim import component as cp
+from hisim import loadtypes as lt
+
+from hisim.components.configuration import PhysicsConfig
+from hisim import log
+from hisim import utils
+__authors__ = "Frank Burkrad, Maximilian Hillen"
+__copyright__ = "Copyright 2021, the House Infrastructure Project"
+__credits__ = ["Noah Pflugradt"]
+__license__ = ""
+__version__ = ""
+__maintainer__ = "Johanna Ganglbauer"
+__email__ = "johanna.ganglbauer@4wardenergy.at"
+__status__ = ""
+#
+
+@dataclass_json
+@dataclass
+class ElectrolyzerConfig:
+    name: str
+    source_weight : int
+    min_power: float # [W]
+    max_power: float # [W]
+    min_hydrogen_production_rate_hour: float # [Nl/h]
+    max_hydrogen_production_rate_hour: float # [Nl/h]
+    
+    def init( self, name : str,
+                    source_weight : int,
+                    min_power : float,
+                    max_power : float,
+                    min_hydrogen_production_rate_hour : float,
+                    max_hydrogen_production_rate_hour : float ):
+        self.name = name
+        self.source_weight = source_weight
+        self.min_power = min_power
+        self.max_powwer = max_power
+        self.min_hydrogen_production_rate_hour = min_hydrogen_production_rate_hour
+        self.max_hydrogen_production_rate_hour = max_hydrogen_production_rate_hour
+        
+class ElectrolyzerState:
+    """
+    This data class saves the state of the electrolyzer.
+    """
+
+    def __init__( self, hydrogen : float = 0, electricity : float = 0 ):
+        self.hydrogen = hydrogen
+        self.electricity = electricity
+        
+    def clone( self ):
+        return ElectrolyzerState( hydrogen = self.hydrogen, electricity = self.electricity )
+        
+    
+class Electrolyzer( cp.Component ):
+    ElectricityTarget = "ElectricityTarget"
+    HydrogenOutput = "HydrogenOutput"
+    
+    ElectricityOutput = "ElectricityOutput"   
+    
+    def __init__( self, my_simulation_parameters : SimulationParameters, config : ElectrolyzerConfig ):
+        """
+        The electrolyzer converts electrical energy [kWh] into hydrogen [kg]
+        It can work in a certain range from x to 100% or be switched off = 0%
+        The conversion rate is given by the supplier and is directly used
+            maybe a change to efficiency can be made but its just making things more complex with no benefit
+        Between the given values, the values are calculated by an interpolation.
+            --> If the load curve is linear a fixed factor could be calculated.
+
+        Therefore it has an operational state
+        All the min values and  all the max values are connected and the electrolyzer can operate between them.
+
+        The waste energy in electolyzers is not used to provide heat for the households demand
+        Output pressure may be used in the future for the
+        """
+        
+        super().__init__( name = config.name + str( config.source_weight ), 
+                              my_simulation_parameters = my_simulation_parameters )
+        self.build( config )
+        
+        self.ElectricityTargetC: cp.ComponentInput = self.add_input( self.ComponentName, 
+                                                                     Electrolyzer.ElectricityTarget, 
+                                                                     lt.LoadTypes.Electricity, 
+                                                                     lt.Units.Watt, 
+                                                                     True )
+        self.HydrogenOutputC: cp.ComponentOutput = self.add_output( self.ComponentName, 
+                                                                    Electrolyzer.HydrogenOutput, 
+                                                                    lt.LoadTypes.Hydrogen, 
+                                                                    lt.Units.kg_per_sec )
+        self.ElectricityOutputC: cp.ComponentOutput = self.add_output( self.ComponentName, 
+                                                                       Electrolyzer.ElectricityOutput, 
+                                                                       lt.LoadTypes.Electricity, 
+                                                                       lt.Units.Watt )
+        self.add_default_connections( L1_Controller, self.get_l1_controller_default_connections( ) )
+        
+    @staticmethod
+    def get_default_config():
+        config = ElectrolyzerConfig( name = "Electrolyzer",
+                                     source_weight = 1,
+                                     min_power = 1200,  # [W]
+                                     max_power = 2400,  # [W]
+                                     min_hydrogen_production_rate_hour = 300,  # [Nl/h]
+                                     max_hydrogen_production_rate_hour = 5000  # [Nl/h]
+                                     )
+        return config
+    
+    def get_l1_controller_default_connections( self ):
+        log.information("setting l1 default connections in generic electrolyzer" )
+        connections = [ ]
+        controller_classname = L1_Controller.get_classname( )
+        connections.append( cp.ComponentConnection( Electrolyzer.ElectricityTarget, controller_classname, L1_Controller.ElectricityTarget ) )
+        return connections
+    
+    def build( self, config ):
+        self.state = ElectrolyzerState( )
+        self.previous_state = ElectrolyzerState( )
+        
+        self.source_weight = config.source_weight
+        self.min_power = config.min_power
+        self.max_power = config.max_power
+        self.min_hydrogen_production_rate = config.min_hydrogen_production_rate_hour / 3600
+        self.max_hydrogen_production_rate = config.max_hydrogen_production_rate_hour / 3600
+        
+    def i_save_state(self):
+        self.previous_state = self.state.clone( )
+
+    def i_restore_state(self):
+        self.state = self.previous_state.clone( )
+        
+    def i_doublecheck(self, timestep: int, stsv: cp.SingleTimeStepValues):
+        pass
+    
+    def i_simulate( self, timestep: int, stsv: cp.SingleTimeStepValues,  force_convergence: bool ):
+        # check demand, and change state of self.has_heating_demand, and self._has_cooling_demand
+        if force_convergence:
+            pass
+        
+        electricity_target = stsv.get_input_value( self.ElectricityTargetC )
+        if electricity_target < 0:
+            raise ValueError( 'Target electricity needs to be positive in Electrolyzer' )
+        elif 0 <= electricity_target < self.min_power:
+            self.state.electricity = 0
+        elif electricity_target > self.max_power:
+            self.state.electricity = self.max_power
+        else:
+            self.state.electricity = electricity_target
+
+        #interpolation between points
+        # Nl / s
+        if electricity_target == 0:
+            hydrogen_output_liter = 0
+        else:
+            hydrogen_output_liter = self.min_hydrogen_production_rate + ( ( self.max_hydrogen_production_rate - self.min_hydrogen_production_rate ) * \
+                                                                          ( self.state.electricity - self.min_power ) / ( self.max_power - self.min_power ) )
+        self.state.hydrogen = ( hydrogen_output_liter / 1000 ) * PhysicsConfig.hydrogen_density
+        stsv.set_output_value( self.HydrogenOutputC, self.state.hydrogen  )
+        stsv.set_output_value( self.ElectricityOutputC, self.state.electricity )
+        
+@dataclass_json
+@dataclass
+class L1ElectrolyzerConfig:
+    """
+    L1Electrolyzer Config
+    """
+    name : str
+    source_weight : int
+    min_operation_time : int
+    min_idle_time : int
+    P_min_electrolyzer : float
+
+    def __init__( self,
+                  name : str,
+                  source_weight : int,
+                  min_operation_time : int,
+                  min_idle_time : int,
+                  P_min_electrolyzer : float ):
+        self.name = name
+        self.source_weight = source_weight
+        self.min_operation_time = min_operation_time
+        self.min_idle_time = min_idle_time
+        self.P_min_electrolyzer = P_min_electrolyzer
+        
+class L1_ControllerState:
+    """
+    This data class saves the state of the controller.
+    """
+
+    def __init__( self, timestep_actual : int = -1, state : int = 0, timestep_of_last_action : int = 0 ):
+        self.timestep_actual = timestep_actual
+        self.state = state
+        self.timestep_of_last_action = timestep_of_last_action
+        
+    def clone( self ):
+        return L1_ControllerState( timestep_actual = self.timestep_actual, state = self.state, timestep_of_last_action = self.timestep_of_last_action )
+    
+    def is_first_iteration( self, timestep ):
+        if self.timestep_actual + 1 == timestep:
+            self.timestep_actual += 1
+            return True
+        else:
+            return False
+        
+    def activation( self, timestep ):
+        self.state = 1
+        self.timestep_of_last_action = timestep
+        
+    def deactivation( self, timestep ):
+        self.state = 0
+        self.timestep_of_last_action = timestep 
+
+class L1_Controller( cp.Component ):
+    
+    """
+    L1 CHP Controller. It takes care of the operation of the CHP only in terms of running times.
+
+    Parameters
+    --------------
+    min_running_time: int, optional
+        Minimal running time of device, in seconds. The default is 3600 seconds.
+    min_idle_time : int, optional
+        Minimal off time of device, in seconds. The default is 900 seconds.
+    source_weight : int, optional
+        Weight of component, relevant if there is more than one component of same type, defines hierachy in control. The default is 1.
+    component type : str, optional
+        Name of component to be controlled
+    """
+    # Inputs
+    l2_ElectricityTarget = "l2_ElectricityTarget"
+
+    # Outputs
+    ElectricityTarget = "ElectricityTarget"
+    
+    # Similar components to connect to:
+    # 1. Building
+    @utils.measure_execution_time
+    def __init__( self, 
+                  my_simulation_parameters : SimulationParameters,
+                  config : L1ElectrolyzerConfig ):
+        
+        super().__init__( name = config.name + str( config.source_weight ), 
+                          my_simulation_parameters = my_simulation_parameters )
+        
+        self.build( config )
+        
+        #add inputs
+        self.l2_ElectricityTargetC : cp.ComponentInput = self.add_input( self.ComponentName,
+                                                                         self.l2_ElectricityTarget,
+                                                                         lt.LoadTypes.Electricity,
+                                                                         lt.Units.Watt,
+                                                                         mandatory = True )
+        #add outputs
+        self.ElectricityTargetC: cp.ComponentOutput = self.add_output(  self.ComponentName,
+                                                                        self.ElectricityTarget,
+                                                                        lt.LoadTypes.Electricity,
+                                                                        lt.Units.Watt )
+
+    def build( self, config ):
+        
+        self.on_time = int( config.min_operation_time / self.my_simulation_parameters.seconds_per_timestep )
+        self.off_time = int( config.min_idle_time / self.my_simulation_parameters.seconds_per_timestep )
+        self.name = config.name
+        self.source_weight = config.source_weight
+        self.Pmin = config.P_min_electrolyzer
+        
+        self.state0 = L1_ControllerState( )
+        self.state = L1_ControllerState( )
+        self.previous_state = L1_ControllerState( )
+
+    def i_save_state(self):
+        self.previous_state = self.state.clone( )
+
+    def i_restore_state(self):
+        self.state = self.previous_state.clone( )
+
+    def i_doublecheck(self, timestep: int, stsv: cp.SingleTimeStepValues):
+        pass
+
+    def i_simulate( self, timestep: int, stsv: cp.SingleTimeStepValues,  force_convergence: bool ):
+        # check demand, and change state of self.has_heating_demand, and self._has_cooling_demand
+        if force_convergence:
+            pass
+        
+        l2_electricity_target = stsv.get_input_value( self.l2_ElectricityTargetC )
+        
+        #save reference state state0 in first iteration
+        if self.state.is_first_iteration( timestep ):
+            self.state0 = self.state.clone( )
+        
+        #return device on if minimum operation time is not fulfilled and device was on in previous state
+        if ( self.state0.state == 1 and self.state0.timestep_of_last_action + self.on_time >= timestep ):
+            self.state.state = 1
+            l2_electricity_target = max( self.Pmin, l2_electricity_target )
+        #return device off if minimum idle time is not fulfilled and device was off in previous state
+        elif ( self.state0.state == 0 and self.state0.timestep_of_last_action + self.off_time >= timestep ):
+            self.state.state = 0
+            l2_electricity_target = 0
+        #check signal from l2 and turn on or off if it is necesary
+        else:
+            if l2_electricity_target < self.Pmin and self.state0.state == 1:
+                self.state.deactivation( timestep )
+            elif l2_electricity_target >= self.Pmin and self.state0.state == 0:
+                self.state.activation( timestep )
+        
+        stsv.set_output_value( self.ElectricityTargetC, self.state.state * l2_electricity_target )
+        
+    @staticmethod
+    def get_default_config():
+        config = L1ElectrolyzerConfig( name = 'L1Electrolyzer',
+                                       source_weight =  1,
+                                       min_operation_time = 14400,
+                                       min_idle_time = 7200,
+                                       P_min_electrolyzer = 1200 )
+        return config
+
+    def prin1t_outpu1t(self, t_m, state):
+        log.information("==========================================")
+        log.information("T m: {}".format(t_m))
+        log.information("State: {}".format(state))
+

--- a/hisim/components/generic_hydrogen_storage.py
+++ b/hisim/components/generic_hydrogen_storage.py
@@ -156,7 +156,7 @@ class HydrogenStorage( cp.Component ):
             amount_stored = self.max_capacity - self.state.fill
             self.state.fill += amount_stored
             delta_not_stored = charging_rate - amount_stored / self.my_simulation_parameters.seconds_per_timestep
-            charging_rate = amount_stored / self.seconds_per_timestep
+            charging_rate = amount_stored / self.my_simulation_parameters.seconds_per_timestep
 
         power_demand = charging_rate * self.energy_for_charge * 3.6e6
         return charging_rate, power_demand, delta_not_stored

--- a/hisim/components/generic_hydrogen_storage.py
+++ b/hisim/components/generic_hydrogen_storage.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+# Owned
+from hisim.simulationparameters import SimulationParameters
+
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json
+
+from hisim import loadtypes as lt
+from hisim import component as cp
+
+from hisim.components.configuration import PhysicsConfig
+from hisim import log
+
+from hisim.components import generic_CHP
+from hisim.components import generic_electrolyzer
+
+__authors__ = "Frank Burkrad, Maximilian Hillen"
+__copyright__ = "Copyright 2021, the House Infrastructure Project"
+__credits__ = ["Noah Pflugradt"]
+__license__ = ""
+__version__ = ""
+__maintainer__ = "Johanna Ganglbauer"
+__email__ = "johanna.ganglbauer@4wardenergy.at"
+__status__ = ""
+
+@dataclass_json
+@dataclass
+class HydrogenStorageConfig:
+    name: str
+    source_weight : int
+    min_capacity: float # [kg_H2]
+    max_capacity: float # [kg_H2]
+    starting_fill: float # [kg_H2]
+    max_charging_rate_hour: float # [kg/h]
+    max_discharging_rate_hour: float # [kg/h]
+    energy_for_charge: float # [kWh/kg]
+    energy_for_discharge: float # [kWh/kg]
+    loss_factor_per_day: float # [lost_%/day]
+    
+    def init( self, name : str,
+                    source_weight : int,
+                    min_capacity : float,
+                    max_capacity : float,
+                    starting_fill : float,
+                    max_charging_rate_hour : float,
+                    max_discharging_rate_hour : float,
+                    energy_for_charge : float,
+                    energy_for_discharge : float,
+                    loss_factor_per_day : float):
+        self.name = name
+        self.source_weight = source_weight
+        self.min_capacity = min_capacity
+        self.max_capacity = max_capacity
+        self.starting_fill = starting_fill
+        self.max_charging_rate_hour = max_charging_rate_hour
+        self.max_discharging_rate_hour = max_discharging_rate_hour
+        self.energy_for_charge = energy_for_charge
+        self.energy_for_discharge = energy_for_discharge
+        self.loss_factor_per_day = loss_factor_per_day
+        
+class HydrogenStorageState:
+    """
+    This data class saves the state of the electrolyzer.
+    """
+
+    def __init__( self, fill : float = 0 ):
+        self.fill = fill
+        
+    def clone( self ):
+        return HydrogenStorageState( fill = self.fill )
+
+    
+
+class HydrogenStorage( cp.Component ):
+    # input
+    HydrogenInput = "HydrogenInput"                 # kg/s
+    HydrogenOutput = "HydrogenOutput"               # kg/s
+    
+    # output
+    HydrogenSOC = "HydrogenSOC"          # kg/s
+
+    def __init__( self, my_simulation_parameters : SimulationParameters,
+                        config : HydrogenStorageConfig ):
+        super().__init__( config.name + str( config.source_weight ), my_simulation_parameters = my_simulation_parameters )
+        
+        self.build( config )
+        
+        self.HydrogenInputC : cp.ComponentInput = self.add_input( self.ComponentName, 
+                                                                  self.HydrogenInput, 
+                                                                  lt.LoadTypes.Hydrogen, 
+                                                                  lt.Units.kg_per_sec,
+                                                                  True)
+        self.HydrogenOutputC : cp.ComponentInput = self.add_input( self.ComponentName, 
+                                                                   self.HydrogenOutput,
+                                                                   lt.LoadTypes.Hydrogen, 
+                                                                   lt.Units.kg_per_sec,
+                                                                   True )
+
+        self.HydrogenSOCC : cp.ComponentOutput = self.add_output( self.ComponentName,
+                                                                  self.HydrogenSOC,
+                                                                  lt.LoadTypes.Hydrogen,
+                                                                  lt.Units.Percent )
+        
+        self.add_default_connections( generic_electrolyzer.Electrolyzer, self.get_electrolyzer_default_connections( ) )
+        self.add_default_connections( generic_CHP.GCHP, self.get_fuelcell_default_connections( ) )
+
+    @staticmethod
+    def get_default_config():
+        config = HydrogenStorageConfig( name = "HydrogenStorage",
+                                        source_weight = 1,
+                                        min_capacity = 0,
+                                        max_capacity = 500,
+                                        starting_fill = 400,
+                                        max_charging_rate_hour = 2,
+                                        max_discharging_rate_hour = 2,
+                                        energy_for_charge = 0,
+                                        energy_for_discharge = 0,
+                                        loss_factor_per_day = 0)
+        return config
+    
+    def get_fuelcell_default_connections( self ):
+        log.information("setting fuel cell default connections in generic H2 storage" )
+        connections = [ ]
+        chp_classname = generic_CHP.GCHP.get_classname( )
+        connections.append( cp.ComponentConnection( HydrogenStorage.HydrogenOutput, chp_classname, generic_CHP.GCHP.FuelDelivered ) )
+        return connections
+    
+    def get_electrolyzer_default_connections( self ):
+        log.information("setting electrolyzer default connections in generic H2 storage" )
+        connections = [ ]
+        electrolyzer_classname = generic_electrolyzer.Electrolyzer.get_classname( )
+        connections.append( cp.ComponentConnection( HydrogenStorage.HydrogenInput, electrolyzer_classname, generic_electrolyzer.Electrolyzer.HydrogenOutput ) )
+        return connections
+    
+    def store( self, charging_rate : float ):
+
+        #limitation of charging rate
+        delta_not_stored : float = 0
+        if charging_rate > self.max_charging_rate :
+            delta_not_stored = delta_not_stored + charging_rate - self.max_charging_rate
+            charging_rate = self.max_charging_rate
+
+        #limitation of storage size
+        if self.state.fill + charging_rate * self.my_simulation_parameters.seconds_per_timestep < self.max_capacity:
+            # fits completely
+            self.state.fill = self.state.fill + charging_rate * self.my_simulation_parameters.seconds_per_timestep
+         
+        elif self.state.fill >= self.max_capacity:
+            # tank is already full
+            delta_not_stored += charging_rate
+            charging_rate = 0
+            
+        else:
+            # fits partially
+            # returns amount which an be put in
+            amount_stored = self.max_capacity - self.state.fill
+            self.state.fill += amount_stored
+            delta_not_stored = charging_rate - amount_stored / self.my_simulation_parameters.seconds_per_timestep
+            charging_rate = amount_stored / self.seconds_per_timestep
+
+        power_demand = charging_rate * self.energy_for_charge * 3.6e6
+        return charging_rate, power_demand, delta_not_stored
+     
+    def withdraw( self, discharging_rate : float ):
+        
+        #limitations of discharging rate
+        delta_not_released : float = 0
+        if discharging_rate > self.max_discharging_rate:
+            delta_not_released = delta_not_released + discharging_rate - self.max_discharging_rate
+            discharging_rate = self.max_discharging_rate
+
+        if self.state.fill > self.min_capacity + discharging_rate * self.my_simulation_parameters.seconds_per_timestep:
+            # has enough
+            self.state.fill -= discharging_rate * self.my_simulation_parameters.seconds_per_timestep
+            
+        elif self.state.fill <= self.min_capacity:
+            # empty
+            delta_not_released = delta_not_released + discharging_rate
+            discharging_rate = 0
+
+        else:
+            # can provide hydrogen partially,
+            # added recently :but in this case to simplify work of CHP, say that no hydrogen can be provided
+            amount_released = self.state.fill - self.min_capacity
+            self.state.fill -= amount_released
+            delta_not_released = discharging_rate - amount_released / self.my_simulation_parameters.seconds_per_timestep
+            discharging_rate = amount_released / self.my_simulation_parameters.seconds_per_timestep
+            
+        power_demand = discharging_rate * self.energy_for_discharge * 3.6e6
+        return discharging_rate, power_demand, delta_not_released
+    
+    def storage_losses( self ):
+        self.state.fill -= self.state.fill * self.loss_factor
+    
+    def build( self, config ):
+        self.name = config.name
+        self.source_weight = config.source_weight
+        self.min_capacity = config.min_capacity
+        self.max_capacity = config.max_capacity
+        self.max_charging_rate = ( config.max_charging_rate_hour / 3.6e6 ) * PhysicsConfig.hydrogen_density
+        self.max_discharging_rate = ( config.max_discharging_rate_hour / 3.6e6 ) * PhysicsConfig.hydrogen_density
+        self.loss_factor = ( config.loss_factor_per_day / 100 ) * self.my_simulation_parameters.seconds_per_timestep / ( 24 * 3600 )
+        self.energy_for_charge = config.energy_for_charge
+        self.energy_for_discharge = config.energy_for_discharge
+        
+        self.state = HydrogenStorageState( )
+        self.previous_state = HydrogenStorageState( )
+    
+    def i_save_state(self):
+        self.previous_state = self.state.clone( )
+
+    def i_restore_state(self):
+        self.state = self.previous_state.clone( )
+
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool):
+        
+        # get input values
+        charging_rate = stsv.get_input_value( self.HydrogenInputC )
+        discharging_rate = stsv.get_input_value( self.HydrogenOutputC )
+
+        if charging_rate < 0:
+            raise Exception( "trying to charge with negative amount" + str( charging_rate ) )
+        if discharging_rate < 0:
+            raise Exception("trying to discharge with negative amount: " + str( discharging_rate ) )
+
+        if charging_rate > 0 and discharging_rate > 0:
+            # simultaneous charging and discharging has to be prevented
+            # hydrogen can be used directly
+            delta = charging_rate - discharging_rate
+            if delta >= 0:
+                charging_rate = delta
+                discharging_rate = 0
+            else:
+                charging_rate = 0
+                discharging_rate = -delta
+
+        if charging_rate > 0:
+            charging_rate, power_demand, delta_not_stored = self.store( charging_rate )
+
+        if discharging_rate > 0:
+            discharging_rate, power_demand, delta_not_released = self.withdraw( discharging_rate )
+            
+        self.storage_losses( )
+        
+        #delta not released and delta not stored is not used so far -> must be taken into account later
+        percent_fill = 100 * self.state.fill / self.max_capacity
+
+        stsv.set_output_value( self.HydrogenSOCC, percent_fill )
+
+    def i_doublecheck(self, timestep: int, stsv: cp.SingleTimeStepValues):
+        # alle ausgabewerte die zu überprüfen sind können hiermit fehlerausgabeüberprüft werden
+        pass

--- a/hisim/loadtypes.py
+++ b/hisim/loadtypes.py
@@ -104,6 +104,7 @@ class ComponentType(str, enum.Enum):
     Boiler = "Boiler"
     Battery = "Battery"
     FuelCell = "FuelCell"
+    Electrolyzer = "Electrolyzer"
     Heaters = [HeatPump, GasHeater]
     
 @enum.unique

--- a/hisim/loadtypes.py
+++ b/hisim/loadtypes.py
@@ -122,6 +122,10 @@ class InandOutputType(str, enum.Enum):
     #Energy Management System
     Production = "Production"
     Consumption = "Consumption"
+    
+    #Heating
+    HeatToBuilding = "HeatToBuilding"
+    HeatToBuffer = "HeatToBuffer"
 
 
 

--- a/hisim/simulationparameters.py
+++ b/hisim/simulationparameters.py
@@ -14,7 +14,8 @@ class SystemConfig:
                  smart_devices_included : bool = True,
                  boiler_included : Optional[ str ] = 'electricity',
                  heating_device_included : Optional[ str ] = 'heat_pump',
-                 battery_included : bool = False ):
+                 battery_included : bool = False,
+                 chp_included : bool = False ):
         self.predictive = predictive
         self.prediction_horizon = prediction_horizon
         self.pv_included = pv_included
@@ -22,6 +23,7 @@ class SystemConfig:
         self.boiler_included = boiler_included
         self.heating_device_included = heating_device_included
         self.battery_included = battery_included
+        self.chp_included = chp_included
 
 class SimulationParameters:
     def __init__(self, start_date, end_date, seconds_per_timestep, post_processing_options:List = []):
@@ -65,14 +67,16 @@ class SimulationParameters:
         return str(self.start_date) + "###" + str(self.end_date) + "###"  + str(self.seconds_per_timestep) + "###" + str(self.year) + "###" + str(self.timesteps)
     
     def reset_system_config( self, predictive : bool = False, prediction_horizon : int = 0, pv_included : bool = True, smart_devices_included : bool = True, 
-                                   boiler_included : Optional[ str ] = 'electricity', heating_device_included : Optional[ str ] = 'heat_pump', battery_included : bool = False ):
+                                   boiler_included : Optional[ str ] = 'electricity', heating_device_included : Optional[ str ] = 'heat_pump', battery_included : bool = False,
+                                   chp_included : bool = False ):
         self.system_config = SystemConfig( predictive = predictive,
                                            prediction_horizon = prediction_horizon,
                                            pv_included = pv_included, 
                                            smart_devices_included = smart_devices_included,
                                            boiler_included = boiler_included,
                                            heating_device_included = heating_device_included,
-                                           battery_included = battery_included )
+                                           battery_included = battery_included,
+                                           chp_included = chp_included )
     
     
 

--- a/hisim/simulationparameters.py
+++ b/hisim/simulationparameters.py
@@ -13,7 +13,7 @@ class SystemConfig:
                  pv_included : bool = True,
                  smart_devices_included : bool = True,
                  boiler_included : Optional[ str ] = 'electricity',
-                 heating_device_included : Optional[ str ] = 'heat_pump',
+                 heatpump_included : bool = True,
                  battery_included : bool = False,
                  chp_included : bool = False ):
         self.predictive = predictive
@@ -21,7 +21,7 @@ class SystemConfig:
         self.pv_included = pv_included
         self.smart_devices_included = smart_devices_included
         self.boiler_included = boiler_included
-        self.heating_device_included = heating_device_included
+        self.heatpump_included = heatpump_included
         self.battery_included = battery_included
         self.chp_included = chp_included
 
@@ -67,14 +67,14 @@ class SimulationParameters:
         return str(self.start_date) + "###" + str(self.end_date) + "###"  + str(self.seconds_per_timestep) + "###" + str(self.year) + "###" + str(self.timesteps)
     
     def reset_system_config( self, predictive : bool = False, prediction_horizon : int = 0, pv_included : bool = True, smart_devices_included : bool = True, 
-                                   boiler_included : Optional[ str ] = 'electricity', heating_device_included : Optional[ str ] = 'heat_pump', battery_included : bool = False,
+                                   boiler_included : Optional[ str ] = 'electricity', heatpump_included : bool = True, battery_included : bool = False,
                                    chp_included : bool = False ):
         self.system_config = SystemConfig( predictive = predictive,
                                            prediction_horizon = prediction_horizon,
                                            pv_included = pv_included, 
                                            smart_devices_included = smart_devices_included,
                                            boiler_included = boiler_included,
-                                           heating_device_included = heating_device_included,
+                                           heatpump_included = heatpump_included,
                                            battery_included = battery_included,
                                            chp_included = chp_included )
     

--- a/tests/test_generic_dhw_boiler.py
+++ b/tests/test_generic_dhw_boiler.py
@@ -7,27 +7,15 @@ from hisim import component as cp
 from hisim.simulationparameters import SimulationParameters
 
 def test_simple_bucket_boiler_state():
+    
+    #simulation parameters
     seconds_per_timestep = 60
     my_simulation_parameters = SimulationParameters.one_day_only( 2017, seconds_per_timestep )
     
-    # Boiler
-    volume = 200
-    surface : float = 1.2
-    u_value : float = 0.36
-    T_warmwater : float = 50
-    T_drainwater : float = 10
-    power : float = 2400
-    efficiency : float = 1
-    fuel : str = 'electricity'
-    
-    # Boiler Controller L1
-    minimum_idle_time = 30 * 60
-    minimum_operation_time = 15 * 60
-
-    # Boiler Controller L2
-    T_min = 45.0
-    T_max = 60.0
-    T_tolerance = 10.0
+    # Boiler defualt config
+    l2_config = controller_l2_generic_dhw_boiler.L2_Controller.get_default_config( )
+    l1_config = controller_l1_generic_runtime.L1_Controller.get_default_config( )
+    boiler_config = generic_dhw_boiler.Boiler.get_default_config( )
     
     #definition of outputs
     number_of_outputs = 5
@@ -35,24 +23,12 @@ def test_simple_bucket_boiler_state():
 
     #===================================================================================================================
     # Set Boiler
-    my_boiler = generic_dhw_boiler.Boiler( my_simulation_parameters=my_simulation_parameters,
-                                           volume = volume, 
-                                           surface = surface,
-                                           u_value = u_value,
-                                           T_warmwater = T_warmwater,
-                                           T_drainwater = T_drainwater,
-                                           power = power,
-                                           efficiency = efficiency,
-                                           fuel = fuel )
+    my_boiler = generic_dhw_boiler.Boiler( config = boiler_config, my_simulation_parameters=my_simulation_parameters )
     # Set L1 Boiler Controller
-    my_boiler_controller_l1 = controller_l1_generic_runtime.L1_Controller( min_operation_time = minimum_operation_time,
-                                                                           min_idle_time = minimum_idle_time, 
-                                                                           my_simulation_parameters = my_simulation_parameters )
+    my_boiler_controller_l1 = controller_l1_generic_runtime.L1_Controller( config = l1_config, my_simulation_parameters = my_simulation_parameters )
     
     # Set L2 Heat Pump Controller
-    my_boiler_controller_l2 = controller_l2_generic_dhw_boiler.L2_Controller(  my_simulation_parameters = my_simulation_parameters,
-                                                                               T_min = T_min,
-                                                                               T_max = T_max )
+    my_boiler_controller_l2 = controller_l2_generic_dhw_boiler.L2_Controller(  config = l2_config, my_simulation_parameters = my_simulation_parameters )
     
     #definition of hot water use 
     WW_use = cp.ComponentOutput( "FakeWarmwaterUse",

--- a/tests/test_heat_pump_modular.py
+++ b/tests/test_heat_pump_modular.py
@@ -9,21 +9,17 @@ from hisim.simulationparameters import SimulationParameters
 
 def test_heat_pump_modular():
 
+    #simulation parameters
     seconds_per_timestep = 60
-    my_simulation_parameters = SimulationParameters.one_day_only(2017,seconds_per_timestep)
+    my_simulation_parameters = SimulationParameters.one_day_only( 2017, seconds_per_timestep )
     
-    # Heat Pump
-    manufacturer = "Viessmann Werke GmbH & Co KG"
-    name = "Vitocal 300-A AWO-AC 301.B07"
+    #reference power
     heat_pump_power = 7420.0
-
-    # L1 Heat Pump Controller 
-    minimum_idle_time = 30 * 60
-    minimum_operation_time = 15 * 60
     
-    # L2 Heat Pump Controller 
-    T_min_heating = 17
-    T_max_heating = 19
+    #default config
+    my_hp_config = generic_heat_pump_modular.HeatPump.get_default_config( )
+    l2_config = controller_l2_generic_heatpump_modular.L2_Controller.get_default_config( )
+    l1_config = controller_l1_generic_runtime.L1_Controller.get_default_config( )
 
     #definition of outputs
     number_of_outputs = 7
@@ -31,18 +27,15 @@ def test_heat_pump_modular():
 
     #===================================================================================================================
     # Set Heat Pump
-    my_heat_pump = generic_heat_pump_modular.HeatPump( manufacturer=manufacturer,
-                                                       name=name,
+    my_heat_pump = generic_heat_pump_modular.HeatPump( config = my_hp_config,
                                                        my_simulation_parameters = my_simulation_parameters )
 
     # Set L1 Heat Pump Controller
-    my_heat_pump_controller_l1 = controller_l1_generic_runtime.L1_Controller( min_operation_time = minimum_operation_time,
-                                                                                       min_idle_time = minimum_idle_time, 
-                                                                                       my_simulation_parameters = my_simulation_parameters )
+    my_heat_pump_controller_l1 = controller_l1_generic_runtime.L1_Controller( config = l1_config,
+                                                                              my_simulation_parameters = my_simulation_parameters )
     
     # Set L2 Heat Pump Controller
-    my_heat_pump_controller_l2 = controller_l2_generic_heatpump_modular.L2_Controller(  T_min_heating = T_min_heating,
-                                                                                        T_max_heating = T_max_heating, 
+    my_heat_pump_controller_l2 = controller_l2_generic_heatpump_modular.L2_Controller(  config = l2_config, 
                                                                                         my_simulation_parameters = my_simulation_parameters )
 
     #definition of weather output


### PR DESCRIPTION
(a) extanded controller_l2_enrgy_management_system to work for source_weights which are sorted, but do not necesarily follow a 1,2,3,4,5,..,N structure and allowed battery charging with CHP power
(b) included simplified generic_CHP with one power level, which is controlled according to electricity and heat demand
(c) included simplified electrolysis and added its control to controller_l2_enrgy_management_system
(d) included hydrogen storage simulation

still missing (next pull request):
(i) test for electrolysis, hydrogen storage, chp
(ii) control of electrolysis and chp according to hydrogen availability