### PR TITLE
Add `get_capacities` for postprocessing

### DIFF
--- a/hisim/component.py
+++ b/hisim/component.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import dataclasses as dc
 import typing
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 import pandas as pd
@@ -53,6 +54,10 @@ class ConfigBase(JSONWizard):
                 first_entry = first_entry.capitalize()
                 my_list.append(first_entry + ": " + str(entry[1]))
         return my_list
+
+    def get_capacity(self) -> Tuple[float, Enum]:
+        """Return capacity and unit."""
+        raise NotImplementedError()
 
 
 @dataclass

--- a/hisim/components/advanced_heat_pump_hplib.py
+++ b/hisim/components/advanced_heat_pump_hplib.py
@@ -3,33 +3,33 @@
 See library on https://github.com/FZJ-IEK3-VSA/hplib/tree/main/hplib
 """
 
-# clean
-from typing import Any, List, Optional, Tuple
 from dataclasses import dataclass
-from dataclasses_json import dataclass_json
 from enum import Enum
 
-import pandas as pd
+# clean
+from typing import Any, List, Optional, Tuple
 
+import pandas as pd
+from dataclasses_json import dataclass_json
 from hplib import hplib as hpl
+
+from hisim import log
 
 # Import modules from HiSim
 from hisim.component import (
     Component,
+    ComponentConnection,
     ComponentInput,
     ComponentOutput,
-    SingleTimeStepValues,
     ConfigBase,
-    ComponentConnection,
     OpexCostDataClass,
+    SingleTimeStepValues,
 )
-from hisim.components import weather, simple_hot_water_storage, heat_distribution_system
-from hisim.loadtypes import LoadTypes, Units, InandOutputType
-from hisim.simulationparameters import SimulationParameters
-from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
+from hisim.components import heat_distribution_system, simple_hot_water_storage, weather
 from hisim.components.heat_distribution_system import HeatingSystemType
-from hisim import log
-
+from hisim.loadtypes import InandOutputType, LoadTypes, Units
+from hisim.sim_repository_singleton import SingletonDictKeyEnum, SingletonSimRepository
+from hisim.simulationparameters import SimulationParameters
 
 __authors__ = "Tjarko Tjaden, Hauke Hoops, Kai Rösken"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"

--- a/hisim/components/advanced_heat_pump_hplib.py
+++ b/hisim/components/advanced_heat_pump_hplib.py
@@ -7,6 +7,7 @@ See library on https://github.com/FZJ-IEK3-VSA/hplib/tree/main/hplib
 from typing import Any, List, Optional, Tuple
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
+from enum import Enum
 
 import pandas as pd
 
@@ -128,6 +129,12 @@ class HeatPumpHplibConfig(ConfigBase):
             maintenance_cost_as_percentage_of_investment=0.025,  # source:  VDI2067-1
             consumption=0,
         )
+
+    def get_capacity(self) -> Tuple[float, Enum]:
+        """Return capacity and unit."""
+        capacity = self.set_thermal_output_power_in_watt
+        unit = Units.WATT
+        return capacity, unit
 
 
 class HeatPumpHplib(Component):

--- a/hisim/components/generic_heat_pump_modular.py
+++ b/hisim/components/generic_heat_pump_modular.py
@@ -1,25 +1,22 @@
 """ Modular Heat Pump Class together with Configuration and State. """
 # Generic/Built-in
 from dataclasses import dataclass
-from typing import Optional, List, Any, Tuple
 from enum import Enum
+from typing import List, Tuple
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 from dataclasses_json import dataclass_json
 
 import hisim.loadtypes as lt
-from hisim import component as cp
-from hisim import log
-from hisim.component import OpexCostDataClass
 
 # Owned
-from hisim import utils
+from hisim import component as cp
+from hisim import log, utils
+from hisim.component import OpexCostDataClass
 from hisim.components import controller_l1_heatpump
-
 from hisim.components.weather import Weather
 from hisim.simulationparameters import SimulationParameters
-from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
 
 __authors__ = "edited Johanna Ganglbauer"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"

--- a/hisim/components/generic_heat_pump_modular.py
+++ b/hisim/components/generic_heat_pump_modular.py
@@ -2,6 +2,7 @@
 # Generic/Built-in
 from dataclasses import dataclass
 from typing import Optional, List, Any, Tuple
+from enum import Enum
 
 import pandas as pd
 import numpy as np
@@ -184,6 +185,12 @@ class HeatPumpConfig(cp.ConfigBase):
             consumption=0,
         )
         return config
+
+    def get_capacity(self) -> Tuple[float, Enum]:
+        """Return capacity and unit."""
+        capacity = self.power_th
+        unit = Units.WATT
+        return capacity, unit
 
 
 class ModularHeatPumpState:

--- a/hisim/components/generic_heat_pump_modular.py
+++ b/hisim/components/generic_heat_pump_modular.py
@@ -189,7 +189,7 @@ class HeatPumpConfig(cp.ConfigBase):
     def get_capacity(self) -> Tuple[float, Enum]:
         """Return capacity and unit."""
         capacity = self.power_th
-        unit = Units.WATT
+        unit = lt.Units.WATT
         return capacity, unit
 
 

--- a/hisim/components/generic_hot_water_storage_modular.py
+++ b/hisim/components/generic_hot_water_storage_modular.py
@@ -5,6 +5,7 @@ The hot water storage simulates only storage and demand and needs to be connnect
 DHW hot water storage or as buffer storage.
 """
 from dataclasses import dataclass
