### PR TITLE
Adopt why scaling in occupancy

### DIFF
--- a/examples/dynamic_components.py
+++ b/examples/dynamic_components.py
@@ -104,7 +104,8 @@ def dynamic_components_demonstration(
     )
 
     my_occupancy_config = loadprofilegenerator_connector.OccupancyConfig.get_default_CHS01()
-    SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.NUMBEROFAPARTMENTS, entry=my_occupancy_config.number_of_apartments)
+    # choose 1 to be the default for the number of apartments
+    SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.NUMBEROFAPARTMENTS, entry=1)
     my_occupancy = loadprofilegenerator_connector.Occupancy(
         config=my_occupancy_config, my_simulation_parameters=my_simulation_parameters
     )

--- a/examples/modular_example.py
+++ b/examples/modular_example.py
@@ -239,7 +239,7 @@ def modular_household_explicit(
     else:
         # Build occupancy
         my_occupancy_config = loadprofilegenerator_connector.OccupancyConfig(
-            "Occupancy", occupancy_profile or "", location, int(my_building.buildingdata["n_Apartment"].iloc[0])
+            "Occupancy", occupancy_profile or "", location,
         )
         my_occupancy = loadprofilegenerator_connector.Occupancy(
             config=my_occupancy_config,
@@ -366,7 +366,6 @@ def modular_household_explicit(
             my_electricity_controller=my_electricity_controller,
             my_weather=my_weather,
             water_heating_system_installed=water_heating_system_installed,
-            number_of_households=int(my_building.buildingdata["n_Apartment"].iloc[0]),
             controlable=clever,
             count=count,
         )
@@ -378,7 +377,6 @@ def modular_household_explicit(
             my_simulation_parameters=my_simulation_parameters,
             my_occupancy=my_occupancy,
             water_heating_system_installed=water_heating_system_installed,
-            number_of_households=int(my_building.buildingdata["n_Apartment"].iloc[0]),
             count=count,
         )
 

--- a/hisim/components/generic_hot_water_storage_modular.py
+++ b/hisim/components/generic_hot_water_storage_modular.py
@@ -22,6 +22,7 @@ from hisim.components.loadprofilegenerator_connector import Occupancy
 from hisim.components.loadprofilegenerator_utsp_connector import \
     UtspLpgConnector
 from hisim.simulationparameters import SimulationParameters
+from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
 
 __authors__ = "Johanna Ganglbauer - johanna.ganglbauer@4wardenergy.at"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -61,8 +62,15 @@ class StorageConfig:
     power: float
 
     @staticmethod
-    def get_default_config_boiler(number_of_households: int) -> "StorageConfig":
+    def get_default_config_boiler() -> "StorageConfig":
         """ Returns default configuration for boiler. """
+        # get default number of households
+        if SingletonSimRepository().exist_entry(key=SingletonDictKeyEnum.NUMBEROFAPARTMENTS):
+            number_of_households = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.NUMBEROFAPARTMENTS)
+        else:
+            raise KeyError("Key for number of apartments was not found in the singleton sim repository." +
+                           "This might be because the building was not initialized before the loadprofilegenerator_connector." +
+                           "Please check the order of the initialization of the components in your example.")
         volume = 230 * max(number_of_households, 1)
         radius = (volume * 1e-3 / (4 * np.pi)) ** (1 / 3)  # l to m^3 so that radius is given in m
         surface = 2 * radius * radius * np.pi + 2 * radius * np.pi * (4 * radius)

--- a/hisim/modular_household/component_connections.py
+++ b/hisim/modular_household/component_connections.py
@@ -424,7 +424,6 @@ def configure_water_heating(
     my_simulation_parameters: SimulationParameters,
     my_occupancy: loadprofilegenerator_connector.Occupancy,
     water_heating_system_installed: lt.HeatingSystems,
-    number_of_households: int,
     count: int,
 ) -> int:
     """Sets Boiler with Heater, L1 Controller and L2 Controller for Water Heating System.
@@ -439,8 +438,6 @@ def configure_water_heating(
         The initialized occupancy component.
     water_heating_system_installed: str
         Type of installed WaterHeatingSystem
-    number_of_households: int
-        Number of households considered in reference building.
     count: int
         Integer tracking component hierachy for EMS.
 
@@ -460,7 +457,7 @@ def configure_water_heating(
     [heater_config.source_weight, heater_l1_config.source_weight] = [count] * 2
     count += 1
     boiler_config = (
-        generic_hot_water_storage_modular.StorageConfig.get_default_config_boiler(number_of_households)
+        generic_hot_water_storage_modular.StorageConfig.get_default_config_boiler()
     )
     boiler_config.compute_default_cycle(temperature_difference_in_kelvin=heater_l1_config.t_max_heating_in_celsius - heater_l1_config.t_min_heating_in_celsius)
 
@@ -505,7 +502,6 @@ def configure_water_heating_electric(
     my_electricity_controller: controller_l2_energy_management_system.L2GenericEnergyManagementSystem,
     my_weather: weather.Weather,
     water_heating_system_installed: lt.HeatingSystems,
-    number_of_households: int,
     controlable: bool,
     count: int,
 ) -> int:
@@ -527,8 +523,6 @@ def configure_water_heating_electric(
         Type of installed WaterHeatingSystem
     controlable: bool
         True if control of heating device is smart, False if not.
-    number_of_households: int
-        Number of households considered in reference building.
     count: int
         Integer tracking component hierachy for EMS.
 
@@ -562,7 +556,7 @@ def configure_water_heating_electric(
         )
     )
     boiler_config = (
-        generic_hot_water_storage_modular.StorageConfig.get_default_config_boiler(number_of_households)
+        generic_hot_water_storage_modular.StorageConfig.get_default_config_boiler()
     )
     boiler_config.compute_default_cycle(temperature_difference_in_kelvin=heatpump_l1_config.t_max_heating_in_celsius - heatpump_l1_config.t_min_heating_in_celsius)
 

--- a/tests/test_generic_dhw_boiler.py
+++ b/tests/test_generic_dhw_boiler.py
@@ -17,7 +17,7 @@ def test_simple_bucket_boiler_state():
 
     # Boiler default config
     l1_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw("HP Controller")
-    boiler_config = generic_hot_water_storage_modular.StorageConfig.get_default_config_boiler(number_of_households=1)
+    boiler_config = generic_hot_water_storage_modular.StorageConfig.get_default_config_boiler()
     boiler_config.volume = 200
     heater_config = generic_heat_source.HeatSourceConfig.get_default_config_waterheating()
 

--- a/tests/test_loadprofilegenerator_connector.py
+++ b/tests/test_loadprofilegenerator_connector.py
@@ -17,7 +17,7 @@ def test_occupancy():
     my_simulation_parameters = SimulationParameters.one_day_only(2017, seconds_per_timestep)
     my_simulation_parameters.predictive_control = False
     my_occupancy_config=loadprofilegenerator_connector.OccupancyConfig.get_default_CHS01()
-    SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.NUMBEROFAPARTMENTS, entry=my_occupancy_config.number_of_apartments)
+    SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.NUMBEROFAPARTMENTS, entry=1)
     my_occupancy_config.profile_name=my_occupancy_profile
     my_occupancy = loadprofilegenerator_connector.Occupancy(config=my_occupancy_config, my_simulation_parameters=my_simulation_parameters)
 

--- a/tests/test_occupancy_scalability.py
+++ b/tests/test_occupancy_scalability.py
@@ -97,10 +97,6 @@ def simulation_for_one_time_step(
     my_occupancy_config = (
         loadprofilegenerator_connector.OccupancyConfig.get_default_CHS01()
     )
-    log.information(
-        "Set Occupancy Config Number of Apartments "
-        + str(my_occupancy_config.number_of_apartments)
-    )
     my_occupancy = loadprofilegenerator_connector.Occupancy(
         config=my_occupancy_config,
         my_simulation_parameters=my_simulation_parameters,
@@ -156,7 +152,7 @@ def simulation_for_one_time_step(
     my_occupancy.i_simulate(1, stsv, False)
 
     scaling_factor_number_of_apartments = (
-        building_number_of_apartments / my_occupancy_config.number_of_apartments
+        building_number_of_apartments
     )
 
     occupancy_outputs = stsv.values[-4:]


### PR DESCRIPTION
removed number_of_apartments of the OccupancyConfig of loadprofilegenerator_connector and the StorageConfig of generic_hot_water_storage_modular , because it is in SingletonRepository now and adopted WHY scaling to approach from Kathi