### PR TITLE
Fix utsp connector for households without flexibility file

### DIFF
--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -642,8 +642,8 @@ class UtspLpgConnector(cp.Component):
         else:
             cache_dir_path = self.utsp_config.cache_dir_path
 
-        # config household is list of jsonreferences
-        if isinstance(self.utsp_config.household, List):
+        # config household is list of jsonreferences and no other guid than default is given ("")
+        if isinstance(self.utsp_config.household, List) and self.utsp_config.guid == "":
             # get specific guid list in order to prevent duplicated requests
             guid_list = self.vary_guids_for_lpg_utsp_requests_if_config_household_is_a_list_and_contains_duplicated_household_types()
 
@@ -655,9 +655,7 @@ class UtspLpgConnector(cp.Component):
                 new_config_object.guid = guid_list[index]
 
                 file_exists, cache_filepath = utils.get_cache_file(
-                    component_key=self.component_name
-                    + "_"
-                    + str(new_config_object.household),
+                    component_key=self.component_name,
                     parameter_class=new_config_object,
                     my_simulation_parameters=self.my_simulation_parameters,
                     cache_dir_path=cache_dir_path,
@@ -670,9 +668,7 @@ class UtspLpgConnector(cp.Component):
         else:
 
             file_exists, cache_filepath = utils.get_cache_file(
-                component_key=self.component_name
-                + "_"
-                + str(self.utsp_config.household),
+                component_key=self.component_name,
                 parameter_class=self.utsp_config,
                 my_simulation_parameters=self.my_simulation_parameters,
                 cache_dir_path=cache_dir_path,

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -709,17 +709,24 @@ class UtspLpgConnector(cp.Component):
             self.utsp_config.url, request, self.utsp_config.api_key
         )
 
+        # decode required result files
         electricity_file = result.data[electricity].decode()
         warm_water_file = result.data[warm_water].decode()
         inner_device_heat_gains_file = result.data[inner_device_heat_gains].decode()
         high_activity_file = result.data[high_activity].decode()
         low_activity_file = result.data[low_activity].decode()
-        flexibility_file = result.data[flexibility].decode()
 
-        # Save flexibility and transportation files
         saved_files: List[str] = []
-        path = self.save_result_file(name=flexibility, content=flexibility_file)
-        saved_files.append(path)
+        # try to decode and save optional flexibility result files if available
+        try:
+            flexibility_file = result.data[flexibility].decode()
+            # Save flexibility
+            path = self.save_result_file(name=flexibility, content=flexibility_file)
+            saved_files.append(path)
+        except Exception:
+            pass
+
+        # decode and save transportation files
         for filename in itertools.chain(
             car_states.keys(), car_locations.keys(), driving_distances.keys()
         ):
@@ -782,7 +789,6 @@ class UtspLpgConnector(cp.Component):
         inner_device_heat_gains_file: List = []
         high_activity_file: List = []
         low_activity_file: List = []
-        flexibility_file: List = []
         saved_files: List = []
 
         for result in results:
@@ -799,14 +805,20 @@ class UtspLpgConnector(cp.Component):
             ].decode()
             high_activity_file_one_result = result.data[high_activity].decode()
             low_activity_file_one_result = result.data[low_activity].decode()
-            flexibility_file_one_result = result.data[flexibility].decode()
 
-            # Save flexibility and transportation files
             saved_files_one_result: List = []
-            path = self.save_result_file(
+            # try to decode and save optional flexibility result files if available
+            try:
+                flexibility_file_one_result = result.data[flexibility].decode()
+                # Save flexibility
+                path = self.save_result_file(
                 name=flexibility, content=flexibility_file_one_result
-            )
-            saved_files_one_result.append(path)
+                )
+                saved_files_one_result.append(path)
+            except Exception:
+                pass
+
+            # decode and save transportation files
             for filename in itertools.chain(
                 car_states.keys(), car_locations.keys(), driving_distances.keys()
             ):
@@ -822,7 +834,6 @@ class UtspLpgConnector(cp.Component):
             inner_device_heat_gains_file.append(inner_device_heat_gains_file_one_result)
             high_activity_file.append(high_activity_file_one_result)
             low_activity_file.append(low_activity_file_one_result)
-            flexibility_file.append(flexibility_file_one_result)
             saved_files.append(saved_files_one_result)
 
         return (
@@ -889,9 +900,10 @@ class UtspLpgConnector(cp.Component):
                 inner_device_heat_gains,
                 high_activity,
                 low_activity,
-                flexibility,
             ]
         }
+        optional_files = {
+            flexibility: datastructures.ResultFileRequirement.OPTIONAL}
         # Define transportation result files
         car_states = result_file_filters.LPGFilters.all_car_states_optional()
         car_locations = result_file_filters.LPGFilters.all_car_locations_optional()