+from enum import Enum
 
 # clean
 # Generic/Built-in
@@ -184,6 +185,12 @@ class StorageConfig(cp.ConfigBase):
         self.energy_full_cycle = (
             self.volume * temperature_difference_in_kelvin * 0.977 * 4.182 / 3600
         )
+
+    def get_capacity(self) -> Tuple[float, Enum]:
+        """Return capacity and unit."""
+        capacity = self.volume
+        unit = lt.Units.CUBICMETERS
+        return capacity, unit
 
 
 class StorageState:

--- a/hisim/components/generic_hot_water_storage_modular.py
+++ b/hisim/components/generic_hot_water_storage_modular.py
@@ -10,8 +10,9 @@ from enum import Enum
 # clean
 # Generic/Built-in
 from typing import Any, List, Optional, Tuple
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 from dataclasses_json import dataclass_json
 
 # Owned
@@ -19,17 +20,17 @@ import hisim.component as cp
 import hisim.dynamic_component as dycp
 import hisim.log
 from hisim import loadtypes as lt
+from hisim.component import OpexCostDataClass
 from hisim.components import (
+    configuration,
     controller_l1_building_heating,
     generic_CHP,
     generic_heat_pump_modular,
     generic_heat_source,
-    configuration,
 )
 from hisim.components.loadprofilegenerator_connector import Occupancy
 from hisim.components.loadprofilegenerator_utsp_connector import UtspLpgConnector
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import OpexCostDataClass
 
 __authors__ = "Johanna Ganglbauer - johanna.ganglbauer@4wardenergy.at"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"

--- a/hisim/components/simple_hot_water_storage.py
+++ b/hisim/components/simple_hot_water_storage.py
@@ -5,6 +5,7 @@
 from typing import List, Any, Tuple
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
+from enum import Enum
 
 import pandas as pd
 
@@ -103,6 +104,12 @@ class SimpleHotWaterStorageConfig(cp.ConfigBase):
             maintenance_cost_as_percentage_of_investment=0.0,  # Todo: set correct value
         )
         return config
+
+    def get_capacity(self) -> Tuple[float, Enum]:
+        """Return capacity and unit."""
+        capacity = self.volume_heating_water_storage_in_liter
+        unit = lt.Units.LITER
+        return capacity, unit
 
 
 @dataclass

--- a/hisim/components/simple_hot_water_storage.py
+++ b/hisim/components/simple_hot_water_storage.py
@@ -2,25 +2,25 @@
 
 # clean
 # Owned
-from typing import List, Any, Tuple
 from dataclasses import dataclass
-from dataclasses_json import dataclass_json
 from enum import Enum
+from typing import Any, List, Tuple
 
 import pandas as pd
+from dataclasses_json import dataclass_json
 
 import hisim.component as cp
+from hisim import loadtypes as lt
+from hisim import utils
 from hisim.component import (
-    SingleTimeStepValues,
     ComponentInput,
     ComponentOutput,
     OpexCostDataClass,
+    SingleTimeStepValues,
 )
-from hisim.simulationparameters import SimulationParameters
-from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
 from hisim.components.configuration import PhysicsConfig
-from hisim import loadtypes as lt
-from hisim import utils
+from hisim.sim_repository_singleton import SingletonDictKeyEnum, SingletonSimRepository
+from hisim.simulationparameters import SimulationParameters
 
 __authors__ = "Katharina Rieck, Noah Pflugradt"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"

--- a/hisim/postprocessing/capacities.py
+++ b/hisim/postprocessing/capacities.py
@@ -1,0 +1,25 @@
+"""Get capacities for each componente."""
+
+from typing import List
+
+from hisim import log
+from hisim.component_wrapper import ComponentWrapper
+
+
+def get_capacities(
+    components: List[ComponentWrapper],
+) -> List:
+    capacities = {}
+    capacities["Component"] = "Capacity"
+    for component in components:
+        component_unwrapped = component.my_component
+        try:
+            capacity, unit = component_unwrapped.config.get_capacity()
+            capacities[
+                component_unwrapped.component_name + f" [Capacity in {unit.value}]"
+            ] = capacity
+        except NotImplementedError:
+            log.debug(
+                f"No `get_capacity` method for {component_unwrapped.component_name}"
+            )
+    return capacities

--- a/hisim/postprocessing/capacities.py
+++ b/hisim/postprocessing/capacities.py
@@ -1,6 +1,7 @@
 """Get capacities for each componente."""
 
