### PR TITLE
enable calculation for zero households

### DIFF
--- a/hisim/components/generic_hot_water_storage_modular.py
+++ b/hisim/components/generic_hot_water_storage_modular.py
@@ -63,7 +63,7 @@ class StorageConfig:
     @staticmethod
     def get_default_config_boiler(number_of_households: int) -> "StorageConfig":
         """ Returns default configuration for boiler. """
-        volume = 230 * number_of_households
+        volume = 230 * max(number_of_households, 1)
         radius = (volume * 1e-3 / (4 * np.pi)) ** (1 / 3)  # l to m^3 so that radius is given in m
         surface = 2 * radius * radius * np.pi + 2 * radius * np.pi * (4 * radius)
         config = StorageConfig(name='DHWBoiler', use=lt.ComponentType.BOILER, source_weight=1, volume=volume,

--- a/hisim/modular_household/interface_configs/archetype_config.py
+++ b/hisim/modular_household/interface_configs/archetype_config.py
@@ -27,7 +27,7 @@ class ArcheTypeConfig:
     # available options: "AVG" - average consumption profile over Europe and "CH01" - example output of the LPG
     occupancy_profile: Optional[str] = "AVG"
     #: building code of considered type of building originated from the Tabula data base (https://episcope.eu/building-typology/webtool/)
-    building_code: str = "DK.N.TH.04.Gen.ReEx.001.002"  # "DE.N.SFH.05.Gen.ReEx.001.002"
+    building_code: str = "DK.N.AB.09.Gen.ReEx.001.001"  # "DE.N.SFH.05.Gen.ReEx.001.002"
     #: absolute area considered for heating and cooling
     absolute_conditioned_floor_area: Optional[float] = None
     #: type of water heating system


### PR DESCRIPTION
There was a small problem with the tabula data in HiSIM, where the number of households in a building is set to zero -> set it at least to one by default to solve problems with scaling of consumption data and boiler sizes