@@ -900,6 +912,7 @@ class UtspLpgConnector(cp.Component):
         )
         result_files: Dict[str, Optional[datastructures.ResultFileRequirement]] = {
             **required_files,
+            **optional_files,
             **car_states,
             **car_locations,
             **driving_distances,

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -709,24 +709,17 @@ class UtspLpgConnector(cp.Component):
             self.utsp_config.url, request, self.utsp_config.api_key
         )
 
-        # decode required result files
         electricity_file = result.data[electricity].decode()
         warm_water_file = result.data[warm_water].decode()
         inner_device_heat_gains_file = result.data[inner_device_heat_gains].decode()
         high_activity_file = result.data[high_activity].decode()
         low_activity_file = result.data[low_activity].decode()
+        flexibility_file = result.data[flexibility].decode()
 
+        # Save flexibility and transportation files
         saved_files: List[str] = []
-        # try to decode and save optional flexibility result files if available
-        try:
-            flexibility_file = result.data[flexibility].decode()
-            # Save flexibility
-            path = self.save_result_file(name=flexibility, content=flexibility_file)
-            saved_files.append(path)
-        except Exception:
-            pass
-
-        # decode and save transportation files
+        path = self.save_result_file(name=flexibility, content=flexibility_file)
+        saved_files.append(path)
         for filename in itertools.chain(
             car_states.keys(), car_locations.keys(), driving_distances.keys()
         ):
@@ -789,6 +782,7 @@ class UtspLpgConnector(cp.Component):
         inner_device_heat_gains_file: List = []
         high_activity_file: List = []
         low_activity_file: List = []
+        flexibility_file: List = []
         saved_files: List = []
 
         for result in results:
@@ -805,20 +799,14 @@ class UtspLpgConnector(cp.Component):
             ].decode()
             high_activity_file_one_result = result.data[high_activity].decode()
             low_activity_file_one_result = result.data[low_activity].decode()
+            flexibility_file_one_result = result.data[flexibility].decode()
 
+            # Save flexibility and transportation files
             saved_files_one_result: List = []
-            # try to decode and save optional flexibility result files if available
-            try:
-                flexibility_file_one_result = result.data[flexibility].decode()
-                # Save flexibility
-                path = self.save_result_file(
+            path = self.save_result_file(
                 name=flexibility, content=flexibility_file_one_result
-                )
-                saved_files_one_result.append(path)
-            except Exception:
-                pass
-
-            # decode and save transportation files
+            )
+            saved_files_one_result.append(path)
             for filename in itertools.chain(
                 car_states.keys(), car_locations.keys(), driving_distances.keys()
             ):
@@ -834,6 +822,7 @@ class UtspLpgConnector(cp.Component):
             inner_device_heat_gains_file.append(inner_device_heat_gains_file_one_result)
             high_activity_file.append(high_activity_file_one_result)
             low_activity_file.append(low_activity_file_one_result)
+            flexibility_file.append(flexibility_file_one_result)
             saved_files.append(saved_files_one_result)
 
         return (
@@ -900,10 +889,9 @@ class UtspLpgConnector(cp.Component):
                 inner_device_heat_gains,
                 high_activity,
                 low_activity,
+                flexibility,
             ]
         }
-        optional_files = {
-            flexibility: datastructures.ResultFileRequirement.OPTIONAL}
         # Define transportation result files
         car_states = result_file_filters.LPGFilters.all_car_states_optional()
         car_locations = result_file_filters.LPGFilters.all_car_locations_optional()