-from typing import List
+from typing import List, Tuple, Dict
+from enum import Enum
 
 from hisim import log
 from hisim.component_wrapper import ComponentWrapper
@@ -8,9 +9,8 @@ from hisim.component_wrapper import ComponentWrapper
 
 def get_capacities(
     components: List[ComponentWrapper],
-) -> List:
-    capacities = {}
-    capacities["Component"] = "Capacity"
+) -> Dict[str, float]:
+    capacities: Dict[str, float] = {}
     for component in components:
         component_unwrapped = component.my_component
         try:

--- a/hisim/postprocessing/capacities.py
+++ b/hisim/postprocessing/capacities.py
@@ -1,7 +1,6 @@
 """Get capacities for each componente."""
 
-from typing import List, Tuple, Dict
-from enum import Enum
+from typing import Dict, List
 
 from hisim import log
 from hisim.component_wrapper import ComponentWrapper

--- a/hisim/postprocessing/postprocessing_main.py
+++ b/hisim/postprocessing/postprocessing_main.py
@@ -1,38 +1,35 @@
 """ Main postprocessing module that starts all other modules. """
 # clean
-import os
-import sys
 import copy
-from typing import Any, Optional, List, Dict
-from timeit import default_timer as timer
+import os
 import string
+import sys
+from timeit import default_timer as timer
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from hisim.components import building
-from hisim.components import loadprofilegenerator_connector
-from hisim.postprocessing import reportgenerator
-from hisim.postprocessing import charts
-from hisim import log
-from hisim import utils
-from hisim.postprocessingoptions import PostProcessingOptions
+from hisim import log, utils
+from hisim.component import ComponentOutput
+from hisim.components import building, loadprofilegenerator_connector
+from hisim.json_generator import JsonConfigurationGenerator
+from hisim.postprocessing import charts, reportgenerator
+from hisim.postprocessing.capacities import get_capacities
 from hisim.postprocessing.chart_singleday import ChartSingleDay
 from hisim.postprocessing.compute_kpis import compute_kpis
-from hisim.postprocessing.capacities import get_capacities
 from hisim.postprocessing.generate_csv_for_housing_database import (
     generate_csv_for_database,
 )
 from hisim.postprocessing.opex_and_capex_cost_calculation import (
-    opex_calculation,
     capex_calculation,
+    opex_calculation,
 )
-from hisim.postprocessing.system_chart import SystemChart
-from hisim.component import ComponentOutput
 from hisim.postprocessing.postprocessing_datatransfer import PostProcessingDataTransfer
 from hisim.postprocessing.report_image_entries import ReportImageEntry, SystemChartEntry
-from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
-from hisim.json_generator import JsonConfigurationGenerator
+from hisim.postprocessing.system_chart import SystemChart
 from hisim.postprocessing.webtool_kpi_entries import WebtoolKpiEntries
+from hisim.postprocessingoptions import PostProcessingOptions
+from hisim.sim_repository_singleton import SingletonDictKeyEnum, SingletonSimRepository
 
 
 class PostProcessor:

--- a/hisim/postprocessing/postprocessing_main.py
+++ b/hisim/postprocessing/postprocessing_main.py
@@ -18,6 +18,7 @@ from hisim import utils
 from hisim.postprocessingoptions import PostProcessingOptions
 from hisim.postprocessing.chart_singleday import ChartSingleDay
 from hisim.postprocessing.compute_kpis import compute_kpis
+from hisim.postprocessing.capacities import get_capacities
 from hisim.postprocessing.generate_csv_for_housing_database import (
     generate_csv_for_database,
 )
@@ -1081,11 +1082,17 @@ class PostProcessor:
                 value_list=opex_compute_return
             )
 
+            # get sizes of components
+            dict_with_important_capacities = get_capacities(
+                components=ppdt.wrapped_components,
+            )
+
             # initialize webtool kpi entries dataclass
             webtool_kpi_dataclass = WebtoolKpiEntries(
                 kpi_dict=dict_with_important_kpi,
                 capex_dict=dict_with_important_capex,
                 opex_dict=dict_with_important_opex,
+                capacity_dict=dict_with_important_capacities
             )
 
             # save dict as json file in results folder

--- a/hisim/postprocessing/webtool_kpi_entries.py
+++ b/hisim/postprocessing/webtool_kpi_entries.py
@@ -1,7 +1,8 @@
 """Webtool results with important kpis."""
 
-from typing import Dict, Any
 from dataclasses import dataclass, field
+from typing import Any, Dict
+
 from dataclass_wizard import JSONWizard
 
 

--- a/hisim/postprocessing/webtool_kpi_entries.py
+++ b/hisim/postprocessing/webtool_kpi_entries.py
@@ -15,3 +15,5 @@ class WebtoolKpiEntries(JSONWizard):
     opex_dict: Dict[str, Any] = field(default_factory=dict)
 
     capex_dict: Dict[str, Any] = field(default_factory=dict)
+
+    capacity_dict: Dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
Since we are using the scaled defaults now, I need a way to get the scaled component sizes. This is why I added a `get_capacities()` method to the config base class.