@@ -912,7 +900,6 @@ class UtspLpgConnector(cp.Component):
         )
         result_files: Dict[str, Optional[datastructures.ResultFileRequirement]] = {
             **required_files,
-            **optional_files,
             **car_states,
             **car_locations,
             **driving_distances,

--- a/tests/test_lpg_utsp_connector_all_profiles_and_multiple_requests_with_cache.py
+++ b/tests/test_lpg_utsp_connector_all_profiles_and_multiple_requests_with_cache.py
@@ -8,10 +8,14 @@ all lpg household profiles and do calculation with it.
 # import pytest
 # from utspclient.helpers.lpgdata import Households
 # from utspclient.helpers.lpgpythonbindings import JsonReference
+# from dotenv import load_dotenv
+
 # from tests import functions_for_testing as fft
 # from hisim import component
 # from hisim.components import loadprofilegenerator_utsp_connector
 # from hisim.simulationparameters import SimulationParameters
+
+# load_dotenv()
 
 
 # def initialize_lpg_utsp_connector_and_cache_results_if_not_already_done(
@@ -25,6 +29,7 @@ all lpg household profiles and do calculation with it.
 #     my_occupancy_config = (
 #         loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
 #     )
+
 #     my_occupancy_config.cache_dir_path = cache_dir_path
 #     my_occupancy_config.household = household
 

--- a/tests/test_lpg_utsp_connector_scaling.py
+++ b/tests/test_lpg_utsp_connector_scaling.py
@@ -45,8 +45,8 @@ def test_occupancy_scaling_with_utsp():
     household_list = [
         Households.CHR02_Couple_30_64_age_with_work,
         Households.CHR02_Couple_30_64_age_with_work,
-        Households.CHR02_Couple_30_64_age_with_work,
-        Households.CHR02_Couple_30_64_age_with_work,
+        # Households.CHR02_Couple_30_64_age_with_work,
+        # Households.CHR02_Couple_30_64_age_with_work,
     ]
     (
         number_of_residents_two,
@@ -100,6 +100,7 @@ def initialize_lpg_utsp_connector_and_return_results(
     transportation_device_set = TransportationDeviceSets.Bus_and_one_30_km_h_Car
     charging_station_set = ChargingStationSets.Charging_At_Home_with_11_kW
     energy_intensity = EnergyIntensityType.EnergySaving
+    guid = "guid should not be varied automatically"
 
     # Build Simu Params
     my_simulation_parameters = SimulationParameters.full_year(
@@ -120,6 +121,7 @@ def initialize_lpg_utsp_connector_and_return_results(
         profile_with_washing_machine_and_dishwasher=True,
         predictive_control=False,
         energy_intensity=energy_intensity,
+        guid=guid
     )
 
     my_occupancy = loadprofilegenerator_utsp_connector.UtspLpgConnector(
@@ -134,7 +136,7 @@ def initialize_lpg_utsp_connector_and_return_results(
 
     my_occupancy.i_simulate(0, stsv, False)
 
-    timestep = 10
+    timestep = 0
     my_occupancy.i_simulate(timestep, stsv, False)
     number_of_residents = stsv.values[
         my_occupancy.number_of_residents_channel.global_index
@@ -148,9 +150,10 @@ def initialize_lpg_utsp_connector_and_return_results(
     electricity_consumption = stsv.values[
         my_occupancy.electricity_output_channel.global_index
     ]
-    print(electricity_consumption)
+
     water_consumption = stsv.values[my_occupancy.water_consumption_channel.global_index]
 
+    print(number_of_residents, heating_by_residents, heating_by_devices, electricity_consumption)
     return (
         number_of_residents,
         heating_by_residents,

--- a/tests/test_lpg_utsp_connector_scaling.py
+++ b/tests/test_lpg_utsp_connector_scaling.py
@@ -12,11 +12,15 @@ from utspclient.helpers.lpgdata import (
     EnergyIntensityType,
 )
 from utspclient.helpers.lpgpythonbindings import JsonReference
+from dotenv import load_dotenv
 from tests import functions_for_testing as fft
 from hisim import component
 from hisim.components import loadprofilegenerator_utsp_connector
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
+
+
+load_dotenv()
 
 
 @pytest.mark.utsp
@@ -41,6 +45,8 @@ def test_occupancy_scaling_with_utsp():
     household_list = [
         Households.CHR02_Couple_30_64_age_with_work,
         Households.CHR02_Couple_30_64_age_with_work,
+        Households.CHR02_Couple_30_64_age_with_work,
+        Households.CHR02_Couple_30_64_age_with_work,
     ]
     (
         number_of_residents_two,
@@ -51,24 +57,24 @@ def test_occupancy_scaling_with_utsp():
     ) = initialize_lpg_utsp_connector_and_return_results(households=household_list)
 
     log.information(
-        "number of residents in 2 households " + str(number_of_residents_two)
+        f"number of residents in {len(household_list)} households " + str(number_of_residents_two)
     )
 
     # now test if results are doubled when occupancy is initialzed with 2 households
     np.testing.assert_allclose(
-        number_of_residents_two, 2 * number_of_residents_one, rtol=0.01
+        number_of_residents_two, len(household_list) * number_of_residents_one, rtol=0.01
     )
     np.testing.assert_allclose(
-        heating_by_residents_two, 2 * heating_by_residents_one, rtol=0.01
+        heating_by_residents_two, len(household_list) * heating_by_residents_one, rtol=0.01
     )
     np.testing.assert_allclose(
-        heating_by_devices_two, 2 * heating_by_devices_one, rtol=0.01
+        heating_by_devices_two, len(household_list) * heating_by_devices_one, rtol=0.01
     )
     np.testing.assert_allclose(
-        electricity_consumption_two, 2 * electricity_consumption_one, rtol=0.01
+        electricity_consumption_two, len(household_list) * electricity_consumption_one, rtol=0.01
     )
     np.testing.assert_allclose(
-        water_consumption_two, 2 * water_consumption_one, rtol=0.01
+        water_consumption_two, len(household_list) * water_consumption_one, rtol=0.01
     )
 
 
@@ -99,6 +105,7 @@ def initialize_lpg_utsp_connector_and_return_results(
     my_simulation_parameters = SimulationParameters.full_year(
         year=year, seconds_per_timestep=seconds_per_timestep
     )
+
     # Build occupancy
     my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig(
         name="UTSPConnector",


### PR DESCRIPTION
- vary guid if dupicated lpg requests are given
- make flexibility file optional because some lpg households do not have flexible devices