### PR TITLE
Black formatting

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -46,6 +46,7 @@ pycodestyle:
     - N802
     - E128
     - E122
+    - E203
 
 pydocstyle:
   run: true

--- a/.pyproject.toml
+++ b/.pyproject.toml
@@ -1,2 +1,0 @@
-[tool.black]
-line-length = 150

--- a/hisim/component.py
+++ b/hisim/component.py
@@ -224,11 +224,15 @@ class Component:
             if connection.source_class_name != component_name:
                 raise ValueError("Trying to add connections to different components in one go.")
         self.default_connections[component_name] = connections
-        log.trace("added default connections for connections from : " + component_name + "\n" + str(self.default_connections))
+        log.trace(
+            "added default connections for connections from : " + component_name + "\n" + str(self.default_connections)
+        )
 
     def i_prepare_simulation(self) -> None:
         """Gets called before the simulation to prepare the calculation."""
-        raise NotImplementedError("Simulation preparation is missing for " + self.component_name + " (" + self.get_full_classname() + ")")
+        raise NotImplementedError(
+            "Simulation preparation is missing for " + self.component_name + " (" + self.get_full_classname() + ")"
+        )
 
     def set_sim_repo(self, simulation_repository: SimRepository) -> None:
         """Sets the SimRepository."""
@@ -285,7 +289,13 @@ class Component:
         for component_input in self.inputs:
             if component_input.field_name == input_fieldname:
                 if input_to_set is not None:
-                    raise ValueError("The input " + input_fieldname + " of the component " + self.component_name + " was already set.")
+                    raise ValueError(
+                        "The input "
+                        + input_fieldname
+                        + " of the component "
+                        + self.component_name
+                        + " was already set."
+                    )
                 input_to_set = component_input
         if input_to_set is None:
             raise ValueError("The component " + self.component_name + " has no input with the name " + input_fieldname)

--- a/hisim/component_wrapper.py
+++ b/hisim/component_wrapper.py
@@ -9,10 +9,10 @@ from hisim import log
 
 class ComponentWrapper:
 
-    """ Wraps components for use. """
+    """Wraps components for use."""
 
     def __init__(self, component: cp.Component, is_cachable: bool, connect_automatically: bool):
-        """ Initializes the component wrapper.
+        """Initializes the component wrapper.
 
         Used to handle the connection of inputs and outputs.
         """
@@ -24,13 +24,13 @@ class ComponentWrapper:
         self.connect_automatically = connect_automatically
 
     def clear(self):
-        """ Clears properties to help with saving memory. """
+        """Clears properties to help with saving memory."""
         del self.my_component
         del self.component_inputs
         del self.component_outputs
 
     def register_component_outputs(self, all_outputs: List[cp.ComponentOutput]) -> None:
-        """ Registers component outputs in the global list of components. """
+        """Registers component outputs in the global list of components."""
         log.information("Registering component outputs on " + self.my_component.component_name)
         # register the output column
         output_columns = self.my_component.get_outputs()
@@ -44,7 +44,7 @@ class ComponentWrapper:
             self.component_outputs.append(col)
 
     def register_component_inputs(self, global_column_dict: Dict[str, Any]) -> None:
-        """ Gets the inputs for the current component from the global column dict and puts them into component_inputs. """
+        """Gets the inputs for the current component from the global column dict and puts them into component_inputs."""
         log.information("Registering component inputs for " + self.my_component.component_name)
         # look up input columns and cache, so we only have the correct columns saved
         input_columns: List[cp.ComponentInput] = self.my_component.get_input_definitions()
@@ -53,7 +53,7 @@ class ComponentWrapper:
             self.component_inputs.append(global_column_entry)
 
     def save_state(self) -> None:
-        """ Saves the state.
+        """Saves the state.
 
         This gets called at the beginning of a timestep and wraps the i_save_state
         i_save_state should always cache the current state at the beginning of a time step.
@@ -61,7 +61,7 @@ class ComponentWrapper:
         self.my_component.i_save_state()
 
     def doublecheck(self, timestep: int, stsv: cp.SingleTimeStepValues) -> None:
-        """  Wrapper for i_doublecheck.
+        """Wrapper for i_doublecheck.
 
         Doublecheck is completely optional call that can be used while debugging to
         double check the component results after the iteration finished for a timestep.
@@ -69,23 +69,23 @@ class ComponentWrapper:
         self.my_component.i_doublecheck(timestep, stsv)
 
     def restore_state(self) -> None:
-        """ Wrapper for i_restore_state.
+        """Wrapper for i_restore_state.
 
         Gets called at the beginning of every iteration to return to the state at the beginning of the iteration.
         """
         self.my_component.i_restore_state()
 
     def calculate_component(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
-        """ Wrapper for the core simulation function in each component. """
+        """Wrapper for the core simulation function in each component."""
         self.my_component.i_simulate(timestep, stsv, force_convergence)
 
     def prepare_calculation(self):
-        """ Wrapper for i_prepare_calculation. """
+        """Wrapper for i_prepare_calculation."""
         log.information("Preparing " + self.my_component.component_name + " for simulation.")
         self.my_component.i_prepare_simulation()
 
     def connect_inputs(self, all_outputs: List[cp.ComponentOutput]) -> None:
-        """ Connects cp.ComponentOutputs to ComponentInputs of WrapperComponent. """
+        """Connects cp.ComponentOutputs to ComponentInputs of WrapperComponent."""
 
         # Returns a List of ComponentInputs
         self.my_component.get_input_definitions()
@@ -101,16 +101,21 @@ class ComponentWrapper:
             # Loop through all the existent component outputs in the current simulation
             for global_output in all_outputs:
                 # Check if ComponentOutput and ComponentInput match
-                if global_output.component_name == cinput.src_object_name and global_output.field_name == cinput.src_field_name:
+                if (
+                    global_output.component_name == cinput.src_object_name
+                    and global_output.field_name == cinput.src_field_name
+                ):
                     # Check if ComponentOutput and ComponentInput have the same units
                     if cinput.unit != global_output.unit:
                         # Check the use of "Units.Any"
                         if (cinput.unit == lt.Units.ANY and global_output.unit != lt.Units.ANY) or (
-                                cinput.unit != lt.Units.ANY and global_output.unit == lt.Units.ANY):
+                            cinput.unit != lt.Units.ANY and global_output.unit == lt.Units.ANY
+                        ):
                             log.warning(
                                 f"The input {cinput.field_name} (cp: {cinput.component_name}, unit: {cinput.unit}) "
                                 f"and output {global_output.field_name}(cp: {global_output.component_name}, unit: {global_output.unit}) "
-                                f"might not have compatible units.")  #
+                                f"might not have compatible units."
+                            )  #
                             # Connect, i.e, save ComponentOutput in ComponentInput
                             cinput.source_output = global_output
                             log.debug("Connected input '" + cinput.fullname + "' to '" + global_output.full_name + "'")
@@ -118,7 +123,8 @@ class ComponentWrapper:
                             raise SystemError(
                                 f"The input {cinput.field_name} (cp: {cinput.component_name}, unit: {cinput.unit}) and "
                                 f"output {global_output.field_name}(cp: {global_output.component_name}, unit: {global_output.unit}) "
-                                f"do not have the same unit!")  #
+                                f"do not have the same unit!"
+                            )  #
                     else:
                         # Connect, i.e, save ComponentOutput in ComponentInput
                         cinput.source_output = global_output
@@ -128,4 +134,5 @@ class ComponentWrapper:
             if cinput.is_mandatory and cinput.source_output is None:
                 raise SystemError(
                     f"The ComponentInput {cinput.field_name} (cp: {cinput.component_name}, "
-                    f"unit: {cinput.unit}) is not connected to any ComponentOutput.")  #
+                    f"unit: {cinput.unit}) is not connected to any ComponentOutput."
+                )  #

--- a/hisim/components/advanced_battery_bslib.py
+++ b/hisim/components/advanced_battery_bslib.py
@@ -71,14 +71,14 @@ class BatteryConfig(ConfigBase):
     @classmethod
     def get_default_config(cls) -> "BatteryConfig":
         """Returns default configuration of battery."""
-        custom_battery_capacity_generic_in_kilowatt_hour = 10  # size/capacity of battery should be approx. the same as default pv power
+        custom_battery_capacity_generic_in_kilowatt_hour = (
+            10  # size/capacity of battery should be approx. the same as default pv power
+        )
         config = BatteryConfig(
             name="Battery",
             # https://www.energieinstitut.at/die-richtige-groesse-von-batteriespeichern/
             custom_battery_capacity_generic_in_kilowatt_hour=custom_battery_capacity_generic_in_kilowatt_hour,
-            custom_pv_inverter_power_generic_in_watt=10
-            * 0.5
-            * 1e3,  # c-rate is 0.5C (0.5/h) here
+            custom_pv_inverter_power_generic_in_watt=10 * 0.5 * 1e3,  # c-rate is 0.5C (0.5/h) here
             source_weight=1,
             system_id="SG1",
             charge_in_kwh=0,
@@ -96,15 +96,15 @@ class BatteryConfig(ConfigBase):
     @classmethod
     def get_scaled_battery(cls, total_pv_power_in_watt_peak: float) -> "BatteryConfig":
         """Returns scaled configuration of battery according to pv power."""
-        custom_battery_capacity_generic_in_kilowatt_hour = total_pv_power_in_watt_peak * 1e-3  # size/capacity of battery should be approx. the same as default pv power
+        custom_battery_capacity_generic_in_kilowatt_hour = (
+            total_pv_power_in_watt_peak * 1e-3
+        )  # size/capacity of battery should be approx. the same as default pv power
         c_rate = 0.5  # 0.5C corresponds to 0.5/h for fully charging or discharging
         config = BatteryConfig(
             name="Battery",
             # https://www.energieinstitut.at/die-richtige-groesse-von-batteriespeichern/
             custom_battery_capacity_generic_in_kilowatt_hour=custom_battery_capacity_generic_in_kilowatt_hour,
-            custom_pv_inverter_power_generic_in_watt=custom_battery_capacity_generic_in_kilowatt_hour
-            * c_rate
-            * 1e3,
+            custom_pv_inverter_power_generic_in_watt=custom_battery_capacity_generic_in_kilowatt_hour * c_rate * 1e3,
             source_weight=1,
             system_id="SG1",
             charge_in_kwh=0,
@@ -141,15 +141,11 @@ class Battery(Component):
     DcBatteryPower = "DcBatteryPower"  # W
     StateOfCharge = "StateOfCharge"  # [0..1]
 
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: BatteryConfig
-    ):
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: BatteryConfig):
         """Loads the parameters of the specified battery storage."""
         self.battery_config = config
         super().__init__(
-            name=self.battery_config.name
-            + "_w"
-            + str(self.battery_config.source_weight),
+            name=self.battery_config.name + "_w" + str(self.battery_config.source_weight),
             my_simulation_parameters=my_simulation_parameters,
             my_config=config,
         )
@@ -158,9 +154,7 @@ class Battery(Component):
 
         self.system_id = self.battery_config.system_id
 
-        self.custom_pv_inverter_power_generic_in_watt = (
-            self.battery_config.custom_pv_inverter_power_generic_in_watt
-        )
+        self.custom_pv_inverter_power_generic_in_watt = self.battery_config.custom_pv_inverter_power_generic_in_watt
 
         self.custom_battery_capacity_generic_in_kilowatt_hour = (
             self.battery_config.custom_battery_capacity_generic_in_kilowatt_hour
@@ -232,17 +226,13 @@ class Battery(Component):
         """Prepares the simulation."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         # Parameters
         time_increment_in_seconds = self.my_simulation_parameters.seconds_per_timestep
 
         # Load input values
-        set_point_for_ac_battery_power_in_watt = stsv.get_input_value(
-            self.loading_power_input_channel
-        )
+        set_point_for_ac_battery_power_in_watt = stsv.get_input_value(self.loading_power_input_channel)
         state_of_charge = self.state.state_of_charge
 
         # Simulate on timestep
@@ -283,10 +273,7 @@ class Battery(Component):
         for index, output in enumerate(all_outputs):
             if (
                 output.postprocessing_flag is not None
-                and output.component_name
-                == self.battery_config.name
-                + "_w"
-                + str(self.battery_config.source_weight)
+                and output.component_name == self.battery_config.name + "_w" + str(self.battery_config.source_weight)
             ):
                 if InandOutputType.CHARGE_DISCHARGE in output.postprocessing_flag:
                     self.battery_config.charge_in_kwh = round(
@@ -302,9 +289,7 @@ class Battery(Component):
                         1,
                     )
 
-        opex_cost_per_simulated_period_in_euro = (
-            self.calc_maintenance_cost()
-        )
+        opex_cost_per_simulated_period_in_euro = self.calc_maintenance_cost()
         opex_cost_data_class = OpexCostDataClass(
             opex_cost=opex_cost_per_simulated_period_in_euro,
             co2_footprint=0,
@@ -325,8 +310,7 @@ class Battery(Component):
         # Todo: Think about better approximation for costs of battery aging
 
         virtual_number_of_full_charge_cycles = (
-            self.battery_config.charge_in_kwh
-            / self.battery_config.custom_battery_capacity_generic_in_kilowatt_hour
+            self.battery_config.charge_in_kwh / self.battery_config.custom_battery_capacity_generic_in_kilowatt_hour
         )
         # virtual_number_of_full_discharge_cycles = self.battery_config.discharge_in_kwh / self.battery_config.custom_battery_capacity_generic_in_kilowatt_hour
 

--- a/hisim/components/advanced_ev_battery_bslib.py
+++ b/hisim/components/advanced_ev_battery_bslib.py
@@ -95,9 +95,7 @@ class CarBattery(Component):
     DcBatteryPower = "DcBatteryPower"  # W
     StateOfCharge = "StateOfCharge"  # [0..1]
 
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: CarBatteryConfig
-    ):
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: CarBatteryConfig):
         """Loads the parameters of the specified battery storage."""
         self.battery_config = config
         super().__init__(
@@ -164,9 +162,7 @@ class CarBattery(Component):
             output_description="State of charge of the battery.",
         )
 
-        self.add_default_connections(
-            self.get_default_connections_from_charge_controller()
-        )
+        self.add_default_connections(self.get_default_connections_from_charge_controller())
 
     def get_default_connections_from_charge_controller(self) -> Any:
         """Get default connections from charge controller."""
@@ -175,9 +171,7 @@ class CarBattery(Component):
         component_module = importlib.import_module(name=component_module_name)
         component_class = getattr(component_module, "L1Controller")
         connections: List[ComponentConnection] = []
-        ev_charge_controller_classname = (
-            component_class.get_classname()
-        )
+        ev_charge_controller_classname = component_class.get_classname()
         connections.append(
             ComponentConnection(
                 CarBattery.LoadingPowerInput,
@@ -203,9 +197,7 @@ class CarBattery(Component):
         """Prepares the simulation."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         # Parameters
         seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep
@@ -223,9 +215,7 @@ class CarBattery(Component):
 
         # Simulate battery discharge without losses (this is included in the car consumption of the car component)
         else:
-            soc = soc + (
-                p_set * self.my_simulation_parameters.seconds_per_timestep / 3600
-            ) / (self.e_bat_custom * 1e3)
+            soc = soc + (p_set * self.my_simulation_parameters.seconds_per_timestep / 3600) / (self.e_bat_custom * 1e3)
             if soc < 0:
                 raise ValueError(
                     "Car cannot drive, because battery is empty."
@@ -261,10 +251,7 @@ class CarBattery(Component):
         for index, output in enumerate(all_outputs):
             if (
                 output.postprocessing_flag is not None
-                and output.component_name
-                == self.battery_config.name
-                + "_w"
-                + str(self.battery_config.source_weight)
+                and output.component_name == self.battery_config.name + "_w" + str(self.battery_config.source_weight)
             ):
                 if InandOutputType.CHARGE_DISCHARGE in output.postprocessing_flag:
                     self.battery_config.charge = round(

--- a/hisim/components/advanced_fuel_cell.py
+++ b/hisim/components/advanced_fuel_cell.py
@@ -177,9 +177,7 @@ class CHP(Component):
     ThermalOutputPower = "ThermalOutputPower"
     GasDemandReal = "GasDemandReal"
 
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: CHPConfig
-    ) -> None:
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: CHPConfig) -> None:
         """Initialize the class."""
         self.chp_config = config
         super().__init__(
@@ -189,12 +187,8 @@ class CHP(Component):
         )
         self.min_operation_time = self.chp_config.min_operation_time
         self.min_idle_time = self.chp_config.min_idle_time
-        self.gas_type = (
-            self.chp_config.gas_type
-        )  # Gas Type can be "Hydrogen" or "Methan"
-        self.operating_mode = (
-            self.chp_config.operating_mode
-        )  # operating_mode=["both","heat","electricity"]
+        self.gas_type = self.chp_config.gas_type  # Gas Type can be "Hydrogen" or "Methan"
+        self.operating_mode = self.chp_config.operating_mode  # operating_mode=["both","heat","electricity"]
 
         self.number_of_cycles = 0
         self.number_of_cycles_previous = copy.deepcopy(self.number_of_cycles)
@@ -212,9 +206,7 @@ class CHP(Component):
             self.p_el_max = self.p_el_min + 100
             self.p_th_max = self.p_th_max + 100
 
-        self.mass_flow_max = self.chp_config.mass_flow_max * (
-            self.p_el_max / usually_p_el_max
-        )
+        self.mass_flow_max = self.chp_config.mass_flow_max * (self.p_el_max / usually_p_el_max)
         if self.mass_flow_max < self.chp_config.mass_flow_max:
             self.mass_flow_max = self.chp_config.mass_flow_max
         self.eff_th_min: float = self.chp_config.eff_th_min
@@ -325,9 +317,7 @@ class CHP(Component):
         """Doubelchecks."""
         pass
 
-    def simulate_chp(
-        self, control_signal: float, stsv: SingleTimeStepValues, timestep: int
-    ) -> Any:
+    def simulate_chp(self, control_signal: float, stsv: SingleTimeStepValues, timestep: int) -> Any:
         """Simualtes the component."""
 
         specific_heat_capacity_water = 4182
@@ -338,11 +328,7 @@ class CHP(Component):
             # Checks if the minimum running time has been reached
 
             # Minimium running time has been reached and the CHP wants to shut off -->so it shuts off
-            if (
-                timestep >= self.state.start_timestep + self.min_operation_time
-                and control_signal == 0.0
-            ):
-
+            if timestep >= self.state.start_timestep + self.min_operation_time and control_signal == 0.0:
                 # all Outputs zero
                 mass_out_temp: float = 0
                 mass_out: float = 0
@@ -357,30 +343,17 @@ class CHP(Component):
                     electricity_output=el_power,
                 )
 
-                stsv.set_output_value(
-                    self.mass_out_temp_channel, mass_out_temp
-                )  # mass output temp
-                stsv.set_output_value(
-                    self.mass_out_channel, mass_out
-                )  # mass output flow
-                stsv.set_output_value(
-                    self.el_power_channel, el_power
-                )  # mass output flow
-                stsv.set_output_value(
-                    self.th_power_channel, th_power
-                )  # mass output flow
+                stsv.set_output_value(self.mass_out_temp_channel, mass_out_temp)  # mass output temp
+                stsv.set_output_value(self.mass_out_channel, mass_out)  # mass output flow
+                stsv.set_output_value(self.el_power_channel, el_power)  # mass output flow
+                stsv.set_output_value(self.th_power_channel, th_power)  # mass output flow
 
                 # zu ändern, da gas_demand=!gas_power
-                stsv.set_output_value(
-                    self.number_of_cycles_channel, self.number_of_cycles
-                )
+                stsv.set_output_value(self.number_of_cycles_channel, self.number_of_cycles)
                 return el_power, th_power, eff_el_real, eff_th_real
 
             # Minimium running time has not been reached and the CHP wants to shut off -->so it won't shut off
-            if (
-                timestep < self.state.start_timestep + self.min_operation_time
-                and control_signal == 0
-            ):
+            if timestep < self.state.start_timestep + self.min_operation_time and control_signal == 0:
                 # CHP doesn't want to run but has to, therefore is going to run in minimum power
 
                 maximum_power_th: float = self.p_th_min
@@ -391,16 +364,14 @@ class CHP(Component):
                 th_power = maximum_power_th * eff_th_real
                 el_power = maximum_power_el * eff_el_real
 
-                mass_out_temp = self.delta_t + stsv.get_input_value(
-                    self.mass_inp_temp_channel
-                )
+                mass_out_temp = self.delta_t + stsv.get_input_value(self.mass_inp_temp_channel)
                 mass_out = th_power / (specific_heat_capacity_water * self.delta_t)
 
                 if mass_out > self.mass_flow_max:
                     mass_out = self.mass_flow_max
-                    mass_out_temp = stsv.get_input_value(
-                        self.mass_inp_temp_channel
-                    ) + th_power / (mass_out * specific_heat_capacity_water)
+                    mass_out_temp = stsv.get_input_value(self.mass_inp_temp_channel) + th_power / (
+                        mass_out * specific_heat_capacity_water
+                    )
 
             # CHP doens't want to shut off and its activated--> so its stays activated
             else:
@@ -427,16 +398,14 @@ class CHP(Component):
                 th_power = maximum_power_th * eff_th_real
                 el_power = maximum_power_el * eff_el_real
 
-                mass_out_temp = self.delta_t + stsv.get_input_value(
-                    self.mass_inp_temp_channel
-                )
+                mass_out_temp = self.delta_t + stsv.get_input_value(self.mass_inp_temp_channel)
                 mass_out = th_power / (specific_heat_capacity_water * self.delta_t)
 
                 if mass_out > self.mass_flow_max:
                     mass_out = self.mass_flow_max
-                    mass_out_temp = stsv.get_input_value(
-                        self.mass_inp_temp_channel
-                    ) + th_power / (mass_out * specific_heat_capacity_water)
+                    mass_out_temp = stsv.get_input_value(self.mass_inp_temp_channel) + th_power / (
+                        mass_out * specific_heat_capacity_water
+                    )
 
             th_power = (
                 (mass_out_temp - stsv.get_input_value(self.mass_inp_temp_channel))
@@ -444,9 +413,7 @@ class CHP(Component):
                 * mass_out
             )
             stsv.set_output_value(self.th_power_channel, th_power)  # ThermalPowerOutput
-            stsv.set_output_value(
-                self.mass_out_temp_channel, mass_out_temp
-            )  # mass output temp
+            stsv.set_output_value(self.mass_out_temp_channel, mass_out_temp)  # mass output temp
             stsv.set_output_value(self.mass_out_channel, mass_out)  # mass output flow
             stsv.set_output_value(self.el_power_channel, el_power)  # mass output flow
             # zu ändern, da gas_demand=!gas_power
@@ -456,9 +423,7 @@ class CHP(Component):
 
         # CHP is Off
         # CHP wants to start and waited long enough since last start--> so it starts
-        if control_signal != 0 and (
-            timestep >= self.state.start_timestep + self.min_idle_time
-        ):
+        if control_signal != 0 and (timestep >= self.state.start_timestep + self.min_idle_time):
             self.number_of_cycles = self.number_of_cycles + 1
             number_of_cycles = self.number_of_cycles
 
@@ -485,16 +450,14 @@ class CHP(Component):
             th_power = maximum_power_th * eff_th_real
             el_power = maximum_power_el * eff_el_real
 
-            mass_out_temp = self.delta_t + stsv.get_input_value(
-                self.mass_inp_temp_channel
-            )
+            mass_out_temp = self.delta_t + stsv.get_input_value(self.mass_inp_temp_channel)
             mass_out = th_power / (specific_heat_capacity_water * self.delta_t)
 
             if mass_out > self.mass_flow_max:
                 mass_out = self.mass_flow_max
-                mass_out_temp = stsv.get_input_value(
-                    self.mass_inp_temp_channel
-                ) + th_power / (mass_out * specific_heat_capacity_water)
+                mass_out_temp = stsv.get_input_value(self.mass_inp_temp_channel) + th_power / (
+                    mass_out * specific_heat_capacity_water
+                )
 
             self.state = CHPState(
                 start_timestep=timestep,
@@ -513,9 +476,7 @@ class CHP(Component):
             eff_th_real = 0
 
         stsv.set_output_value(self.th_power_channel, th_power)  # ThermalPowerOutput
-        stsv.set_output_value(
-            self.mass_out_temp_channel, mass_out_temp
-        )  # mass output temp
+        stsv.set_output_value(self.mass_out_temp_channel, mass_out_temp)  # mass output temp
         stsv.set_output_value(self.mass_out_channel, mass_out)  # mass output flow
         stsv.set_output_value(self.el_power_channel, el_power)  # mass output flow
         # zu ändern, da gas_demand=!gas_power
@@ -528,14 +489,10 @@ class CHP(Component):
         if (stsv.get_input_value(self.electricity_target_channel)) < 30:
             control_signal: float = 0
             return control_signal
-        if (
-            stsv.get_input_value(self.electricity_target_channel)
-        ) < self.p_el_min * self.eff_el_min:
+        if (stsv.get_input_value(self.electricity_target_channel)) < self.p_el_min * self.eff_el_min:
             control_signal = 0.4
             return control_signal
-        if (
-            stsv.get_input_value(self.electricity_target_channel)
-        ) > self.p_el_max * self.eff_el_max:
+        if (stsv.get_input_value(self.electricity_target_channel)) > self.p_el_max * self.eff_el_max:
             control_signal = 1
             return control_signal
 
@@ -574,9 +531,7 @@ class CHP(Component):
 
         return x_2
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
         control_signal: float = -1
         if self.operating_mode == "heat":
@@ -608,29 +563,22 @@ class CHP(Component):
             gas_demand_real_used = 0
         else:
             if self.gas_type == "Hydrogen":
-                gas_demand_target = (
-                    (el_power / eff_el_real) + (th_power / eff_th_real)
-                ) / (PhysicsConfig.hydrogen_specific_fuel_value_per_kg)
+                gas_demand_target = ((el_power / eff_el_real) + (th_power / eff_th_real)) / (
+                    PhysicsConfig.hydrogen_specific_fuel_value_per_kg
+                )
                 if stsv.get_input_value(self.hydrogen_not_released_channel) == 0:
                     # Gas Demand can completly be charged from storage
                     gas_demand_real_used = gas_demand_target
 
                 elif stsv.get_input_value(self.hydrogen_not_released_channel) < 0:
-                    log.warning(
-                        "Fault, bc. GasDemandpossible>gasdemandtarget @ "
-                        + str(timestep)
-                    )
+                    log.warning("Fault, bc. GasDemandpossible>gasdemandtarget @ " + str(timestep))
 
                 elif stsv.get_input_value(self.hydrogen_not_released_channel) > 0:
                     # not enough Gas for running CHP on power demanded/calculated before
                     # to simplify, turn of CHP complelty, also when minimum running time isn't reached, bec. no Hydrogen is there
 
-                    stsv.set_output_value(
-                        self.th_power_channel, 0
-                    )  # ThermalPowerOutput
-                    stsv.set_output_value(
-                        self.mass_out_temp_channel, 0
-                    )  # mass output temp
+                    stsv.set_output_value(self.th_power_channel, 0)  # ThermalPowerOutput
+                    stsv.set_output_value(self.mass_out_temp_channel, 0)  # mass output temp
                     stsv.set_output_value(self.mass_out_channel, 0)  # mass output flow
                     stsv.set_output_value(self.el_power_channel, 0)  # mass output flow
                     self.number_of_cycles = self.state.cycle_number
@@ -641,9 +589,7 @@ class CHP(Component):
                         electricity_output=el_power,
                     )
 
-                    stsv.set_output_value(
-                        self.number_of_cycles_channel, self.number_of_cycles
-                    )
+                    stsv.set_output_value(self.number_of_cycles_channel, self.number_of_cycles)
                     gas_demand_real_used = 0
             elif self.gas_type == "Methan":
                 gas_demand_target = (
@@ -653,12 +599,8 @@ class CHP(Component):
             else:
                 raise Exception("No Gas chosen which is integrated in System")
 
-        stsv.set_output_value(
-            self.gas_demand_target_channel, gas_demand_target
-        )  # CHP runs with
-        stsv.set_output_value(
-            self.gas_demand_real_used_channel, gas_demand_real_used
-        )  # ThermalPowerOutput
+        stsv.set_output_value(self.gas_demand_target_channel, gas_demand_target)  # CHP runs with
+        stsv.set_output_value(self.gas_demand_real_used_channel, gas_demand_real_used)  # ThermalPowerOutput
 
     def write_to_report(self) -> List[str]:
         """Write to report."""

--- a/hisim/components/advanced_fuel_cell_controller.py
+++ b/hisim/components/advanced_fuel_cell_controller.py
@@ -59,9 +59,7 @@ class ExtendedControllerSimulation:
                 if state_chp == 0:
                     pass
                 else:
-                    minimum_timesteps = (
-                        CHPControllerConfig.minimum_runtime_minutes * 60
-                    ) / seconds_per_timestep
+                    minimum_timesteps = (CHPControllerConfig.minimum_runtime_minutes * 60) / seconds_per_timestep
                     if runtime_chp >= minimum_timesteps:
                         # switch off chp
                         state_chp = 0
@@ -76,9 +74,7 @@ class ExtendedControllerSimulation:
                     if state_chp == 0:
                         pass  # state_chp = 0
                     else:
-                        minimum_timesteps = (
-                            CHPControllerConfig.minimum_runtime_minutes * 60
-                        ) / seconds_per_timestep
+                        minimum_timesteps = (CHPControllerConfig.minimum_runtime_minutes * 60) / seconds_per_timestep
                         if runtime_chp >= minimum_timesteps:
                             # switch off chp
                             state_chp = 0
@@ -87,9 +83,7 @@ class ExtendedControllerSimulation:
                             state_chp = 1 / power_states_possible
             elif chp.CHPConfig.p_el_min <= demand < chp.CHPConfig.p_el_max:
                 # minimum power plus the demand depending power
-                state_chp = (
-                    1 + ceil((demand - chp.CHPConfig.p_el_min) / power_per_step_size)
-                ) / power_states_possible
+                state_chp = (1 + ceil((demand - chp.CHPConfig.p_el_min) / power_per_step_size)) / power_states_possible
                 assert (1 / power_states_possible) < state_chp <= 1
             else:  # demand >= chp.CHPConfig.P_el_max
                 state_chp = 1
@@ -111,9 +105,7 @@ class ExtendedControllerSimulation:
                 if state_chp == 0:
                     power_from_or_to_grid = demand
                 else:
-                    minimum_timesteps = (
-                        CHPControllerConfig.minimum_runtime_minutes * 60
-                    ) / seconds_per_timestep
+                    minimum_timesteps = (CHPControllerConfig.minimum_runtime_minutes * 60) / seconds_per_timestep
                     if runtime_chp >= minimum_timesteps:
                         state_chp = 0
                         power_from_or_to_grid = demand
@@ -148,10 +140,7 @@ class ExtendedControllerSimulation:
 
         heights_in_tank = CHPControllerConfig.heights_in_tank
 
-        if (
-            CHPControllerConfig.height_upper_sensor
-            or CHPControllerConfig.height_lower_sensor
-        ) not in heights_in_tank:
+        if (CHPControllerConfig.height_upper_sensor or CHPControllerConfig.height_lower_sensor) not in heights_in_tank:
             log.error(
                 "Wrong sensor setting. Only 0, 20, 40, 60, 80, 100% are allowed.\n"
                 "You tried "
@@ -176,9 +165,7 @@ class ExtendedControllerSimulation:
         # lower sensor (no check needed if chp is off)
         if state_chp == 1:
             if temperature_lower_sensor > CHPControllerConfig.temperature_switch_off:
-                minimum_timesteps = (
-                    CHPControllerConfig.minimum_runtime_minutes * 60
-                ) / seconds_per_timestep
+                minimum_timesteps = (CHPControllerConfig.minimum_runtime_minutes * 60) / seconds_per_timestep
                 if runtime_chp > minimum_timesteps:
                     # switch off is possible if chp has run at least xx min
                     state_chp = 0
@@ -192,11 +179,7 @@ class ExtendedControllerSimulation:
             log.error("Wrong state_chp")
             raise ValueError
         # 'easy equation' --> no modulation
-        power_from_or_to_grid = (
-            electricity_demand_household
-            - pv_production
-            - chp.CHPConfig.p_el_max * state_chp
-        )
+        power_from_or_to_grid = electricity_demand_household - pv_production - chp.CHPConfig.p_el_max * state_chp
 
         return state_chp, runtime_chp, power_from_or_to_grid
 
@@ -213,10 +196,7 @@ class ExtendedControllerSimulation:
         # ToDo: future --> make modulating possible if the waste energy is to high? reduce power, increase mass_flow
 
         heights_in_tank = CHPControllerConfig.heights_in_tank
-        if (
-            GasControllerConfig.height_upper_sensor
-            or GasControllerConfig.height_lower_sensor
-        ) not in heights_in_tank:
+        if (GasControllerConfig.height_upper_sensor or GasControllerConfig.height_lower_sensor) not in heights_in_tank:
             log.error(
                 "Wrong sensor setting. Only 0, 20, 40, 60, 80, 100% are allowed.\n"
                 "You tried "
@@ -240,9 +220,7 @@ class ExtendedControllerSimulation:
         # lower sensor (no check needed if gas heater is off)
         if state_gas_heater == 1:
             if temperature_lower_sensor > GasControllerConfig.temperature_switch_off:
-                minimum_timesteps = (
-                    GasControllerConfig.minimum_runtime_minutes * 60
-                ) / seconds_per_timestep
+                minimum_timesteps = (GasControllerConfig.minimum_runtime_minutes * 60) / seconds_per_timestep
                 if runtime_counter > minimum_timesteps:
                     # switch off is possible if gas_heater has run at least xx min
                     state_gas_heater = 0
@@ -274,11 +252,7 @@ class ExtendedControllerSimulation:
             power_to_electrolyzer = 0
             # no change
             # power_from_or_to_grid = power_available
-        elif (
-            AdvElectrolyzerConfig.min_power
-            <= power_available
-            <= AdvElectrolyzerConfig.max_power
-        ):
+        elif AdvElectrolyzerConfig.min_power <= power_available <= AdvElectrolyzerConfig.max_power:
             power_to_electrolyzer = power_available
             power_from_or_to_grid = 0
         else:  # power_available > ElectrolyzerConfig.max_power:
@@ -461,24 +435,17 @@ class ExtendedController(Component):
         self.state_gas_heater1 = deepcopy(self.previous_state_gas_heater1)
         self.runtime_gas_heater1 = deepcopy(self.previous_runtime_gas_heater1)
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the state."""
         if force_convergence:
             return
 
         # Inputs
-        electricity_demand_household = stsv.get_input_value(
-            self.electricity_demand_household_channel
-        )
+        electricity_demand_household = stsv.get_input_value(self.electricity_demand_household_channel)
         pv_production: float = stsv.get_input_value(self.pv_production_channel)
 
         # not needed for power
-        if (
-            ExtendedControllerConfig.chp_mode == "heat"
-            or ExtendedControllerConfig.gas_heater
-        ):
+        if ExtendedControllerConfig.chp_mode == "heat" or ExtendedControllerConfig.gas_heater:
             temperature_0_percent = stsv.get_input_value(self.temperature_0_percent_channel)
             temperature_20_percent = stsv.get_input_value(self.temperature_20_percent_channel)
             temperature_40_percent = stsv.get_input_value(self.temperature_40_percent_channel)
@@ -524,9 +491,7 @@ class ExtendedController(Component):
                     self.seconds_per_timestep,
                 )
             else:
-                log.error(
-                    "Wrong chp controller settings! Choose between heat and power"
-                )
+                log.error("Wrong chp controller settings! Choose between heat and power")
                 raise ValueError
         else:
             power_from_or_to_grid = pv_production - electricity_demand_household
@@ -554,9 +519,7 @@ class ExtendedController(Component):
             (
                 power_to_electrolyzer,
                 power_from_or_to_grid,
-            ) = self.extended_controller.power_distribution_to_electrolyzer(
-                power_from_or_to_grid
-            )
+            ) = self.extended_controller.power_distribution_to_electrolyzer(power_from_or_to_grid)
         else:
             power_to_electrolyzer = 0
 
@@ -585,22 +548,13 @@ class ExtendedController(Component):
         # check the electricity balance
         if chp.CHPConfig.is_modulating:
             if self.test_state > 0:
-                power_chp_test = chp.CHPConfig.p_el_min + (
-                    chp.CHPConfig.p_el_max - chp.CHPConfig.p_el_min
-                ) / (ExtendedControllerConfig.chp_power_states_possible - 1) * (
-                    self.test_state * ExtendedControllerConfig.chp_power_states_possible
-                    - 1
-                )
+                power_chp_test = chp.CHPConfig.p_el_min + (chp.CHPConfig.p_el_max - chp.CHPConfig.p_el_min) / (
+                    ExtendedControllerConfig.chp_power_states_possible - 1
+                ) * (self.test_state * ExtendedControllerConfig.chp_power_states_possible - 1)
             else:
                 power_chp_test = 0
 
-            if 0.00001 > (
-                self.test_pv
-                + power_chp_test
-                + self.test_grid
-                - self.test_demand
-                - self.test_electrolyzer
-            ):
+            if 0.00001 > (self.test_pv + power_chp_test + self.test_grid - self.test_demand - self.test_electrolyzer):
                 pass
             else:
                 log.error("Wrong energy balance:")

--- a/hisim/components/advanced_heat_pump_hplib.py
+++ b/hisim/components/advanced_heat_pump_hplib.py
@@ -96,9 +96,7 @@ class HeatPumpHplibConfig(ConfigBase):
             co2_footprint=set_thermal_output_power_in_watt
             * 1e-3
             * 165.84,  # value from emission_factros_and_costs_devices.csv
-            cost=set_thermal_output_power_in_watt
-            * 1e-3
-            * 1513.74,  # value from emission_factros_and_costs_devices.csv
+            cost=set_thermal_output_power_in_watt * 1e-3 * 1513.74,  # value from emission_factros_and_costs_devices.csv
             lifetime=10,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.025,  # source:  VDI2067-1
             consumption=0,
@@ -127,9 +125,7 @@ class HeatPumpHplibConfig(ConfigBase):
             co2_footprint=set_thermal_output_power_in_watt
             * 1e-3
             * 165.84,  # value from emission_factros_and_costs_devices.csv
-            cost=set_thermal_output_power_in_watt
-            * 1e-3
-            * 1513.74,  # value from emission_factros_and_costs_devices.csv
+            cost=set_thermal_output_power_in_watt * 1e-3 * 1513.74,  # value from emission_factros_and_costs_devices.csv
             lifetime=10,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.025,  # source:  VDI2067-1
             consumption=0,
@@ -208,15 +204,11 @@ class HeatPumpHplib(Component):
         postprocessing_flag = [InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED]
 
         # Component has states
-        self.state = HeatPumpState(
-            time_on=0, time_off=0, time_on_cooling=0, on_off_previous=0
-        )
+        self.state = HeatPumpState(time_on=0, time_off=0, time_on_cooling=0, on_off_previous=0)
         self.previous_state = self.state.self_copy()
 
         # Load parameters from heat pump database
-        self.parameters = hpl.get_parameters(
-            self.model, self.group_id, self.t_in, self.t_out_val, self.p_th_set
-        )
+        self.parameters = hpl.get_parameters(self.model, self.group_id, self.t_in, self.t_out_val, self.p_th_set)
 
         # Define component inputs
         self.on_off_switch: ComponentInput = self.add_input(
@@ -315,13 +307,9 @@ class HeatPumpHplib(Component):
             output_description="Time turned off",
         )
 
-        self.add_default_connections(
-            self.get_default_connections_from_heat_pump_controller()
-        )
+        self.add_default_connections(self.get_default_connections_from_heat_pump_controller())
         self.add_default_connections(self.get_default_connections_from_weather())
-        self.add_default_connections(
-            self.get_default_connections_from_simple_hot_water_storage()
-        )
+        self.add_default_connections(self.get_default_connections_from_simple_hot_water_storage())
 
     def get_default_connections_from_heat_pump_controller(
         self,
@@ -404,9 +392,7 @@ class HeatPumpHplib(Component):
         """Prepare simulation."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
 
         # Load input values
@@ -420,7 +406,6 @@ class HeatPumpHplib(Component):
 
         # cycling means periodic turning on and off of the heat pump
         if self.cycling_mode is True:
-
             # Parameter
             time_on_min = self.minimum_running_time_in_seconds  # [s]
             time_off_min = self.minimum_idle_time_in_seconds
@@ -447,7 +432,6 @@ class HeatPumpHplib(Component):
 
         # OnOffSwitch
         if on_off == 1:
-
             results = self.get_cached_results_or_run_hplib_simulation(
                 t_in_primary=t_in_primary,
                 t_in_secondary=t_in_secondary,
@@ -463,9 +447,7 @@ class HeatPumpHplib(Component):
             eer = results["EER"].values[0]
             t_out = results["T_out"].values[0]
             m_dot = results["m_dot"].values[0]
-            time_on_heating = (
-                time_on_heating + self.my_simulation_parameters.seconds_per_timestep
-            )
+            time_on_heating = time_on_heating + self.my_simulation_parameters.seconds_per_timestep
             time_on_cooling = 0
             time_off = 0
 
@@ -485,9 +467,7 @@ class HeatPumpHplib(Component):
             eer = results["EER"].values[0]
             t_out = results["T_out"].values[0]
             m_dot = results["m_dot"].values[0]
-            time_on_cooling = (
-                time_on_cooling + self.my_simulation_parameters.seconds_per_timestep
-            )
+            time_on_cooling = time_on_cooling + self.my_simulation_parameters.seconds_per_timestep
             time_on_heating = 0
             time_on_heating = 0
             time_off = 0
@@ -542,8 +522,7 @@ class HeatPumpHplib(Component):
         """
         for index, output in enumerate(all_outputs):
             if (
-                output.component_name == "HeatPumpHPLib"
-                and output.load_type == LoadTypes.ELECTRICITY
+                output.component_name == "HeatPumpHPLib" and output.load_type == LoadTypes.ELECTRICITY
             ):  # Todo: check component name from system_setups: find another way of using only heatpump-outputs
                 self.config.consumption = round(
                     sum(postprocessing_results.iloc[:, index])
@@ -587,9 +566,7 @@ class HeatPumpHplib(Component):
             results = self.calculation_cache[my_hash_key]
 
         else:
-            results = hpl.simulate(
-                t_in_primary, t_in_secondary, parameters, t_amb, mode=mode
-            )
+            results = hpl.simulate(t_in_primary, t_in_secondary, parameters, t_amb, mode=mode)
 
             self.calculation_cache[my_hash_key] = results
 
@@ -610,9 +587,7 @@ class HeatPumpState:
         self,
     ):
         """Copy the Heat Pump State."""
-        return HeatPumpState(
-            self.time_on, self.time_off, self.time_on_cooling, self.on_off_previous
-        )
+        return HeatPumpState(self.time_on, self.time_off, self.time_on_cooling, self.on_off_previous)
 
 
 # ===========================================================================
@@ -674,18 +649,12 @@ class HeatPumpHplibController(Component):
     """
 
     # Inputs
-    WaterTemperatureInputFromHeatWaterStorage = (
-        "WaterTemperatureInputFromHeatWaterStorage"
-    )
-    HeatingFlowTemperatureFromHeatDistributionSystem = (
-        "HeatingFlowTemperatureFromHeatDistributionSystem"
-    )
+    WaterTemperatureInputFromHeatWaterStorage = "WaterTemperatureInputFromHeatWaterStorage"
+    HeatingFlowTemperatureFromHeatDistributionSystem = "HeatingFlowTemperatureFromHeatDistributionSystem"
 
     DailyAverageOutsideTemperature = "DailyAverageOutsideTemperature"
 
-    SimpleHotWaterStorageTemperatureModifier = (
-        "SimpleHotWaterStorageTemperatureModifier"
-    )
+    SimpleHotWaterStorageTemperatureModifier = "SimpleHotWaterStorageTemperatureModifier"
 
     # Outputs
     State = "State"
@@ -703,9 +672,7 @@ class HeatPumpHplibController(Component):
             my_config=config,
         )
 
-        self.heat_distribution_system_type = (
-            self.heatpump_controller_config.heat_distribution_system_type
-        )
+        self.heat_distribution_system_type = self.heatpump_controller_config.heat_distribution_system_type
         self.build(
             mode=self.heatpump_controller_config.mode,
             temperature_offset_for_state_conditions_in_celsius=self.heatpump_controller_config.temperature_offset_for_state_conditions_in_celsius,
@@ -726,24 +693,20 @@ class HeatPumpHplibController(Component):
             Units.CELSIUS,
             True,
         )
-        self.daily_avg_outside_temperature_input_channel: ComponentInput = (
-            self.add_input(
-                self.component_name,
-                self.DailyAverageOutsideTemperature,
-                LoadTypes.TEMPERATURE,
-                Units.CELSIUS,
-                True,
-            )
+        self.daily_avg_outside_temperature_input_channel: ComponentInput = self.add_input(
+            self.component_name,
+            self.DailyAverageOutsideTemperature,
+            LoadTypes.TEMPERATURE,
+            Units.CELSIUS,
+            True,
         )
 
-        self.simple_hot_water_storage_temperature_modifier_channel: ComponentInput = (
-            self.add_input(
-                self.component_name,
-                self.SimpleHotWaterStorageTemperatureModifier,
-                LoadTypes.TEMPERATURE,
-                Units.CELSIUS,
-                mandatory=False,
-            )
+        self.simple_hot_water_storage_temperature_modifier_channel: ComponentInput = self.add_input(
+            self.component_name,
+            self.SimpleHotWaterStorageTemperatureModifier,
+            LoadTypes.TEMPERATURE,
+            Units.CELSIUS,
+            mandatory=False,
         )
 
         self.state_channel: ComponentOutput = self.add_output(
@@ -757,22 +720,16 @@ class HeatPumpHplibController(Component):
         self.controller_heatpumpmode: Any
         self.previous_heatpump_mode: Any
 
-        self.add_default_connections(
-            self.get_default_connections_from_heat_distribution_controller()
-        )
+        self.add_default_connections(self.get_default_connections_from_heat_distribution_controller())
         self.add_default_connections(self.get_default_connections_from_weather())
-        self.add_default_connections(
-            self.get_default_connections_from_simple_hot_water_storage()
-        )
+        self.add_default_connections(self.get_default_connections_from_simple_hot_water_storage())
 
     def get_default_connections_from_heat_distribution_controller(
         self,
     ):
         """Get default connections."""
         connections = []
-        hdsc_classname = (
-            heat_distribution_system.HeatDistributionController.get_classname()
-        )
+        hdsc_classname = heat_distribution_system.HeatDistributionController.get_classname()
         connections.append(
             ComponentConnection(
                 HeatPumpHplibController.HeatingFlowTemperatureFromHeatDistributionSystem,
@@ -827,9 +784,7 @@ class HeatPumpHplibController(Component):
 
         # Configuration
         self.mode = mode
-        self.temperature_offset_for_state_conditions_in_celsius = (
-            temperature_offset_for_state_conditions_in_celsius
-        )
+        self.temperature_offset_for_state_conditions_in_celsius = temperature_offset_for_state_conditions_in_celsius
 
     def i_prepare_simulation(self) -> None:
         """Prepare the simulation."""
@@ -851,9 +806,7 @@ class HeatPumpHplibController(Component):
         """Write important variables to report."""
         return self.heatpump_controller_config.get_string_dict()
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the heat pump comtroller."""
 
         if force_convergence:
@@ -861,14 +814,12 @@ class HeatPumpHplibController(Component):
         else:
             # Retrieves inputs
 
-            water_temperature_input_from_heat_water_storage_in_celsius = (
-                stsv.get_input_value(self.water_temperature_input_channel)
+            water_temperature_input_from_heat_water_storage_in_celsius = stsv.get_input_value(
+                self.water_temperature_input_channel
             )
 
-            heating_flow_temperature_from_heat_distribution_system = (
-                stsv.get_input_value(
-                    self.heating_flow_temperature_from_heat_distribution_system_channel
-                )
+            heating_flow_temperature_from_heat_distribution_system = stsv.get_input_value(
+                self.heating_flow_temperature_from_heat_distribution_system_channel
             )
 
             daily_avg_outside_temperature_in_celsius = stsv.get_input_value(
@@ -896,11 +847,7 @@ class HeatPumpHplibController(Component):
                 )
 
             # mode 2 is regulated controller (meaning heating, cooling, off). this is only possible if heating system is floor heating
-            elif (
-                self.mode == 2
-                and self.heat_distribution_system_type
-                == HeatDistributionSystemType.FLOORHEATING
-            ):
+            elif self.mode == 2 and self.heat_distribution_system_type == HeatDistributionSystemType.FLOORHEATING:
                 # turning heat pump cooling mode off when the average daily outside temperature is below a certain threshold
                 summer_cooling_mode = self.summer_cooling_condition(
                     daily_average_outside_temperature_in_celsius=daily_avg_outside_temperature_in_celsius,
@@ -957,7 +904,6 @@ class HeatPumpHplibController(Component):
                 return
 
         elif self.controller_heatpumpmode == "off":
-
             # heat pump is only turned on if the water temperature is below the flow temperature
             # and if the avg daily outside temperature is cold enough (summer mode on)
             if (
@@ -1000,15 +946,11 @@ class HeatPumpHplibController(Component):
                 self.controller_heatpumpmode = "off"
                 return
         elif self.controller_heatpumpmode == "cooling":
-            if (
-                water_temperature_input_in_celsius <= cooling_set_temperature
-                or summer_cooling_mode == "off"
-            ):
+            if water_temperature_input_in_celsius <= cooling_set_temperature or summer_cooling_mode == "off":
                 self.controller_heatpumpmode = "off"
                 return
 
         elif self.controller_heatpumpmode == "off":
-
             # heat pump is only turned on if the water temperature is below the flow temperature
             # and if the avg daily outside temperature is cold enough (summer heating mode on)
             if (
@@ -1027,10 +969,7 @@ class HeatPumpHplibController(Component):
             # and if the avg daily outside temperature is warm enough (summer cooling mode on)
             if (
                 water_temperature_input_in_celsius
-                > (
-                    cooling_set_temperature
-                    + temperature_offset_for_state_conditions_in_celsius
-                )
+                > (cooling_set_temperature + temperature_offset_for_state_conditions_in_celsius)
                 and summer_cooling_mode == "on"
             ):
                 self.controller_heatpumpmode = "cooling"
@@ -1051,17 +990,11 @@ class HeatPumpHplibController(Component):
             heating_mode = "on"
 
         # it is too hot for heating
-        elif (
-            daily_average_outside_temperature_in_celsius
-            > set_heating_threshold_temperature_in_celsius
-        ):
+        elif daily_average_outside_temperature_in_celsius > set_heating_threshold_temperature_in_celsius:
             heating_mode = "off"
 
         # it is cold enough for heating
-        elif (
-            daily_average_outside_temperature_in_celsius
-            < set_heating_threshold_temperature_in_celsius
-        ):
+        elif daily_average_outside_temperature_in_celsius < set_heating_threshold_temperature_in_celsius:
             heating_mode = "on"
 
         else:
@@ -1083,17 +1016,11 @@ class HeatPumpHplibController(Component):
             cooling_mode = "on"
 
         # it is hot enough for cooling
-        elif (
-            daily_average_outside_temperature_in_celsius
-            > set_cooling_threshold_temperature_in_celsius
-        ):
+        elif daily_average_outside_temperature_in_celsius > set_cooling_threshold_temperature_in_celsius:
             cooling_mode = "on"
 
         # it is too cold for cooling
-        elif (
-            daily_average_outside_temperature_in_celsius
-            < set_cooling_threshold_temperature_in_celsius
-        ):
+        elif daily_average_outside_temperature_in_celsius < set_cooling_threshold_temperature_in_celsius:
             cooling_mode = "off"
 
         else:
@@ -1118,12 +1045,4 @@ class CalculationRequest(JSONWizard):
     def get_key(self):
         """Get key of class with important parameters."""
 
-        return (
-            str(self.t_in_primary)
-            + " "
-            + str(self.t_in_secondary)
-            + " "
-            + str(self.t_amb)
-            + " "
-            + str(self.mode)
-        )
+        return str(self.t_in_primary) + " " + str(self.t_in_secondary) + " " + str(self.t_amb) + " " + str(self.mode)

--- a/hisim/components/air_conditioner.py
+++ b/hisim/components/air_conditioner.py
@@ -286,9 +286,7 @@ class AirConditioner(cp.Component):
         )
 
         self.add_default_connections(self.get_default_connections_from_weather())
-        self.add_default_connections(
-            self.get_default_connections_from_air_condition_controller()
-        )
+        self.add_default_connections(self.get_default_connections_from_air_condition_controller())
 
         self.control = self.air_conditioner_config.control
 
@@ -382,13 +380,9 @@ class AirConditioner(cp.Component):
 
         """
 
-        for air_conditioner_tout in air_conditioner[
-            "Outdoor temperature range - cooling"
-        ]:
+        for air_conditioner_tout in air_conditioner["Outdoor temperature range - cooling"]:
             self.t_out_cooling_ref.append([air_conditioner_tout][0])
-        for air_conditioner_tout in air_conditioner[
-            "Outdoor temperature range - heating"
-        ]:
+        for air_conditioner_tout in air_conditioner["Outdoor temperature range - heating"]:
             self.t_out_heating_ref.append([air_conditioner_tout][0])
 
         for air_conditioner_eers in air_conditioner["EER W/W"]:
@@ -403,33 +397,21 @@ class AirConditioner(cp.Component):
         print(str(self.t_out_cooling_ref))
         print(str(self.eer_ref))
         self.eer_coef = np.polyfit(self.t_out_cooling_ref, self.eer_ref, 1)
-        self.cooling_capacity_coef = np.polyfit(
-            self.t_out_cooling_ref, self.cooling_capacity_ref, 1
-        )
+        self.cooling_capacity_coef = np.polyfit(self.t_out_cooling_ref, self.cooling_capacity_ref, 1)
 
         self.cop_coef = np.polyfit(self.t_out_heating_ref, self.cop_ref, 1)
-        self.heating_capacity_coef = np.polyfit(
-            self.t_out_heating_ref, self.heating_capacity_ref, 1
-        )
+        self.heating_capacity_coef = np.polyfit(self.t_out_heating_ref, self.heating_capacity_ref, 1)
 
         # Retrieves air conditioner from database - END
 
-        SingletonSimRepository().set_entry(
-            key=SingletonDictKeyEnum.COPCOEFFICIENTHEATING, entry=self.cop_coef
-        )
-        SingletonSimRepository().set_entry(
-            key=SingletonDictKeyEnum.EERCOEFFICIENTCOOLING, entry=self.eer_coef
-        )
+        SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.COPCOEFFICIENTHEATING, entry=self.cop_coef)
+        SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.EERCOEFFICIENTCOOLING, entry=self.eer_coef)
         # self.simulation_repository.set_entry(self.cop_coef_heating, self.cop_coef)
         # self.simulation_repository.set_entry(self.eer_coef_cooling, self.eer_coef)
 
         # Sets the time operation restricitions
-        self.on_time = (
-            self.min_operation_time / self.my_simulation_parameters.seconds_per_timestep
-        )
-        self.off_time = (
-            self.min_idle_time / self.my_simulation_parameters.seconds_per_timestep
-        )
+        self.on_time = self.min_operation_time / self.my_simulation_parameters.seconds_per_timestep
+        self.off_time = self.min_idle_time / self.my_simulation_parameters.seconds_per_timestep
 
         # self.state = AirConditionerState()
         # self.previous_state = AirConditionerState()
@@ -475,9 +457,7 @@ class AirConditioner(cp.Component):
         lines.append(f"Control: {self.control}")
         return self.air_conditioner_config.get_string_dict() + lines
 
-    def i_simulate(  # noqa: C901
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:  # noqa: C901
         """Core simulation function."""
         # Inputs
         t_out = stsv.get_input_value(self.t_out_channel)
@@ -497,21 +477,12 @@ class AirConditioner(cp.Component):
                 self.state0 = self.state.clone()
 
             # return device on if minimum operation time is not fulfilled and device was on in previous state
-            if (
-                self.state0.state == 1
-                and self.state0.timestep_of_last_action + self.on_time >= timestep
-            ):
+            if self.state0.state == 1 and self.state0.timestep_of_last_action + self.on_time >= timestep:
                 self.state.state = 1
-            elif (
-                self.state0.state == -1
-                and self.state0.timestep_of_last_action + self.on_time >= timestep
-            ):
+            elif self.state0.state == -1 and self.state0.timestep_of_last_action + self.on_time >= timestep:
                 self.state.state = -1
             # return device off if minimum idle time is not fulfilled and device was off in previous state
-            elif (
-                self.state0.state == 0
-                and self.state0.timestep_of_last_action + self.off_time >= timestep
-            ):
+            elif self.state0.state == 0 and self.state0.timestep_of_last_action + self.off_time >= timestep:
                 self.state.state = 0
             # check signal from l2 and turn on or off if it is necesary
             else:
@@ -531,9 +502,7 @@ class AirConditioner(cp.Component):
                 electricity_output = 0
 
             # log.information("thermal_energy_delivered {}".format(thermal_energy_delivered))
-            stsv.set_output_value(
-                self.thermal_energy_delivered_channel, thermal_energy_delivered
-            )
+            stsv.set_output_value(self.thermal_energy_delivered_channel, thermal_energy_delivered)
             stsv.set_output_value(self.electricity_output_channel, electricity_output)
             stsv.set_output_value(self.cooling_eer_channel, eer)
 
@@ -559,25 +528,15 @@ class AirConditioner(cp.Component):
                 thermal_energy_delivered = -15000
 
             stsv.set_output_value(self.electricity_output_channel, electricity_output)
-            stsv.set_output_value(
-                self.thermal_energy_delivered_channel, thermal_energy_delivered
-            )
+            stsv.set_output_value(self.thermal_energy_delivered_channel, thermal_energy_delivered)
 
         if self.control == "MPC":
             mode = stsv.get_input_value(self.operating_mode_channel)
-            optimal_electric_power_grid = stsv.get_input_value(
-                self.optimal_electric_power_grid_channel
-            )
-            optimal_electric_power_pv = stsv.get_input_value(
-                self.optimal_electric_power_pv_channel
-            )
-            optimal_electric_power_battery = stsv.get_input_value(
-                self.optimal_electric_power_battery_channel
-            )
+            optimal_electric_power_grid = stsv.get_input_value(self.optimal_electric_power_grid_channel)
+            optimal_electric_power_pv = stsv.get_input_value(self.optimal_electric_power_pv_channel)
+            optimal_electric_power_battery = stsv.get_input_value(self.optimal_electric_power_battery_channel)
             optimal_electric_power_total = (
-                optimal_electric_power_grid
-                + optimal_electric_power_pv
-                + optimal_electric_power_battery
+                optimal_electric_power_grid + optimal_electric_power_pv + optimal_electric_power_battery
             )
 
             if mode == 1:
@@ -593,9 +552,7 @@ class AirConditioner(cp.Component):
                 electricity_output = 0
 
             stsv.set_output_value(self.electricity_output_channel, electricity_output)
-            stsv.set_output_value(
-                self.thermal_energy_delivered_channel, thermal_energy_delivered
-            )
+            stsv.set_output_value(self.thermal_energy_delivered_channel, thermal_energy_delivered)
 
 
 class AirConditionerController(cp.Component):
@@ -676,9 +633,7 @@ class AirConditionerController(cp.Component):
 
     def get_default_connections_from_building(self):
         """Get default inputs from the building component."""
-        log.information(
-            "setting building default connections in AirConditionerController"
-        )
+        log.information("setting building default connections in AirConditionerController")
         connections = []
         building_classname = Building.get_classname()
         connections.append(
@@ -722,17 +677,11 @@ class AirConditionerController(cp.Component):
         lines = []
         lines.append("Air Conditioner Controller")
         lines.append("Control algorith of the Air conditioner is: on-off control\n")
-        lines.append(
-            f"Controller heating set temperature is {format(self.t_set_heating)} Deg C \n"
-        )
-        lines.append(
-            f"Controller cooling set temperature is {format(self.t_set_cooling)} Deg C \n"
-        )
+        lines.append(f"Controller heating set temperature is {format(self.t_set_heating)} Deg C \n")
+        lines.append(f"Controller cooling set temperature is {format(self.t_set_cooling)} Deg C \n")
         return self.air_conditioner_controller_config.get_string_dict() + lines
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Core simulation."""
         # check demand, and change state of self.has_heating_demand, and self._has_cooling_demand
         if force_convergence:

--- a/hisim/components/building.py
+++ b/hisim/components/building.py
@@ -129,23 +129,20 @@ class BuildingState:
     ):
         """Construct all the neccessary attributes for the BuildingState object."""
         # this is labeled as t_m in the paper [1] (** Check header)
-        self.thermal_mass_temperature_in_celsius: float = (
-            thermal_mass_temperature_in_celsius
-        )
+        self.thermal_mass_temperature_in_celsius: float = thermal_mass_temperature_in_celsius
 
         # this is labeled as c_m in the paper [1] (** Check header)
-        self.thermal_capacitance_in_joule_per_kelvin: float = (
-            thermal_capacitance_in_joule_per_kelvin
-        )
+        self.thermal_capacitance_in_joule_per_kelvin: float = thermal_capacitance_in_joule_per_kelvin
 
-    def calc_stored_thermal_power_in_watt(self,) -> float:
+    def calc_stored_thermal_power_in_watt(
+        self,
+    ) -> float:
         """Calculate the thermal power stored by the thermal mass per second."""
-        return (
-            self.thermal_mass_temperature_in_celsius
-            * self.thermal_capacitance_in_joule_per_kelvin
-        ) / 3600
+        return (self.thermal_mass_temperature_in_celsius * self.thermal_capacitance_in_joule_per_kelvin) / 3600
 
-    def self_copy(self,):
+    def self_copy(
+        self,
+    ):
         """Copy the Building State."""
         return BuildingState(
             self.thermal_mass_temperature_in_celsius,
@@ -215,7 +212,9 @@ class Building(cp.Component):
 
     @utils.measure_execution_time
     def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: BuildingConfig,
+        self,
+        my_simulation_parameters: SimulationParameters,
+        config: BuildingConfig,
     ):
         """Construct all the neccessary attributes."""
         self.buildingconfig = config
@@ -229,16 +228,17 @@ class Building(cp.Component):
         # =================================================================================================================================
         # Initialization of variables
 
-        self.set_heating_temperature_in_celsius = (
-            self.buildingconfig.set_heating_temperature_in_celsius
-        )
-        self.set_cooling_temperature_in_celsius = (
-            self.buildingconfig.set_cooling_temperature_in_celsius
-        )
+        self.set_heating_temperature_in_celsius = self.buildingconfig.set_heating_temperature_in_celsius
+        self.set_cooling_temperature_in_celsius = self.buildingconfig.set_cooling_temperature_in_celsius
         self.window_open: int = 0
 
-        (self.is_in_cache, self.cache_file_path,) = utils.get_cache_file(
-            self.component_name, self.buildingconfig, self.my_simulation_parameters,
+        (
+            self.is_in_cache,
+            self.cache_file_path,
+        ) = utils.get_cache_file(
+            self.component_name,
+            self.buildingconfig,
+            self.my_simulation_parameters,
         )
 
         self.cache: List[float]
@@ -278,7 +278,11 @@ class Building(cp.Component):
             True,
         )
         self.azimuth_channel: cp.ComponentInput = self.add_input(
-            self.component_name, self.Azimuth, lt.LoadTypes.ANY, lt.Units.DEGREES, True,
+            self.component_name,
+            self.Azimuth,
+            lt.LoadTypes.ANY,
+            lt.Units.DEGREES,
+            True,
         )
         self.apparent_zenith_channel: cp.ComponentInput = self.add_input(
             self.component_name,
@@ -429,24 +433,32 @@ class Building(cp.Component):
         self.add_default_connections(self.get_default_connections_from_hds())
         self.add_default_connections(self.get_default_connections_from_outdated_occupancy())
 
-    def get_default_connections_from_weather(self,):
+    def get_default_connections_from_weather(
+        self,
+    ):
         """Get weather default connnections."""
 
         connections = []
         weather_classname = Weather.get_classname()
         connections.append(
             cp.ComponentConnection(
-                Building.Altitude, weather_classname, Weather.Altitude,
+                Building.Altitude,
+                weather_classname,
+                Weather.Altitude,
             )
         )
         connections.append(
             cp.ComponentConnection(
-                Building.Azimuth, weather_classname, Weather.Azimuth,
+                Building.Azimuth,
+                weather_classname,
+                Weather.Azimuth,
             )
         )
         connections.append(
             cp.ComponentConnection(
-                Building.ApparentZenith, weather_classname, Weather.ApparentZenith,
+                Building.ApparentZenith,
+                weather_classname,
+                Weather.ApparentZenith,
             )
         )
         connections.append(
@@ -486,7 +498,9 @@ class Building(cp.Component):
         )
         return connections
 
-    def get_default_connections_from_utsp_occupancy(self,):
+    def get_default_connections_from_utsp_occupancy(
+        self,
+    ):
         """Get UTSP default connections."""
 
         connections = []
@@ -507,7 +521,9 @@ class Building(cp.Component):
         )
         return connections
 
-    def get_default_connections_from_outdated_occupancy(self,):
+    def get_default_connections_from_outdated_occupancy(
+        self,
+    ):
         """Get occupancy default connections."""
 
         connections = []
@@ -528,7 +544,9 @@ class Building(cp.Component):
         )
         return connections
 
-    def get_default_connections_from_hds(self,):
+    def get_default_connections_from_hds(
+        self,
+    ):
         """Get heat distribution default connections."""
 
         # use importlib for importing the other component in order to avoid circular-import errors
@@ -549,59 +567,39 @@ class Building(cp.Component):
     # =================================================================================================================================
     # Simulation of the building class
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the thermal behaviour of the building."""
 
         # Gets inputs
         if hasattr(self, "solar_gain_through_windows") is False:
             azimuth = stsv.get_input_value(self.azimuth_channel)
-            direct_normal_irradiance = stsv.get_input_value(
-                self.direct_normal_irradiance_channel
-            )
-            direct_horizontal_irradiance = stsv.get_input_value(
-                self.direct_horizontal_irradiance_channel
-            )
-            global_horizontal_irradiance = stsv.get_input_value(
-                self.global_horizontal_irradiance_channel
-            )
-            direct_normal_irradiance_extra = stsv.get_input_value(
-                self.direct_normal_irradiance_extra_channel
-            )
+            direct_normal_irradiance = stsv.get_input_value(self.direct_normal_irradiance_channel)
+            direct_horizontal_irradiance = stsv.get_input_value(self.direct_horizontal_irradiance_channel)
+            global_horizontal_irradiance = stsv.get_input_value(self.global_horizontal_irradiance_channel)
+            direct_normal_irradiance_extra = stsv.get_input_value(self.direct_normal_irradiance_extra_channel)
             apparent_zenith = stsv.get_input_value(self.apparent_zenith_channel)
 
-        internal_heat_gains_through_occupancy_in_watt = stsv.get_input_value(
-            self.occupancy_heat_gain_channel
-        )
+        internal_heat_gains_through_occupancy_in_watt = stsv.get_input_value(self.occupancy_heat_gain_channel)
 
         internal_heat_gains_through_devices_in_watt = 0.0  # stsv.get_input_value(
         #     self.device_heat_gain_channel
         # )
 
-        temperature_outside_in_celsius = stsv.get_input_value(
-            self.temperature_outside_channel
-        )
+        temperature_outside_in_celsius = stsv.get_input_value(self.temperature_outside_channel)
 
-        building_temperature_modifier = stsv.get_input_value(
-            self.building_temperature_modifier_channel
-        )
+        building_temperature_modifier = stsv.get_input_value(self.building_temperature_modifier_channel)
 
         thermal_power_delivered_in_watt = 0.0
         if self.thermal_power_delivered_channel.source_output is not None:
-            thermal_power_delivered_in_watt = (
-                thermal_power_delivered_in_watt
-                + stsv.get_input_value(self.thermal_power_delivered_channel)
+            thermal_power_delivered_in_watt = thermal_power_delivered_in_watt + stsv.get_input_value(
+                self.thermal_power_delivered_channel
             )
         if self.thermal_power_chp_channel.source_output is not None:
-            thermal_power_delivered_in_watt = (
-                thermal_power_delivered_in_watt
-                + stsv.get_input_value(self.thermal_power_chp_channel)
+            thermal_power_delivered_in_watt = thermal_power_delivered_in_watt + stsv.get_input_value(
+                self.thermal_power_chp_channel
             )
 
-        previous_thermal_mass_temperature_in_celsius = (
-            self.state.thermal_mass_temperature_in_celsius
-        )
+        previous_thermal_mass_temperature_in_celsius = self.state.thermal_mass_temperature_in_celsius
 
         # Performs calculations
         if hasattr(self, "solar_gain_through_windows") is False:
@@ -614,9 +612,7 @@ class Building(cp.Component):
                 apparent_zenith=apparent_zenith,
             )
         else:
-            solar_heat_gain_through_windows = self.solar_heat_gain_through_windows[
-                timestep
-            ]
+            solar_heat_gain_through_windows = self.solar_heat_gain_through_windows[timestep]
 
         (
             thermal_mass_average_bulk_temperature_in_celsius,
@@ -635,9 +631,7 @@ class Building(cp.Component):
             outside_temperature_in_celsius=temperature_outside_in_celsius,
             thermal_mass_temperature_prev_in_celsius=previous_thermal_mass_temperature_in_celsius,
         )
-        self.state.thermal_mass_temperature_in_celsius = (
-            thermal_mass_average_bulk_temperature_in_celsius
-        )
+        self.state.thermal_mass_temperature_in_celsius = thermal_mass_average_bulk_temperature_in_celsius
 
         # if indoor temperature is too high make complete air exchange by opening the windows until outdoor temperature or set_heating_temperature + 1°C is reached
         if (
@@ -680,18 +674,18 @@ class Building(cp.Component):
         )
 
         stsv.set_output_value(
-            self.indoor_air_temperature_channel, indoor_air_temperature_in_celsius,
+            self.indoor_air_temperature_channel,
+            indoor_air_temperature_in_celsius,
         )
 
         # phi_loss is already given in W, time correction factor applied to thermal transmittance h_tr
         stsv.set_output_value(self.total_power_to_residence_channel, heat_loss_in_watt)
 
-        stsv.set_output_value(
-            self.solar_gain_through_windows_channel, solar_heat_gain_through_windows
-        )
+        stsv.set_output_value(self.solar_gain_through_windows_channel, solar_heat_gain_through_windows)
 
         stsv.set_output_value(
-            self.heat_loss_channel, heat_loss_in_watt,
+            self.heat_loss_channel,
+            heat_loss_in_watt,
         )
 
         stsv.set_output_value(
@@ -708,7 +702,8 @@ class Building(cp.Component):
             heat_flux_internal_room_surface_in_watt,
         )
         stsv.set_output_value(
-            self.open_window_channel, self.window_open,
+            self.open_window_channel,
+            self.window_open,
         )
 
         # Saves solar gains cache
@@ -716,22 +711,29 @@ class Building(cp.Component):
             self.cache[timestep] = solar_heat_gain_through_windows
             if timestep + 1 == self.my_simulation_parameters.timesteps:
                 database = pd.DataFrame(
-                    self.cache, columns=["solar_gain_through_windows"],
+                    self.cache,
+                    columns=["solar_gain_through_windows"],
                 )
                 database.to_csv(
-                    self.cache_file_path, sep=",", decimal=".", index=False,
+                    self.cache_file_path,
+                    sep=",",
+                    decimal=".",
+                    index=False,
                 )
 
     # =================================================================================================================================
 
-    def i_save_state(self,) -> None:
+    def i_save_state(
+        self,
+    ) -> None:
         """Save the current state."""
         self.previous_state = self.state.self_copy()
 
-    def i_prepare_simulation(self,) -> None:
+    def i_prepare_simulation(
+        self,
+    ) -> None:
         """Prepare the simulation."""
         if self.buildingconfig.predictive:
-
             # get weather forecast to compute forecasted solar gains
             # ambient_temperature_forecast = SingletonSimRepository().get_entry(
             #     key=SingletonDictKeyEnum.Weather_TemperatureOutside_yearly_forecast
@@ -739,9 +741,7 @@ class Building(cp.Component):
             # altitude_forecast = SingletonSimRepository().get_entry(
             #     key=SingletonDictKeyEnum.Weather_Altitude_yearly_forecast
             # )
-            azimuth_forecast = SingletonSimRepository().get_entry(
-                key=SingletonDictKeyEnum.WEATHERAZIMUTHYEARLYFORECAST
-            )
+            azimuth_forecast = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.WEATHERAZIMUTHYEARLYFORECAST)
             apparent_zenith_forecast = SingletonSimRepository().get_entry(
                 key=SingletonDictKeyEnum.WEATHERAPPARENTZENITHYEARLYFORECAST
             )
@@ -763,15 +763,9 @@ class Building(cp.Component):
                 solar_gains_forecast_yearly = self.get_solar_heat_gain_through_windows(
                     azimuth=azimuth_forecast[i],
                     direct_normal_irradiance=direct_normal_irradiance_forecast[i],
-                    direct_horizontal_irradiance=direct_horizontal_irradiance_forecast[
-                        i
-                    ],
-                    global_horizontal_irradiance=global_horizontal_irradiance_forecast[
-                        i
-                    ],
-                    direct_normal_irradiance_extra=direct_normal_irradiance_extra_forecast[
-                        i
-                    ],
+                    direct_horizontal_irradiance=direct_horizontal_irradiance_forecast[i],
+                    global_horizontal_irradiance=global_horizontal_irradiance_forecast[i],
+                    direct_normal_irradiance_extra=direct_normal_irradiance_extra_forecast[i],
                     apparent_zenith=apparent_zenith_forecast[i],
                 )
 
@@ -787,8 +781,14 @@ class Building(cp.Component):
             phi_st_forecast: list = []
             phi_ia_forecast: list = []
             for i in range(self.my_simulation_parameters.timesteps):
-                (_, phi_ia_yearly, phi_st_yearly, phi_m_yearly,) = self.calc_heat_flow(
-                    internal_gains_forecast[i], solar_gains_forecast[i],
+                (
+                    _,
+                    phi_ia_yearly,
+                    phi_st_yearly,
+                    phi_m_yearly,
+                ) = self.calc_heat_flow(
+                    internal_gains_forecast[i],
+                    solar_gains_forecast[i],
                 )
                 phi_m_forecast.append(phi_m_yearly)
                 phi_st_forecast.append(phi_st_yearly)
@@ -808,15 +808,23 @@ class Building(cp.Component):
                 entry=phi_ia_forecast,
             )
 
-    def i_restore_state(self,) -> None:
+    def i_restore_state(
+        self,
+    ) -> None:
         """Restore the previous state."""
         self.state = self.previous_state.self_copy()
 
-    def i_doublecheck(self, timestep: int, stsv: cp.SingleTimeStepValues,) -> None:
+    def i_doublecheck(
+        self,
+        timestep: int,
+        stsv: cp.SingleTimeStepValues,
+    ) -> None:
         """Doublecheck."""
         pass
 
-    def build(self,):
+    def build(
+        self,
+    ):
         """Build function.
 
         The function sets important constants and parameters for the calculations.
@@ -866,7 +874,9 @@ class Building(cp.Component):
         # Get windows
         self.windows, self.total_scaled_windows_area = self.get_windows()
 
-    def get_windows(self,):
+    def get_windows(
+        self,
+    ):
         """Retrieve data about windows sizes.
 
         :return:
@@ -884,31 +894,16 @@ class Building(cp.Component):
             "Horizontal": None,
         }
 
-        reduction_factor_for_non_perpedicular_radiation = self.my_building_information.buildingdata[
-            "F_w"
-        ].values[
-            0
-        ]
-        reduction_factor_for_frame_area_fraction_of_window = self.my_building_information.buildingdata[
-            "F_f"
-        ].values[
-            0
-        ]
-        reduction_factor_for_external_vertical_shading = self.my_building_information.buildingdata[
-            "F_sh_vert"
-        ].values[
+        reduction_factor_for_non_perpedicular_radiation = self.my_building_information.buildingdata["F_w"].values[0]
+        reduction_factor_for_frame_area_fraction_of_window = self.my_building_information.buildingdata["F_f"].values[0]
+        reduction_factor_for_external_vertical_shading = self.my_building_information.buildingdata["F_sh_vert"].values[
             0
         ]
         total_solar_energy_transmittance_for_perpedicular_radiation = self.my_building_information.buildingdata[
             "g_gl_n"
-        ].values[
-            0
-        ]
+        ].values[0]
 
-        for index, windows_direction in enumerate(
-            self.my_building_information.windows_directions
-        ):
-
+        for index, windows_direction in enumerate(self.my_building_information.windows_directions):
             if windows_direction == "Horizontal":
                 window_tilt_angle = 0
             else:
@@ -926,44 +921,45 @@ class Building(cp.Component):
                 )
             )
 
-            total_windows_area += self.my_building_information.scaled_window_areas_in_m2[
-                index
-            ]
+            total_windows_area += self.my_building_information.scaled_window_areas_in_m2[index]
         # if nothing exists, initialize the empty arrays for caching, else read stuff
-        if (
-            not self.is_in_cache
-        ):  # cache_filepath is None or  (not os.path.isfile(cache_filepath)):
+        if not self.is_in_cache:  # cache_filepath is None or  (not os.path.isfile(cache_filepath)):
             self.cache = [0] * self.my_simulation_parameters.timesteps
         else:
             self.solar_heat_gain_through_windows = pd.read_csv(
-                self.cache_file_path, sep=",", decimal=".",
+                self.cache_file_path,
+                sep=",",
+                decimal=".",
             )["solar_gain_through_windows"].tolist()
 
         return windows, total_windows_area
 
     # =====================================================================================================================================
 
-    def __str__(self,):
+    def __str__(
+        self,
+    ):
         """Return lines from report as string format."""
         entire = str()
         lines = self.write_to_report()
-        for (index, line,) in enumerate(lines):
+        for (
+            index,
+            line,
+        ) in enumerate(lines):
             if index == 0:
                 entire = line
             else:
                 entire = f"{entire}\n{line}"
         return entire
 
-    def write_to_report(self,):
+    def write_to_report(
+        self,
+    ):
         """Write important variables to report."""
         lines = []
 
-        lines.append(
-            f"Max Thermal Demand [W]: {self.my_building_information.max_thermal_building_demand_in_watt}"
-        )
-        lines.append(
-            "-------------------------------------------------------------------------------------------"
-        )
+        lines.append(f"Max Thermal Demand [W]: {self.my_building_information.max_thermal_building_demand_in_watt}")
+        lines.append("-------------------------------------------------------------------------------------------")
         lines.append("Building Thermal Conductances:")
         lines.append("--------------------------------------------")
         lines.append(
@@ -988,17 +984,11 @@ class Building(cp.Component):
             f"{self.my_building_information.heat_transfer_coeff_by_ventilation_reference_in_watt_per_kelvin:.2f}"
         )
 
-        lines.append(
-            "-------------------------------------------------------------------------------------------"
-        )
+        lines.append("-------------------------------------------------------------------------------------------")
         lines.append("Building Construction:")
         lines.append("--------------------------------------------")
-        lines.append(
-            f"Number of Apartments: {self.my_building_information.number_of_apartments}"
-        )
-        lines.append(
-            f"Number of Storeys: {self.my_building_information.number_of_storeys}"
-        )
+        lines.append(f"Number of Apartments: {self.my_building_information.number_of_apartments}")
+        lines.append(f"Number of Storeys: {self.my_building_information.number_of_storeys}")
         lines.append(
             f"Conditioned Floor Area (A_f) [m2]: {self.my_building_information.scaled_conditioned_floor_area_in_m2:.2f}"
         )
@@ -1011,9 +1001,7 @@ class Building(cp.Component):
 
         lines.append(f"Total Window Area [m2]: {self.total_scaled_windows_area:.2f}")
 
-        lines.append(
-            "-------------------------------------------------------------------------------------------"
-        )
+        lines.append("-------------------------------------------------------------------------------------------")
         lines.append("Building Thermal Capacitances:")
         lines.append("--------------------------------------------")
         lines.append(
@@ -1024,9 +1012,7 @@ class Building(cp.Component):
             f"Floor Related Thermal Capacitance of Thermal Mass, based on TABULA [Wh/m2.K]: "
             f"{(self.my_building_information.thermal_capacity_of_building_thermal_mass_reference_in_watthour_per_m2_per_kelvin):.2f}"
         )
-        lines.append(
-            "-------------------------------------------------------------------------------------------"
-        )
+        lines.append("-------------------------------------------------------------------------------------------")
         lines.append("Building Heat Transfers:")
         lines.append("--------------------------------------------")
         lines.append(
@@ -1052,7 +1038,9 @@ class Building(cp.Component):
     # (**/*** Check header)
 
     @property
-    def transmission_heat_transfer_coeff_1_in_watt_per_kelvin(self,):
+    def transmission_heat_transfer_coeff_1_in_watt_per_kelvin(
+        self,
+    ):
         """Definition to simplify calc_phi_m_tot. Long form for H_tr_1.
 
         # (C.6) in [C.3 ISO 13790]
@@ -1060,12 +1048,13 @@ class Building(cp.Component):
         """
         return 1.0 / (
             1.0 / self.thermal_conductance_by_ventilation_in_watt_per_kelvin
-            + 1.0
-            / self.heat_transfer_coeff_indoor_air_and_internal_surface_in_watt_per_kelvin
+            + 1.0 / self.heat_transfer_coeff_indoor_air_and_internal_surface_in_watt_per_kelvin
         )
 
     @property
-    def transmission_heat_transfer_coeff_2_in_watt_per_kelvin(self,):
+    def transmission_heat_transfer_coeff_2_in_watt_per_kelvin(
+        self,
+    ):
         """Definition to simplify calc_phi_m_tot. Long form for H_tr_2.
 
         # (C.7) in [C.3 ISO 13790]
@@ -1077,7 +1066,9 @@ class Building(cp.Component):
         )
 
     @property
-    def transmission_heat_transfer_coeff_3_in_watt_per_kelvin(self,):
+    def transmission_heat_transfer_coeff_3_in_watt_per_kelvin(
+        self,
+    ):
         """Definition to simplify calc_phi_m_tot. Long form for H_tr_3.
 
         # (C.8) in [C.3 ISO 13790]
@@ -1085,8 +1076,7 @@ class Building(cp.Component):
         """
         return 1.0 / (
             1.0 / self.transmission_heat_transfer_coeff_2_in_watt_per_kelvin
-            + 1.0
-            / self.internal_part_of_transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin
+            + 1.0 / self.internal_part_of_transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin
         )
 
     def get_thermal_conductance_between_exterior_and_windows_and_door_in_watt_per_kelvin(
@@ -1104,14 +1094,10 @@ class Building(cp.Component):
             # with with H_Tr = U * A * b_tr [W/K], here b_tr is not given in TABULA data, so it is chosen 1.0
             h_tr_i = (
                 self.my_building_information.buildingdata["U_Actual_" + w_i].values[0]
-                * self.my_building_information.scaled_windows_and_door_envelope_areas_in_m2[
-                    index
-                ]
+                * self.my_building_information.scaled_windows_and_door_envelope_areas_in_m2[index]
                 * 1.0
             )
-            transmission_heat_transfer_coeff_windows_and_door_in_watt_per_kelvin += float(
-                h_tr_i
-            )
+            transmission_heat_transfer_coeff_windows_and_door_in_watt_per_kelvin += float(h_tr_i)
 
         return transmission_heat_transfer_coeff_windows_and_door_in_watt_per_kelvin
 
@@ -1143,33 +1129,17 @@ class Building(cp.Component):
             # with with H_Tr = U * A * b_tr [W/K]
             h_tr_i = (
                 self.my_building_information.buildingdata["U_Actual_" + o_w].values[0]
-                * self.my_building_information.scaled_opaque_surfaces_envelope_area_in_m2[
-                    index
-                ]
-                * self.my_building_information.buildingdata[
-                    "b_Transmission_" + o_w
-                ].values[0]
+                * self.my_building_information.scaled_opaque_surfaces_envelope_area_in_m2[index]
+                * self.my_building_information.buildingdata["b_Transmission_" + o_w].values[0]
             )
-            transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin += float(
-                h_tr_i
-            )
+            transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin += float(h_tr_i)
         if (
             transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin != 0
-            and internal_part_of_transmission_coeff_opaque_elements_in_watt_per_kelvin
-            != 0
+            and internal_part_of_transmission_coeff_opaque_elements_in_watt_per_kelvin != 0
         ):
-            external_part_of_transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin = (
-                1
-                / (
-                    (
-                        1
-                        / transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin
-                    )
-                    - (
-                        1
-                        / internal_part_of_transmission_coeff_opaque_elements_in_watt_per_kelvin
-                    )
-                )
+            external_part_of_transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin = 1 / (
+                (1 / transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin)
+                - (1 / internal_part_of_transmission_coeff_opaque_elements_in_watt_per_kelvin)
             )
 
         return (
@@ -1190,7 +1160,9 @@ class Building(cp.Component):
 
         return heat_transfer_coeff_indoor_air_and_internal_surface_in_watt_per_kelvin
 
-    def get_thermal_conductance_ventilation_in_watt_per_kelvin(self,) -> float:
+    def get_thermal_conductance_ventilation_in_watt_per_kelvin(
+        self,
+    ) -> float:
         """Based on the EPISCOPE TABULA (* Check header)."""
         # Long from for H_ve_adj: Ventilation
         # Determine the ventilation conductance
@@ -1200,9 +1172,7 @@ class Building(cp.Component):
             heat_capacity_of_air_per_volume_in_watt_hour_per_m3_per_kelvin
             * float(
                 self.my_building_information.buildingdata["n_air_use"].iloc[0]
-                + self.my_building_information.buildingdata["n_air_infiltration"].iloc[
-                    0
-                ]
+                + self.my_building_information.buildingdata["n_air_infiltration"].iloc[0]
             )
             * self.my_building_information.scaled_conditioned_floor_area_in_m2
             * float(self.my_building_information.buildingdata["h_room"].iloc[0])
@@ -1210,7 +1180,9 @@ class Building(cp.Component):
 
         return thermal_conductance_by_ventilation_in_watt_per_kelvin
 
-    def get_conductances(self,) -> Tuple[float, float, float, float, float, float]:
+    def get_conductances(
+        self,
+    ) -> Tuple[float, float, float, float, float, float]:
         """Get the thermal conductances based on the norm EN ISO 13970.
 
         :key
@@ -1268,12 +1240,7 @@ class Building(cp.Component):
         """
         solar_heat_gains = 0.0
 
-        if (
-            direct_normal_irradiance != 0
-            or direct_horizontal_irradiance != 0
-            or global_horizontal_irradiance != 0
-        ):
-
+        if direct_normal_irradiance != 0 or direct_horizontal_irradiance != 0 or global_horizontal_irradiance != 0:
             for window in self.windows:
                 solar_heat_gain = window.calc_solar_heat_gains(
                     sun_azimuth=azimuth,
@@ -1452,10 +1419,7 @@ class Building(cp.Component):
         # (C.9) in [C.3 ISO 13790]
         Based on the RC_BuildingSimulator project @[rc_buildingsimulator-jayathissa] (** Check header)
         """
-        return (
-            previous_thermal_mass_temperature_in_celsius
-            + next_thermal_mass_temperature_in_celsius
-        ) / 2
+        return (previous_thermal_mass_temperature_in_celsius + next_thermal_mass_temperature_in_celsius) / 2
 
     def calc_temperature_of_internal_room_surfaces_in_celsius(
         self,
@@ -1479,8 +1443,7 @@ class Building(cp.Component):
             self.internal_part_of_transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin
             * thermal_mass_temperature_in_celsius
             + heat_flux_internal_room_surface_in_watt
-            + self.transmission_heat_transfer_coeff_windows_and_door_in_watt_per_kelvin
-            * temperature_outside_in_celsius
+            + self.transmission_heat_transfer_coeff_windows_and_door_in_watt_per_kelvin * temperature_outside_in_celsius
             + self.transmission_heat_transfer_coeff_1_in_watt_per_kelvin
             * (
                 t_supply
@@ -1543,7 +1506,10 @@ class Building(cp.Component):
             heat_flux_internal_room_surface_in_watt,
             heat_flux_thermal_mass_in_watt,
             heat_loss_in_watt,
-        ) = self.calc_heat_flow(internal_heat_gains_in_watt, solar_heat_gains_in_watt,)
+        ) = self.calc_heat_flow(
+            internal_heat_gains_in_watt,
+            solar_heat_gains_in_watt,
+        )
 
         # Updates total flow
         equivalent_heat_flux_in_watt = self.calc_equivalent_heat_flux_in_watt(
@@ -1561,9 +1527,11 @@ class Building(cp.Component):
         )
 
         # calculates the AVERAGE bulk temperature used for the remaining
-        thermal_mass_average_bulk_temperature_in_celsius = self.calc_thermal_mass_averag_bulk_temperature_in_celsius_used_for_calculations(
-            previous_thermal_mass_temperature_in_celsius=thermal_mass_temperature_prev_in_celsius,
-            next_thermal_mass_temperature_in_celsius=next_thermal_mass_temperature_in_celsius,
+        thermal_mass_average_bulk_temperature_in_celsius = (
+            self.calc_thermal_mass_averag_bulk_temperature_in_celsius_used_for_calculations(
+                previous_thermal_mass_temperature_in_celsius=thermal_mass_temperature_prev_in_celsius,
+                next_thermal_mass_temperature_in_celsius=next_thermal_mass_temperature_in_celsius,
+            )
         )
 
         # keep these calculations if later you are interested in the indoor surface or air temperature
@@ -1630,8 +1598,7 @@ class Building(cp.Component):
 
         elif (
             indoor_air_temperature_zero_in_celsius > set_cooling_temperature_in_celsius
-            or indoor_air_temperature_zero_in_celsius
-            < set_heating_temperature_in_celsius
+            or indoor_air_temperature_zero_in_celsius < set_heating_temperature_in_celsius
         ):
             # step2, heating or cooling is needed, calculate air temperature when therma power delivered is 10 W/m2
             (
@@ -1645,26 +1612,18 @@ class Building(cp.Component):
                 heat_flux_internal_room_surface_in_watt=heat_flux_internal_room_surface_in_watt,
             )
             # set air temperature
-            if (
-                indoor_air_temperature_zero_in_celsius
-                > set_cooling_temperature_in_celsius
-            ):
-                indoor_air_temperature_set_in_celsius = (
-                    set_cooling_temperature_in_celsius
-                )
-            elif (
-                indoor_air_temperature_zero_in_celsius
-                < set_heating_temperature_in_celsius
-            ):
-                indoor_air_temperature_set_in_celsius = (
-                    set_heating_temperature_in_celsius
-                )
+            if indoor_air_temperature_zero_in_celsius > set_cooling_temperature_in_celsius:
+                indoor_air_temperature_set_in_celsius = set_cooling_temperature_in_celsius
+            elif indoor_air_temperature_zero_in_celsius < set_heating_temperature_in_celsius:
+                indoor_air_temperature_set_in_celsius = set_heating_temperature_in_celsius
 
-            theoretical_thermal_building_demand_in_watt = self.calc_theoretical_thermal_building_demand_when_heating_or_cooling_needed_step_two(
-                ten_thermal_power_delivered_in_watt=ten_thermal_power_delivered_in_watt,
-                indoor_air_temperature_zero_in_celsius=indoor_air_temperature_zero_in_celsius,
-                indoor_air_temperature_ten_in_celsius=indoor_air_temperature_ten_in_celsius,
-                indoor_air_temperature_set_in_celsius=indoor_air_temperature_set_in_celsius,
+            theoretical_thermal_building_demand_in_watt = (
+                self.calc_theoretical_thermal_building_demand_when_heating_or_cooling_needed_step_two(
+                    ten_thermal_power_delivered_in_watt=ten_thermal_power_delivered_in_watt,
+                    indoor_air_temperature_zero_in_celsius=indoor_air_temperature_zero_in_celsius,
+                    indoor_air_temperature_ten_in_celsius=indoor_air_temperature_ten_in_celsius,
+                    indoor_air_temperature_set_in_celsius=indoor_air_temperature_set_in_celsius,
+                )
             )
         else:
             raise ValueError(
@@ -1687,9 +1646,11 @@ class Building(cp.Component):
         zero_thermal_power_delivered_in_watt = 0
 
         # calculate temperatures (C.9 - C.11)
-        thermal_mass_average_bulk_temperature_in_celsius = self.calc_thermal_mass_averag_bulk_temperature_in_celsius_used_for_calculations(
-            previous_thermal_mass_temperature_in_celsius=previous_thermal_mass_temperature_in_celsius,
-            next_thermal_mass_temperature_in_celsius=next_thermal_mass_temperature_in_celsius,
+        thermal_mass_average_bulk_temperature_in_celsius = (
+            self.calc_thermal_mass_averag_bulk_temperature_in_celsius_used_for_calculations(
+                previous_thermal_mass_temperature_in_celsius=previous_thermal_mass_temperature_in_celsius,
+                next_thermal_mass_temperature_in_celsius=next_thermal_mass_temperature_in_celsius,
+            )
         )
 
         internal_room_surface_temperature_in_celsius = self.calc_temperature_of_internal_room_surfaces_in_celsius(
@@ -1720,14 +1681,15 @@ class Building(cp.Component):
         """Calculate indoor air temperature for thermal power delivered (Phi_HC_nd) of 10 W/m2 according to ISO 13790 (C.4.2)."""
         heating_power_in_watt_per_m2 = 10
         ten_thermal_power_delivered_in_watt = (
-            heating_power_in_watt_per_m2
-            * self.my_building_information.scaled_conditioned_floor_area_in_m2
+            heating_power_in_watt_per_m2 * self.my_building_information.scaled_conditioned_floor_area_in_m2
         )
 
         # calculate temperatures (C.9 - C.11)
-        thermal_mass_average_bulk_temperature_in_celsius = self.calc_thermal_mass_averag_bulk_temperature_in_celsius_used_for_calculations(
-            previous_thermal_mass_temperature_in_celsius=previous_thermal_mass_temperature_in_celsius,
-            next_thermal_mass_temperature_in_celsius=next_thermal_mass_temperature_in_celsius,
+        thermal_mass_average_bulk_temperature_in_celsius = (
+            self.calc_thermal_mass_averag_bulk_temperature_in_celsius_used_for_calculations(
+                previous_thermal_mass_temperature_in_celsius=previous_thermal_mass_temperature_in_celsius,
+                next_thermal_mass_temperature_in_celsius=next_thermal_mass_temperature_in_celsius,
+            )
         )
 
         internal_room_surface_temperature_in_celsius = self.calc_temperature_of_internal_room_surfaces_in_celsius(
@@ -1762,14 +1724,8 @@ class Building(cp.Component):
 
         theoretical_thermal_building_demand_in_watt = (
             ten_thermal_power_delivered_in_watt
-            * (
-                indoor_air_temperature_set_in_celsius
-                - indoor_air_temperature_zero_in_celsius
-            )
-            / (
-                indoor_air_temperature_ten_in_celsius
-                - indoor_air_temperature_zero_in_celsius
-            )
+            * (indoor_air_temperature_set_in_celsius - indoor_air_temperature_zero_in_celsius)
+            / (indoor_air_temperature_ten_in_celsius - indoor_air_temperature_zero_in_celsius)
         )
 
         return theoretical_thermal_building_demand_in_watt
@@ -1807,9 +1763,7 @@ class Window:
 
         # Reduction factors
         self.nonperpendicular_reduction_factor = nonperpendicular_reduction_factor
-        self.external_shading_vertical_reduction_factor = (
-            external_shading_vertical_reduction_factor
-        )
+        self.external_shading_vertical_reduction_factor = external_shading_vertical_reduction_factor
         self.frame_area_fraction_reduction_factor = frame_area_fraction_reduction_factor
 
         self.reduction_factor = (
@@ -1822,7 +1776,10 @@ class Window:
         self.reduction_factor_with_area = self.reduction_factor * self.area
 
     def calc_direct_solar_factor(
-        self, sun_altitude, sun_azimuth, apparent_zenith,
+        self,
+        sun_altitude,
+        sun_azimuth,
+        apparent_zenith,
     ):
         """Calculate the cosine of the angle of incidence on the window.
 
@@ -1847,7 +1804,9 @@ class Window:
 
         return direct_factor
 
-    def calc_diffuse_solar_factor(self,):
+    def calc_diffuse_solar_factor(
+        self,
+    ):
         """Calculate the proportion of diffuse radiation.
 
         Based on the RC_BuildingSimulator project @[rc_buildingsimulator-jayathissa] (** Check header)
@@ -1888,9 +1847,7 @@ class Window:
         if window_azimuth_angle is None:
             window_azimuth_angle = 0
             if self.warning_message_already_shown is False:
-                log.warning(
-                    "window azimuth angle was set to 0 south because no value was set."
-                )
+                log.warning("window azimuth angle was set to 0 south because no value was set.")
                 self.warning_message_already_shown = True
 
         poa_irrad = pvlib.irradiance.get_total_irradiance(
@@ -1933,17 +1890,13 @@ class BuildingInformation:
         self.build()
 
         # get set temperatures for building
-        self.set_heating_temperature_for_building_in_celsius = (
-            self.buildingconfig.set_heating_temperature_in_celsius
-        )
-        self.set_cooling_temperature_for_building_in_celsius = (
-            self.buildingconfig.set_cooling_temperature_in_celsius
-        )
-        self.heating_reference_temperature_in_celsius = (
-            self.buildingconfig.heating_reference_temperature_in_celsius
-        )
+        self.set_heating_temperature_for_building_in_celsius = self.buildingconfig.set_heating_temperature_in_celsius
+        self.set_cooling_temperature_for_building_in_celsius = self.buildingconfig.set_cooling_temperature_in_celsius
+        self.heating_reference_temperature_in_celsius = self.buildingconfig.heating_reference_temperature_in_celsius
 
-    def get_building(self,):
+    def get_building(
+        self,
+    ):
         """Get the building code from a TABULA building."""
         d_f = pd.read_csv(
             utils.HISIMPATH["housing"],
@@ -1954,28 +1907,20 @@ class BuildingInformation:
         )
 
         # Gets parameters from chosen building
-        self.buildingdata = d_f.loc[
-            d_f["Code_BuildingVariant"] == self.buildingconfig.building_code
-        ]
+        self.buildingdata = d_f.loc[d_f["Code_BuildingVariant"] == self.buildingconfig.building_code]
         self.buildingcode = self.buildingconfig.building_code
-        self.building_heat_capacity_class = (
-            self.buildingconfig.building_heat_capacity_class
-        )
+        self.building_heat_capacity_class = self.buildingconfig.building_heat_capacity_class
 
     def build(self):
         """Set important parameters."""
 
         # CONSTANTS
         # Heat transfer coefficient between nodes "m" and "s" (12.2.2 E64 P79); labeled as h_ms in paper [2] (*** Check header)
-        self.heat_transfer_coeff_thermal_mass_and_internal_surface_fixed_value_in_watt_per_m2_per_kelvin = (
-            9.1
-        )
+        self.heat_transfer_coeff_thermal_mass_and_internal_surface_fixed_value_in_watt_per_m2_per_kelvin = 9.1
         # Dimensionless ratio between surfaces and the useful surfaces (7.2.2.2 E9 P36); labeled as A_at in paper [2] (*** Check header); before lambda_at
         self.ratio_between_internal_surface_area_and_floor_area = 4.5
         # Heat transfer coefficient between nodes "air" and "s" (7.2.2.2 E9 P35); labeled as h_is in paper [2] (*** Check header)
-        self.heat_transfer_coeff_indoor_air_and_internal_surface_fixed_value_in_watt_per_m2_per_kelvin = (
-            3.45
-        )
+        self.heat_transfer_coeff_indoor_air_and_internal_surface_fixed_value_in_watt_per_m2_per_kelvin = 3.45
 
         self.building_heat_capacity_class_f_a = {
             "very light": 2.5,
@@ -2025,9 +1970,7 @@ class BuildingInformation:
         # Room Capacitance [J/K] (TABULA: Internal heat capacity) Ref: ISO standard 12.3.1.2
         # labeled as C_m in the paper [1] (** Check header), before c_m
         self.thermal_capacity_of_building_thermal_mass_in_joule_per_kelvin = (
-            self.building_heat_capacity_class_f_c_in_joule_per_m2_per_kelvin[
-                self.building_heat_capacity_class
-            ]
+            self.building_heat_capacity_class_f_c_in_joule_per_m2_per_kelvin[self.building_heat_capacity_class]
             * self.scaled_conditioned_floor_area_in_m2
         )
         # Room Capacitance [Wh/m2K] (TABULA: Internal heat capacity) Ref: ISO standard 12.3.1.2
@@ -2042,8 +1985,7 @@ class BuildingInformation:
         )
         # before labeled as a_t
         self.total_internal_surface_area_in_m2 = (
-            self.scaled_conditioned_floor_area_in_m2
-            * self.ratio_between_internal_surface_area_and_floor_area
+            self.scaled_conditioned_floor_area_in_m2 * self.ratio_between_internal_surface_area_and_floor_area
         )
 
         # Get number of apartments
@@ -2064,21 +2006,17 @@ class BuildingInformation:
             heat_transfer_coeff_by_ventilation_in_watt_per_m2_per_kelvin=heat_transfer_coeff_by_ventilation_reference_in_watt_per_m2_per_kelvin,
         )
 
-    def get_physical_param(
-        self, buildingdata: Any
-    ) -> Tuple[float, List, List, float, List, float, float, float, Any]:
+    def get_physical_param(self, buildingdata: Any) -> Tuple[float, List, List, float, List, float, float, float, Any]:
         """Get the physical parameters from the building data."""
 
         # Reference area [m^2] (TABULA: Reference floor area A_C_Ref )Ref: ISO standard 7.2.2.2
-        conditioned_floor_area_in_m2_reference = float(
-            (buildingdata["A_C_Ref"].values[0])
-        )
+        conditioned_floor_area_in_m2_reference = float((buildingdata["A_C_Ref"].values[0]))
 
         room_height_in_m = float(buildingdata["h_room"].values[0])
 
-        rooftop_area_in_m2_reference = float(
-            buildingdata["A_Roof_1"].values[0]
-        ) + float(buildingdata["A_Roof_2"].values[0])
+        rooftop_area_in_m2_reference = float(buildingdata["A_Roof_1"].values[0]) + float(
+            buildingdata["A_Roof_2"].values[0]
+        )
 
         number_of_storeys = float(buildingdata["n_Storey"].values[0])
 
@@ -2129,10 +2067,7 @@ class BuildingInformation:
                 heat_transfer_coeff_by_transmission_in_watt_per_m2_per_kelvin
                 + heat_transfer_coeff_by_ventilation_in_watt_per_m2_per_kelvin
             )
-            * (
-                initial_temperature_in_celsius
-                - heating_reference_temperature_in_celsius
-            )
+            * (initial_temperature_in_celsius - heating_reference_temperature_in_celsius)
             * scaled_conditioned_floor_area_in_m2
         )
         return max_thermal_building_demand_in_watt
@@ -2155,10 +2090,7 @@ class BuildingInformation:
             if number_of_apartments_origin == 0:
                 # check table from the link for the year 2021
                 average_living_area_per_apartment_in_2021_in_m2 = 92.1
-                number_of_apartments = (
-                    conditioned_floor_area_in_m2
-                    / average_living_area_per_apartment_in_2021_in_m2
-                )
+                number_of_apartments = conditioned_floor_area_in_m2 / average_living_area_per_apartment_in_2021_in_m2
             elif number_of_apartments_origin > 0:
                 number_of_apartments = number_of_apartments_origin
 
@@ -2166,17 +2098,13 @@ class BuildingInformation:
                 raise ValueError("Number of apartments can not be negative.")
 
         elif self.buildingconfig.number_of_apartments is None:
-
             number_of_apartments_origin = float(buildingdata["n_Apartment"].values[0])
 
             # if no value given or if the area given in the config is bigger than the tabula ref area
             if number_of_apartments_origin == 0 or scaling_factor != 1:
                 # check table from the link for the year 2021
                 average_living_area_per_apartment_in_2021_in_m2 = 92.1
-                number_of_apartments = (
-                    conditioned_floor_area_in_m2
-                    / average_living_area_per_apartment_in_2021_in_m2
-                )
+                number_of_apartments = conditioned_floor_area_in_m2 / average_living_area_per_apartment_in_2021_in_m2
             elif number_of_apartments_origin > 0:
                 number_of_apartments = number_of_apartments_origin
 
@@ -2222,48 +2150,37 @@ class BuildingInformation:
             self.buildingconfig.absolute_conditioned_floor_area_in_m2 is not None
             and self.buildingconfig.total_base_area_in_m2 is not None
         ):
-            raise ValueError(
-                "Only one variable can be used, the other one must be None."
-            )
+            raise ValueError("Only one variable can be used, the other one must be None.")
 
         if self.buildingconfig.absolute_conditioned_floor_area_in_m2 is not None:
-
             # this is for preventing that the conditioned_floor_area is 0 (some buildings in TABULA have conditioned_floor_area (A_C_Ref) = 0)
             if conditioned_floor_area_in_m2 == 0:
-                scaled_conditioned_floor_area_in_m2 = (
-                    self.buildingconfig.absolute_conditioned_floor_area_in_m2
-                )
+                scaled_conditioned_floor_area_in_m2 = self.buildingconfig.absolute_conditioned_floor_area_in_m2
                 factor_of_absolute_floor_area_to_tabula_floor_area = 1.0
                 buildingdata["A_C_Ref"] = scaled_conditioned_floor_area_in_m2
             # scaling conditioned floor area
             else:
                 factor_of_absolute_floor_area_to_tabula_floor_area = (
-                    self.buildingconfig.absolute_conditioned_floor_area_in_m2
-                    / conditioned_floor_area_in_m2
+                    self.buildingconfig.absolute_conditioned_floor_area_in_m2 / conditioned_floor_area_in_m2
                 )
                 scaled_conditioned_floor_area_in_m2 = (
-                    conditioned_floor_area_in_m2
-                    * factor_of_absolute_floor_area_to_tabula_floor_area
+                    conditioned_floor_area_in_m2 * factor_of_absolute_floor_area_to_tabula_floor_area
                 )
             scaling_factor = factor_of_absolute_floor_area_to_tabula_floor_area
 
         elif self.buildingconfig.total_base_area_in_m2 is not None:
             # this is for preventing that the conditioned_floor_area is 0
             if conditioned_floor_area_in_m2 == 0:
-                scaled_conditioned_floor_area_in_m2 = (
-                    self.buildingconfig.total_base_area_in_m2
-                )
+                scaled_conditioned_floor_area_in_m2 = self.buildingconfig.total_base_area_in_m2
                 factor_of_total_base_area_to_tabula_floor_area = 1.0
                 buildingdata["A_C_Ref"] = scaled_conditioned_floor_area_in_m2
             # scaling conditioned floor area
             else:
                 factor_of_total_base_area_to_tabula_floor_area = (
-                    self.buildingconfig.total_base_area_in_m2
-                    / conditioned_floor_area_in_m2
+                    self.buildingconfig.total_base_area_in_m2 / conditioned_floor_area_in_m2
                 )
                 scaled_conditioned_floor_area_in_m2 = (
-                    conditioned_floor_area_in_m2
-                    * factor_of_total_base_area_to_tabula_floor_area
+                    conditioned_floor_area_in_m2 * factor_of_total_base_area_to_tabula_floor_area
                 )
             scaling_factor = factor_of_total_base_area_to_tabula_floor_area
 
@@ -2300,28 +2217,17 @@ class BuildingInformation:
         ]
 
         # assumption: building is a cuboid with square floor area (area_of_one_wall = wall_length * wall_height, with wall_length = sqrt(floor_area))
-        total_wall_area_in_m2_tabula = (
-            4 * math.sqrt(conditioned_floor_area_in_m2) * room_height_in_m
-        )
+        total_wall_area_in_m2_tabula = 4 * math.sqrt(conditioned_floor_area_in_m2) * room_height_in_m
 
-        scaled_total_wall_area_in_m2 = (
-            4 * math.sqrt(scaled_conditioned_floor_area_in_m2) * room_height_in_m
-        )
+        scaled_total_wall_area_in_m2 = 4 * math.sqrt(scaled_conditioned_floor_area_in_m2) * room_height_in_m
 
         scaled_window_areas_in_m2 = []
         for windows_direction in self.windows_directions:
-            window_area_in_m2 = float(
-                buildingdata["A_Window_" + windows_direction].iloc[0]
-            )
+            window_area_in_m2 = float(buildingdata["A_Window_" + windows_direction].iloc[0])
 
             if scaling_factor != 1.0:
-                factor_window_area_to_wall_area_tabula = (
-                    window_area_in_m2 / total_wall_area_in_m2_tabula
-                )
-                scaled_window_areas_in_m2.append(
-                    scaled_total_wall_area_in_m2
-                    * factor_window_area_to_wall_area_tabula
-                )
+                factor_window_area_to_wall_area_tabula = window_area_in_m2 / total_wall_area_in_m2_tabula
+                scaled_window_areas_in_m2.append(scaled_total_wall_area_in_m2 * factor_window_area_to_wall_area_tabula)
             else:
                 scaled_window_areas_in_m2.append(window_area_in_m2)
 
@@ -2381,19 +2287,13 @@ class BuildingInformation:
         )
         # Floor area related internal heat sources during heating season
         # reference taken from TABULA (* Check header) as Q_int [kWh/m2.a], before q_int_ref
-        internal_heat_sources_reference_in_kilowatthour_per_m2_per_year = float(
-            buildingdata["q_int"].values[0]
-        )
+        internal_heat_sources_reference_in_kilowatthour_per_m2_per_year = float(buildingdata["q_int"].values[0])
         # Floor area related annual losses
         # reference taken from TABULA (* Check header) as Q_ht [kWh/m2.a], before q_ht_ref
-        total_heat_transfer_reference_in_kilowatthour_per_m2_per_year = float(
-            buildingdata["q_ht"].values[0]
-        )
+        total_heat_transfer_reference_in_kilowatthour_per_m2_per_year = float(buildingdata["q_ht"].values[0])
         # Energy need for heating
         # reference taken from TABULA (* Check header) as Q_H_nd [kWh/m2.a], before q_h_nd_ref
-        energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year = float(
-            buildingdata["q_h_nd"].values[0]
-        )
+        energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year = float(buildingdata["q_h_nd"].values[0])
         # Internal heat capacity per m2 reference area [Wh/(m^2.K)] (TABULA: Internal heat capacity)
         thermal_capacity_of_building_thermal_mass_reference_in_watthour_per_m2_per_kelvin = float(
             buildingdata["c_m"].values[0]
@@ -2403,25 +2303,18 @@ class BuildingInformation:
         heat_transfer_coeff_by_ventilation_reference_in_watt_per_m2_per_kelvin = float(
             buildingdata["h_Ventilation"].values[0]
         )
-        if (
-            heat_transfer_coeff_by_ventilation_reference_in_watt_per_m2_per_kelvin
-            is None
-        ):
+        if heat_transfer_coeff_by_ventilation_reference_in_watt_per_m2_per_kelvin is None:
             raise ValueError("h_Ventilation was none.")
         # Heat transfer coefficient by ventilation in watt per kelvin
         heat_transfer_coeff_by_ventilation_reference_in_watt_per_kelvin = (
-            float(buildingdata["h_Ventilation"].values[0])
-            * scaled_conditioned_floor_area_in_m2
+            float(buildingdata["h_Ventilation"].values[0]) * scaled_conditioned_floor_area_in_m2
         )
 
         # Heat transfer coefficient by transmission in watt per m2 per kelvin
         heat_transfer_coeff_by_transmission_reference_in_watt_per_m2_per_kelvin = float(
             buildingdata["h_Transmission"].values[0]
         )
-        if (
-            heat_transfer_coeff_by_transmission_reference_in_watt_per_m2_per_kelvin
-            is None
-        ):
+        if heat_transfer_coeff_by_transmission_reference_in_watt_per_m2_per_kelvin is None:
             raise ValueError("h_Transmission was none.")
 
         return (

--- a/hisim/components/configuration.py
+++ b/hisim/components/configuration.py
@@ -246,9 +246,7 @@ class PhysicsConfig:
     hydrogen_density = 0.08989  # [kg/m³]
     hydrogen_specific_volume = 1 / hydrogen_density  # [m^3/kg]
     hydrogen_specific_fuel_value_per_m_3 = 10.782 * 10**6  # [J/m³]
-    hydrogen_specific_fuel_value_per_kg = (
-        hydrogen_specific_fuel_value_per_m_3 / hydrogen_density
-    )  # [J/kg]
+    hydrogen_specific_fuel_value_per_kg = hydrogen_specific_fuel_value_per_m_3 / hydrogen_density  # [J/kg]
 
     # Schmidt 2020: Wasserstofftechnik  S.170ff
     # fuel value Methan:    35.894 MJ/m³    (S.172)
@@ -256,9 +254,7 @@ class PhysicsConfig:
     natural_gas_density = 0.71750  # [kg/m³]
     natural_gas_specific_volume = 1 / hydrogen_density  # [m^3/kg]
     natural_gas_specific_fuel_value_per_m_3 = 35.894 * 10**6  # [J/m³]
-    natural_gas_specific_fuel_value_per_kg = (
-        natural_gas_specific_fuel_value_per_m_3 / natural_gas_density
-    )  # [J/kg]
+    natural_gas_specific_fuel_value_per_kg = natural_gas_specific_fuel_value_per_m_3 / natural_gas_density  # [J/kg]
 
 
 @dataclass_json
@@ -380,6 +376,4 @@ class EmissionFactorsAndCostsForFuelsConfig:
                 diesel_footprint_in_kg_per_l=2.0,  # kgCO2eq/l
             )
 
-        raise KeyError(
-            f"No Emission and cost factors implemented yet for the year {year}."
-        )
+        raise KeyError(f"No Emission and cost factors implemented yet for the year {year}.")

--- a/hisim/components/controller_l1_building_heating.py
+++ b/hisim/components/controller_l1_building_heating.py
@@ -129,34 +129,22 @@ class L1BuildingHeatController(cp.Component):
         """ Initializes the class. """
         self.source_weight: int = config.source_weight
         self.heating_season_begin = (
-            config.day_of_heating_season_begin
-            * 24
-            * 3600
-            / self.my_simulation_parameters.seconds_per_timestep
+            config.day_of_heating_season_begin * 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep
         )
         self.heating_season_end = (
-            config.day_of_heating_season_end
-            * 24
-            * 3600
-            / self.my_simulation_parameters.seconds_per_timestep
+            config.day_of_heating_season_end * 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep
         )
         self.state: L1BuildingHeatControllerState = L1BuildingHeatControllerState()
-        self.previous_state: L1BuildingHeatControllerState = (
-            L1BuildingHeatControllerState()
-        )
-        self.processed_state: L1BuildingHeatControllerState = (
-            L1BuildingHeatControllerState()
-        )
+        self.previous_state: L1BuildingHeatControllerState = L1BuildingHeatControllerState()
+        self.processed_state: L1BuildingHeatControllerState = L1BuildingHeatControllerState()
 
         # Component Outputs
-        self.heat_controller_target_percentage_channel: cp.ComponentOutput = (
-            self.add_output(
-                self.component_name,
-                self.HeatControllerTargetPercentage,
-                LoadTypes.ON_OFF,
-                Units.BINARY,
-                output_description="Heating controller of buffer storage.",
-            )
+        self.heat_controller_target_percentage_channel: cp.ComponentOutput = self.add_output(
+            self.component_name,
+            self.HeatControllerTargetPercentage,
+            LoadTypes.ON_OFF,
+            Units.BINARY,
+            output_description="Heating controller of buffer storage.",
         )
 
         # Component Inputs
@@ -185,9 +173,7 @@ class L1BuildingHeatController(cp.Component):
         )
 
         self.add_default_connections(self.get_building_default_connections())
-        self.add_default_connections(
-            self.get_default_connections_from_hot_water_storage()
-        )
+        self.add_default_connections(self.get_default_connections_from_hot_water_storage())
         self.add_default_connections(self.get_default_connections_from_ems())
 
     def get_building_default_connections(self):
@@ -208,9 +194,7 @@ class L1BuildingHeatController(cp.Component):
         """Sets the default connections for the energy management system."""
 
         connections = []
-        ems_classname = (
-            controller_l2_energy_management_system.L2GenericEnergyManagementSystem.get_classname()
-        )
+        ems_classname = controller_l2_energy_management_system.L2GenericEnergyManagementSystem.get_classname()
         connections.append(
             cp.ComponentConnection(
                 L1BuildingHeatController.BuildingTemperatureModifier,
@@ -227,9 +211,7 @@ class L1BuildingHeatController(cp.Component):
         component_module = importlib.import_module(name=component_module_name)
         component_class = getattr(component_module, "HotWaterStorage")
         connections = []
-        boiler_classname = (
-            component_class.get_classname()
-        )
+        boiler_classname = component_class.get_classname()
         connections.append(
             cp.ComponentConnection(
                 L1BuildingHeatController.BufferTemperature,
@@ -270,20 +252,12 @@ class L1BuildingHeatController(cp.Component):
             self.state.state = 0
             return
         # "surplus heat control" when storage is getting hot
-        if (
-            temperature_modifier > 0
-            and t_buffer > self.config.t_buffer_activation_threshold_in_celsius
-        ):
+        if temperature_modifier > 0 and t_buffer > self.config.t_buffer_activation_threshold_in_celsius:
             # heat with 75 % power and building can still be heated
-            if (
-                t_control
-                < self.config.t_max_heating_in_celsius + temperature_modifier / 2
-            ):
+            if t_control < self.config.t_max_heating_in_celsius + temperature_modifier / 2:
                 self.state.state = 0.75
             # heat with 50 % power when storage is getting hot and building can still be heated, but is already on the upper side of the tolerance interval
-            elif (
-                t_control < self.config.t_max_heating_in_celsius + temperature_modifier
-            ):
+            elif t_control < self.config.t_max_heating_in_celsius + temperature_modifier:
                 self.state.state = 0.5
         return
 
@@ -299,9 +273,7 @@ class L1BuildingHeatController(cp.Component):
         """For double checking results."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the control of the building temperature, when building is heated from buffer."""
         if force_convergence:
             pass
@@ -312,9 +284,7 @@ class L1BuildingHeatController(cp.Component):
                 t_buffer = stsv.get_input_value(self.buffer_temperature_channel)
             else:
                 t_buffer = 0
-            temperature_modifier = stsv.get_input_value(
-                self.building_temperature_modifier_channel
-            )
+            temperature_modifier = stsv.get_input_value(self.building_temperature_modifier_channel)
             self.control_heating(
                 timestep=timestep,
                 t_control=t_control,
@@ -322,9 +292,7 @@ class L1BuildingHeatController(cp.Component):
                 temperature_modifier=temperature_modifier,
             )
             self.processed_state = self.state.clone()
-        stsv.set_output_value(
-            self.heat_controller_target_percentage_channel, self.processed_state.state
-        )
+        stsv.set_output_value(self.heat_controller_target_percentage_channel, self.processed_state.state)
 
     def write_to_report(self) -> List[str]:
         """Writes the information of the current component to the report."""

--- a/hisim/components/controller_l1_chp.py
+++ b/hisim/components/controller_l1_chp.py
@@ -240,12 +240,10 @@ class L1CHPController(cp.Component):
             my_config=config,
         )
         self.minimum_runtime_in_timesteps = int(
-            config.min_operation_time_in_seconds
-            / self.my_simulation_parameters.seconds_per_timestep
+            config.min_operation_time_in_seconds / self.my_simulation_parameters.seconds_per_timestep
         )
         self.minimum_resting_time_in_timesteps = int(
-            config.min_idle_time_in_seconds
-            / self.my_simulation_parameters.seconds_per_timestep
+            config.min_idle_time_in_seconds / self.my_simulation_parameters.seconds_per_timestep
         )
         """ Initializes the class. """
         if config.day_of_heating_season_begin is None:
@@ -253,16 +251,10 @@ class L1CHPController(cp.Component):
         if config.day_of_heating_season_end is None:
             raise ValueError("Day of heating season end was None")
         self.heating_season_begin = (
-            config.day_of_heating_season_begin
-            * 24
-            * 3600
-            / self.my_simulation_parameters.seconds_per_timestep
+            config.day_of_heating_season_begin * 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep
         )
         self.heating_season_end = (
-            config.day_of_heating_season_end
-            * 24
-            * 3600
-            / self.my_simulation_parameters.seconds_per_timestep
+            config.day_of_heating_season_end * 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep
         )
         self.state: L1CHPControllerState = L1CHPControllerState(0, 0, 0, 0)
         self.previous_state: L1CHPControllerState = self.state.clone()
@@ -317,9 +309,7 @@ class L1CHPController(cp.Component):
             mandatory=False,
         )
 
-        self.add_default_connections(
-            self.get_default_connections_generic_hot_water_storage_modular()
-        )
+        self.add_default_connections(self.get_default_connections_generic_hot_water_storage_modular())
         self.add_default_connections(self.get_default_connections_from_building())
         self.add_default_connections(self.get_default_connections_from_h2_storage())
 
@@ -330,9 +320,7 @@ class L1CHPController(cp.Component):
         component_module = importlib.import_module(name=component_module_name)
         component_class = getattr(component_module, "HotWaterStorage")
         connections = []
-        boiler_classname = (
-            component_class.get_classname()
-        )
+        boiler_classname = component_class.get_classname()
         connections.append(
             cp.ComponentConnection(
                 L1CHPController.HotWaterStorageTemperature,
@@ -366,9 +354,7 @@ class L1CHPController(cp.Component):
         component_module = importlib.import_module(name=component_module_name)
         component_class = getattr(component_module, "GenericHydrogenStorage")
         connections = []
-        h2_storage_classname = (
-            component_class.get_classname()
-        )
+        h2_storage_classname = component_class.get_classname()
         connections.append(
             cp.ComponentConnection(
                 L1CHPController.HydrogenSOC,
@@ -394,9 +380,7 @@ class L1CHPController(cp.Component):
         """For double checking results."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Core Simulation function."""
         if force_convergence:
             # states are saved after each timestep, outputs after each iteration
@@ -408,16 +392,10 @@ class L1CHPController(cp.Component):
             t_dhw = stsv.get_input_value(self.dhw_temperature_channel)
             # surplus/deficit electricity threshold exceeded?
             if self.electricity_target_channel.source_output is not None:
-                electricity_target = stsv.get_input_value(
-                    self.electricity_target_channel
-                )
+                electricity_target = stsv.get_input_value(self.electricity_target_channel)
                 electricity_threshold_ok = (
-                    electricity_target <= -self.config.electricity_threshold
-                    and self.state.on_off == 0
-                ) or (
-                    electricity_target <= self.config.electricity_threshold
-                    and self.state.on_off == 1
-                )
+                    electricity_target <= -self.config.electricity_threshold and self.state.on_off == 0
+                ) or (electricity_target <= self.config.electricity_threshold and self.state.on_off == 1)
             else:
                 electricity_threshold_ok = True
             if self.hydrogen_soc_channel.source_output is not None:
@@ -426,16 +404,12 @@ class L1CHPController(cp.Component):
             else:
                 hydrogen_soc_ok = True
             self.determine_heating_mode(timestep, t_building, t_dhw)
-            self.calculate_state(
-                timestep, t_building, t_dhw, electricity_threshold_ok, hydrogen_soc_ok
-            )
+            self.calculate_state(timestep, t_building, t_dhw, electricity_threshold_ok, hydrogen_soc_ok)
             self.processed_state = self.state.clone()
         stsv.set_output_value(self.chp_onoff_signal_channel, self.state.on_off)
         stsv.set_output_value(self.chp_heatingmode_signal_channel, self.state.mode)
 
-    def determine_heating_mode(
-        self, timestep: int, t_building: float, t_dhw: float
-    ) -> None:
+    def determine_heating_mode(self, timestep: int, t_building: float, t_dhw: float) -> None:
         """Determines if hot water or building should be heated.
 
         The mode in the state is 0 if water heating is considered and 1 if heating is enforced.
@@ -470,18 +444,12 @@ class L1CHPController(cp.Component):
     ) -> None:
         """Calculate the CHP state and activate / deactives."""
         # return device on if minimum operation time is not fulfilled and device was on in previous state
-        if (
-            self.state.on_off == 1
-            and self.state.activation_time_step + self.minimum_runtime_in_timesteps
-            >= timestep
-        ):
+        if self.state.on_off == 1 and self.state.activation_time_step + self.minimum_runtime_in_timesteps >= timestep:
             # mandatory on, minimum runtime not reached
             return
         if (
             self.state.on_off == 0
-            and self.state.deactivation_time_step
-            + self.minimum_resting_time_in_timesteps
-            >= timestep
+            and self.state.deactivation_time_step + self.minimum_resting_time_in_timesteps >= timestep
         ):
             # mandatory off, minimum resting time not reached
             return
@@ -505,22 +473,14 @@ class L1CHPController(cp.Component):
                 )  # activate CHP when storage temperature is too low and electricity is needed
                 return
             if t_dhw > self.config.t_max_heating_in_celsius:
-                self.state.deactivate(
-                    timestep
-                )  # deactivate CHP when storage temperature is too high
+                self.state.deactivate(timestep)  # deactivate CHP when storage temperature is too high
                 return
         else:
-            if (
-                t_building < self.config.t_min_heating_in_celsius
-                or t_dhw < self.config.t_min_dhw_in_celsius
-            ):
+            if t_building < self.config.t_min_heating_in_celsius or t_dhw < self.config.t_min_dhw_in_celsius:
                 # activate heating when either dhw storage or building temperature is too low and electricity is needed
                 self.state.activate(timestep)
                 return
-            if (
-                t_building > self.config.t_max_heating_in_celsius
-                and t_dhw > self.config.t_max_dhw_in_celsius
-            ):
+            if t_building > self.config.t_max_heating_in_celsius and t_dhw > self.config.t_max_dhw_in_celsius:
                 # deactivate heating when dhw storage and building temperature is too high
                 self.state.deactivate(timestep)
                 return

--- a/hisim/components/controller_l1_electrolyzer.py
+++ b/hisim/components/controller_l1_electrolyzer.py
@@ -120,12 +120,10 @@ class L1GenericElectrolyzerController(cp.Component):
             my_config=config,
         )
         self.minimum_runtime_in_timesteps = int(
-            config.min_operation_time_in_seconds
-            / self.my_simulation_parameters.seconds_per_timestep
+            config.min_operation_time_in_seconds / self.my_simulation_parameters.seconds_per_timestep
         )
         self.minimum_resting_time_in_timesteps = int(
-            config.min_idle_time_in_seconds
-            / self.my_simulation_parameters.seconds_per_timestep
+            config.min_idle_time_in_seconds / self.my_simulation_parameters.seconds_per_timestep
         )
 
         self.state = L1ElectrolyzerControllerState()
@@ -165,9 +163,7 @@ class L1GenericElectrolyzerController(cp.Component):
         component_module = importlib.import_module(name=component_module_name)
         component_class = getattr(component_module, "GenericHydrogenStorage")
         connections = []
-        h2_storage_classname = (
-            component_class.get_classname()
-        )
+        h2_storage_classname = component_class.get_classname()
         connections.append(
             cp.ComponentConnection(
                 L1GenericElectrolyzerController.HydrogenSOC,
@@ -193,9 +189,7 @@ class L1GenericElectrolyzerController(cp.Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
 
         if force_convergence:
@@ -208,41 +202,28 @@ class L1GenericElectrolyzerController(cp.Component):
             self.processed_state = self.state.clone()
 
         # minimum power of electrolyzer fulfilled when running
-        if (
-            self.state.state == 1
-            and electricity_target < self.config.p_min_electrolyzer
-        ):
+        if self.state.state == 1 and electricity_target < self.config.p_min_electrolyzer:
             electricity_target = self.config.p_min_electrolyzer
         stsv.set_output_value(
             self.available_electicity_output_channel,
             self.state.state * electricity_target,
         )
 
-    def calculate_state(
-        self, timestep: int, electricity_target: float, h2_soc: float
-    ) -> None:
+    def calculate_state(self, timestep: int, electricity_target: float, h2_soc: float) -> None:
         """Calculate the state."""
         # return device on if minimum operation time is not fulfilled and device was on in previous state
-        if (
-            self.state.state == 1
-            and self.state.activation_time_step + self.minimum_runtime_in_timesteps
-            >= timestep
-        ):
+        if self.state.state == 1 and self.state.activation_time_step + self.minimum_runtime_in_timesteps >= timestep:
             # mandatory on, minimum runtime not reached
             return
         if (
             self.state.state == 0
-            and self.state.deactivation_time_step
-            + self.minimum_resting_time_in_timesteps
-            >= timestep
+            and self.state.deactivation_time_step + self.minimum_resting_time_in_timesteps >= timestep
         ):
             # mandatory off, minimum resting time not reached
             return
 
         # available electricity too low or hydrogen storage too full
-        if (electricity_target < self.config.p_min_electrolyzer) or (
-            h2_soc > self.config.h2_soc_threshold
-        ):
+        if (electricity_target < self.config.p_min_electrolyzer) or (h2_soc > self.config.h2_soc_threshold):
             self.state.deactivate(timestep)
             return
 

--- a/hisim/components/controller_l1_electrolyzer_h2.py
+++ b/hisim/components/controller_l1_electrolyzer_h2.py
@@ -67,9 +67,7 @@ class ElectrolyzerControllerConfig(ConfigBase):
     def read_config(electrolyzer_name):
         """Opens the according JSON-file, based on the electrolyzer_name."""
 
-        config_file = os.path.join(
-            utils.HISIMPATH["inputs"], "electrolyzer_manufacturer_config.json"
-        )
+        config_file = os.path.join(utils.HISIMPATH["inputs"], "electrolyzer_manufacturer_config.json")
         with open(config_file, "r", encoding="utf-8") as json_file:
             data = json.load(json_file)
             return data.get("Electrolyzer variants", {}).get(electrolyzer_name, {})
@@ -201,9 +199,7 @@ class ElectrolyzerController(Component):
     def load_check(self, current_load, min_load, max_load, standby_load):
         """Load check."""
         if None in (current_load, min_load, max_load, standby_load):
-            raise ValueError(
-                f"None type not accepted. {current_load}, {min_load}, {max_load}, {standby_load}"
-            )
+            raise ValueError(f"None type not accepted. {current_load}, {min_load}, {max_load}, {standby_load}")
         if current_load > max_load:
             current_load_to_system = max_load
             self.curtailed_load_count += current_load - max_load
@@ -251,16 +247,11 @@ class ElectrolyzerController(Component):
             # Test start
             if self.current_state in ["StartingfromOFF", "StartingfromSTANDBY"]:
                 # pdb.set_trace()
-                if (
-                    self.activation_runtime
-                    <= self.my_simulation_parameters.seconds_per_timestep
-                ):
+                if self.activation_runtime <= self.my_simulation_parameters.seconds_per_timestep:
                     self.current_state = "Startingtomin"
                     # pdb.set_trace()
                 else:
-                    self.activation_runtime -= (
-                        self.my_simulation_parameters.seconds_per_timestep
-                    )
+                    self.activation_runtime -= self.my_simulation_parameters.seconds_per_timestep
                     # pdb.set_trace()
                     # self.current_state = self.current_state
                     # starting to min auch unten aufnehmen um so min_load zu verteilen. "Starting to min" kann verwendet werden,
@@ -274,13 +265,8 @@ class ElectrolyzerController(Component):
                 self.current_state = "StartingfromSTANDBY"
                 self.activation_runtime = warm_start_time_to_min
             else:
-                if (
-                    self.activation_runtime
-                    > self.my_simulation_parameters.seconds_per_timestep
-                ):
-                    self.activation_runtime -= (
-                        self.my_simulation_parameters.seconds_per_timestep
-                    )
+                if self.activation_runtime > self.my_simulation_parameters.seconds_per_timestep:
+                    self.activation_runtime -= self.my_simulation_parameters.seconds_per_timestep
                     # self.current_state = self.current_state
                 # elif self.activation_runtime <= self.my_simulation_parameters.seconds_per_timestep:
                 #    self.activation_runtime -= self.my_simulation_parameters.seconds_per_timestep
@@ -312,9 +298,7 @@ class ElectrolyzerController(Component):
         self.off_count = self.off_count_previous
         self.activation_runtime = self.activation_runtime_previous
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
         if force_convergence:
             return
@@ -370,17 +354,7 @@ class ElectrolyzerController(Component):
         for config_string in self.controllerconfig.get_string_dict():
             lines.append(config_string)
         lines.append("Component Name" + str(self.component_name))
-        lines.append(
-            "Total curtailed load: " + str(self.curtailed_load_count) + " [kW]"
-        )
-        lines.append(
-            "Number of times the system was switched off: "
-            + str(self.off_count)
-            + " [#]"
-        )
-        lines.append(
-            "Number of times the system was switched to standby mode: "
-            + str(self.standby_count)
-            + " [#]"
-        )
+        lines.append("Total curtailed load: " + str(self.curtailed_load_count) + " [kW]")
+        lines.append("Number of times the system was switched off: " + str(self.off_count) + " [#]")
+        lines.append("Number of times the system was switched to standby mode: " + str(self.standby_count) + " [#]")
         return lines

--- a/hisim/components/controller_l1_example_controller.py
+++ b/hisim/components/controller_l1_example_controller.py
@@ -64,9 +64,7 @@ class SimpleController(Component):
     ) -> None:
         """Initialize the class."""
 
-        super().__init__(
-            name, my_simulation_parameters=my_simulation_parameters, my_config=config
-        )
+        super().__init__(name, my_simulation_parameters=my_simulation_parameters, my_config=config)
         self.input1_channel: ComponentInput = self.add_input(
             self.component_name,
             SimpleController.StorageFillLevel,
@@ -91,9 +89,7 @@ class SimpleController(Component):
         """Restores the state."""
         self.state = self.previous_state
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
 
         if force_convergence:

--- a/hisim/components/controller_l1_fuel_cell.py
+++ b/hisim/components/controller_l1_fuel_cell.py
@@ -69,9 +69,7 @@ class FuelCellControllerConfig(ConfigBase):
     def read_config(fuel_cell_name):
         """Opens the according JSON-file, based on the fuel_cell_name."""
 
-        config_file = os.path.join(
-            utils.HISIMPATH["inputs"], "fuel_cell_manufacturer_config.json"
-        )
+        config_file = os.path.join(utils.HISIMPATH["inputs"], "fuel_cell_manufacturer_config.json")
         with open(config_file, "r", encoding="utf-8") as json_file:
             data = json.load(json_file)
             return data.get("Fuel Cell variants", {}).get(fuel_cell_name, {})
@@ -259,16 +257,11 @@ class FuelCellController(Component):
             # Test start
             if self.current_state in ["Starting from OFF", "Starting from STANDBY"]:
                 # pdb.set_trace()
-                if (
-                    self.activation_runtime
-                    <= self.my_simulation_parameters.seconds_per_timestep
-                ):
+                if self.activation_runtime <= self.my_simulation_parameters.seconds_per_timestep:
                     self.current_state = "Starting to min"
                     # pdb.set_trace()
                 else:
-                    self.activation_runtime -= (
-                        self.my_simulation_parameters.seconds_per_timestep
-                    )
+                    self.activation_runtime -= self.my_simulation_parameters.seconds_per_timestep
                     # pdb.set_trace()
                     # self.current_state = self.current_state
                     # starting to min auch unten aufnehmen um so min_load zu verteilen. "Starting to min" kann verwendet werden,
@@ -282,13 +275,8 @@ class FuelCellController(Component):
                 self.current_state = "Starting from STANDBY"
                 self.activation_runtime = warm_start_time_to_min
             else:
-                if (
-                    self.activation_runtime
-                    > self.my_simulation_parameters.seconds_per_timestep
-                ):
-                    self.activation_runtime -= (
-                        self.my_simulation_parameters.seconds_per_timestep
-                    )
+                if self.activation_runtime > self.my_simulation_parameters.seconds_per_timestep:
+                    self.activation_runtime -= self.my_simulation_parameters.seconds_per_timestep
                     # self.current_state = self.current_state
                 # elif self.activation_runtime <= self.my_simulation_parameters.seconds_per_timestep:
                 #    self.activation_runtime -= self.my_simulation_parameters.seconds_per_timestep
@@ -320,9 +308,7 @@ class FuelCellController(Component):
         self.off_count = self.off_count_previous
         self.activation_runtime = self.activation_runtime_previous
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
         if force_convergence:
             return
@@ -335,12 +321,8 @@ class FuelCellController(Component):
         self.warm_start_time = config.warm_start_time
         self.cold_start_time = config.cold_start_time
         """
-        warm_start_time_to_min = self.warm_start_time * (
-            self.min_output / self.nom_output
-        )
-        cold_start_time_to_min = self.cold_start_time * (
-            self.min_output / self.nom_output
-        )
+        warm_start_time_to_min = self.warm_start_time * (self.min_output / self.nom_output)
+        cold_start_time_to_min = self.cold_start_time * (self.min_output / self.nom_output)
 
         (current_load_to_system, state, self.curtailed_load_count) = self.load_check(
             (abs(stsv.get_input_value(self.demand_profile))),

--- a/hisim/components/controller_l1_generic_ev_charge.py
+++ b/hisim/components/controller_l1_generic_ev_charge.py
@@ -64,9 +64,7 @@ class ChargingStationConfig(cp.ConfigBase):
         charging_station_set: JsonReference = ChargingStationSets.Charging_At_Home_with_03_7_kW,
     ) -> "ChargingStationConfig":
         """Returns default configuration of charging station and desired SOC Level."""
-        charging_power = float(
-            (charging_station_set.Name or "").split("with ")[1].split(" kW")[0]
-        )
+        charging_power = float((charging_station_set.Name or "").split("with ")[1].split(" kW")[0])
         lower_threshold_charging_power = (
             charging_power * 1e3 * 0.1
         )  # 10 % of charging power for acceptable efficiencies
@@ -205,11 +203,7 @@ class L1Controller(cp.Component):
                 generic_car.Car.ElectricityOutput,
             )
         )
-        connections.append(
-            cp.ComponentConnection(
-                L1Controller.CarLocation, car_classname, generic_car.Car.CarLocation
-            )
-        )
+        connections.append(cp.ComponentConnection(L1Controller.CarLocation, car_classname, generic_car.Car.CarLocation))
         return connections
 
     def get_default_connections_advanced_battery(self) -> List[cp.ComponentConnection]:
@@ -268,9 +262,7 @@ class L1Controller(cp.Component):
             return min(electricity_target, self.power)
         return 0
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Returns battery charge and discharge (energy consumption of car) of battery at each timestep."""
         if force_convergence:
             self.state = self.processed_state.clone()
@@ -294,9 +286,7 @@ class L1Controller(cp.Component):
         ac_battery_power = stsv.get_input_value(self.ac_battery_power_channel)
         if ac_battery_power > 0:
             # charging of EV
-            stsv.set_output_value(
-                self.battery_charging_power_to_ems_channel, ac_battery_power
-            )
+            stsv.set_output_value(self.battery_charging_power_to_ems_channel, ac_battery_power)
         else:
             # no charging of EV
             stsv.set_output_value(self.battery_charging_power_to_ems_channel, 0)
@@ -311,9 +301,7 @@ class L1Controller(cp.Component):
         self.config = config
         # get charging station location and charging station power out of ChargingStationSet
         if config.charging_station_set.Name is not None:
-            charging_station_string = config.charging_station_set.Name.partition("At ")[
-                2
-            ]
+            charging_station_string = config.charging_station_set.Name.partition("At ")[2]
             location = charging_station_string.partition(" with")[0]
             if location == "Home":
                 self.charging_location = 1
@@ -323,18 +311,13 @@ class L1Controller(cp.Component):
             log.error(
                 'Charging location not known, check the input on the charging station set. It was set to "charging at home per default.'
             )
-        power = (
-            float(charging_station_string.partition("with ")[2].partition(" kW")[0])
-            * 1e3
-        )
+        power = float(charging_station_string.partition("with ")[2].partition(" kW")[0]) * 1e3
         self.power = power
 
     def write_to_report(self) -> List[str]:
         """Writes EV charge controller values to report."""
         lines = []
-        lines.append(
-            self.name + "_w" + str(self.source_weight) + "charging controller: "
-        )
+        lines.append(self.name + "_w" + str(self.source_weight) + "charging controller: ")
         lines.append(f"Power [kW]: {self.power * 1e-3:2.1f}")
         if self.charging_location == 1:
             lines.append("At Home")

--- a/hisim/components/controller_l1_generic_gas_heater.py
+++ b/hisim/components/controller_l1_generic_gas_heater.py
@@ -66,7 +66,7 @@ class GenericGasHeaterControllerL1Config(ConfigBase):
 
     @classmethod
     def get_scaled_generic_gas_heater_controller_config(
-            cls, heating_load_of_building_in_watt: float
+        cls, heating_load_of_building_in_watt: float
     ) -> "GenericGasHeaterControllerL1Config":
         """Gets a default Generic Heat Pump Controller."""
         maximal_thermal_power_in_watt = heating_load_of_building_in_watt
@@ -101,14 +101,10 @@ class GenericGasHeaterControllerL1(Component):
     """
 
     # Inputs
-    WaterTemperatureInputFromHeatWaterStorage = (
-        "WaterTemperatureInputFromHeatWaterStorage"
-    )
+    WaterTemperatureInputFromHeatWaterStorage = "WaterTemperatureInputFromHeatWaterStorage"
 
     # set heating  flow temperature
-    HeatingFlowTemperatureFromHeatDistributionSystem = (
-        "HeatingFlowTemperatureFromHeatDistributionSystem"
-    )
+    HeatingFlowTemperatureFromHeatDistributionSystem = "HeatingFlowTemperatureFromHeatDistributionSystem"
 
     DailyAverageOutsideTemperature = "DailyAverageOutsideTemperature"
 
@@ -148,14 +144,12 @@ class GenericGasHeaterControllerL1(Component):
             Units.CELSIUS,
             True,
         )
-        self.daily_avg_outside_temperature_input_channel: ComponentInput = (
-            self.add_input(
-                self.component_name,
-                self.DailyAverageOutsideTemperature,
-                LoadTypes.TEMPERATURE,
-                Units.CELSIUS,
-                True,
-            )
+        self.daily_avg_outside_temperature_input_channel: ComponentInput = self.add_input(
+            self.component_name,
+            self.DailyAverageOutsideTemperature,
+            LoadTypes.TEMPERATURE,
+            Units.CELSIUS,
+            True,
         )
 
         self.control_signal_to_gasheater_channel: ComponentOutput = self.add_output(
@@ -170,12 +164,8 @@ class GenericGasHeaterControllerL1(Component):
         self.previous_gasheater_mode: Any
 
         self.add_default_connections(self.get_default_connections_from_weather())
-        self.add_default_connections(
-            self.get_default_connections_from_simple_hot_water_storage()
-        )
-        self.add_default_connections(
-            self.get_default_connections_from_heat_distribution_controller()
-        )
+        self.add_default_connections(self.get_default_connections_from_simple_hot_water_storage())
+        self.add_default_connections(self.get_default_connections_from_heat_distribution_controller())
 
     def get_default_connections_from_simple_hot_water_storage(
         self,
@@ -262,9 +252,7 @@ class GenericGasHeaterControllerL1(Component):
         """Write important variables to report."""
         return self.gas_heater_controller_config.get_string_dict()
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the Gas Heater comtroller."""
 
         if force_convergence:
@@ -272,14 +260,12 @@ class GenericGasHeaterControllerL1(Component):
         else:
             # Retrieves inputs
 
-            water_temperature_input_from_heat_water_storage_in_celsius = (
-                stsv.get_input_value(self.water_temperature_input_channel)
+            water_temperature_input_from_heat_water_storage_in_celsius = stsv.get_input_value(
+                self.water_temperature_input_channel
             )
 
-            heating_flow_temperature_from_heat_distribution_system = (
-                stsv.get_input_value(
-                    self.heating_flow_temperature_from_heat_distribution_system_channel
-                )
+            heating_flow_temperature_from_heat_distribution_system = stsv.get_input_value(
+                self.heating_flow_temperature_from_heat_distribution_system_channel
             )
 
             daily_avg_outside_temperature_in_celsius = stsv.get_input_value(
@@ -313,9 +299,7 @@ class GenericGasHeaterControllerL1(Component):
             else:
                 raise ValueError("Gas Heater Controller control_signal unknown.")
 
-            stsv.set_output_value(
-                self.control_signal_to_gasheater_channel, control_signal
-            )
+            stsv.set_output_value(self.control_signal_to_gasheater_channel, control_signal)
 
     def modulate_power(
         self,
@@ -342,18 +326,14 @@ class GenericGasHeaterControllerL1(Component):
             linear_fit = 1 - (
                 (
                     self.gas_heater_controller_config.set_temperature_difference_for_full_power
-                    - (
-                        set_heating_flow_temperature_in_celsius
-                        - water_temperature_input_in_celsius
-                    )
+                    - (set_heating_flow_temperature_in_celsius - water_temperature_input_in_celsius)
                 )
                 / self.gas_heater_controller_config.set_temperature_difference_for_full_power
             )
             percentage = max(minimal_percentage, linear_fit)
             return percentage
         if (
-            water_temperature_input_in_celsius
-            <= set_heating_flow_temperature_in_celsius + 0.5
+            water_temperature_input_in_celsius <= set_heating_flow_temperature_in_celsius + 0.5
         ):  # use same hysteresis like in conditions_on_off()
             percentage = minimal_percentage
             return percentage
@@ -371,8 +351,7 @@ class GenericGasHeaterControllerL1(Component):
 
         if self.controller_gasheatermode == "heating":
             if (
-                water_temperature_input_in_celsius
-                > (set_heating_flow_temperature_in_celsius + 0.5)
+                water_temperature_input_in_celsius > (set_heating_flow_temperature_in_celsius + 0.5)
                 or summer_heating_mode == "off"
             ):  # + 1:
                 self.controller_gasheatermode = "off"
@@ -382,8 +361,7 @@ class GenericGasHeaterControllerL1(Component):
             # gas heater is only turned on if the water temperature is below the flow temperature
             # and if the avg daily outside temperature is cold enough (summer mode on)
             if (
-                water_temperature_input_in_celsius
-                < (set_heating_flow_temperature_in_celsius - 1.0)
+                water_temperature_input_in_celsius < (set_heating_flow_temperature_in_celsius - 1.0)
                 and summer_heating_mode == "on"
             ):  # - 1:
                 self.controller_gasheatermode = "heating"
@@ -404,17 +382,11 @@ class GenericGasHeaterControllerL1(Component):
             heating_mode = "on"
 
         # it is too hot for heating
-        elif (
-            daily_average_outside_temperature_in_celsius
-            > set_heating_threshold_temperature_in_celsius
-        ):
+        elif daily_average_outside_temperature_in_celsius > set_heating_threshold_temperature_in_celsius:
             heating_mode = "off"
 
         # it is cold enough for heating
-        elif (
-            daily_average_outside_temperature_in_celsius
-            < set_heating_threshold_temperature_in_celsius
-        ):
+        elif daily_average_outside_temperature_in_celsius < set_heating_threshold_temperature_in_celsius:
             heating_mode = "on"
 
         else:

--- a/hisim/components/controller_l1_generic_runtime.py
+++ b/hisim/components/controller_l1_generic_runtime.py
@@ -125,9 +125,7 @@ class L1GenericRuntimeController(cp.Component):
     # Similar components to connect to:
     # 1. Building
     @utils.measure_execution_time
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: L1Config
-    ) -> None:
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: L1Config) -> None:
         """Initializes the controller."""
         super().__init__(
             name=config.name + "_w" + str(config.source_weight),
@@ -138,12 +136,10 @@ class L1GenericRuntimeController(cp.Component):
         self.name = config.name
         self.source_weight = config.source_weight
         self.minimum_runtime_in_timesteps = int(
-            config.min_operation_time_in_seconds
-            / self.my_simulation_parameters.seconds_per_timestep
+            config.min_operation_time_in_seconds / self.my_simulation_parameters.seconds_per_timestep
         )
         self.minimum_resting_time_in_timesteps = int(
-            config.min_idle_time_in_seconds
-            / self.my_simulation_parameters.seconds_per_timestep
+            config.min_idle_time_in_seconds / self.my_simulation_parameters.seconds_per_timestep
         )
 
         self.state = L1GenericRuntimeControllerState(0, 0, 0)
@@ -156,9 +152,7 @@ class L1GenericRuntimeController(cp.Component):
             Units.BINARY,
             mandatory=True,
         )
-        self.add_default_connections(
-            self.get_default_connections_from_controller_l2_generic_heat_clever_simple()
-        )
+        self.add_default_connections(self.get_default_connections_from_controller_l2_generic_heat_clever_simple())
 
         # add outputs
         self.l1_device_signal_channel: cp.ComponentOutput = self.add_output(
@@ -178,9 +172,7 @@ class L1GenericRuntimeController(cp.Component):
         component_module = importlib.import_module(name=component_module_name)
         component_class = getattr(component_module, "L2HeatSmartController")
         connections = []
-        controller_classname = (
-            component_class.get_classname()
-        )
+        controller_classname = component_class.get_classname()
         connections.append(
             cp.ComponentConnection(
                 L1GenericRuntimeController.L2DeviceSignal,
@@ -206,9 +198,7 @@ class L1GenericRuntimeController(cp.Component):
         """For checking for problems."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Main simulation function."""
         # check demand, and change state of self.has_heating_demand, and self._has_cooling_demand
         if force_convergence:
@@ -220,19 +210,13 @@ class L1GenericRuntimeController(cp.Component):
         l2_devicesignal = stsv.get_input_value(self.l2_device_signal_channel)
 
         # return device on if minimum operation time is not fulfilled and device was on in previous state
-        if (
-            self.state.on_off == 1
-            and self.state.activation_time_step + self.minimum_runtime_in_timesteps
-            >= timestep
-        ):
+        if self.state.on_off == 1 and self.state.activation_time_step + self.minimum_runtime_in_timesteps >= timestep:
             # mandatory on, minimum runtime not reached
             self.state.on_off = 1
             pass
         elif (
             self.state.on_off == 0
-            and self.state.deactivation_time_step
-            + self.minimum_resting_time_in_timesteps
-            >= timestep
+            and self.state.deactivation_time_step + self.minimum_resting_time_in_timesteps >= timestep
         ):
             self.state.on_off = 0
         # check signal from l2 and turn on or off if it is necesary

--- a/hisim/components/controller_l1_heat_old.py
+++ b/hisim/components/controller_l1_heat_old.py
@@ -124,9 +124,7 @@ class ControllerHeat(cp.Component):
             my_config=config,
         )
         self.mode: Any
-        self.temperature_storage_target_warm_water = (
-            self.controller_heat_config.temperature_storage_target_warm_water
-        )
+        self.temperature_storage_target_warm_water = self.controller_heat_config.temperature_storage_target_warm_water
         self.temperature_storage_target_heating_water = (
             self.controller_heat_config.temperature_storage_target_heating_water
         )
@@ -268,16 +266,10 @@ class ControllerHeat(cp.Component):
 
                 # Storage warm enough. Try to turn off Heaters
             elif delta_temperature <= 0:
-                if (
-                    temperature_storage_target_c == temperature_storage_target
-                    and timestep_of_hysteresis != timestep
-                ):
+                if temperature_storage_target_c == temperature_storage_target and timestep_of_hysteresis != timestep:
                     temperature_storage_target_c = temperature_storage_target_hysteresis
                     timestep_of_hysteresis = timestep
-                elif (
-                    temperature_storage_target_c != temperature_storage_target
-                    and timestep_of_hysteresis != timestep
-                ):
+                elif temperature_storage_target_c != temperature_storage_target and timestep_of_hysteresis != timestep:
                     control_signal_heat_pump = 0
                     control_signal_gas_heater = 0
                     control_signal_chp = 0
@@ -291,9 +283,7 @@ class ControllerHeat(cp.Component):
 
         return temperature_storage_target_c, timestep_of_hysteresis
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         if force_convergence:
             return
@@ -302,13 +292,11 @@ class ControllerHeat(cp.Component):
         # First heat up WarmWaterStorage->more important, than heat up HeatingWater
         # But only one Storage can be heated up in a TimeStep!
         # Simulate WarmWater
-        delta_temperature_ww = (
-            self.state.temperature_storage_target_ww_c
-            - stsv.get_input_value(self.temperature_storage_warm_water_channel)
+        delta_temperature_ww = self.state.temperature_storage_target_ww_c - stsv.get_input_value(
+            self.temperature_storage_warm_water_channel
         )
-        delta_temperature_hw = (
-            self.state.temperature_storage_target_hw_c
-            - stsv.get_input_value(self.temperature_storage_heating_water_channel)
+        delta_temperature_hw = self.state.temperature_storage_target_hw_c - stsv.get_input_value(
+            self.temperature_storage_heating_water_channel
         )
         if (
             stsv.get_input_value(self.temperature_storage_warm_water_channel) == 0
@@ -346,18 +334,15 @@ class ControllerHeat(cp.Component):
                 stsv=stsv,
                 delta_temperature=delta_temperature_ww,
                 timestep=timestep,
-                temperature_storage=stsv.get_input_value(
-                    self.temperature_storage_warm_water_channel
-                ),
+                temperature_storage=stsv.get_input_value(self.temperature_storage_warm_water_channel),
                 temperature_storage_target=self.temperature_storage_target_warm_water,
                 temperature_storage_target_hysteresis=self.temperature_storage_target_hysteresis_ww,
                 temperature_storage_target_c=self.state.temperature_storage_target_ww_c,
                 timestep_of_hysteresis=self.state.timestep_of_hysteresis_ww,
             )
         elif control_signal_choose_storage == 2:
-            delta_temperature_hw = (
-                self.state.temperature_storage_target_hw_c
-                - stsv.get_input_value(self.temperature_storage_heating_water_channel)
+            delta_temperature_hw = self.state.temperature_storage_target_hw_c - stsv.get_input_value(
+                self.temperature_storage_heating_water_channel
             )
             (
                 self.state.temperature_storage_target_hw_c,
@@ -366,15 +351,11 @@ class ControllerHeat(cp.Component):
                 stsv=stsv,
                 delta_temperature=delta_temperature_hw,
                 timestep=timestep,
-                temperature_storage=stsv.get_input_value(
-                    self.temperature_storage_heating_water_channel
-                ),
+                temperature_storage=stsv.get_input_value(self.temperature_storage_heating_water_channel),
                 temperature_storage_target=self.temperature_storage_target_heating_water,
                 temperature_storage_target_hysteresis=self.temperature_storage_target_hysteresis_hw,
                 temperature_storage_target_c=self.state.temperature_storage_target_hw_c,
                 timestep_of_hysteresis=self.state.timestep_of_hysteresis_hw,
             )
 
-        stsv.set_output_value(
-            self.control_signal_choose_storage_channel, control_signal_choose_storage
-        )
+        stsv.set_output_value(self.control_signal_choose_storage_channel, control_signal_choose_storage)

--- a/hisim/components/controller_l1_rsoc.py
+++ b/hisim/components/controller_l1_rsoc.py
@@ -60,9 +60,7 @@ class RsocControllerConfig(ConfigBase):
     def read_config(rsoc_name):
         """Opens the according JSON-file, based on the rSOC_name."""
 
-        config_file = os.path.join(
-            utils.HISIMPATH["inputs"], "rSOC_manufacturer_config.json"
-        )
+        config_file = os.path.join(utils.HISIMPATH["inputs"], "rSOC_manufacturer_config.json")
         with open(config_file, "r", encoding="utf-8") as json_file:
             data = json.load(json_file)
             return data.get("rSOC variants", {}).get(rsoc_name, {})
@@ -79,17 +77,13 @@ class RsocControllerConfig(ConfigBase):
             max_load_soec=config_json.get("max_load_soec", 0.0),
             warm_start_time_soec=config_json.get("warm_start_time_soec", 0.0),
             cold_start_time_soec=config_json.get("cold_start_time_soec", 0.0),
-            switching_time_from_soec_to_sofc=config_json.get(
-                "switching_time_from_soec_to_sofc", 0.0
-            ),
+            switching_time_from_soec_to_sofc=config_json.get("switching_time_from_soec_to_sofc", 0.0),
             nom_power_sofc=config_json.get("nom_power_sofc", 0.0),
             min_power_sofc=config_json.get("min_power_sofc", 0.0),
             max_power_sofc=config_json.get("max_power_sofc", 0.0),
             warm_start_time_sofc=config_json.get("warm_start_time_sofc", 0.0),
             cold_start_time_sofc=config_json.get("cold_start_time_sofc", 0.0),
-            switching_time_from_sofc_to_soec=config_json.get(
-                "switching_time_from_sofc_to_soec", 0.0
-            ),
+            switching_time_from_sofc_to_soec=config_json.get("switching_time_from_sofc_to_soec", 0.0),
         )
         return config
 
@@ -295,9 +289,7 @@ class RsocController(Component):
         self.rsoc_state = self.rsoc_state_previous
         self.total_switch_time_count = self.total_switch_time_count_previous
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
         if force_convergence:
             return
@@ -341,16 +333,11 @@ class RsocController(Component):
                 self.current_state = "Starting"
                 self.standby_count += 1
             elif self.current_state == "Starting":
-                if (
-                    self.activation_runtime
-                    <= self.my_simulation_parameters.seconds_per_timestep
-                ):
+                if self.activation_runtime <= self.my_simulation_parameters.seconds_per_timestep:
                     self.activation_runtime = 0.0
                     self.current_state = "ON"
                 else:
-                    self.activation_runtime -= (
-                        self.my_simulation_parameters.seconds_per_timestep
-                    )
+                    self.activation_runtime -= self.my_simulation_parameters.seconds_per_timestep
             else:
                 self.activation_runtime = 0.0
                 self.current_state = "ON"
@@ -392,18 +379,13 @@ class RsocController(Component):
                 state_to_rsoc = 0
                 self.total_switch_time_count += self.switching_time_from_sofc_to_soec
             else:
-                if (
-                    self.elapsed_time
-                    <= self.my_simulation_parameters.seconds_per_timestep
-                ):
+                if self.elapsed_time <= self.my_simulation_parameters.seconds_per_timestep:
                     self.elapsed_time = 0.0
                     self.rsoc_state = "SOEC"
                     power_to_rsco = 0.0
                     state_to_rsoc = 0
                 else:
-                    self.elapsed_time -= (
-                        self.my_simulation_parameters.seconds_per_timestep
-                    )
+                    self.elapsed_time -= self.my_simulation_parameters.seconds_per_timestep
                     power_to_rsco = 0.0
                     state_to_rsoc = 0
 
@@ -418,18 +400,13 @@ class RsocController(Component):
                 state_to_rsoc = 0
                 self.total_switch_time_count += self.switching_time_from_soec_to_sofc
             else:
-                if (
-                    self.elapsed_time
-                    <= self.my_simulation_parameters.seconds_per_timestep
-                ):
+                if self.elapsed_time <= self.my_simulation_parameters.seconds_per_timestep:
                     self.elapsed_time = 0.0
                     self.rsoc_state = "SOFC"
                     power_to_rsco = 0.0
                     state_to_rsoc = 0
                 else:
-                    self.elapsed_time -= (
-                        self.my_simulation_parameters.seconds_per_timestep
-                    )
+                    self.elapsed_time -= self.my_simulation_parameters.seconds_per_timestep
                     power_to_rsco = 0.0
                     state_to_rsoc = 0
         elif power < 0.0 and self.current_state == "STANDBY":

--- a/hisim/components/controller_l2_energy_management_system.py
+++ b/hisim/components/controller_l2_energy_management_system.py
@@ -134,9 +134,7 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
     ElectricityToOrFromGrid = "ElectricityToOrFromGrid"
     TotalElectricityConsumption = "TotalElectricityConsumption"
     FlexibleElectricity = "FlexibleElectricity"
-    BuildingTemperatureModifier = (
-        "BuildingTemperatureModifier"  # connect to HDS controller and Building
-    )
+    BuildingTemperatureModifier = "BuildingTemperatureModifier"  # connect to HDS controller and Building
     StorageTemperatureModifier = "StorageTemperatureModifier"  # used for L1HeatPumpController  # Todo: change name?
     SimpleHotWaterStorageTemperatureModifier = (
         "SimpleHotWaterStorageTemperatureModifier"  # used for HeatPumpHplibController
@@ -145,9 +143,7 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
     CheckPeakShaving = "CheckPeakShaving"
 
     @utils.measure_execution_time
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: EMSConfig
-    ):
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: EMSConfig):
         """Initializes."""
         self.my_component_inputs: List[dynamic_component.DynamicConnectionInput] = []
         self.my_component_outputs: List[dynamic_component.DynamicConnectionOutput] = []
@@ -160,9 +156,7 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
             my_config=config,
         )
 
-        self.state = EMSState(
-            production=0, consumption_uncontrolled=0, consumption_ems_controlled=0
-        )
+        self.state = EMSState(production=0, consumption_uncontrolled=0, consumption_ems_controlled=0)
         self.previous_state = self.state.clone()
 
         self.components_sorted: List[lt.ComponentType] = []
@@ -175,12 +169,8 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
         self.mode: Any
         self.strategy = self.ems_config.strategy
         self.limit_to_shave = self.ems_config.limit_to_shave
-        self.building_temperature_offset_value = (
-            self.ems_config.building_temperature_offset_value
-        )
-        self.storage_temperature_offset_value = (
-            self.ems_config.storage_temperature_offset_value
-        )
+        self.building_temperature_offset_value = self.ems_config.building_temperature_offset_value
+        self.storage_temperature_offset_value = self.ems_config.storage_temperature_offset_value
         self.simple_hot_water_storage_temperature_offset_value = (
             self.ems_config.simple_hot_water_storage_temperature_offset_value
         )
@@ -261,9 +251,7 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
         self.add_dynamic_default_connections(self.get_default_connections_from_utsp_occupancy())
         self.add_dynamic_default_connections(self.get_default_connections_from_pv_system())
         self.add_dynamic_default_connections(self.get_default_connections_from_dhw_heat_pump())
-        self.add_dynamic_default_connections(
-            self.get_default_connections_from_advanced_heat_pump()
-        )
+        self.add_dynamic_default_connections(self.get_default_connections_from_advanced_heat_pump())
         self.add_dynamic_default_connections(self.get_default_connections_from_advanced_battery())
 
     def get_default_connections_from_utsp_occupancy(
@@ -271,7 +259,9 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
     ):
         """Get utsp occupancy default connections."""
 
-        from hisim.components.loadprofilegenerator_utsp_connector import UtspLpgConnector  # pylint: disable=import-outside-toplevel
+        from hisim.components.loadprofilegenerator_utsp_connector import (
+            UtspLpgConnector,
+        )  # pylint: disable=import-outside-toplevel
 
         dynamic_connections = []
         occupancy_class_name = UtspLpgConnector.get_classname()
@@ -294,6 +284,7 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
         """Get pv system default connections."""
 
         from hisim.components.generic_pv_system import PVSystem  # pylint: disable=import-outside-toplevel
+
         print("sett defalt connections for ems")
         dynamic_connections = []
         pv_class_name = PVSystem.get_classname()
@@ -318,7 +309,9 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
     ):
         """Get dhw heat pump default connections."""
 
-        from hisim.components.generic_heat_pump_modular import ModularHeatPump  # pylint: disable=import-outside-toplevel
+        from hisim.components.generic_heat_pump_modular import (
+            ModularHeatPump,
+        )  # pylint: disable=import-outside-toplevel
 
         dynamic_connections = []
         dhw_heat_pump_class_name = ModularHeatPump.get_classname()
@@ -381,9 +374,7 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
 
     def sort_source_weights_and_components(self) -> None:
         """Sorts dynamic Inputs and Outputs according to source weights."""
-        inputs = [
-            elem for elem in self.my_component_inputs if elem.source_weight != 999
-        ]
+        inputs = [elem for elem in self.my_component_inputs if elem.source_weight != 999]
 
         source_tags = [elem.source_tags[0] for elem in inputs]
         source_weights = [elem.source_weight for elem in inputs]
@@ -391,9 +382,7 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
         source_weights = [source_weights[i] for i in sortindex]
 
         self.components_sorted = [source_tags[i] for i in sortindex]
-        self.inputs_sorted = [
-            getattr(self, inputs[i].source_component_class) for i in sortindex
-        ]
+        self.inputs_sorted = [getattr(self, inputs[i].source_component_class) for i in sortindex]
         self.outputs_sorted = []
 
         for ind, source_weight in enumerate(source_weights):
@@ -410,15 +399,11 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
             else:
                 raise Exception("Dynamic input is not conncted to dynamic output")
 
-        self.production_inputs = self.get_dynamic_inputs(
-            tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION]
-        )
+        self.production_inputs = self.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION])
         self.consumption_uncontrolled_inputs = self.get_dynamic_inputs(
             tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED]
         )
-        self.consumption_ems_controlled_inputs = self.get_dynamic_inputs(
-            tags=[lt.InandOutputType.ELECTRICITY_REAL]
-        )
+        self.consumption_ems_controlled_inputs = self.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_REAL])
 
     def write_to_report(self):
         """Writes relevant information to report."""
@@ -494,9 +479,7 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
                 deltademand = deltademand - previous_signal
             else:
                 stsv.set_output_value(self.building_temperature_modifier, 0)
-                stsv.set_output_value(
-                    self.simple_hot_water_storage_temperature_modifier, 0
-                )
+                stsv.set_output_value(self.simple_hot_water_storage_temperature_modifier, 0)
                 stsv.set_output_value(output=output, value=deltademand)
         elif component_type == lt.ComponentType.ELECTROLYZER:
             if deltademand > 0:
@@ -538,38 +521,23 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
                 output=output,
             )
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates iteration of surplus controller."""
         if timestep == 0:
             self.sort_source_weights_and_components()
 
         # get production
-        self.state.production = sum(
-            [
-                stsv.get_input_value(component_input=elem)
-                for elem in self.production_inputs
-            ]
-        )
+        self.state.production = sum([stsv.get_input_value(component_input=elem) for elem in self.production_inputs])
         self.state.consumption_uncontrolled = sum(
-            [
-                stsv.get_input_value(component_input=elem)
-                for elem in self.consumption_uncontrolled_inputs
-            ]
+            [stsv.get_input_value(component_input=elem) for elem in self.consumption_uncontrolled_inputs]
         )
         self.state.consumption_ems_controlled = sum(
-            [
-                stsv.get_input_value(component_input=elem)
-                for elem in self.consumption_ems_controlled_inputs
-            ]
+            [stsv.get_input_value(component_input=elem) for elem in self.consumption_ems_controlled_inputs]
         )
 
         # Production of Electricity positve sign
         # Consumption of Electricity negative sign
-        flexible_electricity = (
-            self.state.production - self.state.consumption_uncontrolled
-        )
+        flexible_electricity = self.state.production - self.state.consumption_uncontrolled
         if self.strategy == "optimize_own_consumption":
             self.optimize_own_consumption_iterative(
                 delta_demand=flexible_electricity,
@@ -578,9 +546,7 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
 
         # Set other output values
         electricity_to_grid = (
-            self.state.production
-            - self.state.consumption_uncontrolled
-            - self.state.consumption_ems_controlled
+            self.state.production - self.state.consumption_uncontrolled - self.state.consumption_ems_controlled
         )
         stsv.set_output_value(self.electricity_to_or_from_grid, electricity_to_grid)
         stsv.set_output_value(self.flexible_electricity_channel, flexible_electricity)

--- a/hisim/components/controller_l2_energy_management_system.py
+++ b/hisim/components/controller_l2_energy_management_system.py
@@ -259,9 +259,9 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
     ):
         """Get utsp occupancy default connections."""
 
-        from hisim.components.loadprofilegenerator_utsp_connector import (
+        from hisim.components.loadprofilegenerator_utsp_connector import (  # pylint: disable=import-outside-toplevel
             UtspLpgConnector,
-        )  # pylint: disable=import-outside-toplevel
+        )
 
         dynamic_connections = []
         occupancy_class_name = UtspLpgConnector.get_classname()
@@ -309,9 +309,9 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
     ):
         """Get dhw heat pump default connections."""
 
-        from hisim.components.generic_heat_pump_modular import (
+        from hisim.components.generic_heat_pump_modular import (  # pylint: disable=import-outside-toplevel
             ModularHeatPump,
-        )  # pylint: disable=import-outside-toplevel
+        )
 
         dynamic_connections = []
         dhw_heat_pump_class_name = ModularHeatPump.get_classname()

--- a/hisim/components/controller_l2_generic_heat_clever_simple.py
+++ b/hisim/components/controller_l2_generic_heat_clever_simple.py
@@ -156,9 +156,7 @@ class L2HeatSmartController(cp.Component):
     # 2. HeatPump
 
     @utils.measure_execution_time
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: L2HeatSmartConfig
-    ) -> None:
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: L2HeatSmartConfig) -> None:
         """Initialize the class."""
         if not config.__class__.__name__ == L2HeatSmartConfig.__name__:
             raise ValueError("Wrong config class: " + config.__class__.__name__)
@@ -191,12 +189,8 @@ class L2HeatSmartController(cp.Component):
         )
 
         self.add_default_connections(self.get_default_connections_from_buildings())
-        self.add_default_connections(
-            self.get_default_connections_from_hot_water_storage()
-        )
-        self.add_default_connections(
-            self.get_default_connections_from_controller_l1_generic_runtime()
-        )
+        self.add_default_connections(self.get_default_connections_from_hot_water_storage())
+        self.add_default_connections(self.get_default_connections_from_controller_l1_generic_runtime())
 
         self.electricity_target_channel: cp.ComponentInput = self.add_input(
             self.component_name,
@@ -230,9 +224,7 @@ class L2HeatSmartController(cp.Component):
         """Get default connections from hot water storage."""
 
         connections = []
-        boiler_classname = (
-            generic_hot_water_storage_modular.HotWaterStorage.get_classname()
-        )
+        boiler_classname = generic_hot_water_storage_modular.HotWaterStorage.get_classname()
         connections.append(
             cp.ComponentConnection(
                 L2HeatSmartController.ReferenceTemperature,
@@ -246,9 +238,7 @@ class L2HeatSmartController(cp.Component):
         """Get default connections from controller l1 generic runtime."""
 
         connections = []
-        l1_classname = (
-            controller_l1_generic_runtime.L1GenericRuntimeController.get_classname()
-        )
+        l1_classname = controller_l1_generic_runtime.L1GenericRuntimeController.get_classname()
         connections.append(
             cp.ComponentConnection(
                 L2HeatSmartController.l1_RunTimeSignal,
@@ -325,16 +315,10 @@ class L2HeatSmartController(cp.Component):
             self.temperature_min_cooling = config.temperature_min_cooling
             self.temperature_max_cooling = config.temperature_max_cooling
             self.heating_season_begin = (
-                config.heating_season_begin
-                * 24
-                * 3600
-                / self.my_simulation_parameters.seconds_per_timestep
+                config.heating_season_begin * 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep
             )
             self.heating_season_end = (
-                config.heating_season_end
-                * 24
-                * 3600
-                / self.my_simulation_parameters.seconds_per_timestep
+                config.heating_season_end * 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep
             )
         self.state = L2HeatSmartControllerState()
         self.previous_state = L2HeatSmartControllerState()
@@ -364,9 +348,7 @@ class L2HeatSmartController(cp.Component):
                 # use previous state if l3 was not available
                 self.state = self.previous_state.clone()
 
-    def control_heating(
-        self, temperature_control: float, temperature_min_heating: float, l3state: Any
-    ) -> int:
+    def control_heating(self, temperature_control: float, temperature_min_heating: float, l3state: Any) -> int:
         """Control heating."""
         if l3state > 0:
             temperature_min_heating = temperature_min_heating + 5
@@ -386,9 +368,7 @@ class L2HeatSmartController(cp.Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         if force_convergence:
             return
@@ -439,7 +419,9 @@ class L2HeatSmartController(cp.Component):
         # #check out during heating season
         # else:
         control_signal = self.control_heating(
-            temperature_control=temperature_control, temperature_min_heating=self.temperature_min_heating, l3state=l3state
+            temperature_control=temperature_control,
+            temperature_min_heating=self.temperature_min_heating,
+            l3state=l3state,
         )
         stsv.set_output_value(self.l2_devicesignal_channel, control_signal)
 

--- a/hisim/components/controller_l2_generic_heat_simple.py
+++ b/hisim/components/controller_l2_generic_heat_simple.py
@@ -210,21 +210,13 @@ class L2GenericHeatController(cp.Component):
             if config.day_of_heating_season_end is None:
                 raise ValueError("Day of heating season end was None")
             self.heating_season_begin = (
-                config.day_of_heating_season_begin
-                * 24
-                * 3600
-                / self.my_simulation_parameters.seconds_per_timestep
+                config.day_of_heating_season_begin * 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep
             )
             self.heating_season_end = (
-                config.day_of_heating_season_end
-                * 24
-                * 3600
-                / self.my_simulation_parameters.seconds_per_timestep
+                config.day_of_heating_season_end * 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep
             )
         self.state: L2GenericHeatControllerState = L2GenericHeatControllerState()
-        self.previous_state: L2GenericHeatControllerState = (
-            L2GenericHeatControllerState()
-        )
+        self.previous_state: L2GenericHeatControllerState = L2GenericHeatControllerState()
 
         # Component Outputs
         self.l2_device_signal_channel: cp.ComponentOutput = self.add_output(
@@ -241,9 +233,7 @@ class L2GenericHeatController(cp.Component):
         )
 
         self.add_default_connections(self.get_default_connections_from_buildings())
-        self.add_default_connections(
-            self.get_default_connections_from_generic_hot_water_storage_modular()
-        )
+        self.add_default_connections(self.get_default_connections_from_generic_hot_water_storage_modular())
 
     def get_default_connections_from_buildings(self):
         """Sets the default connections for the building."""
@@ -263,9 +253,7 @@ class L2GenericHeatController(cp.Component):
         """Sets default connections for the boiler."""
 
         connections = []
-        hotwaterstorage_classname = (
-            generic_hot_water_storage_modular.HotWaterStorage.get_classname()
-        )
+        hotwaterstorage_classname = generic_hot_water_storage_modular.HotWaterStorage.get_classname()
         connections.append(
             cp.ComponentConnection(
                 L2GenericHeatController.ReferenceTemperature,
@@ -307,9 +295,7 @@ class L2GenericHeatController(cp.Component):
                 # use previous state if l3 was not available
                 self.state = self.previous_state.clone()
 
-    def control_heating(
-        self, t_control: float, t_min_heating: float, t_max_heating: float
-    ) -> None:
+    def control_heating(self, t_control: float, t_min_heating: float, t_max_heating: float) -> None:
         """Controles the heating."""
         if t_control > t_max_heating:
             # stop heating if temperature exceeds upper limit
@@ -340,9 +326,7 @@ class L2GenericHeatController(cp.Component):
         """For double checking results."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Core Simulation function."""
         if force_convergence:
             return
@@ -381,10 +365,6 @@ class L2GenericHeatController(cp.Component):
         """Writes the information of the current component to the report."""
         lines: List[str] = []
         lines.append(f"Name: {self.component_name + str(self.config.source_weight)}")
-        lines.append(
-            f"upper set temperature: {self.config.t_max_heating_in_celsius:4.0f} °C"
-        )
-        lines.append(
-            f"lower set temperature: {self.config.t_min_heating_in_celsius:4.0f} °C"
-        )
+        lines.append(f"upper set temperature: {self.config.t_max_heating_in_celsius:4.0f} °C")
+        lines.append(f"lower set temperature: {self.config.t_min_heating_in_celsius:4.0f} °C")
         return lines

--- a/hisim/components/controller_l2_ptx_energy_management_system.py
+++ b/hisim/components/controller_l2_ptx_energy_management_system.py
@@ -48,9 +48,7 @@ class PTXControllerConfig(ConfigBase):
     @staticmethod
     def read_config(electrolyzer_name):
         """Read config."""
-        config_file = os.path.join(
-            utils.HISIMPATH["inputs"], "electrolyzer_manufacturer_config.json"
-        )
+        config_file = os.path.join(utils.HISIMPATH["inputs"], "electrolyzer_manufacturer_config.json")
         with open(config_file, "r", encoding="utf-8") as json_file:
             data = json.load(json_file)
             return data.get("Electrolyzer variants", {}).get(electrolyzer_name, {})
@@ -171,9 +169,7 @@ class PTXController(Component):
         """System operation."""
         if operation_mode == "NominalLoad":
             load_to_system = self.nom_load
-            power_to_battery = (
-                res_load - self.nom_load
-            )  # postive battery charge, negative battery discharges
+            power_to_battery = res_load - self.nom_load  # postive battery charge, negative battery discharges
 
         elif operation_mode == "MinimumLoad":
             if self.min_load <= res_load <= self.max_load:
@@ -219,9 +215,7 @@ class PTXController(Component):
                 else:
                     load_to_system = self.standby_load
                     power_to_battery = res_load - self.standby_load
-                    self.standby_time_count += (
-                        self.my_simulation_parameters.seconds_per_timestep
-                    )
+                    self.standby_time_count += self.my_simulation_parameters.seconds_per_timestep
 
         else:
             if res_load <= self.max_load:
@@ -251,9 +245,7 @@ class PTXController(Component):
         self.standby_time_count = self.standby_time_count_previous
         self.total_energy_to_battery = self.total_energy_to_battery_previous
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
         if force_convergence:
             return
@@ -276,9 +268,7 @@ class PTXController(Component):
             self.system_state = "ON"
 
         """
-        (load_to_system, power_to_battery) = self.system_operation(
-            self.operation_mode, res_load
-        )
+        (load_to_system, power_to_battery) = self.system_operation(self.operation_mode, res_load)
 
         """
         if self.system_state == "OFF":
@@ -290,9 +280,7 @@ class PTXController(Component):
             power_to_battery = res_load
             load_to_system = 0.0
         """
-        self.total_energy_to_battery += power_to_battery * (
-            self.my_simulation_parameters.seconds_per_timestep / 3600
-        )
+        self.total_energy_to_battery += power_to_battery * (self.my_simulation_parameters.seconds_per_timestep / 3600)
 
         stsv.set_output_value(self.load_to_battery, power_to_battery)
         stsv.set_output_value(self.load_to_system, load_to_system)

--- a/hisim/components/controller_l2_rsoc_battery_system.py
+++ b/hisim/components/controller_l2_rsoc_battery_system.py
@@ -54,9 +54,7 @@ class RsocBatteryControllerConfig(ConfigBase):
     def read_config(rsoc_name):
         """Opens the according JSON-file, based on the rSOC_name."""
 
-        config_file = os.path.join(
-            utils.HISIMPATH["inputs"], "rSOC_manufacturer_config.json"
-        )
+        config_file = os.path.join(utils.HISIMPATH["inputs"], "rSOC_manufacturer_config.json")
         with open(config_file, "r", encoding="utf-8") as json_file:
             data = json.load(json_file)
             return data.get("rSOC variants", {}).get(rsoc_name, {})
@@ -192,13 +190,10 @@ class RsocBatteryController(Component):
 
         if operation_mode == "NominalLoad":
             load_to_system = nom_power
-            power_to_battery = (
-                power_delta - nom_power
-            )  # postive battery charge, negative battery discharges
+            power_to_battery = power_delta - nom_power  # postive battery charge, negative battery discharges
 
             # pdb.set_trace()
         elif operation_mode == "MinimumLoad":
-
             # pdb.set_trace()
             if min_power <= power_delta <= max_power:
                 load_to_system = power_delta
@@ -245,9 +240,7 @@ class RsocBatteryController(Component):
         self.system_state = self.system_state_previous
         self.threshold_exceeded = self.threshold_exceeded_previous
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
         if force_convergence:
             return
@@ -305,9 +298,7 @@ class RsocBatteryController(Component):
             # pdb.set_trace()
         """
 
-        stsv.set_output_value(
-            self.load_to_battery, (power_to_battery * 1000)
-        )  # Output: WATT
+        stsv.set_output_value(self.load_to_battery, (power_to_battery * 1000))  # Output: WATT
         stsv.set_output_value(self.load_to_system, load_to_system)
         stsv.set_output_value(self.power, power_delta)
 

--- a/hisim/components/controller_l2_smart_controller.py
+++ b/hisim/components/controller_l2_smart_controller.py
@@ -141,9 +141,7 @@ class SmartController(Component):
         """Doublecheck."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the Smart Controller class."""
         for index, _ in enumerate(self.wrapped_controllers):
             self.wrapped_controllers[index].i_simulate(

--- a/hisim/components/controller_l2_xtp_fuel_cell_ems.py
+++ b/hisim/components/controller_l2_xtp_fuel_cell_ems.py
@@ -48,9 +48,7 @@ class XTPControllerConfig(ConfigBase):
     @staticmethod
     def read_config(fuel_cell_name):
         """Read config."""
-        config_file = os.path.join(
-            utils.HISIMPATH["inputs"], "fuel_cell_manufacturer_config.json"
-        )
+        config_file = os.path.join(utils.HISIMPATH["inputs"], "fuel_cell_manufacturer_config.json")
         with open(config_file, "r", encoding="utf-8") as json_file:
             data = json.load(json_file)
             return data.get("Fuel Cell variants", {}).get(fuel_cell_name, {})
@@ -189,9 +187,7 @@ class XTPController(Component):
                 else:
                     demand_to_system = self.standby_load
                     power_from_battery = -self.standby_load
-                    self.standby_time_count += (
-                        self.my_simulation_parameters.seconds_per_timestep
-                    )
+                    self.standby_time_count += self.my_simulation_parameters.seconds_per_timestep
 
         else:
             demand_to_system = demand_load
@@ -215,16 +211,12 @@ class XTPController(Component):
         self.threshold_exceeded = self.threshold_exceeded_previous
         self.standby_time_count = self.standby_time_count_previous
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
         if force_convergence:
             return
 
-        demand_load = abs(
-            stsv.get_input_value(self.demand_input) / 1000
-        )  # WATT input to KILOWATT
+        demand_load = abs(stsv.get_input_value(self.demand_input) / 1000)  # WATT input to KILOWATT
 
         """ Only for household testing
         if self.system_state == "OFF" and soc < 0.2:
@@ -241,9 +233,7 @@ class XTPController(Component):
             )
             self.system_state = "ON"
         """
-        (demand_to_system, power_from_battery) = self.system_operation(
-            self.operation_mode, demand_load
-        )
+        (demand_to_system, power_from_battery) = self.system_operation(self.operation_mode, demand_load)
 
         """
         if self.system_state == "OFF":
@@ -256,9 +246,7 @@ class XTPController(Component):
             demand_to_system = 0.0
         """
 
-        stsv.set_output_value(
-            self.load_from_battery, power_from_battery * 1000
-        )  # Battery Output in WATT
+        stsv.set_output_value(self.load_from_battery, power_from_battery * 1000)  # Battery Output in WATT
         stsv.set_output_value(self.demand_to_system, demand_to_system)
 
     def write_to_report(self) -> List[str]:

--- a/hisim/components/controller_mpc.py
+++ b/hisim/components/controller_mpc.py
@@ -367,8 +367,7 @@ class MpcController(cp.Component):
 
         if self.mpcconfig.prediction_horizon is not None:
             self.prediction_horizon = int(
-                self.mpcconfig.prediction_horizon
-                / self.my_simulation_parameters.seconds_per_timestep
+                self.mpcconfig.prediction_horizon / self.my_simulation_parameters.seconds_per_timestep
             )
         self.state: MPCcontrollerState = MPCcontrollerState(
             t_m=self.mpcconfig.initial_temeperature,
@@ -395,25 +394,17 @@ class MpcController(cp.Component):
         self.battery_efficiency = self.mpcconfig.battery_efficiency
         self.inverter_efficiency = self.mpcconfig.inverter_efficiency
 
-        self.temperature_forecast_24h_1min = (
-            self.mpcconfig.temperature_forecast_24h_1min
-        )
+        self.temperature_forecast_24h_1min = self.mpcconfig.temperature_forecast_24h_1min
         self.phi_m_forecast_24h_1min = self.mpcconfig.phi_m_forecast_24h_1min
         self.phi_ia_forecast_24h_1min = self.mpcconfig.phi_ia_forecast_24h_1min
         self.phi_st_forecast_24h_1min = self.mpcconfig.phi_st_forecast_24h_1min
         self.pv_forecast_24h_1min = self.mpcconfig.pv_forecast_24h_1min
-        self.price_purchase_forecast_24h_1min = (
-            self.mpcconfig.price_purchase_forecast_24h_1min
-        )
-        self.price_injection_forecast_24h_1min = (
-            self.mpcconfig.price_injection_forecast_24h_1min
-        )
+        self.price_purchase_forecast_24h_1min = self.mpcconfig.price_purchase_forecast_24h_1min
+        self.price_injection_forecast_24h_1min = self.mpcconfig.price_injection_forecast_24h_1min
         self.optimal_cost = self.mpcconfig.optimal_cost
         self.revenues = self.mpcconfig.revenues
         self.air_conditioning_electricity = self.mpcconfig.air_conditioning_electricity
-        self.cost_optimal_temperature_set_point = (
-            self.mpcconfig.cost_optimal_temperature_set_point
-        )
+        self.cost_optimal_temperature_set_point = self.mpcconfig.cost_optimal_temperature_set_point
         self.pv2load = self.mpcconfig.pv2load
         self.electricity_from_grid = self.mpcconfig.electricity_from_grid
         self.electricity_to_grid = self.mpcconfig.electricity_to_grid
@@ -456,9 +447,7 @@ class MpcController(cp.Component):
             )
 
             """"getting pv forecast"""
-            self.pv_forecast_yearly = SingletonSimRepository().get_entry(
-                key=SingletonDictKeyEnum.PVFORECASTYEARLY
-            )
+            self.pv_forecast_yearly = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.PVFORECASTYEARLY)
 
             """ getting battery specifications """
             self.maximum_storage_capacity = SingletonSimRepository().get_entry(
@@ -473,20 +462,13 @@ class MpcController(cp.Component):
             self.maximum_discharging_power = SingletonSimRepository().get_entry(
                 key=SingletonDictKeyEnum.MAXIMALDISCHARGINGPOWER
             )
-            self.battery_efficiency = SingletonSimRepository().get_entry(
-                key=SingletonDictKeyEnum.BATTERYEFFICIENCY
-            )
-            self.inverter_efficiency = SingletonSimRepository().get_entry(
-                key=SingletonDictKeyEnum.INVERTEREFFICIENCY
-            )
-            log.information(
-                f"self.inverter_efficiency {format(self.inverter_efficiency)}"
-            )
+            self.battery_efficiency = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.BATTERYEFFICIENCY)
+            self.inverter_efficiency = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.INVERTEREFFICIENCY)
+            log.information(f"self.inverter_efficiency {format(self.inverter_efficiency)}")
 
     def build(self):
         """Build function: The function sets important constants and parameters for the calculations."""
         if self.mpcconfig.predictive:
-
             """getting building physical properties for state space model"""
             self.h_tr_w = SingletonSimRepository().get_entry(
                 key=SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTGLAZING
@@ -503,9 +485,7 @@ class MpcController(cp.Component):
             self.h_tr_is = SingletonSimRepository().get_entry(
                 key=SingletonDictKeyEnum.THERMALTRANSMISSIONSURFACEINDOORAIR
             )
-            self.c_m = SingletonSimRepository().get_entry(
-                key=SingletonDictKeyEnum.THERMALCAPACITYENVELOPE
-            )
+            self.c_m = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.THERMALCAPACITYENVELOPE)
             """"
             self.h_tr_w = my_simulation_repository.get_entry(
                 Building.Thermal_transmission_coefficient_glazing
@@ -528,29 +508,21 @@ class MpcController(cp.Component):
             """
 
             """ getting cop_coef and eer_coef from the air conditioner omponenent to be used in the cost optimization"""
-            self.cop_coef = SingletonSimRepository().get_entry(
-                key=SingletonDictKeyEnum.COPCOEFFICIENTHEATING
-            )
-            self.eer_coef = SingletonSimRepository().get_entry(
-                key=SingletonDictKeyEnum.EERCOEFFICIENTCOOLING
-            )
+            self.cop_coef = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.COPCOEFFICIENTHEATING)
+            self.eer_coef = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.EERCOEFFICIENTCOOLING)
 
     def statespace(self):
         """State Space Model of the 5R1C network, Used as a prediction model to the building behavior in the MPC."""
 
         seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep
 
-        state_space_matrix_coefficient_x = (
-            (self.h_tr_w + self.h_tr_ms) * (self.h_ve_adj + self.h_tr_is)
-        ) + (self.h_ve_adj * self.h_tr_is)
+        state_space_matrix_coefficient_x = ((self.h_tr_w + self.h_tr_ms) * (self.h_ve_adj + self.h_tr_is)) + (
+            self.h_ve_adj * self.h_tr_is
+        )
 
         # Entries for system matrix
         a11 = (
-            (
-                (self.h_tr_ms**2)
-                * (self.h_tr_is + self.h_ve_adj)
-                / state_space_matrix_coefficient_x
-            )
+            ((self.h_tr_ms**2) * (self.h_tr_is + self.h_ve_adj) / state_space_matrix_coefficient_x)
             - self.h_tr_ms
             - self.h_tr_em
         ) / (
@@ -558,25 +530,16 @@ class MpcController(cp.Component):
         )  # ((self.c_m_ref * self.A_f) * 3600)
 
         # Entries for input matrix
-        b11 = (self.h_tr_ms * self.h_tr_is) / (
-            (self.c_m / seconds_per_timestep) * state_space_matrix_coefficient_x
-        )
+        b11 = (self.h_tr_ms * self.h_tr_is) / ((self.c_m / seconds_per_timestep) * state_space_matrix_coefficient_x)
 
         b_d11 = (
-            (
-                self.h_tr_ms
-                * self.h_tr_w
-                * (self.h_tr_is + self.h_ve_adj)
-                / state_space_matrix_coefficient_x
-            )
+            (self.h_tr_ms * self.h_tr_w * (self.h_tr_is + self.h_ve_adj) / state_space_matrix_coefficient_x)
             + self.h_tr_em
         ) / (self.c_m / seconds_per_timestep)
         b_d12 = (self.h_tr_ms * self.h_tr_is * self.h_ve_adj) / (
             (self.c_m / seconds_per_timestep) * state_space_matrix_coefficient_x
         )
-        b_d13 = (self.h_tr_ms * self.h_tr_is) / (
-            (self.c_m / seconds_per_timestep) * state_space_matrix_coefficient_x
-        )
+        b_d13 = (self.h_tr_ms * self.h_tr_is) / ((self.c_m / seconds_per_timestep) * state_space_matrix_coefficient_x)
         b_d14 = (self.h_tr_ms * (self.h_tr_is + self.h_ve_adj)) / (
             (self.c_m / seconds_per_timestep) * state_space_matrix_coefficient_x
         )
@@ -584,30 +547,18 @@ class MpcController(cp.Component):
 
         # Entries for output matrix
         c11 = (self.h_tr_ms * self.h_tr_is) / state_space_matrix_coefficient_x
-        c21 = (
-            self.h_tr_ms * (self.h_tr_is + self.h_ve_adj)
-        ) / state_space_matrix_coefficient_x
+        c21 = (self.h_tr_ms * (self.h_tr_is + self.h_ve_adj)) / state_space_matrix_coefficient_x
 
         # Entries for feedthrough matrix
-        d11 = (
-            self.h_tr_ms + self.h_tr_w + self.h_tr_is
-        ) / state_space_matrix_coefficient_x
+        d11 = (self.h_tr_ms + self.h_tr_w + self.h_tr_is) / state_space_matrix_coefficient_x
         d21 = self.h_tr_is / state_space_matrix_coefficient_x
 
         d_d11 = (self.h_tr_w * self.h_tr_is) / state_space_matrix_coefficient_x
-        d_d12 = (
-            (self.h_tr_ms + self.h_tr_is + self.h_tr_w)
-            * self.h_ve_adj
-            / state_space_matrix_coefficient_x
-        )
-        d_d13 = (
-            self.h_tr_ms + self.h_tr_is + self.h_tr_w
-        ) / state_space_matrix_coefficient_x
+        d_d12 = (self.h_tr_ms + self.h_tr_is + self.h_tr_w) * self.h_ve_adj / state_space_matrix_coefficient_x
+        d_d13 = (self.h_tr_ms + self.h_tr_is + self.h_tr_w) / state_space_matrix_coefficient_x
         d_d14 = self.h_tr_is / state_space_matrix_coefficient_x
         d_d15 = 0
-        d_d21 = (
-            self.h_tr_w * (self.h_tr_is + self.h_ve_adj)
-        ) / state_space_matrix_coefficient_x
+        d_d21 = (self.h_tr_w * (self.h_tr_is + self.h_ve_adj)) / state_space_matrix_coefficient_x
         d_d22 = (self.h_tr_is * self.h_ve_adj) / state_space_matrix_coefficient_x
         d_d23 = self.h_tr_is / state_space_matrix_coefficient_x
         d_d24 = (self.h_tr_is + self.h_ve_adj) / state_space_matrix_coefficient_x
@@ -615,12 +566,8 @@ class MpcController(cp.Component):
 
         # Build arrays for state space representation
         state_space_system_matrix_a = np.array([[a11]])  # system matrix
-        state_space_input_matrix_b_d = np.array(
-            [[b_d11, b_d12, b_d13, b_d14, b_d15]]
-        )  # input matrix discrete
-        state_space_input_matrix_b = np.array(
-            [[b11, b_d11, b_d12, b_d13, b_d14, b_d15]]
-        )  # input matrix
+        state_space_input_matrix_b_d = np.array([[b_d11, b_d12, b_d13, b_d14, b_d15]])  # input matrix discrete
+        state_space_input_matrix_b = np.array([[b11, b_d11, b_d12, b_d13, b_d14, b_d15]])  # input matrix
         state_space_output_matrix_c = np.array([[c11], [c21]])  # output matrix
         state_space_feedthrough_matrix_d_d = np.array(
             [[d_d11, d_d12, d_d13, d_d14, d_d15], [d_d21, d_d22, d_d23, d_d24, d_d25]]
@@ -674,21 +621,11 @@ class MpcController(cp.Component):
         """Get yearly weather forecast."""
         # slicing yearly forecast to extract data points for the prediction horizon (24 hours)
         # number of data points extracted equals= self.prediction_horizon = 3600 * 24 h / seconds_per_timestep
-        self.temperature_forecast_24h_1min = self.temp_forecast[
-            start_horizon: start_horizon + self.prediction_horizon
-        ]
-        self.phi_m_forecast_24h_1min = self.phi_m_forecast[
-            start_horizon: start_horizon + self.prediction_horizon
-        ]
-        self.phi_ia_forecast_24h_1min = self.phi_ia_forecast[
-            start_horizon: start_horizon + self.prediction_horizon
-        ]
-        self.phi_st_forecast_24h_1min = self.phi_st_forecast[
-            start_horizon: start_horizon + self.prediction_horizon
-        ]
-        self.pv_forecast_24h_1min = self.pv_forecast_yearly[
-            start_horizon: start_horizon + self.prediction_horizon
-        ]
+        self.temperature_forecast_24h_1min = self.temp_forecast[start_horizon : start_horizon + self.prediction_horizon]
+        self.phi_m_forecast_24h_1min = self.phi_m_forecast[start_horizon : start_horizon + self.prediction_horizon]
+        self.phi_ia_forecast_24h_1min = self.phi_ia_forecast[start_horizon : start_horizon + self.prediction_horizon]
+        self.phi_st_forecast_24h_1min = self.phi_st_forecast[start_horizon : start_horizon + self.prediction_horizon]
+        self.pv_forecast_24h_1min = self.pv_forecast_yearly[start_horizon : start_horizon + self.prediction_horizon]
 
         self.price_purchase_forecast_24h_1min = SingletonSimRepository().get_entry(
             key=SingletonDictKeyEnum.PRICEPURCHASEFORECAST24H
@@ -704,12 +641,8 @@ class MpcController(cp.Component):
         phi_m_forecast_24h = self.phi_m_forecast_24h_1min[0::sampling_rate]
         phi_ia_forecast_24h = self.phi_ia_forecast_24h_1min[0::sampling_rate]
         phi_st_forecast_24h = self.phi_st_forecast_24h_1min[0::sampling_rate]
-        price_purchase_forecast_24h = self.price_purchase_forecast_24h_1min[
-            0::sampling_rate
-        ]
-        price_injection_forecast_24h = self.price_injection_forecast_24h_1min[
-            0::sampling_rate
-        ]
+        price_purchase_forecast_24h = self.price_purchase_forecast_24h_1min[0::sampling_rate]
+        price_injection_forecast_24h = self.price_injection_forecast_24h_1min[0::sampling_rate]
         pv_forecast_24h = self.pv_forecast_24h_1min[0::sampling_rate]
 
         # only take positive values from PV, otherwise mpc will have an ill-posed problem which will raise errors
@@ -741,9 +674,7 @@ class MpcController(cp.Component):
         # scaled_horizon = scaled_horizon  # scaled prediction horizon
 
         # Discretization of the state space model:
-        identity_matrix = np.identity(
-            self.state_space_system_matrix_a.shape[0]
-        )  # this is an identity matrix
+        identity_matrix = np.identity(self.state_space_system_matrix_a.shape[0])  # this is an identity matrix
         matrix_a_d = np.array(np.exp(self.state_space_system_matrix_a * sampling_rate))
         matrix_b_d = (
             np.linalg.inv(self.state_space_system_matrix_a)
@@ -765,14 +696,8 @@ class MpcController(cp.Component):
         cop_timestep = []
         eer_timestep = []
         for k in range(int(self.prediction_horizon)):
-            cop_timestep.append(
-                self.cop_coef[0] * self.temperature_forecast_24h_1min[k]
-                + self.cop_coef[1]
-            )  # cop
-            eer_timestep.append(
-                self.eer_coef[0] * self.temperature_forecast_24h_1min[k]
-                + self.eer_coef[1]
-            )  # eer
+            cop_timestep.append(self.cop_coef[0] * self.temperature_forecast_24h_1min[k] + self.cop_coef[1])  # cop
+            eer_timestep.append(self.eer_coef[0] * self.temperature_forecast_24h_1min[k] + self.eer_coef[1])  # eer
 
         cop_sampled = cop_timestep[0::sampling_rate]
         eer_sampled = eer_timestep[0::sampling_rate]
@@ -783,13 +708,9 @@ class MpcController(cp.Component):
         eer_sampled_array = np.reshape(np.array(eer_sampled), (1, len(eer_sampled)))
 
         # Numerical values of pv forecast (casadi fromat)
-        pv_forecast_24h = np.reshape(
-            np.array(pv_forecast_24h), (1, len(pv_forecast_24h))
-        )
+        pv_forecast_24h = np.reshape(np.array(pv_forecast_24h), (1, len(pv_forecast_24h)))
 
-        p_el = np.reshape(
-            np.array(price_purchase_forecast_24h), (1, len(price_purchase_forecast_24h))
-        )
+        p_el = np.reshape(np.array(price_purchase_forecast_24h), (1, len(price_purchase_forecast_24h)))
 
         feed_in_tariff = np.reshape(
             np.array(price_injection_forecast_24h),
@@ -836,9 +757,7 @@ class MpcController(cp.Component):
 
         opti = ca.Opti()
 
-        optvar_temperature = opti.variable(
-            1, scaled_horizon + 1
-        )  # state variable: controlled temperature
+        optvar_temperature = opti.variable(1, scaled_horizon + 1)  # state variable: controlled temperature
         optvar_power_thermal_delivered = opti.variable(
             1, scaled_horizon
         )  # manipulated variable: thermal power delivered
@@ -869,9 +788,7 @@ class MpcController(cp.Component):
         cop_values = opti.parameter(
             1, scaled_horizon
         )  # coefiiecient of performance: heating air conditioner efficiency
-        eer_values = opti.parameter(
-            1, scaled_horizon
-        )  # energy efficiency ratio: cooling air conditioner efficiency
+        eer_values = opti.parameter(1, scaled_horizon)  # energy efficiency ratio: cooling air conditioner efficiency
 
         if self.flexibility_element in {"PV_only", "PV_and_Battery"}:
             pv_production = opti.parameter(1, scaled_horizon)
@@ -889,10 +806,7 @@ class MpcController(cp.Component):
             opti.minimize(
                 sum(
                     ca.horzsplit(
-                        (
-                            p_el * optvar_power_bought_from_grid
-                            - 0.5 * feed_in_tariff * optvar_power_sold_to_grid
-                        )
+                        (p_el * optvar_power_bought_from_grid - 0.5 * feed_in_tariff * optvar_power_sold_to_grid)
                     )
                 )
             )
@@ -901,10 +815,7 @@ class MpcController(cp.Component):
             opti.minimize(
                 sum(
                     ca.horzsplit(
-                        (
-                            p_el * optvar_power_bought_from_grid
-                            - 0.5 * feed_in_tariff * optvar_power_sold_to_grid
-                        )
+                        (p_el * optvar_power_bought_from_grid - 0.5 * feed_in_tariff * optvar_power_sold_to_grid)
                     )
                 )
             )
@@ -928,18 +839,10 @@ class MpcController(cp.Component):
                     optvar_battery_soc[:, k + 1]
                     == optvar_battery_soc[:, k]
                     + (optvar_battery_power_flow[:, k])
-                    * (
-                        self.my_simulation_parameters.seconds_per_timestep
-                        * sampling_rate
-                        / 3600
-                    )
+                    * (self.my_simulation_parameters.seconds_per_timestep * sampling_rate / 3600)
                 )
 
-        opti.subject_to(
-            opti.bounded(
-                self.min_comfort_temp, optvar_temperature, self.max_comfort_temp
-            )
-        )
+        opti.subject_to(opti.bounded(self.min_comfort_temp, optvar_temperature, self.max_comfort_temp))
 
         """ a Terminal Constraint is added if Hisim resolution is different than the optimizer resolution:
             e.g, if you run hisim at 60 sec per time step and you would like to reduce the optimization is done by sampling each 20 or 15 min
@@ -961,24 +864,18 @@ class MpcController(cp.Component):
             )
 
         if self.flexibility_element == "PV_only":
-
             """Energy Balance constraint for Grid , PV  interaction"""
             opti.subject_to(
                 optvar_power_bought_from_grid
                 == ca.if_else(
                     optvar_power_thermal_delivered > 0,
-                    ca.fabs(optvar_power_thermal_delivered) / cop_values
-                    - (pv_production - optvar_power_sold_to_grid),
-                    ca.fabs(optvar_power_thermal_delivered) / eer_values
-                    - (pv_production - optvar_power_sold_to_grid),
+                    ca.fabs(optvar_power_thermal_delivered) / cop_values - (pv_production - optvar_power_sold_to_grid),
+                    ca.fabs(optvar_power_thermal_delivered) / eer_values - (pv_production - optvar_power_sold_to_grid),
                 )
             )
-            opti.subject_to(
-                optvar_power_pv == pv_production - optvar_power_sold_to_grid
-            )
+            opti.subject_to(optvar_power_pv == pv_production - optvar_power_sold_to_grid)
 
         if self.flexibility_element == "PV_and_Battery":
-
             """Battery charging and discharging bounds / making sure that charging and discharging doesn't occur at the same time"""
             opti.subject_to(
                 opti.bounded(
@@ -1006,16 +903,11 @@ class MpcController(cp.Component):
                 optvar_battery_power_discharging
                 == ca.if_else(
                     optvar_battery_power_flow < 0,
-                    -optvar_battery_power_flow
-                    / (self.battery_efficiency * self.inverter_efficiency),
+                    -optvar_battery_power_flow / (self.battery_efficiency * self.inverter_efficiency),
                     0,
                 )
             )
-            opti.subject_to(
-                opti.bounded(
-                    0, optvar_battery_power_charging, self.maximum_charging_power
-                )
-            )
+            opti.subject_to(opti.bounded(0, optvar_battery_power_charging, self.maximum_charging_power))
 
             """ Energy Balance constraint for Grid , PV , Battery interaction"""
 
@@ -1032,8 +924,7 @@ class MpcController(cp.Component):
                 )
             )
             opti.subject_to(
-                optvar_power_sold_to_grid
-                == pv_production - optvar_battery_power_charging - optvar_power_pv
+                optvar_power_sold_to_grid == pv_production - optvar_battery_power_charging - optvar_power_pv
             )
 
         if self.flexibility_element in {"PV_only", "PV_and_Battery"}:
@@ -1049,9 +940,7 @@ class MpcController(cp.Component):
             )
 
         """ Initial conditions """
-        opti.subject_to(
-            optvar_temperature[:, 0] == x_init
-        )  # controlled temperature temperature
+        opti.subject_to(optvar_temperature[:, 0] == x_init)  # controlled temperature temperature
         opti.subject_to(
             optvar_disturbances == disturbance_forecast
         )  # building disturbances (solar gains / internal gains / ambient temperature)
@@ -1062,9 +951,7 @@ class MpcController(cp.Component):
             )  # forecasted PV generation by the generic_pv_component
 
         if self.flexibility_element == "PV_and_Battery":
-            opti.subject_to(
-                optvar_battery_soc[:, 0] == soc_init
-            )  # battery state of charge
+            opti.subject_to(optvar_battery_soc[:, 0] == soc_init)  # battery state of charge
 
         """ Choose a concerete solver: The default linear solver used with ipopt is mumps (MUltifrontal Massively Parallel Solver).
         For a faster solution, the default solver is replaced with HSL solver 'ma27' (see 'sol_opts' > 'linear_solver').
@@ -1136,8 +1023,7 @@ class MpcController(cp.Component):
             else:
                 energy_efficiency_timestep[i] = eer_timestep[i]
         airconditioning_electrcitiy_consumption = [
-            abs(p_th_opt_timstep[i]) / energy_efficiency_timestep[i]
-            for i in range(int(self.prediction_horizon))
+            abs(p_th_opt_timstep[i]) / energy_efficiency_timestep[i] for i in range(int(self.prediction_horizon))
         ]
 
         # optimizer solution might lead to values like 1.5e-9 ---> these are replaces with zeros
@@ -1150,7 +1036,6 @@ class MpcController(cp.Component):
                 airconditioning_electrcitiy_consumption[i] = 0
 
         if self.flexibility_element in {"PV_only", "PV_and_Battery"}:
-
             # solution optimize resolution
             pv_consumption = sol.value(optvar_power_pv)
             grid_export = sol.value(optvar_power_sold_to_grid)
@@ -1168,15 +1053,12 @@ class MpcController(cp.Component):
                     grid_export_timestep[i] = 0
 
         if self.flexibility_element == "PV_and_Battery":
-
             # solution optimize resolution
             battery_to_load = sol.value(optvar_battery_power_discharging)
             pv_to_battery = sol.value(optvar_battery_power_charging)
             optvar_battery_power_flow = sol.value(optvar_battery_power_flow)
             batt_soc_actual = sol.value(optvar_battery_soc)
-            batt_soc_normalized = (
-                sol.value(optvar_battery_soc) / self.maximum_storage_capacity
-            )
+            batt_soc_normalized = sol.value(optvar_battery_soc) / self.maximum_storage_capacity
             if self.mpc_scheme == "optimization_once_aday_only":
                 self.state.soc = batt_soc_actual[-1]
                 if self.state.soc < 0.2 * self.maximum_storage_capacity:
@@ -1187,15 +1069,9 @@ class MpcController(cp.Component):
             # solution for actual HiSim timestep
             battery_to_load_timstep = np.repeat(battery_to_load, sampling_rate).tolist()
             pv_to_battery_timestep = np.repeat(pv_to_battery, sampling_rate).tolist()
-            batt_soc_actual_timestep = np.repeat(
-                batt_soc_actual, sampling_rate
-            ).tolist()
-            batt_soc_normalized_timestep = np.repeat(
-                batt_soc_normalized, sampling_rate
-            ).tolist()
-            battery_power_flow_timestep = np.repeat(
-                optvar_battery_power_flow, sampling_rate
-            ).tolist()
+            batt_soc_actual_timestep = np.repeat(batt_soc_actual, sampling_rate).tolist()
+            batt_soc_normalized_timestep = np.repeat(batt_soc_normalized, sampling_rate).tolist()
+            battery_power_flow_timestep = np.repeat(optvar_battery_power_flow, sampling_rate).tolist()
 
             # optimizer solution might lead to values like 1.5e-9 ---> these are replaces with zeros
             for i in range(self.prediction_horizon):
@@ -1272,41 +1148,28 @@ class MpcController(cp.Component):
         revenue = []
         for i in range(int(self.prediction_horizon)):
             costs = grid_import_timestep[i] * self.price_purchase_forecast_24h_1min[i]
-            revenues = (
-                grid_export_timestep[i] * self.price_injection_forecast_24h_1min[i]
-            )
+            revenues = grid_export_timestep[i] * self.price_injection_forecast_24h_1min[i]
             optimal_cost.append(costs)
             revenue.append(revenues)
 
         return optimal_cost, revenue
 
-    def cost_calculation_no_flexibility_element(
-        self, airconditioning_electrcitiy_consumption
-    ):
+    def cost_calculation_no_flexibility_element(self, airconditioning_electrcitiy_consumption):
         """Calculate cost of cooling for buildings without renewables."""
         optimal_cost = []
         for i in range(int(self.prediction_horizon)):
-            costs = (
-                airconditioning_electrcitiy_consumption[i]
-                * self.price_purchase_forecast_24h_1min[i]
-            )
+            costs = airconditioning_electrcitiy_consumption[i] * self.price_purchase_forecast_24h_1min[i]
             optimal_cost.append(costs)
 
         return optimal_cost
 
-    def i_simulate(  # noqa: C901
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:  # noqa: C901
         """Start simulation of the MPC here."""
         # t_m_old = stsv.get_input_value(self.t_m_channel)
         if self.mpcconfig.predictive:
-            if (
-                self.mpc_scheme == "optimization_once_aday_only"
-                and timestep % self.prediction_horizon == 0
-            ) or (
+            if (self.mpc_scheme == "optimization_once_aday_only" and timestep % self.prediction_horizon == 0) or (
                 self.mpc_scheme == "moving_horizon_control"
-                and timestep
-                <= self.my_simulation_parameters.timesteps - self.prediction_horizon
+                and timestep <= self.my_simulation_parameters.timesteps - self.prediction_horizon
             ):
                 if self.my_simulation_parameters.seconds_per_timestep >= 15 * 60:
                     sampling_rate = 1
@@ -1327,7 +1190,6 @@ class MpcController(cp.Component):
                 ) = self.get_forecast_24h(timestep, sampling_rate)
 
                 if self.flexibility_element == "basic_buidling_configuration":
-
                     (
                         p_th_opt_timstep,
                         airconditioning_electrcitiy_consumption,
@@ -1348,13 +1210,10 @@ class MpcController(cp.Component):
                     self.revenues = [0] * self.prediction_horizon
 
                     self.state.cost_optimal_thermal_power = p_th_opt_timstep
-                    self.air_conditioning_electricity = (
-                        airconditioning_electrcitiy_consumption
-                    )
+                    self.air_conditioning_electricity = airconditioning_electrcitiy_consumption
                     self.cost_optimal_temperature_set_point = t_m_opt_timestep
 
                 if self.flexibility_element == "PV_only":
-
                     (
                         p_th_opt_timstep,
                         airconditioning_electrcitiy_consumption,
@@ -1372,14 +1231,10 @@ class MpcController(cp.Component):
                         pv_forecast_24h,
                         scaled_horizon,
                     )
-                    self.optimal_cost, self.revenues = self.cost_calculation(
-                        grid_export_timestep, grid_import_timestep
-                    )
+                    self.optimal_cost, self.revenues = self.cost_calculation(grid_export_timestep, grid_import_timestep)
 
                     self.state.cost_optimal_thermal_power = p_th_opt_timstep
-                    self.air_conditioning_electricity = (
-                        airconditioning_electrcitiy_consumption
-                    )
+                    self.air_conditioning_electricity = airconditioning_electrcitiy_consumption
                     self.pv2load = pv_consumption_timestep
                     self.electricity_from_grid = grid_import_timestep
                     self.electricity_to_grid = grid_export_timestep
@@ -1408,14 +1263,10 @@ class MpcController(cp.Component):
                         pv_forecast_24h,
                         scaled_horizon,
                     )
-                    self.optimal_cost, self.revenues = self.cost_calculation(
-                        grid_export_timestep, grid_import_timestep
-                    )
+                    self.optimal_cost, self.revenues = self.cost_calculation(grid_export_timestep, grid_import_timestep)
 
                     self.state.cost_optimal_thermal_power = p_th_opt_timstep
-                    self.air_conditioning_electricity = (
-                        airconditioning_electrcitiy_consumption
-                    )
+                    self.air_conditioning_electricity = airconditioning_electrcitiy_consumption
                     self.pv2load = pv_consumption_timestep
                     self.electricity_from_grid = grid_import_timestep
                     self.electricity_to_grid = grid_export_timestep
@@ -1430,9 +1281,7 @@ class MpcController(cp.Component):
                             self.battery_control_state.append(state)
                         elif pv_to_battery_timestep[i] != 0:
                             state = 1
-                            self.battery_control_state.append(
-                                state
-                            )  # inform the battery that energy is charged
+                            self.battery_control_state.append(state)  # inform the battery that energy is charged
                         else:
                             state = 0  # No cahrging or discharging
                             self.battery_control_state.append(state)
@@ -1449,8 +1298,7 @@ class MpcController(cp.Component):
             self.state.t_m = self.cost_optimal_temperature_set_point[0]
         if (
             self.mpc_scheme == "moving_horizon_control"
-            and timestep
-            > self.my_simulation_parameters.timesteps - self.prediction_horizon
+            and timestep > self.my_simulation_parameters.timesteps - self.prediction_horizon
         ):
             applied_optimal_solution_index = timestep % self.prediction_horizon
 
@@ -1472,12 +1320,8 @@ class MpcController(cp.Component):
             self.p_elec_mpc_channel,
             self.air_conditioning_electricity[applied_optimal_solution_index],
         )
-        stsv.set_output_value(
-            self.costs_channel, self.optimal_cost[applied_optimal_solution_index]
-        )
-        stsv.set_output_value(
-            self.revenues_channel, self.revenues[applied_optimal_solution_index]
-        )
+        stsv.set_output_value(self.costs_channel, self.optimal_cost[applied_optimal_solution_index])
+        stsv.set_output_value(self.revenues_channel, self.revenues[applied_optimal_solution_index])
 
         if self.flexibility_element == "basic_buidling_configuration":
             stsv.set_output_value(

--- a/hisim/components/controller_pid.py
+++ b/hisim/components/controller_pid.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 import control
 import numpy as np
+
 # Owned
 
 from hisim import component as cp
@@ -145,24 +146,20 @@ class PIDController(cp.Component):
             True,
         )
 
-        self.heat_flow_rate_to_internal_surface_node_channel: cp.ComponentInput = (
-            self.add_input(
-                self.component_name,
-                self.HeatFluxWallNode,
-                LoadTypes.HEATING,
-                Units.WATT,
-                True,
-            )
+        self.heat_flow_rate_to_internal_surface_node_channel: cp.ComponentInput = self.add_input(
+            self.component_name,
+            self.HeatFluxWallNode,
+            LoadTypes.HEATING,
+            Units.WATT,
+            True,
         )
 
-        self.heat_flow_rate_to_internal_mass_node_channel: cp.ComponentInput = (
-            self.add_input(
-                self.component_name,
-                self.HeatFluxThermalMassNode,
-                LoadTypes.HEATING,
-                Units.WATT,
-                True,
-            )
+        self.heat_flow_rate_to_internal_mass_node_channel: cp.ComponentInput = self.add_input(
+            self.component_name,
+            self.HeatFluxThermalMassNode,
+            LoadTypes.HEATING,
+            Units.WATT,
+            True,
         )
 
         self.thermal_power_channel: cp.ComponentOutput = self.add_output(
@@ -258,9 +255,7 @@ class PIDController(cp.Component):
     def build(self):
         """For calculating internal things and preparing the simulation."""
         """ getting building physical properties for state space model """
-        self.h_tr_w = SingletonSimRepository().get_entry(
-            key=SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTGLAZING
-        )
+        self.h_tr_w = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTGLAZING)
         self.h_tr_ms = SingletonSimRepository().get_entry(
             key=SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTOPAQUEMS
         )
@@ -270,12 +265,8 @@ class PIDController(cp.Component):
         self.h_ve_adj = SingletonSimRepository().get_entry(
             key=SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTVENTILLATION
         )
-        self.h_tr_is = SingletonSimRepository().get_entry(
-            key=SingletonDictKeyEnum.THERMALTRANSMISSIONSURFACEINDOORAIR
-        )
-        self.c_m = SingletonSimRepository().get_entry(
-            key=SingletonDictKeyEnum.THERMALCAPACITYENVELOPE
-        )
+        self.h_tr_is = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.THERMALTRANSMISSIONSURFACEINDOORAIR)
+        self.c_m = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.THERMALCAPACITYENVELOPE)
 
     def i_save_state(self):
         """Saves the internal state at the beginning of each timestep."""
@@ -298,17 +289,13 @@ class PIDController(cp.Component):
         lines.append(f"Controller Integral gain is {self.integral_gain:4.2f} \n")
         return lines
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Core smulation function."""
         if force_convergence:
             return
         # Retrieve Disturbance forecast
         phi_m = stsv.get_input_value(self.heat_flow_rate_to_internal_mass_node_channel)
-        phi_st = stsv.get_input_value(
-            self.heat_flow_rate_to_internal_surface_node_channel
-        )
+        phi_st = stsv.get_input_value(self.heat_flow_rate_to_internal_surface_node_channel)
 
         # Retrieve building temperature
         building_temperature_t_mc = stsv.get_input_value(self.temperature_mean_channel)
@@ -368,9 +355,7 @@ class PIDController(cp.Component):
         phi_st_gain: float = self.phi_st_gain
         phi_m_gain: float = self.phi_m_gain
 
-        feed_forward_signal = (
-            -((phi_st_gain * phi_st) + (phi_m_gain * phi_m)) / process_gain
-        )
+        feed_forward_signal = -((phi_st_gain * phi_st) + (phi_m_gain * phi_m)) / process_gain
 
         return feed_forward_signal
 
@@ -384,30 +369,19 @@ class PIDController(cp.Component):
         given these data one could find an acceptable tuning of a PI controller.
         """
         seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep
-        x_value = ((self.h_tr_w + self.h_tr_ms) * (self.h_ve_adj + self.h_tr_is)) + (
-            self.h_ve_adj * self.h_tr_is
-        )
-        a11 = (
-            ((self.h_tr_ms**2) * (self.h_tr_is + self.h_ve_adj) / x_value)
-            - self.h_tr_ms
-            - self.h_tr_em
-        ) / (
+        x_value = ((self.h_tr_w + self.h_tr_ms) * (self.h_ve_adj + self.h_tr_is)) + (self.h_ve_adj * self.h_tr_is)
+        a11 = (((self.h_tr_ms**2) * (self.h_tr_is + self.h_ve_adj) / x_value) - self.h_tr_ms - self.h_tr_em) / (
             self.c_m / seconds_per_timestep
         )  # ((self.c_m_ref * self.A_f) * 3600)
 
         b11 = (self.h_tr_ms * self.h_tr_is) / ((self.c_m / seconds_per_timestep) * x_value)
 
-        b_d11 = (
-            (self.h_tr_ms * self.h_tr_w * (self.h_tr_is + self.h_ve_adj) / x_value)
-            + self.h_tr_em
-        ) / (self.c_m / seconds_per_timestep)
-        b_d12 = (self.h_tr_ms * self.h_tr_is * self.h_ve_adj) / (
-            (self.c_m / seconds_per_timestep) * x_value
+        b_d11 = ((self.h_tr_ms * self.h_tr_w * (self.h_tr_is + self.h_ve_adj) / x_value) + self.h_tr_em) / (
+            self.c_m / seconds_per_timestep
         )
+        b_d12 = (self.h_tr_ms * self.h_tr_is * self.h_ve_adj) / ((self.c_m / seconds_per_timestep) * x_value)
         b_d13 = (self.h_tr_ms * self.h_tr_is) / ((self.c_m / seconds_per_timestep) * x_value)
-        b_d14 = (self.h_tr_ms * (self.h_tr_is + self.h_ve_adj)) / (
-            (self.c_m / seconds_per_timestep) * x_value
-        )
+        b_d14 = (self.h_tr_ms * (self.h_tr_is + self.h_ve_adj)) / ((self.c_m / seconds_per_timestep) * x_value)
         b_d15 = 1 / (self.c_m / seconds_per_timestep)
 
         """ #comment out due to pylint warning W0612 (unused-variable)
@@ -520,9 +494,7 @@ class PIDController(cp.Component):
         settling_time = time_constant_tm * 0.3
         over_shooting = 20
 
-        damping_ratio = -np.log(over_shooting / 100) / (
-            np.pi**2 + (np.log(over_shooting / 100)) ** 2
-        ) ** (1 / 2)
+        damping_ratio = -np.log(over_shooting / 100) / (np.pi**2 + (np.log(over_shooting / 100)) ** 2) ** (1 / 2)
         natural_frequency = 4 / (settling_time * damping_ratio)
         # damping_frequency=natural_frequency * np.sqrt(1-damping_ratio**2) #comment out due to pylint warning W0612 (unused-variable)
 
@@ -544,13 +516,9 @@ class PIDController(cp.Component):
         minimum_cooling_set_temp = set_point - offset_in_degree_celsius
 
         mode = "off"
-        if (
-            mode == "heating" and current_temperature > maximum_heating_set_temp
-        ):  # 23 22.5
+        if mode == "heating" and current_temperature > maximum_heating_set_temp:  # 23 22.5
             return "off"
-        if (
-            mode == "cooling" and current_temperature < minimum_cooling_set_temp
-        ):  # 24 21.5
+        if mode == "cooling" and current_temperature < minimum_cooling_set_temp:  # 24 21.5
             mode = "off"
         if mode == "off":
             if current_temperature < set_point:  # 21

--- a/hisim/components/csvloader.py
+++ b/hisim/components/csvloader.py
@@ -76,9 +76,7 @@ class CSVLoader(cp.Component):
 
     Output1: str = "CSV Profile"
 
-    def __init__(
-        self, config: CSVLoaderConfig, my_simulation_parameters: SimulationParameters
-    ):
+    def __init__(self, config: CSVLoaderConfig, my_simulation_parameters: SimulationParameters):
         """Initialize the class."""
         self.csvconfig = config
         super().__init__(
@@ -126,13 +124,9 @@ class CSVLoader(cp.Component):
         """Restores the state."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
-        stsv.set_output_value(
-            self.output1_channel, float(self.column[timestep]) * self.multiplier
-        )
+        stsv.set_output_value(self.output1_channel, float(self.column[timestep]) * self.multiplier)
 
     def i_prepare_simulation(self) -> None:
         """Prepare the simulation."""

--- a/hisim/components/electricity_meter.py
+++ b/hisim/components/electricity_meter.py
@@ -158,9 +158,9 @@ class ElectricityMeter(DynamicComponent):
     ):
         """Get utsp occupancy default connections."""
 
-        from hisim.components.loadprofilegenerator_utsp_connector import (
+        from hisim.components.loadprofilegenerator_utsp_connector import (  # pylint: disable=import-outside-toplevel
             UtspLpgConnector,
-        )  # pylint: disable=import-outside-toplevel
+        )
 
         dynamic_connections = []
         occupancy_class_name = UtspLpgConnector.get_classname()
@@ -207,9 +207,9 @@ class ElectricityMeter(DynamicComponent):
     ):
         """Get dhw heat pump default connections."""
 
-        from hisim.components.generic_heat_pump_modular import (
+        from hisim.components.generic_heat_pump_modular import (  # pylint: disable=import-outside-toplevel
             ModularHeatPump,
-        )  # pylint: disable=import-outside-toplevel
+        )
 
         dynamic_connections = []
         dhw_heat_pump_class_name = ModularHeatPump.get_classname()

--- a/hisim/components/example_component.py
+++ b/hisim/components/example_component.py
@@ -156,12 +156,8 @@ class ExampleComponent(Component):
         initial_temperature: Optional[float],
     ) -> None:
         """Build load profile for entire simulation duration."""
-        self.time_correction_factor: float = (
-            1 / self.my_simulation_parameters.seconds_per_timestep
-        )
-        self.seconds_per_timestep: float = (
-            self.my_simulation_parameters.seconds_per_timestep
-        )
+        self.time_correction_factor: float = 1 / self.my_simulation_parameters.seconds_per_timestep
+        self.seconds_per_timestep: float = self.my_simulation_parameters.seconds_per_timestep
 
         if electricity is None:
             self.electricity_output: float = -1e3
@@ -198,9 +194,7 @@ class ExampleComponent(Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         electricity_output: float = 0
         if 60 * 6 <= timestep < 60 * 9:
@@ -215,12 +209,8 @@ class ExampleComponent(Component):
             temperature: float = self.initial_temperature
             current_stored_energy = (self.initial_temperature + 273.15) * self.capacity
         else:
-            thermal_delivered_energy = stsv.get_input_value(
-                self.thermal_energy_delivered_c
-            )
-            previous_stored_energy = (
-                self.previous_temperature + 273.15
-            ) * self.capacity
+            thermal_delivered_energy = stsv.get_input_value(self.thermal_energy_delivered_c)
+            previous_stored_energy = (self.previous_temperature + 273.15) * self.capacity
             current_stored_energy = previous_stored_energy + thermal_delivered_energy
             self.temperature = current_stored_energy / self.capacity - 273.15
             temperature = self.temperature

--- a/hisim/components/example_storage.py
+++ b/hisim/components/example_storage.py
@@ -165,9 +165,7 @@ class SimpleStorage(Component):
         """Restores the previous state of the storage."""
         self.state = copy.copy(self.previous_state)
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the storage."""
 
         charging = stsv.get_input_value(self.charging_input)
@@ -175,9 +173,7 @@ class SimpleStorage(Component):
         if charging < 0:
             raise ValueError("trying to charge with negative amount" + str(charging))
         if discharging > 0:
-            raise ValueError(
-                "trying to discharge with positive amount: " + str(discharging)
-            )
+            raise ValueError("trying to discharge with positive amount: " + str(discharging))
         charging_delta = self.state.store(charging)
         discharging_delta = self.state.withdraw(discharging * -1) * -1
         actual_delta = charging_delta + discharging_delta

--- a/hisim/components/example_template.py
+++ b/hisim/components/example_template.py
@@ -180,18 +180,14 @@ class ComponentName(Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         # define local variables
         input_1 = stsv.get_input_value(self.input_from_other_component)
         input_2 = self.state.output_with_state
 
         # do your calculations
-        output_1 = (
-            input_2 + input_1 * self.my_simulation_parameters.seconds_per_timestep
-        )
+        output_1 = input_2 + input_1 * self.my_simulation_parameters.seconds_per_timestep
         output_2 = input_1 + self.factor
 
         # write values for output time series

--- a/hisim/components/example_transformer.py
+++ b/hisim/components/example_transformer.py
@@ -129,9 +129,7 @@ class ExampleTransformer(Component):
         """Prepares the simulation."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the transformer."""
         startval_1 = stsv.get_input_value(self.input1)
         startval_2 = stsv.get_input_value(self.input2)

--- a/hisim/components/generic_battery.py
+++ b/hisim/components/generic_battery.py
@@ -155,9 +155,7 @@ class GenericBattery(cp.Component):
         """Initialize the class."""
         super().__init__("Battery", my_simulation_parameters, my_config=config)
 
-        self.build(
-            manufacturer=config.manufacturer, model=config.model, base=config.base
-        )
+        self.build(manufacturer=config.manufacturer, model=config.model, base=config.base)
 
         self.state = SimpleStorageState(
             max_var_val=self.max_var_stored_energy,
@@ -204,9 +202,7 @@ class GenericBattery(cp.Component):
     def build(self, manufacturer, model, base):
         """Build function."""
         self.base = base
-        self.time_correction_factor = (
-            1 / self.my_simulation_parameters.seconds_per_timestep
-        )
+        self.time_correction_factor = 1 / self.my_simulation_parameters.seconds_per_timestep
         self.seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep
 
         # Gets flexibilities, including heat pump
@@ -226,15 +222,9 @@ class GenericBattery(cp.Component):
         self.min_stored_energy = self.max_stored_energy * 0.0
         self.efficiency = battery["Efficiency"]
         self.efficiency_inverter = battery["Inverter Efficiency"]
-        self.max_var_stored_energy = (
-            battery["Maximal Charging Power"] * 1e3 * self.time_correction_factor
-        )
+        self.max_var_stored_energy = battery["Maximal Charging Power"] * 1e3 * self.time_correction_factor
         if "Maximal Discharging Power" in battery:
-            self.min_var_stored_energy = (
-                -battery["Maximal Discharging Power"]
-                * 1e3
-                * self.time_correction_factor
-            )
+            self.min_var_stored_energy = -battery["Maximal Discharging Power"] * 1e3 * self.time_correction_factor
         else:
             self.min_var_stored_energy = -self.max_var_stored_energy
 
@@ -273,9 +263,7 @@ class GenericBattery(cp.Component):
                 key=SingletonDictKeyEnum.MAXIMALDISCHARGINGPOWER,
                 entry=-self.min_var_stored_energy / self.time_correction_factor,
             )
-            SingletonSimRepository().set_entry(
-                key=SingletonDictKeyEnum.BATTERYEFFICIENCY, entry=self.efficiency
-            )
+            SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.BATTERYEFFICIENCY, entry=self.efficiency)
             SingletonSimRepository().set_entry(
                 key=SingletonDictKeyEnum.INVERTEREFFICIENCY,
                 entry=self.efficiency_inverter,
@@ -289,9 +277,7 @@ class GenericBattery(cp.Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         load = stsv.get_input_value(self.input_channel)
         state = stsv.get_input_value(self.state_channel)
@@ -371,9 +357,7 @@ class BatteryController(cp.Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         load = stsv.get_input_value(self.input_channel)
         state: float = 0

--- a/hisim/components/generic_car.py
+++ b/hisim/components/generic_car.py
@@ -181,9 +181,7 @@ class Car(cp.Component):
         """Prepares the simulation."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Returns consumption and location of car in each timestep."""
 
         if self.config.fuel == lt.LoadTypes.ELECTRICITY:
@@ -209,32 +207,19 @@ class Car(cp.Component):
     ) -> OpexCostDataClass:
         """Calculate OPEX costs, consisting of energy and maintenance costs."""
         for index, output in enumerate(all_outputs):
-            if output.component_name == self.config.name + "_w" + str(
-                self.config.source_weight
-            ):
+            if output.component_name == self.config.name + "_w" + str(self.config.source_weight):
                 if output.unit == lt.Units.LITER:
-                    self.config.consumption = round(
-                        sum(postprocessing_results.iloc[:, index]), 1
+                    self.config.consumption = round(sum(postprocessing_results.iloc[:, index]), 1)
+                    emissions_and_cost_factors = EmissionFactorsAndCostsForFuelsConfig.get_values_for_year(
+                        self.my_simulation_parameters.year
                     )
-                    emissions_and_cost_factors = (
-                        EmissionFactorsAndCostsForFuelsConfig.get_values_for_year(
-                            self.my_simulation_parameters.year
-                        )
-                    )
-                    co2_per_unit = (
-                        emissions_and_cost_factors.diesel_footprint_in_kg_per_l
-                    )
-                    euro_per_unit = (
-                        emissions_and_cost_factors.diesel_costs_in_euro_per_l
-                    )
+                    co2_per_unit = emissions_and_cost_factors.diesel_footprint_in_kg_per_l
+                    euro_per_unit = emissions_and_cost_factors.diesel_costs_in_euro_per_l
 
                     opex_cost_per_simulated_period_in_euro = (
-                        self.calc_maintenance_cost()
-                        + self.config.consumption * euro_per_unit
+                        self.calc_maintenance_cost() + self.config.consumption * euro_per_unit
                     )
-                    co2_per_simulated_period_in_kg = (
-                        self.config.consumption * co2_per_unit
-                    )
+                    co2_per_simulated_period_in_kg = self.config.consumption * co2_per_unit
 
                 elif output.unit == lt.Units.WATT:
                     self.config.consumption = round(
@@ -244,9 +229,7 @@ class Car(cp.Component):
                         1,
                     )
                     # No electricity costs for components except for Electricity Meter, because part of electricity consumption is feed by PV
-                    opex_cost_per_simulated_period_in_euro = (
-                        self.calc_maintenance_cost()
-                    )
+                    opex_cost_per_simulated_period_in_euro = self.calc_maintenance_cost()
                     co2_per_simulated_period_in_kg = 0.0
 
         opex_cost_data_class = OpexCostDataClass(
@@ -280,22 +263,14 @@ class Car(cp.Component):
         )
         if file_exists:
             # load from cache
-            dataframe = pd.read_csv(
-                cache_filepath, sep=",", decimal=".", encoding="cp1252"
-            )
+            dataframe = pd.read_csv(cache_filepath, sep=",", decimal=".", encoding="cp1252")
             self.car_location = dataframe["car_location"].tolist()
             self.meters_driven = dataframe["meters_driven"].tolist()
         else:
             # load car data from LPG output
             filepaths = listdir(utils.HISIMPATH["utsp_results"])
-            filepath_location = [
-                elem for elem in filepaths if "CarLocation." + self.config.name in elem
-            ][0]
-            filepath_meters_driven = [
-                elem
-                for elem in filepaths
-                if "DrivingDistance." + self.config.name in elem
-            ][0]
+            filepath_location = [elem for elem in filepaths if "CarLocation." + self.config.name in elem][0]
+            filepath_meters_driven = [elem for elem in filepaths if "DrivingDistance." + self.config.name in elem][0]
             with open(
                 path.join(utils.HISIMPATH["utsp_results"], filepath_location),
                 encoding="utf-8",
@@ -308,30 +283,20 @@ class Car(cp.Component):
                 meters_driven = json.load(json_file)
 
             # compare time resolution of LPG to time resolution of hisim
-            time_resolution_original = dt.datetime.strptime(
-                car_location["TimeResolution"], "%H:%M:%S"
-            )
+            time_resolution_original = dt.datetime.strptime(car_location["TimeResolution"], "%H:%M:%S")
             seconds_per_timestep_original = (
                 time_resolution_original.hour * 3600
                 + time_resolution_original.minute * 60
                 + time_resolution_original.second
             )
             minutes_per_timestep = int(
-                self.my_simulation_parameters.seconds_per_timestep
-                / seconds_per_timestep_original
+                self.my_simulation_parameters.seconds_per_timestep / seconds_per_timestep_original
             )
 
-            simulation_time_span = (
-                self.my_simulation_parameters.end_date
-                - self.my_simulation_parameters.start_date
-            )
-            minutes_per_timestep = int(
-                self.my_simulation_parameters.seconds_per_timestep / 60
-            )
+            simulation_time_span = self.my_simulation_parameters.end_date - self.my_simulation_parameters.start_date
+            minutes_per_timestep = int(self.my_simulation_parameters.seconds_per_timestep / 60)
             steps_desired = int(
-                simulation_time_span.days
-                * 24
-                * (3600 / self.my_simulation_parameters.seconds_per_timestep)
+                simulation_time_span.days * 24 * (3600 / self.my_simulation_parameters.seconds_per_timestep)
             )
             steps_desired_in_minutes = steps_desired * minutes_per_timestep
 
@@ -341,25 +306,19 @@ class Car(cp.Component):
             initial_data = pd.DataFrame(
                 {
                     "Time": pd.date_range(
-                        start=dt.datetime(
-                            year=self.my_simulation_parameters.year, month=1, day=1
-                        ),
-                        end=dt.datetime(
-                            year=self.my_simulation_parameters.year, month=1, day=1
-                        )
+                        start=dt.datetime(year=self.my_simulation_parameters.year, month=1, day=1),
+                        end=dt.datetime(year=self.my_simulation_parameters.year, month=1, day=1)
                         + dt.timedelta(days=simulation_time_span.days)
                         - dt.timedelta(seconds=60),
                         freq="T",
                     ),
                     "meters_driven": meters_driven["Values"][:steps_desired_in_minutes],
-                    "car_location": [
-                        location_translator[elem] for elem in car_location["Values"]
-                    ][:steps_desired_in_minutes],
+                    "car_location": [location_translator[elem] for elem in car_location["Values"]][
+                        :steps_desired_in_minutes
+                    ],
                 }
             )
-            initial_data = utils.convert_lpg_data_to_utc(
-                data=initial_data, year=self.my_simulation_parameters.year
-            )
+            initial_data = utils.convert_lpg_data_to_utc(data=initial_data, year=self.my_simulation_parameters.year)
             meters_driven = pd.to_numeric(initial_data["meters_driven"]).tolist()
             car_location = pd.to_numeric(initial_data["car_location"]).tolist()
 
@@ -367,20 +326,12 @@ class Car(cp.Component):
             if minutes_per_timestep > 1:
                 for i in range(steps_desired):
                     self.meters_driven.append(
-                        sum(
-                            meters_driven[
-                                i
-                                * minutes_per_timestep: (i + 1)
-                                * minutes_per_timestep
-                            ]
-                        )
+                        sum(meters_driven[i * minutes_per_timestep : (i + 1) * minutes_per_timestep])
                     )  # sum
                     location_list = car_location[
-                        i * minutes_per_timestep: (i + 1) * minutes_per_timestep
+                        i * minutes_per_timestep : (i + 1) * minutes_per_timestep
                     ]  # extract list
-                    occurence_count = most_frequent(
-                        input_list=location_list
-                    )  # extract most common
+                    occurence_count = most_frequent(input_list=location_list)  # extract most common
                     self.car_location.append(occurence_count)
             else:
                 self.meters_driven = meters_driven

--- a/hisim/components/generic_chp.py
+++ b/hisim/components/generic_chp.py
@@ -103,9 +103,7 @@ class SimpleCHP(cp.Component):
     ElectricityOutput = "ElectricityOutput"
     FuelDelivered = "FuelDelivered"
 
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: CHPConfig
-    ) -> None:
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: CHPConfig) -> None:
         """Initializes the class."""
         super().__init__(
             name=config.name + "_w" + str(config.source_weight),
@@ -117,9 +115,7 @@ class SimpleCHP(cp.Component):
         if self.config.use == lt.LoadTypes.HYDROGEN:
             self.p_fuel = config.p_fuel / (3.6e3 * 3.939e4)  # converted to kg / s
         else:
-            self.p_fuel = (
-                config.p_fuel * my_simulation_parameters.seconds_per_timestep / 3.6e3
-            )  # converted to Wh
+            self.p_fuel = config.p_fuel * my_simulation_parameters.seconds_per_timestep / 3.6e3  # converted to Wh
 
         self.state = GenericCHPState(state=0)
         self.previous_state = self.state.clone()
@@ -208,9 +204,7 @@ class SimpleCHP(cp.Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         # Inputs
         self.state.state = int(stsv.get_input_value(self.chp_onoff_signal_channel))
@@ -230,12 +224,8 @@ class SimpleCHP(cp.Component):
                 self.state.state * self.config.p_th,
             )
 
-        stsv.set_output_value(
-            self.electricity_output_channel, self.state.state * self.config.p_el
-        )
-        stsv.set_output_value(
-            self.fuel_consumption_channel, self.state.state * self.p_fuel
-        )
+        stsv.set_output_value(self.electricity_output_channel, self.state.state * self.config.p_el)
+        stsv.set_output_value(self.fuel_consumption_channel, self.state.state * self.p_fuel)
 
     def get_default_connections_from_chp_controller(
         self,

--- a/hisim/components/generic_electrolyzer_h2.py
+++ b/hisim/components/generic_electrolyzer_h2.py
@@ -72,9 +72,7 @@ class ElectrolyzerConfig(cp.ConfigBase):
     def read_config(electrolyzer_name):
         """Opens the according JSON-file, based on the electrolyzer_name."""
 
-        config_file = os.path.join(
-            utils.HISIMPATH["inputs"], "electrolyzer_manufacturer_config.json"
-        )
+        config_file = os.path.join(utils.HISIMPATH["inputs"], "electrolyzer_manufacturer_config.json")
         with open(config_file, "r", encoding="utf-8") as json_file:
             data = json.load(json_file)
             electrolyzer_variants = data["Electrolyzer variants"]
@@ -84,7 +82,6 @@ class ElectrolyzerConfig(cp.ConfigBase):
                 )
 
             for key, values in electrolyzer_variants.items():
-
                 if key == electrolyzer_name:
                     data_for_specific_electrolyzer = values
 
@@ -182,9 +179,7 @@ class Electrolyzer(cp.Component):
 
         self.technology_type = config.electrolyzer_type
         if self.technology_type is None:
-            raise ValueError(
-                "Electrolyzer type should not be None. Please choose a different electrolyzer for config."
-            )
+            raise ValueError("Electrolyzer type should not be None. Please choose a different electrolyzer for config.")
         self.nom_load = config.nom_load
         self.max_load = config.max_load
         self.nom_h2_flow_rate = config.nom_h2_flow_rate
@@ -371,9 +366,7 @@ class Electrolyzer(cp.Component):
         based on the nominal current density.
         """
         # Load data from the JSON file
-        data_file = os.path.join(
-            utils.HISIMPATH["inputs"], "electrolyzer_polarization_curve_data.json"
-        )
+        data_file = os.path.join(utils.HISIMPATH["inputs"], "electrolyzer_polarization_curve_data.json")
         with open(data_file, "r", encoding="utf-8") as file:
             data = json.load(file)
 
@@ -398,9 +391,7 @@ class Electrolyzer(cp.Component):
         spec_el_demand_stack = np.interp(i_cell_nom, i_cell, spec_el_stack_demand_nom)
 
         # calculating aux_power
-        aux_power = nominal_load - (
-            spec_el_demand_stack * h2_flow_rate
-        )  # might needs to be set to a constant value
+        aux_power = nominal_load - (spec_el_demand_stack * h2_flow_rate)  # might needs to be set to a constant value
 
         # interpolarization function
         u_cell_nom = np.interp(i_cell_nom, i_cell, u_cell)  # V
@@ -415,17 +406,13 @@ class Electrolyzer(cp.Component):
         based on the nominal current density.
         """
         # Load data from the JSON file
-        data_file = os.path.join(
-            utils.HISIMPATH["inputs"], "electrolyzer_efficiency_curve_data.json"
-        )
+        data_file = os.path.join(utils.HISIMPATH["inputs"], "electrolyzer_efficiency_curve_data.json")
         with open(data_file, "r", encoding="utf-8") as file:
             data = json.load(file)
 
         # Check if the provided technology is valid
         if electrolyzer_type not in data:
-            raise ValueError(
-                f"Invalid technology. Supported technologies are: {', '.join(data.keys())}"
-            )
+            raise ValueError(f"Invalid technology. Supported technologies are: {', '.join(data.keys())}")
 
         load_perc = data[electrolyzer_type]["load_perc"]
         sys_eff = data[electrolyzer_type]["sys_eff"]
@@ -433,18 +420,14 @@ class Electrolyzer(cp.Component):
         if state == 1:
             current_load_percentage = current_load / max_load
             # Interpolation
-            current_sys_eff_soec = float(
-                np.interp(current_load_percentage, load_perc, sys_eff)
-            )
+            current_sys_eff_soec = float(np.interp(current_load_percentage, load_perc, sys_eff))
 
         else:
             current_sys_eff_soec = 0.0
 
         lhv_h2 = 33.33  # [kWh/kg]
 
-        current_h2_production_rate = (
-            current_sys_eff_soec * current_load
-        ) / lhv_h2  # [kg/h]
+        current_h2_production_rate = (current_sys_eff_soec * current_load) / lhv_h2  # [kg/h]
 
         return current_sys_eff_soec, current_h2_production_rate
 
@@ -478,25 +461,15 @@ class Electrolyzer(cp.Component):
         # Calculates system_power from stack power
         system_power = stack_power + aux_power
 
-        interp_function_h2_production_rate = interp1d(
-            system_power, h2_production_rate, kind="quadratic"
-        )
-        spec_h2_production_rate = (
-            h2_production_rate / system_power
-        )  # kg/kWh (proportional to the system efficiency)
+        interp_function_h2_production_rate = interp1d(system_power, h2_production_rate, kind="quadratic")
+        spec_h2_production_rate = h2_production_rate / system_power  # kg/kWh (proportional to the system efficiency)
 
-        interp_function_spec_h2_production_rate = interp1d(
-            system_power, spec_h2_production_rate, kind="quadratic"
-        )
+        interp_function_spec_h2_production_rate = interp1d(system_power, spec_h2_production_rate, kind="quadratic")
 
         if state == 1:  # and current_load >= min_load:
             # Only produced hydrogen if the system is "on"
-            current_h2_production_rate = float(
-                interp_function_h2_production_rate(current_load)
-            )
-            current_spec_h2_production_rate = float(
-                interp_function_spec_h2_production_rate(current_load)
-            )
+            current_h2_production_rate = float(interp_function_h2_production_rate(current_load))
+            current_spec_h2_production_rate = float(interp_function_spec_h2_production_rate(current_load))
             current_eff = current_spec_h2_production_rate * 33.33  # LHV H2 33.33 kWh/kg
 
         else:
@@ -514,9 +487,7 @@ class Electrolyzer(cp.Component):
         """
         m_o2 = 31.9988
         m_h2 = 2.01588
-        m_dot_o2 = (
-            (m_o2 / m_h2) * 0.5 * current_h2_production_rate
-        )  # Kurzweil (2018) - Elektrolyse von Wasser
+        m_dot_o2 = (m_o2 / m_h2) * 0.5 * current_h2_production_rate  # Kurzweil (2018) - Elektrolyse von Wasser
         return m_dot_o2
 
     def water_demand(self, current_h2_production_rate):
@@ -527,9 +498,7 @@ class Electrolyzer(cp.Component):
         """
         m_h2o = 18.01528
         m_h2 = 2.01588
-        m_dot_h2o = (
-            m_h2o / m_h2
-        ) * current_h2_production_rate  # Kurzweil (2018) - Elektrolyse von Wasser
+        m_dot_h2o = (m_h2o / m_h2) * current_h2_production_rate  # Kurzweil (2018) - Elektrolyse von Wasser
         return m_dot_h2o
 
     def i_save_state(self) -> None:
@@ -574,9 +543,7 @@ class Electrolyzer(cp.Component):
         """Prepares the simulation."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
         if force_convergence:
             return
@@ -595,9 +562,7 @@ class Electrolyzer(cp.Component):
         i_cell_nom = self.i_cell_nom
         ramp_up_rate = self.ramp_up_rate
         ramp_down_rate = self.ramp_down_rate
-        seconds_per_timestep = (
-            self.my_simulation_parameters.seconds_per_timestep
-        )  # [s/timestep]
+        seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep  # [s/timestep]
 
         # ramp up per timestep calculation
         ramp_up_per_timestep = nominal_load * ramp_up_rate * seconds_per_timestep
@@ -625,20 +590,13 @@ class Electrolyzer(cp.Component):
                 self.total_ramp_down_count_state += 0
                 # pdb.set_trace()
             # Ramping up
-            if (
-                new_load >= total_ramp_up_per_timestep
-                and self.current_load_state < p_el
-            ):
+            if new_load >= total_ramp_up_per_timestep and self.current_load_state < p_el:
                 self.total_ramp_up_count_state += seconds_per_timestep
                 self.current_load_state += total_ramp_up_per_timestep
                 # pdb.set_trace()
-            elif (
-                self.current_load_state < p_el and new_load < total_ramp_up_per_timestep
-            ):
+            elif self.current_load_state < p_el and new_load < total_ramp_up_per_timestep:
                 percentage_ramp_up_per_timestep = new_load / total_ramp_up_per_timestep
-                self.total_ramp_up_count_state += (
-                    percentage_ramp_up_per_timestep * seconds_per_timestep
-                )
+                self.total_ramp_up_count_state += percentage_ramp_up_per_timestep * seconds_per_timestep
                 # pdb.set_trace()
                 if self.current_load_state == 0:
                     self.current_load_state += p_el
@@ -647,23 +605,13 @@ class Electrolyzer(cp.Component):
                     self.current_load_state += new_load
                     # pdb.set_trace()
             # Ramping down
-            elif (
-                total_ramp_down_per_timestep <= new_load
-                and p_el < self.current_load_state
-            ):
+            elif total_ramp_down_per_timestep <= new_load and p_el < self.current_load_state:
                 self.total_ramp_down_count_state += seconds_per_timestep
                 self.current_load_state -= new_load
                 # pdb.set_trace()
-            elif (
-                p_el < self.current_load_state
-                and new_load < total_ramp_down_per_timestep
-            ):
-                percentage_ramp_down_per_timestep = (
-                    new_load / total_ramp_down_per_timestep
-                )
-                self.total_ramp_down_count_state += (
-                    percentage_ramp_down_per_timestep * seconds_per_timestep
-                )
+            elif p_el < self.current_load_state and new_load < total_ramp_down_per_timestep:
+                percentage_ramp_down_per_timestep = new_load / total_ramp_down_per_timestep
+                self.total_ramp_down_count_state += percentage_ramp_down_per_timestep * seconds_per_timestep
                 self.current_load_state -= new_load
                 # pdb.set_trace()
         elif state == 0:
@@ -700,7 +648,10 @@ class Electrolyzer(cp.Component):
                 i_cell_nom,
             )
             # Current hydrogen prduction and specific hydrogen production rate
-            (current_h2_production_rate, current_eff,) = self.h2_production_rate(
+            (
+                current_h2_production_rate,
+                current_eff,
+            ) = self.h2_production_rate(
                 i_cell_nom,
                 u_cell_nom,
                 nominal_load,
@@ -716,17 +667,11 @@ class Electrolyzer(cp.Component):
         current_flow_rate_water = self.water_demand(current_h2_production_rate)
 
         # Calculating total amount of hydrogen, oxygen and water
-        total_hydrogen_produced_in_timestep = current_h2_production_rate * (
-            seconds_per_timestep / 3600
-        )
+        total_hydrogen_produced_in_timestep = current_h2_production_rate * (seconds_per_timestep / 3600)
         self.total_hydrogen_produced += total_hydrogen_produced_in_timestep
-        total_oxygen_produced_in_timestep = current_flow_rate_oxygen * (
-            seconds_per_timestep / 3600
-        )
+        total_oxygen_produced_in_timestep = current_flow_rate_oxygen * (seconds_per_timestep / 3600)
         self.total_oxygen_produced += total_oxygen_produced_in_timestep
-        total_water_demand_in_timestep = current_flow_rate_water * (
-            seconds_per_timestep / 3600
-        )
+        total_water_demand_in_timestep = current_flow_rate_water * (seconds_per_timestep / 3600)
         self.total_water_demand += total_water_demand_in_timestep
 
         self.total_energy += self.current_load_state * (seconds_per_timestep / 3600)
@@ -736,15 +681,11 @@ class Electrolyzer(cp.Component):
         stsv.set_output_value(self.oxygen_flow_rate, current_flow_rate_oxygen)
         stsv.set_output_value(self.water_flow_rate, current_flow_rate_water)
         stsv.set_output_value(self.electrolyzer_state, state)
-        stsv.set_output_value(
-            self.current_load, (self.current_load_state * 1000)
-        )  # Transform kW into WATT for EMS
+        stsv.set_output_value(self.current_load, (self.current_load_state * 1000))  # Transform kW into WATT for EMS
         stsv.set_output_value(self.total_energy_consumed, self.total_energy)
 
         stsv.set_output_value(self.total_ramp_up_time, self.total_ramp_up_count_state)
-        stsv.set_output_value(
-            self.total_ramp_down_time, self.total_ramp_down_count_state
-        )
+        stsv.set_output_value(self.total_ramp_down_time, self.total_ramp_down_count_state)
         stsv.set_output_value(self.total_hydrogen, self.total_hydrogen_produced)
         stsv.set_output_value(self.total_oxygen, self.total_oxygen_produced)
         stsv.set_output_value(self.total_water, self.total_water_demand)
@@ -760,39 +701,11 @@ class Electrolyzer(cp.Component):
         for config_string in self.electrolyzerconfig.get_string_dict():
             lines.append(config_string)
         lines.append("Component Name" + str(self.component_name))
-        lines.append(
-            "Total operating time during simulation: "
-            + str(self.total_operating_time)
-            + " [h]"
-        )
-        lines.append(
-            "Total hydrogen produced during simulation: "
-            + str(self.total_hydrogen_produced)
-            + " [kg]"
-        )
-        lines.append(
-            "Total oxygen produced during simulation: "
-            + str(self.total_oxygen_produced)
-            + " [kg]"
-        )
-        lines.append(
-            "Total water demand during simulation: "
-            + str(self.total_water_demand)
-            + " [kg]"
-        )
-        lines.append(
-            "Total energy consumed during simulation: "
-            + str(self.total_energy)
-            + " [kg]"
-        )
-        lines.append(
-            "Total ramp-up time during simulation: "
-            + str(self.total_ramp_up_count_state)
-            + " [kg]"
-        )
-        lines.append(
-            "Total ramp-down time during simulation: "
-            + str(self.total_ramp_down_count_state)
-            + " [kg]"
-        )
+        lines.append("Total operating time during simulation: " + str(self.total_operating_time) + " [h]")
+        lines.append("Total hydrogen produced during simulation: " + str(self.total_hydrogen_produced) + " [kg]")
+        lines.append("Total oxygen produced during simulation: " + str(self.total_oxygen_produced) + " [kg]")
+        lines.append("Total water demand during simulation: " + str(self.total_water_demand) + " [kg]")
+        lines.append("Total energy consumed during simulation: " + str(self.total_energy) + " [kg]")
+        lines.append("Total ramp-up time during simulation: " + str(self.total_ramp_up_count_state) + " [kg]")
+        lines.append("Total ramp-down time during simulation: " + str(self.total_ramp_down_count_state) + " [kg]")
         return lines

--- a/hisim/components/generic_ev_charger.py
+++ b/hisim/components/generic_ev_charger.py
@@ -153,9 +153,7 @@ class VehiclePure(cp.Component):
 
     """
 
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: VehiclePureConfig
-    ) -> None:
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: VehiclePureConfig) -> None:
         """Initialize the class."""
         super().__init__(
             name="EV_charger",
@@ -189,9 +187,7 @@ class VehiclePure(cp.Component):
 
         self.max_capacity = electric_vehicle["Battery Capacity"] * 1e3
         if "Battery Useful Capacity" in electric_vehicle:
-            self.min_capacity = (
-                self.max_capacity - electric_vehicle["Battery Useful Capacity"] * 1e3
-            )
+            self.min_capacity = self.max_capacity - electric_vehicle["Battery Useful Capacity"] * 1e3
         else:
             self.min_capacity = self.max_capacity * 0.1
 
@@ -205,12 +201,10 @@ class VehiclePure(cp.Component):
             self.component_name, self.evconfig, self.my_simulation_parameters
         )
         if cache_file_exists:
-            self.car_in_charging_station = pd.read_csv(
-                cache_filepath, sep=",", decimal="."
-            )["CarInChargingStation"].tolist()
-            self.discharge = pd.read_csv(cache_filepath, sep=",", decimal=".")[
-                "Discharge"
+            self.car_in_charging_station = pd.read_csv(cache_filepath, sep=",", decimal=".")[
+                "CarInChargingStation"
             ].tolist()
+            self.discharge = pd.read_csv(cache_filepath, sep=",", decimal=".")["Discharge"].tolist()
         else:
 
             def open_sql(path, table_name):
@@ -222,9 +216,7 @@ class VehiclePure(cp.Component):
                     data = json.load(file)
                 return data["Values"]
 
-            filepath = utils.load_export_load_profile_generator(
-                target=self.evconfig.profile_name
-            )
+            filepath = utils.load_export_load_profile_generator(target=self.evconfig.profile_name)
             if filepath is None:
                 filepath = utils.HISIMPATH
 
@@ -234,24 +226,17 @@ class VehiclePure(cp.Component):
             list_values = []
             for _, row in filepaths.iterrows():
                 json_info = json.loads(row["Json"])
-                if (
-                    "Charging" in json_info["FileName"]
-                    and "png" not in json_info["FileName"]
-                ):
+                if "Charging" in json_info["FileName"] and "png" not in json_info["FileName"]:
                     filepath = os.path.normpath(json_info["FullFileName"])
                     filepath_list = filepath.split(os.sep)
-                    ev_files[filepath_list[-1].split(".")[0]] = json_info[
-                        "FullFileName"
-                    ]
+                    ev_files[filepath_list[-1].split(".")[0]] = json_info["FullFileName"]
                     list_columns.append(filepath_list[-1].split(".")[0])
                     list_values.append(open_ev_json(json_info["FullFileName"]))
             list_values = list(map(list, zip(*list_values)))
             # ev_pd = pd.DataFrame(list_values, columns=list_columns)
 
             # Gets battery information to calculate discharging while not at home
-            transportation_devices = open_sql(
-                filepath["electric_vehicle"][0], "TransportationDevices"
-            )
+            transportation_devices = open_sql(filepath["electric_vehicle"][0], "TransportationDevices")
             for _, vehicle in transportation_devices.iterrows():
                 if "Charging" in vehicle["Name"]:
                     vehicle_info = json.loads(vehicle["Json"])
@@ -266,13 +251,11 @@ class VehiclePure(cp.Component):
             # car_state = []
             discharge_stats = [0]
             # Gets transportation stats
-            transportation_devices_stats = open_sql(
-                filepath["electric_vehicle"][0], "TransportationDeviceStates"
-            )
+            transportation_devices_stats = open_sql(filepath["electric_vehicle"][0], "TransportationDeviceStates")
             for _, column in transportation_devices_stats.iterrows():
-                if datetime.datetime.strptime(
-                    column["DateTime"], "%d/%m/%Y %H:%M"
-                ) > datetime.datetime.strptime("31/12/2018 23:59", "%d/%m/%Y %H:%M"):
+                if datetime.datetime.strptime(column["DateTime"], "%d/%m/%Y %H:%M") > datetime.datetime.strptime(
+                    "31/12/2018 23:59", "%d/%m/%Y %H:%M"
+                ):
                     if (
                         "ParkingAndFullyCharged" in column["DeviceState"]
                         or "ParkingAndCharging" in column["DeviceState"]
@@ -281,9 +264,7 @@ class VehiclePure(cp.Component):
                     else:
                         car_in_charging_station.append(False)
                     load_stats.append(float(column["CurrentRange"]))
-                    soc.append(
-                        float(column["CurrentRange"]) / battery_stored_energy_meters
-                    )
+                    soc.append(float(column["CurrentRange"]) / battery_stored_energy_meters)
                     if len(load_stats) > 1:
                         diff = load_stats[-1] - load_stats[-2]
                         if diff < 0:
@@ -316,9 +297,7 @@ class VehiclePure(cp.Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         pass
 
@@ -348,9 +327,7 @@ class Vehicle(cp.Component):
     MaxCapacity = "MaxCapacity"
     Discharge = "Discharge"
 
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: VehicleConfig
-    ) -> None:
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: VehicleConfig) -> None:
         """Initialize the class."""
         super().__init__(
             name="ElectricVehicle",
@@ -389,10 +366,7 @@ class Vehicle(cp.Component):
         electric_vehicle_found = False
         electric_vehicle = None
         for electric_vehicle in electric_vehicle_database:
-            if (
-                electric_vehicle["Manufacturer"] == manufacturer
-                and electric_vehicle["Model"] == model
-            ):
+            if electric_vehicle["Manufacturer"] == manufacturer and electric_vehicle["Model"] == model:
                 electric_vehicle_found = True
                 break
 
@@ -401,9 +375,7 @@ class Vehicle(cp.Component):
 
         self.max_capacity = electric_vehicle["Battery Capacity"] * 1e3
         if "Battery Useful Capacity" in electric_vehicle:
-            self.min_capacity = (
-                self.max_capacity - electric_vehicle["Battery Useful Capacity"] * 1e3
-            )
+            self.min_capacity = self.max_capacity - electric_vehicle["Battery Useful Capacity"] * 1e3
         else:
             self.min_capacity = self.max_capacity * 0.1
 
@@ -425,9 +397,7 @@ class Vehicle(cp.Component):
         """Doubelchecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         if timestep == 0:
             capacity = self.capacity
@@ -585,9 +555,7 @@ class EVCharger(cp.Component):
     # 1. EVChargerController
     # 2. Some ChargingInput
 
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: EVChargerConfig
-    ) -> None:
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: EVChargerConfig) -> None:
         """Initialize the class."""
         super().__init__(
             name="EVCharger",
@@ -696,9 +664,7 @@ class EVCharger(cp.Component):
         lines.append(f"Manufacturer: {self.manufacturer}")
         lines.append(f"Model: {self.name}")
         lines.append(f"Charging Power: {self.charging_power_original} kW")
-        lines.append(
-            f"EV Battery Capacity: {self.electric_vehicle.max_capacity * 1e-3}"
-        )
+        lines.append(f"EV Battery Capacity: {self.electric_vehicle.max_capacity * 1e-3}")
         lines.append(f"Vehicle: {self.electric_vehicle.model}")
         return lines
 
@@ -714,9 +680,7 @@ class EVCharger(cp.Component):
         """Doubelchecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         if force_convergence:
             return
@@ -738,9 +702,7 @@ class EVCharger(cp.Component):
             to_be_charged = -charging
 
             if state == 0:
-                charging_delta, after_capacity = self.state.keep_state(
-                    capacity=capacity
-                )
+                charging_delta, after_capacity = self.state.keep_state(capacity=capacity)
             elif state == 1:
                 charging_delta, after_capacity = self.charge_only_from_the_grid(
                     max_capacity=max_capacity, capacity=capacity
@@ -760,8 +722,7 @@ class EVCharger(cp.Component):
                 )
             else:
                 raise Exception(
-                    f"State {state} has not been implemented! "
-                    "Please check EVCharger and EVChargerController "
+                    f"State {state} has not been implemented! " "Please check EVCharger and EVChargerController "
                 )
 
         # Discharges battery according to electric vehicle use
@@ -818,9 +779,7 @@ class EVCharger(cp.Component):
 
     def charge_only_from_the_grid(self, max_capacity, capacity):
         """Charge only from the grid."""
-        charging_delta, after_capacity = self.state.force_store(
-            max_capacity=max_capacity, current_capacity=capacity
-        )
+        charging_delta, after_capacity = self.state.force_store(max_capacity=max_capacity, current_capacity=capacity)
         return charging_delta, after_capacity
 
 
@@ -859,12 +818,12 @@ class EVChargerController(cp.Component):
 
         if self.mode == 1:
             self.mode_description = "Straight Charging"
-            self.mode_extended_description = (
-                "Charge the Electric Vehicle whenever is connected to EV Charger"
-            )
+            self.mode_extended_description = "Charge the Electric Vehicle whenever is connected to EV Charger"
         elif self.mode == 2:
             self.mode_description = "Charge only on Electricity Surplus"
-            self.mode_extended_description = "Charge the Electric Vehicle whenever the home grid is on electricity surplus"
+            self.mode_extended_description = (
+                "Charge the Electric Vehicle whenever the home grid is on electricity surplus"
+            )
         elif self.mode == 3:
             self.mode_description = "Operate on Vehicle-to-Grid"
             self.mode_extended_description = (
@@ -937,9 +896,7 @@ class EVChargerController(cp.Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
         # Gets inputs
         # charging = stsv.get_input_value(self.charging_inputC)
@@ -1009,8 +966,7 @@ class EVChargerController(cp.Component):
         lines.append(f"Mode Number: {self.mode}")
         lines.append(f"Mode: {self.mode_description}")
         try:
-            lines.append(
-                f"Extend Mode Description: {self.mode_extended_description}")
+            lines.append(f"Extend Mode Description: {self.mode_extended_description}")
         except AttributeError:
             lines.append("Extend Mode Description: TO BE IMPLEMENTED")
         return lines

--- a/hisim/components/generic_gas_heater.py
+++ b/hisim/components/generic_gas_heater.py
@@ -85,9 +85,7 @@ class GenericGasHeaterConfig(ConfigBase):
             maximal_mass_flow_in_kilogram_per_second=maximal_power_in_watt
             / (4180 * 25),  # kg/s ## -> ~0.07 P_th_max / (4180 * delta_T)
             maximal_temperature_in_celsius=80,  # [°C])
-            co2_footprint=maximal_power_in_watt
-            * 1e-3
-            * 49.47,  # value from emission_factros_and_costs_devices.csv
+            co2_footprint=maximal_power_in_watt * 1e-3 * 49.47,  # value from emission_factros_and_costs_devices.csv
             cost=7416,  # value from emission_factros_and_costs_devices.csv
             lifetime=20,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.03,  # source: VDI2067-1
@@ -96,9 +94,7 @@ class GenericGasHeaterConfig(ConfigBase):
         return config
 
     @classmethod
-    def get_scaled_gasheater_config(
-            cls, heating_load_of_building_in_watt: float
-    ) -> "GenericGasHeaterConfig":
+    def get_scaled_gasheater_config(cls, heating_load_of_building_in_watt: float) -> "GenericGasHeaterConfig":
         """Get a default Building."""
         maximal_power_in_watt: float = heating_load_of_building_in_watt  # W
         config = GenericGasHeaterConfig(
@@ -114,9 +110,7 @@ class GenericGasHeaterConfig(ConfigBase):
             maximal_mass_flow_in_kilogram_per_second=maximal_power_in_watt
             / (4180 * 25),  # kg/s ## -> ~0.07 P_th_max / (4180 * delta_T)
             maximal_temperature_in_celsius=80,  # [°C])
-            co2_footprint=maximal_power_in_watt
-            * 1e-3
-            * 49.47,  # value from emission_factros_and_costs_devices.csv
+            co2_footprint=maximal_power_in_watt * 1e-3 * 49.47,  # value from emission_factros_and_costs_devices.csv
             cost=7416,  # value from emission_factros_and_costs_devices.csv
             lifetime=20,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.03,  # source: VDI2067-1
@@ -133,9 +127,7 @@ class GasHeater(Component):
     """
 
     # Input
-    ControlSignal = (
-        "ControlSignal"  # at which Procentage is the GasHeater modulating [0..1]
-    )
+    ControlSignal = "ControlSignal"  # at which Procentage is the GasHeater modulating [0..1]
     MassflowInputTemperature = "MassflowInputTemperature"
 
     # Output
@@ -201,25 +193,15 @@ class GasHeater(Component):
             output_description=f"here a description for {self.ThermalOutputPower} will follow.",
         )
 
-        self.minimal_thermal_power_in_watt = (
-            self.gasheater_config.minimal_thermal_power_in_watt
-        )
+        self.minimal_thermal_power_in_watt = self.gasheater_config.minimal_thermal_power_in_watt
         self.maximal_thermal_power_in_watt = self.gasheater_config.maximal_power_in_watt
         self.eff_th_min = self.gasheater_config.eff_th_min
         self.eff_th_max = self.gasheater_config.eff_th_max
-        self.maximal_temperature_in_celsius = (
-            self.gasheater_config.maximal_temperature_in_celsius
-        )
-        self.temperature_delta_in_celsius = (
-            self.gasheater_config.temperature_delta_in_celsius
-        )
+        self.maximal_temperature_in_celsius = self.gasheater_config.maximal_temperature_in_celsius
+        self.temperature_delta_in_celsius = self.gasheater_config.temperature_delta_in_celsius
 
-        self.add_default_connections(
-            self.get_default_connections_from_controller_l1_generic_gas_heater()
-        )
-        self.add_default_connections(
-            self.get_default_connections_from_simple_hot_water_storage()
-        )
+        self.add_default_connections(self.get_default_connections_from_controller_l1_generic_gas_heater())
+        self.add_default_connections(self.get_default_connections_from_simple_hot_water_storage())
 
     def get_default_connections_from_controller_l1_generic_gas_heater(
         self,
@@ -279,9 +261,7 @@ class GasHeater(Component):
         """Doublecheck."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the gas heater."""
         control_signal = stsv.get_input_value(self.control_signal_channel)
         if control_signal > 1:
@@ -292,10 +272,7 @@ class GasHeater(Component):
         # Calculate Eff
         d_eff_th = self.eff_th_max - self.eff_th_min
 
-        if (
-            control_signal * self.maximal_thermal_power_in_watt
-            < self.minimal_thermal_power_in_watt
-        ):
+        if control_signal * self.maximal_thermal_power_in_watt < self.minimal_thermal_power_in_watt:
             maximum_power = self.minimal_thermal_power_in_watt
             eff_th_real = self.eff_th_min
         else:
@@ -304,35 +281,22 @@ class GasHeater(Component):
 
         gas_power_in_watt = maximum_power * eff_th_real * control_signal
         c_w = 4182
-        mass_flow_out_temperature_in_celsius = (
-            self.temperature_delta_in_celsius
-            + stsv.get_input_value(self.mass_flow_input_tempertaure_channel)
+        mass_flow_out_temperature_in_celsius = self.temperature_delta_in_celsius + stsv.get_input_value(
+            self.mass_flow_input_tempertaure_channel
         )
-        mass_flow_out_in_kg_per_s = gas_power_in_watt / (
-            c_w * self.temperature_delta_in_celsius
-        )
+        mass_flow_out_in_kg_per_s = gas_power_in_watt / (c_w * self.temperature_delta_in_celsius)
         # p_th = (
         #     c_w * mass_flow_out_in_kg_per_s * (mass_flow_out_temperature_in_celsius - stsv.get_input_value(self.mass_flow_input_tempertaure_channel))
         # )
-        gas_demand_in_kwh = (
-            gas_power_in_watt
-            * self.my_simulation_parameters.seconds_per_timestep
-            / 3.6e6
-        )
+        gas_demand_in_kwh = gas_power_in_watt * self.my_simulation_parameters.seconds_per_timestep / 3.6e6
 
-        stsv.set_output_value(
-            self.thermal_output_power_channel, gas_power_in_watt
-        )  # efficiency
+        stsv.set_output_value(self.thermal_output_power_channel, gas_power_in_watt)  # efficiency
         stsv.set_output_value(
             self.mass_flow_output_temperature_channel,
             mass_flow_out_temperature_in_celsius,
         )  # efficiency
-        stsv.set_output_value(
-            self.mass_flow_output_channel, mass_flow_out_in_kg_per_s
-        )  # efficiency
-        stsv.set_output_value(
-            self.gas_demand_channel, gas_demand_in_kwh
-        )  # gas consumption
+        stsv.set_output_value(self.mass_flow_output_channel, mass_flow_out_in_kg_per_s)  # efficiency
+        stsv.set_output_value(self.gas_demand_channel, gas_demand_in_kwh)  # gas consumption
 
     @staticmethod
     def get_cost_capex(config: GenericGasHeaterConfig) -> Tuple[float, float, float]:
@@ -346,17 +310,10 @@ class GasHeater(Component):
     ) -> OpexCostDataClass:
         """Calculate OPEX costs, consisting of energy and maintenance costs."""
         for index, output in enumerate(all_outputs):
-            if (
-                output.component_name == self.config.name
-                and output.load_type == lt.LoadTypes.GAS
-            ):
-                self.config.consumption = round(
-                    sum(postprocessing_results.iloc[:, index]), 1
-                )
-        emissions_and_cost_factors = (
-            EmissionFactorsAndCostsForFuelsConfig.get_values_for_year(
-                self.my_simulation_parameters.year
-            )
+            if output.component_name == self.config.name and output.load_type == lt.LoadTypes.GAS:
+                self.config.consumption = round(sum(postprocessing_results.iloc[:, index]), 1)
+        emissions_and_cost_factors = EmissionFactorsAndCostsForFuelsConfig.get_values_for_year(
+            self.my_simulation_parameters.year
         )
         co2_per_unit = emissions_and_cost_factors.gas_footprint_in_kg_per_kwh
         euro_per_unit = emissions_and_cost_factors.gas_costs_in_euro_per_kwh

--- a/hisim/components/generic_heat_pump.py
+++ b/hisim/components/generic_heat_pump.py
@@ -119,25 +119,19 @@ class GenericHeatPumpState:
             self.heating_power_in_watt = 0.0
             self.cooling_power_in_watt = 0.0
             self.cop = 1.0
-            self.electricity_input_in_watt = abs(
-                self.thermal_power_delivered_in_watt / self.cop
-            )
+            self.electricity_input_in_watt = abs(self.thermal_power_delivered_in_watt / self.cop)
         elif self.thermal_power_delivered_in_watt > 0.0:
             self.activation = -1
             self.heating_power_in_watt = self.thermal_power_delivered_in_watt
             self.cooling_power_in_watt = 0.0
             self.cop = cop
-            self.electricity_input_in_watt = abs(
-                self.thermal_power_delivered_in_watt / self.cop
-            )
+            self.electricity_input_in_watt = abs(self.thermal_power_delivered_in_watt / self.cop)
         elif self.thermal_power_delivered_in_watt < 0.0:
             self.activation = 1
             self.heating_power_in_watt = 0
             self.cooling_power_in_watt = self.thermal_power_delivered_in_watt
             self.cop = cop
-            self.electricity_input_in_watt = abs(
-                self.thermal_power_delivered_in_watt / self.cop
-            )
+            self.electricity_input_in_watt = abs(self.thermal_power_delivered_in_watt / self.cop)
         else:
             raise Exception("Impossible Heat Pump State.")
 
@@ -360,9 +354,7 @@ class GenericHeatPump(cp.Component):
         self.cop_ref = []
         self.temperature_outside_ref = []
         for heat_pump_cops in heat_pump["COP"]:
-            self.temperature_outside_ref.append(
-                float([*heat_pump_cops][0][1:].split("/")[0])
-            )
+            self.temperature_outside_ref.append(float([*heat_pump_cops][0][1:].split("/")[0]))
             self.cop_ref.append(float([*heat_pump_cops.values()][0]))
         self.cop_coef = np.polyfit(self.temperature_outside_ref, self.cop_ref, 1)
 
@@ -375,23 +367,15 @@ class GenericHeatPump(cp.Component):
         # Default values: 15 minutes to full power
         # Used only for non-clocked heat pump
         self.max_heating_power_variation_restriction_in_watt = (
-            self.max_heating_power_in_watt
-            * self.my_simulation_parameters.seconds_per_timestep
-            / 900
+            self.max_heating_power_in_watt * self.my_simulation_parameters.seconds_per_timestep / 900
         )
         self.max_cooling_power_variation_restriction_in_watt = (
-            -self.max_heating_power_in_watt
-            * self.my_simulation_parameters.seconds_per_timestep
-            / 900
+            -self.max_heating_power_in_watt * self.my_simulation_parameters.seconds_per_timestep / 900
         )
 
         # Sets the time operation restricitions
-        self.min_operation_time = (
-            min_operation_time / self.my_simulation_parameters.seconds_per_timestep
-        )
-        self.min_idle_time = (
-            min_idle_time / self.my_simulation_parameters.seconds_per_timestep
-        )
+        self.min_operation_time = min_operation_time / self.my_simulation_parameters.seconds_per_timestep
+        self.min_idle_time = min_idle_time / self.my_simulation_parameters.seconds_per_timestep
 
         # Writes info to report
         self.write_to_report()
@@ -434,17 +418,13 @@ class GenericHeatPump(cp.Component):
     def write_to_report(self) -> List[str]:
         """Write important variables to report."""
         lines = []
-        lines.append(
-            f"Max Heating Power [kW]: {(self.max_heating_power_in_watt) * 1e-3:4.3f}"
-        )
+        lines.append(f"Max Heating Power [kW]: {(self.max_heating_power_in_watt) * 1e-3:4.3f}")
         lines.append(
             f"Max Peating Power Variation Restriction [W]: {self.max_heating_power_variation_restriction_in_watt:4.3f}"
         )
         return self.heatpump_config.get_string_dict() + lines
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate heat pump."""
         # Inputs
         state_c = stsv.get_input_value(self.state_channel)
@@ -501,33 +481,20 @@ class GenericHeatPump(cp.Component):
         if self.state.activation != 0:
             number_of_cycles = self.state.cycle_number
             # Checks if the minimum running time has been reached
-            if (
-                timestep >= self.state.start_timestep + self.min_operation_time
-                and state_c == 0
-            ):
-                self.state = GenericHeatPumpState(
-                    start_timestep=timestep, cycle_number=number_of_cycles
-                )
+            if timestep >= self.state.start_timestep + self.min_operation_time and state_c == 0:
+                self.state = GenericHeatPumpState(start_timestep=timestep, cycle_number=number_of_cycles)
             stsv.set_output_value(
                 self.thermal_power_delivered_channel,
                 self.state.thermal_power_delivered_in_watt,
             )
-            stsv.set_output_value(
-                self.heating_channel, self.state.heating_power_in_watt
-            )
-            stsv.set_output_value(
-                self.cooling_channel, self.state.cooling_power_in_watt
-            )
-            stsv.set_output_value(
-                self.electricity_output_channel, self.state.electricity_input_in_watt
-            )
+            stsv.set_output_value(self.heating_channel, self.state.heating_power_in_watt)
+            stsv.set_output_value(self.cooling_channel, self.state.cooling_power_in_watt)
+            stsv.set_output_value(self.electricity_output_channel, self.state.electricity_input_in_watt)
             stsv.set_output_value(self.number_of_cycles_channel, self.number_of_cycles)
             return
 
         # Heat Pump is Off
-        if state_c != 0 and (
-            timestep >= self.state.start_timestep + self.min_idle_time
-        ):
+        if state_c != 0 and (timestep >= self.state.start_timestep + self.min_idle_time):
             self.number_of_cycles = self.number_of_cycles + 1
             number_of_cycles = self.number_of_cycles
             if state_c == 1:
@@ -554,9 +521,7 @@ class GenericHeatPump(cp.Component):
         )
         stsv.set_output_value(self.heating_channel, self.state.heating_power_in_watt)
         stsv.set_output_value(self.cooling_channel, self.state.cooling_power_in_watt)
-        stsv.set_output_value(
-            self.electricity_output_channel, self.state.electricity_input_in_watt
-        )
+        stsv.set_output_value(self.electricity_output_channel, self.state.electricity_input_in_watt)
         stsv.set_output_value(self.number_of_cycles_channel, self.number_of_cycles)
 
     def process_thermal(self, ws_in: float) -> None:
@@ -679,6 +644,7 @@ class GenericHeatPumpController(cp.Component):
         """Get electricity meter default connections."""
 
         from hisim.components.electricity_meter import ElectricityMeter  # pylint: disable=import-outside-toplevel
+
         connections = []
         em_classname = ElectricityMeter.get_classname()
         connections.append(
@@ -732,9 +698,7 @@ class GenericHeatPumpController(cp.Component):
         """Write important variables to report."""
         return self.heatpump_controller_config.get_string_dict()
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the heat pump comtroller."""
         # check demand, and change state of self.has_heating_demand, and self._has_cooling_demand
         if force_convergence:
@@ -781,9 +745,7 @@ class GenericHeatPumpController(cp.Component):
                 self.controller_heatpumpmode = "cooling"
                 return
 
-    def smart_conditions(
-        self, set_temperature: float, electricity_input: float
-    ) -> None:
+    def smart_conditions(self, set_temperature: float, electricity_input: float) -> None:
         """Set smart conditions for the heat pump controller mode."""
         smart_offset_upper = 3
         smart_offset_lower = 0.5

--- a/hisim/components/generic_heat_pump_modular.py
+++ b/hisim/components/generic_heat_pump_modular.py
@@ -79,12 +79,8 @@ class HeatPumpConfig(cp.ConfigBase):
             power_th=power_th,
             water_vs_heating=lt.InandOutputType.HEATING,
             device_category=lt.HeatingSystems.HEAT_PUMP,
-            co2_footprint=power_th
-            * 1e-3
-            * 165.84,  # value from emission_factros_and_costs_devices.csv
-            cost=power_th
-            * 1e-3
-            * 1513.74,  # value from emission_factros_and_costs_devices.csv
+            co2_footprint=power_th * 1e-3 * 165.84,  # value from emission_factros_and_costs_devices.csv
+            cost=power_th * 1e-3 * 1513.74,  # value from emission_factros_and_costs_devices.csv
             lifetime=10,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.025,  # source:  VDI2067-1
             consumption=0,
@@ -103,12 +99,8 @@ class HeatPumpConfig(cp.ConfigBase):
             power_th=power_th,
             water_vs_heating=lt.InandOutputType.WATER_HEATING,
             device_category=lt.HeatingSystems.HEAT_PUMP,
-            co2_footprint=power_th
-            * 1e-3
-            * 165.84,  # value from emission_factros_and_costs_devices.csv
-            cost=power_th
-            * 1e-3
-            * 1513.74,  # value from emission_factros_and_costs_devices.csv
+            co2_footprint=power_th * 1e-3 * 165.84,  # value from emission_factros_and_costs_devices.csv
+            cost=power_th * 1e-3 * 1513.74,  # value from emission_factros_and_costs_devices.csv
             lifetime=10,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.025,  # source:  VDI2067-1
             consumption=0,
@@ -127,9 +119,7 @@ class HeatPumpConfig(cp.ConfigBase):
             power_th=power_th,
             water_vs_heating=lt.InandOutputType.HEATING,
             device_category=lt.HeatingSystems.ELECTRIC_HEATING,
-            co2_footprint=power_th
-            * 1e-3
-            * 1.21,  # value from emission_factros_and_costs_devices.csv
+            co2_footprint=power_th * 1e-3 * 1.21,  # value from emission_factros_and_costs_devices.csv
             cost=4635,  # value from emission_factros_and_costs_devices.csv
             lifetime=20,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.025,  # source:  VDI2067-1
@@ -149,9 +139,7 @@ class HeatPumpConfig(cp.ConfigBase):
             power_th=power_th,
             water_vs_heating=lt.InandOutputType.WATER_HEATING,
             device_category=lt.HeatingSystems.ELECTRIC_HEATING,
-            co2_footprint=power_th
-            * 1e-3
-            * 1.21,  # value from emission_factros_and_costs_devices.csv
+            co2_footprint=power_th * 1e-3 * 1.21,  # value from emission_factros_and_costs_devices.csv
             cost=4635,  # value from emission_factros_and_costs_devices.csv
             lifetime=20,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.025,  # source:  VDI2067-1
@@ -175,12 +163,8 @@ class HeatPumpConfig(cp.ConfigBase):
             power_th=power_th_in_watt,
             water_vs_heating=lt.InandOutputType.WATER_HEATING,
             device_category=lt.HeatingSystems.HEAT_PUMP,
-            co2_footprint=power_th_in_watt
-            * 1e-3
-            * 165.84,  # value from emission_factros_and_costs_devices.csv
-            cost=power_th_in_watt
-            * 1e-3
-            * 1513.74,  # value from emission_factros_and_costs_devices.csv
+            co2_footprint=power_th_in_watt * 1e-3 * 165.84,  # value from emission_factros_and_costs_devices.csv
+            cost=power_th_in_watt * 1e-3 * 1513.74,  # value from emission_factros_and_costs_devices.csv
             lifetime=10,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.025,  # source:  VDI2067-1
             consumption=0,
@@ -224,9 +208,7 @@ class ModularHeatPump(cp.Component):
     PowerModifier = "PowerModifier"
 
     @utils.measure_execution_time
-    def __init__(
-        self, config: HeatPumpConfig, my_simulation_parameters: SimulationParameters
-    ):
+    def __init__(self, config: HeatPumpConfig, my_simulation_parameters: SimulationParameters):
         """Initialize the class."""
         super().__init__(
             name=config.name + "_w" + str(config.source_weight),
@@ -296,9 +278,7 @@ class ModularHeatPump(cp.Component):
         )
 
         self.add_default_connections(self.get_default_connections_from_weather())
-        self.add_default_connections(
-            self.get_default_connections_from_controller_l1_heatpump()
-        )
+        self.add_default_connections(self.get_default_connections_from_controller_l1_heatpump())
 
     def get_default_connections_from_weather(self):
         """Sets default connections of Weather."""
@@ -318,9 +298,7 @@ class ModularHeatPump(cp.Component):
         """Sets default connections of heat pump controller."""
 
         connections = []
-        controller_classname = (
-            controller_l1_heatpump.L1HeatPumpController.get_classname()
-        )
+        controller_classname = controller_l1_heatpump.L1HeatPumpController.get_classname()
         connections.append(
             cp.ComponentConnection(
                 ModularHeatPump.HeatControllerTargetPercentage,
@@ -342,10 +320,7 @@ class ModularHeatPump(cp.Component):
         heat_pump_found = False
         heat_pump = None
         for heat_pump in heat_pumps_database:
-            if (
-                heat_pump["Manufacturer"] == self.config.manufacturer
-                and heat_pump["Name"] == self.config.device_name
-            ):
+            if heat_pump["Manufacturer"] == self.config.manufacturer and heat_pump["Name"] == self.config.device_name:
                 heat_pump_found = True
                 break
 
@@ -384,15 +359,11 @@ class ModularHeatPump(cp.Component):
         """Writes relevant data to report."""
         return self.config.get_string_dict()
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Iteration of heat pump simulation."""
 
         # Inputs
-        target_percentage = stsv.get_input_value(
-            self.heat_controller_power_modifier_channel
-        )
+        target_percentage = stsv.get_input_value(self.heat_controller_power_modifier_channel)
 
         temperature_outside: float = stsv.get_input_value(self.temperature_outside_channel)
         cop = self.cal_cop(temperature_outside)
@@ -406,14 +377,10 @@ class ModularHeatPump(cp.Component):
 
         power_modifier = min(1, power_modifier)
 
-        stsv.set_output_value(
-            self.thermal_power_delicered_channel, self.config.power_th * power_modifier
-        )
+        stsv.set_output_value(self.thermal_power_delicered_channel, self.config.power_th * power_modifier)
         stsv.set_output_value(self.power_modifier_channel, power_modifier)
 
-        stsv.set_output_value(
-            self.electricity_output_channel, electric_power * power_modifier
-        )
+        stsv.set_output_value(self.electricity_output_channel, electric_power * power_modifier)
 
     @staticmethod
     def get_cost_capex(config: HeatPumpConfig) -> Tuple[float, float, float]:
@@ -432,8 +399,7 @@ class ModularHeatPump(cp.Component):
         """
         for index, output in enumerate(all_outputs):
             if (
-                output.component_name
-                == self.config.name + "_w" + str(self.config.source_weight)
+                output.component_name == self.config.name + "_w" + str(self.config.source_weight)
                 and output.load_type == lt.LoadTypes.ELECTRICITY
             ):  # Todo: check component name from system_setups: find another way of using only heatpump-outputs
                 self.config.consumption = round(

--- a/hisim/components/generic_heat_source.py
+++ b/hisim/components/generic_heat_source.py
@@ -106,9 +106,7 @@ class HeatSource(cp.Component):
     ThermalPowerDelivered = "ThermalPowerDelivered"
     FuelDelivered = "FuelDelivered"
 
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: HeatSourceConfig
-    ) -> None:
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: HeatSourceConfig) -> None:
         """Initialize the class."""
 
         super().__init__(
@@ -158,9 +156,7 @@ class HeatSource(cp.Component):
         else:
             self.fuel_delivered_channel.unit = lt.Units.WATT_HOUR
 
-        self.add_default_connections(
-            self.get_default_connections_controller_l1_heatpump()
-        )
+        self.add_default_connections(self.get_default_connections_controller_l1_heatpump())
 
     def get_default_connections_controller_l1_heatpump(
         self,
@@ -168,9 +164,7 @@ class HeatSource(cp.Component):
         """Sets default connections of heat source controller."""
         log.information("setting l1 default connections in Generic Heat Source")
         connections = []
-        controller_classname = (
-            controller_l1_heatpump.L1HeatPumpController.get_classname()
-        )
+        controller_classname = controller_l1_heatpump.L1HeatPumpController.get_classname()
         connections.append(
             cp.ComponentConnection(
                 HeatSource.L1HeatSourceTargetPercentage,
@@ -184,8 +178,7 @@ class HeatSource(cp.Component):
         """Writes relevant data to report."""
 
         lines = []
-        lines.append(
-            f"Name: {self.config.name + str(self.config.source_weight)})")
+        lines.append(f"Name: {self.config.name + str(self.config.source_weight)})")
         lines.append(f"Fuel: {self.config.fuel}")
         lines.append(f"Power: {(self.config.power_th) * 1e-3:4.0f} kW")
         lines.append(f"Efficiency : {(self.config.efficiency) * 100:4.0f} %")
@@ -207,9 +200,7 @@ class HeatSource(cp.Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Performs the simulation of the heat source model."""
 
         # Inputs
@@ -243,8 +234,5 @@ class HeatSource(cp.Component):
         else:
             stsv.set_output_value(
                 self.fuel_delivered_channel,
-                power_modifier
-                * self.config.power_th
-                * self.my_simulation_parameters.seconds_per_timestep
-                / 3.6e3,
+                power_modifier * self.config.power_th * self.my_simulation_parameters.seconds_per_timestep / 3.6e3,
             )

--- a/hisim/components/generic_heat_water_storage.py
+++ b/hisim/components/generic_heat_water_storage.py
@@ -75,9 +75,7 @@ class HeatStorageControllerConfig(ConfigBase):
     heating_load_of_building_in_watt: float
 
     @classmethod
-    def get_default_heat_storage_controller_config(
-        cls, heating_load_of_building_in_watt: float
-    ) -> Any:
+    def get_default_heat_storage_controller_config(cls, heating_load_of_building_in_watt: float) -> Any:
         """Get default config."""
         config = HeatStorageControllerConfig(
             name="HeatStorageController",
@@ -116,12 +114,8 @@ class HeatStorage(Component):
     """
 
     # Inputs
-    ThermalDemandHeatingWater = (
-        "ThermalDemandHeatingWater"  # Heating Water to regulate room Temperature
-    )
-    ThermalDemandWarmWater = (
-        "ThermalDemandHeating"  # Warmwater for showering, washing etc...
-    )
+    ThermalDemandHeatingWater = "ThermalDemandHeatingWater"  # Heating Water to regulate room Temperature
+    ThermalDemandWarmWater = "ThermalDemandHeating"  # Warmwater for showering, washing etc...
     ControlSignalChooseStorage = "ControlSignalChooseStorage"
     BuildingTemperature = "BuildingTemperature"
 
@@ -140,9 +134,7 @@ class HeatStorage(Component):
     StorageEnergyLoss = "StorageEnergyLoss"
     RealHeatForBuilding = "RealHeatForBuilding"
 
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: HeatStorageConfig
-    ) -> None:
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: HeatStorageConfig) -> None:
         """Initialize the class."""
         self.heat_storage_config = config
         super().__init__(
@@ -152,9 +144,7 @@ class HeatStorage(Component):
         )
         self.volume_sp_heating_water = self.heat_storage_config.volume_sp_heating_water
         self.volume_sp_warm_water = self.heat_storage_config.volume_sp_warm_water
-        self.temperature_of_warm_water_extratcion = (
-            self.heat_storage_config.temperature_of_warm_water_extraction
-        )
+        self.temperature_of_warm_water_extratcion = self.heat_storage_config.temperature_of_warm_water_extraction
         self.ambient_temperature = self.heat_storage_config.ambient_temperature
         self.temperature_sp_warm_water = self.heat_storage_config.temperature_sp_ww
         self.temperature_sp_heating_water = self.heat_storage_config.temperature_sp_hw
@@ -273,16 +263,10 @@ class HeatStorage(Component):
         lines.append("Name: HeatWaterStorage")
         lines.append(f"Volume Warm Water Storage [L]: {self.volume_sp_warm_water}")
         lines.append(f"Volume Heat Water Storage [L]: {self.volume_sp_heating_water}")
-        lines.append(
-            f"Temperature of Warm Water Extraction [°C]: {self.temperature_of_warm_water_extratcion}"
-        )
+        lines.append(f"Temperature of Warm Water Extraction [°C]: {self.temperature_of_warm_water_extratcion}")
         lines.append(f"Ambient Temperature [°C]: {self.ambient_temperature}")
-        lines.append(
-            f"Temperature Warm Water Storage [°C]: {self.temperature_sp_warm_water}"
-        )
-        lines.append(
-            f"temperature Heat Water Storage [°C]: {self.temperature_sp_heating_water}"
-        )
+        lines.append(f"Temperature Warm Water Storage [°C]: {self.temperature_sp_warm_water}")
+        lines.append(f"temperature Heat Water Storage [°C]: {self.temperature_sp_heating_water}")
 
         return self.heat_storage_config.get_string_dict() + lines
 
@@ -308,30 +292,19 @@ class HeatStorage(Component):
         # function to add all possible mass flows
 
         if self.thermal_input_power_one_channel.source_output is not None:
-            production = (
-                stsv.get_input_value(self.thermal_input_power_one_channel) + production
-            )
+            production = stsv.get_input_value(self.thermal_input_power_one_channel) + production
 
         if self.thermal_input_power_two_channel.source_output is not None:
-            production = (
-                stsv.get_input_value(self.thermal_input_power_two_channel) + production
-            )
+            production = stsv.get_input_value(self.thermal_input_power_two_channel) + production
 
         if self.thermal_input_power_three_channel.source_output is not None:
-            production = (
-                stsv.get_input_value(self.thermal_input_power_three_channel)
-                + production
-            )
+            production = stsv.get_input_value(self.thermal_input_power_three_channel) + production
 
         if self.thermal_input_power_four_channel.source_output is not None:
-            production = (
-                stsv.get_input_value(self.thermal_input_power_four_channel) + production
-            )
+            production = stsv.get_input_value(self.thermal_input_power_four_channel) + production
 
         if self.thermal_input_power_five_channel.source_output is not None:
-            production = (
-                stsv.get_input_value(self.thermal_input_power_five_channel) + production
-            )
+            production = stsv.get_input_value(self.thermal_input_power_five_channel) + production
 
         return production
 
@@ -355,11 +328,7 @@ class HeatStorage(Component):
         temperature_sp = (
             temperature_sp
             + (1 / (mass_sp_h * c_w))
-            * (
-                production
-                - last
-                - heat_loss_storage * (temperature_sp - temperature_ext_sp)
-            )
+            * (production - last - heat_loss_storage * (temperature_sp - temperature_ext_sp))
             * seconds_per_timestep
         )
         # T_SP = T_sp + (dt/(m_SP_h*c_w))*(P_h_HS*(T_sp-T_ext_SP) - last*(T_sp-T_ext_SP) - UA_SP*(T_sp-T_ext_SP))
@@ -374,9 +343,7 @@ class HeatStorage(Component):
 
     # def regarding_heating_water_storage (self, T_sp: int):
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
 
         temperature_sp_var_ww = self.state.temperature_sp_ww  # Start-Temp-Storage
@@ -446,12 +413,8 @@ class HeatStorage(Component):
             self.water_output_temperature_heating_water_channel,
             self.state.temperature_sp_hw,
         )
-        stsv.set_output_value(
-            self.water_output_temperature_storage_for_heaters_channel, temperature_sp_c
-        )
-        stsv.set_output_value(
-            self.storage_energy_loss_channel, result_ww[1] + result_hw[1]
-        )
+        stsv.set_output_value(self.water_output_temperature_storage_for_heaters_channel, temperature_sp_c)
+        stsv.set_output_value(self.storage_energy_loss_channel, result_ww[1] + result_hw[1])
         stsv.set_output_value(self.real_heat_for_building_channel, last_var_hw)
 
         # Output Massenstrom von Wasser entspricht dem Input Massenstrom. Nur Temperatur hat sich geändert. Wie ist das zu behandelN?
@@ -493,16 +456,10 @@ class HeatStorageController(cp.Component):
             my_simulation_parameters=my_simulation_parameters,
             my_config=config,
         )
-        self.initial_temperature_heating_storage = (
-            self.heatstoragecontroller_config.initial_temperature_heating_storage
-        )
-        self.initial_temperature_building = (
-            self.heatstoragecontroller_config.initial_temperature_building
-        )
+        self.initial_temperature_heating_storage = self.heatstoragecontroller_config.initial_temperature_heating_storage
+        self.initial_temperature_building = self.heatstoragecontroller_config.initial_temperature_building
 
-        self.ref_max_thermal_build_demand_in_watt = (
-            self.heatstoragecontroller_config.heating_load_of_building_in_watt
-        )
+        self.ref_max_thermal_build_demand_in_watt = self.heatstoragecontroller_config.heating_load_of_building_in_watt
         # ===================================================================================================================
         # Inputs
         # self.ref_max_thermal_build_demand: ComponentInput = self.add_input(
@@ -554,12 +511,8 @@ class HeatStorageController(cp.Component):
         """Write to report."""
         lines = []
         lines.append("Name: HeatWaterStorage Controller")
-        lines.append(
-            f"Initial Temperature Building [°C]: {self.initial_temperature_building}"
-        )
-        lines.append(
-            f"Initial Temperature Heat Water Storage [°C]: {self.initial_temperature_heating_storage}"
-        )
+        lines.append(f"Initial Temperature Building [°C]: {self.initial_temperature_building}")
+        lines.append(f"Initial Temperature Heat Water Storage [°C]: {self.initial_temperature_heating_storage}")
         return self.heatstoragecontroller_config.get_string_dict() + lines
 
     def i_save_state(self) -> None:
@@ -574,36 +527,22 @@ class HeatStorageController(cp.Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
-        temperature_sp_var_hw = stsv.get_input_value(
-            self.heating_storage_temperature_channel
-        )  # Start-Temp-Storage
+        temperature_sp_var_hw = stsv.get_input_value(self.heating_storage_temperature_channel)  # Start-Temp-Storage
         last_var_hw = stsv.get_input_value(self.real_thermal_demand_building_channel)
         max_mass_flow_heat_storage = self.ref_max_thermal_build_demand_in_watt / (
-            4.1851
-            * 1000
-            * (
-                self.initial_temperature_heating_storage
-                - self.initial_temperature_building
-            )
+            4.1851 * 1000 * (self.initial_temperature_heating_storage - self.initial_temperature_building)
         )
 
         max_last_var_hw = (
             max_mass_flow_heat_storage
             * 4.185
             * 1000
-            * (
-                temperature_sp_var_hw
-                - stsv.get_input_value(self.building_temperature_channel)
-            )
+            * (temperature_sp_var_hw - stsv.get_input_value(self.building_temperature_channel))
         )
 
         if max_last_var_hw < last_var_hw:
             last_var_hw = max_last_var_hw
 
-        stsv.set_output_value(
-            self.real_thermal_demand_heating_water_channel, last_var_hw
-        )
+        stsv.set_output_value(self.real_thermal_demand_heating_water_channel, last_var_hw)

--- a/hisim/components/generic_hot_water_storage_modular.py
+++ b/hisim/components/generic_hot_water_storage_modular.py
@@ -81,9 +81,7 @@ class StorageConfig(cp.ConfigBase):
         """Returns default configuration for boiler."""
 
         volume = 230
-        radius = (volume * 1e-3 / (4 * np.pi)) ** (
-            1 / 3
-        )  # l to m^3 so that radius is given in m
+        radius = (volume * 1e-3 / (4 * np.pi)) ** (1 / 3)  # l to m^3 so that radius is given in m
         surface = 2 * radius * radius * np.pi + 2 * radius * np.pi * (4 * radius)
         config = StorageConfig(
             name="DHWBoiler",
@@ -108,9 +106,7 @@ class StorageConfig(cp.ConfigBase):
         """Returns default configuration for boiler."""
 
         volume = default_volume_in_liter * max(number_of_apartments, 1)
-        radius = (volume * 1e-3 / (4 * np.pi)) ** (
-            1 / 3
-        )  # l to m^3 so that radius is given in m
+        radius = (volume * 1e-3 / (4 * np.pi)) ** (1 / 3)  # l to m^3 so that radius is given in m
         surface = 2 * radius * radius * np.pi + 2 * radius * np.pi * (4 * radius)
         config = StorageConfig(
             name="DHWBoiler",
@@ -132,9 +128,7 @@ class StorageConfig(cp.ConfigBase):
     def get_default_config_buffer(power: float = 2000, volume: float = 500) -> Any:
         """Returns default configuration for buffer (radius:height = 1:4)."""
         # volume = r^2 * pi * h = r^2 * pi * 4r = 4 * r^3 * pi
-        radius = (volume * 1e-3 / (4 * np.pi)) ** (
-            1 / 3
-        )  # l to m^3 so that radius is given in m
+        radius = (volume * 1e-3 / (4 * np.pi)) ** (1 / 3)  # l to m^3 so that radius is given in m
         # cylinder surface area = floor and ceiling area + lateral surface
         surface = 2 * radius * radius * np.pi + 2 * radius * np.pi * (4 * radius)
         config = StorageConfig(
@@ -161,28 +155,18 @@ class StorageConfig(cp.ConfigBase):
     ) -> None:
         """Computes default volume and surface from power and min idle time of heating system."""
         if self.use != lt.ComponentType.BUFFER:
-            raise Exception(
-                "Default volume can only be computed for buffer storage not for boiler."
-            )
+            raise Exception("Default volume can only be computed for buffer storage not for boiler.")
 
         energy_in_kilo_joule = self.power * time_in_seconds * 1e-3
-        self.volume = (
-            energy_in_kilo_joule
-            * multiplier
-            / (temperature_difference_in_kelvin * 0.977 * 4.182)
-        )
+        self.volume = energy_in_kilo_joule * multiplier / (temperature_difference_in_kelvin * 0.977 * 4.182)
         # volume = r^2 * pi * h = r^2 * pi * 4r = 4 * r^3 * pi
-        radius = (self.volume * 1e-3 / (4 * np.pi)) ** (
-            1 / 3
-        )  # l to m^3 so that radius is given in m
+        radius = (self.volume * 1e-3 / (4 * np.pi)) ** (1 / 3)  # l to m^3 so that radius is given in m
         # cylinder surface area = floor and ceiling area + lateral surface
         self.surface = 2 * radius * radius * np.pi + 2 * radius * np.pi * (4 * radius)
 
     def compute_default_cycle(self, temperature_difference_in_kelvin: float) -> None:
         """Computes energy needed to heat storage from lower threshold of hysteresis to upper threshold."""
-        self.energy_full_cycle = (
-            self.volume * temperature_difference_in_kelvin * 0.977 * 4.182 / 3600
-        )
+        self.energy_full_cycle = self.volume * temperature_difference_in_kelvin * 0.977 * 4.182 / 3600
 
 
 class StorageState:
@@ -216,17 +200,13 @@ class StorageState:
         """Converts temperature of storage (K) into energy contained in storage (kJ)."""
         # 0.977 is the density of water in kg/l
         # 4.182 is the specific heat of water in kJ / (K * kg)
-        return (
-            self.temperature_in_kelvin * self.volume_in_l * 0.977 * 4.182
-        )  # energy given in kJ
+        return self.temperature_in_kelvin * self.volume_in_l * 0.977 * 4.182  # energy given in kJ
 
     def set_temperature_from_energy(self, energy_in_kilo_joule: float) -> None:
         """Converts energy contained in storage (kJ) into temperature (K)."""
         # 0.977 is the density of water in kg/l
         # 4.182 is the specific heat of water in kJ / (K * kg)
-        self.temperature_in_kelvin = energy_in_kilo_joule / (
-            self.volume_in_l * 0.977 * 4.182
-        )  # temperature given in K
+        self.temperature_in_kelvin = energy_in_kilo_joule / (self.volume_in_l * 0.977 * 4.182)  # temperature given in K
         # filter for boiling water
         # no filtering -> this hides major problems - Noah
         if self.temperature_in_kelvin > 95 + 273.15:
@@ -244,13 +224,7 @@ class StorageState:
 
         For heating up the building in winter. Here 30°C is set as the lower limit for the temperature in the buffer storage in winter.
         """
-        return (
-            (self.temperature_in_kelvin - 273.15 - 25)
-            * self.volume_in_l
-            * 0.977
-            * 4.182
-            * 1e3
-        )
+        return (self.temperature_in_kelvin - 273.15 - 25) * self.volume_in_l * 0.977 * 4.182 * 1e3
 
 
 # class HotWaterStorage(dycp.DynamicComponent):
@@ -285,9 +259,7 @@ class HotWaterStorage(cp.Component):
     # outputs for buffer storage
     PowerFromHotWaterStorage = "PowerFromHotWaterStorage"
 
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: StorageConfig
-    ):
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: StorageConfig):
         """Initializes instance of HotWaterStorage class."""
 
         super().__init__(
@@ -304,9 +276,7 @@ class HotWaterStorage(cp.Component):
         self.heat_to_buffer_inputs: List[cp.ComponentInput]
 
         # initialize Boiler State
-        self.state = StorageState(
-            volume_in_l=config.volume, temperature_in_kelvin=273 + 60
-        )
+        self.state = StorageState(volume_in_l=config.volume, temperature_in_kelvin=273 + 60)
         self.previous_state = self.state.clone()
         self.write_to_report()
 
@@ -322,18 +292,14 @@ class HotWaterStorage(cp.Component):
             self.add_default_connections(self.get_occupancy_default_connections())
             self.add_default_connections(self.get_utsp_default_connections())
         elif self.use == lt.ComponentType.BUFFER:
-            self.heat_controller_target_percentage_channel: cp.ComponentInput = (
-                self.add_input(
-                    self.component_name,
-                    self.HeatControllerTargetPercentage,
-                    lt.LoadTypes.ON_OFF,
-                    lt.Units.BINARY,
-                    mandatory=True,
-                )
+            self.heat_controller_target_percentage_channel: cp.ComponentInput = self.add_input(
+                self.component_name,
+                self.HeatControllerTargetPercentage,
+                lt.LoadTypes.ON_OFF,
+                lt.Units.BINARY,
+                mandatory=True,
             )
-            self.add_default_connections(
-                self.get_heating_controller_default_connections()
-            )
+            self.add_default_connections(self.get_heating_controller_default_connections())
         else:
             hisim.log.error("Type of hot water storage is not defined")
 
@@ -371,9 +337,7 @@ class HotWaterStorage(cp.Component):
             output_description="Power transfered to Building or Hot Water Pipe.",
         )
 
-        self.add_default_connections(
-            self.get_default_connections_from_generic_heat_pump_modular()
-        )
+        self.add_default_connections(self.get_default_connections_from_generic_heat_pump_modular())
         self.add_default_connections(self.get_heatsource_default_connections())
         self.add_default_connections(self.get_chp_default_connections())
 
@@ -451,9 +415,7 @@ class HotWaterStorage(cp.Component):
         """Sets heating controller default connections in hot water storage."""
 
         connections = []
-        heating_controller_classname = (
-            controller_l1_building_heating.L1BuildingHeatController.get_classname()
-        )
+        heating_controller_classname = controller_l1_building_heating.L1BuildingHeatController.get_classname()
         connections.append(
             cp.ComponentConnection(
                 HotWaterStorage.HeatControllerTargetPercentage,
@@ -476,9 +438,7 @@ class HotWaterStorage(cp.Component):
         self.volume = config.volume
         self.surface = config.surface
         self.u_value = config.u_value
-        self.drain_water_temperature = (
-            configuration.HouseholdWarmWaterDemandConfig.freshwater_temperature
-        )
+        self.drain_water_temperature = configuration.HouseholdWarmWaterDemandConfig.freshwater_temperature
         self.warm_water_temperature = (
             configuration.HouseholdWarmWaterDemandConfig.ww_temperature_demand
             - configuration.HouseholdWarmWaterDemandConfig.temperature_difference_hot
@@ -498,9 +458,7 @@ class HotWaterStorage(cp.Component):
         """Abstract. Restores the state of the component. Can be called many times while iterating."""
         self.state = self.previous_state.clone()
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates iteration of hot water storage."""
 
         thermal_energy_delivered = 0.0
@@ -542,9 +500,7 @@ class HotWaterStorage(cp.Component):
         self.state.set_temperature_from_energy(new_energy)
 
         # save outputs
-        stsv.set_output_value(
-            self.temperature_mean_channel, self.state.temperature_in_kelvin - 273.15
-        )
+        stsv.set_output_value(self.temperature_mean_channel, self.state.temperature_in_kelvin - 273.15)
 
     def calculate_heat_consumption(
         self,
@@ -569,15 +525,11 @@ class HotWaterStorage(cp.Component):
                 * self.my_simulation_parameters.seconds_per_timestep
                 * 1e-3
             )  # 1e-3 conversion J to kJ
-            available_energy = (
-                self.state.return_available_energy() + thermal_energy_delivered
-            )
+            available_energy = self.state.return_available_energy() + thermal_energy_delivered
             if heatconsumption > available_energy:
                 heatconsumption = max(available_energy, 0)
             return heatconsumption
-        raise Exception(
-            "Modular storage must be defined either as buffer or as boiler."
-        )
+        raise Exception("Modular storage must be defined either as buffer or as boiler.")
 
     @staticmethod
     def get_cost_capex(config: StorageConfig) -> Tuple[float, float, float]:

--- a/hisim/components/generic_hydrogen_storage.py
+++ b/hisim/components/generic_hydrogen_storage.py
@@ -111,9 +111,7 @@ class GenericHydrogenStorage(cp.Component):
         )
         self.config = config
         self.loss_factor = (
-            (config.loss_factor_per_day / 100)
-            * self.my_simulation_parameters.seconds_per_timestep
-            / (24 * 3600)
+            (config.loss_factor_per_day / 100) * self.my_simulation_parameters.seconds_per_timestep / (24 * 3600)
         )
         self.state = GenericHydrogenStorageState()
         self.previous_state = GenericHydrogenStorageState()
@@ -142,9 +140,7 @@ class GenericHydrogenStorage(cp.Component):
             output_description="Hydrogen SOC",
         )
 
-        self.add_default_connections(
-            self.get_default_connections_from_generic_electrolyzer()
-        )
+        self.add_default_connections(self.get_default_connections_from_generic_electrolyzer())
         self.add_default_connections(self.get_default_connections_from_generic_chp())
 
     def i_prepare_simulation(self) -> None:
@@ -171,9 +167,7 @@ class GenericHydrogenStorage(cp.Component):
         """Get default connections from generic electrolyzer."""
 
         connections: List[cp.ComponentConnection] = []
-        electrolyzer_classname = (
-            generic_electrolyzer.GenericElectrolyzer.get_classname()
-        )
+        electrolyzer_classname = generic_electrolyzer.GenericElectrolyzer.get_classname()
         connections.append(
             cp.ComponentConnection(
                 GenericHydrogenStorage.HydrogenInput,
@@ -189,22 +183,16 @@ class GenericHydrogenStorage(cp.Component):
         # limitation of charging rate
         delta_not_stored: float = 0
         if charging_rate > self.config.max_charging_rate:
-            delta_not_stored = (
-                delta_not_stored + charging_rate - self.config.max_charging_rate
-            )
+            delta_not_stored = delta_not_stored + charging_rate - self.config.max_charging_rate
             charging_rate = self.config.max_charging_rate
 
         # limitation of storage size
         if (
-            self.state.fill
-            + charging_rate * self.my_simulation_parameters.seconds_per_timestep
+            self.state.fill + charging_rate * self.my_simulation_parameters.seconds_per_timestep
             < self.config.max_capacity
         ):
             # fits completely
-            self.state.fill = (
-                self.state.fill
-                + charging_rate * self.my_simulation_parameters.seconds_per_timestep
-            )
+            self.state.fill = self.state.fill + charging_rate * self.my_simulation_parameters.seconds_per_timestep
 
         elif self.state.fill >= self.config.max_capacity:
             # tank is already full
@@ -216,13 +204,8 @@ class GenericHydrogenStorage(cp.Component):
             # returns amount which an be put in
             amount_stored = self.config.max_capacity - self.state.fill
             self.state.fill += amount_stored
-            delta_not_stored = (
-                charging_rate
-                - amount_stored / self.my_simulation_parameters.seconds_per_timestep
-            )
-            charging_rate = (
-                amount_stored / self.my_simulation_parameters.seconds_per_timestep
-            )
+            delta_not_stored = charging_rate - amount_stored / self.my_simulation_parameters.seconds_per_timestep
+            charging_rate = amount_stored / self.my_simulation_parameters.seconds_per_timestep
 
         power_demand = charging_rate * self.config.energy_for_charge * 3.6e3
         return charging_rate, power_demand, delta_not_stored
@@ -233,20 +216,15 @@ class GenericHydrogenStorage(cp.Component):
         # limitations of discharging rate
         delta_not_released: float = 0
         if discharging_rate > self.config.max_discharging_rate:
-            delta_not_released = (
-                delta_not_released + discharging_rate - self.config.max_discharging_rate
-            )
+            delta_not_released = delta_not_released + discharging_rate - self.config.max_discharging_rate
             discharging_rate = self.config.max_discharging_rate
 
         if (
             self.state.fill
-            > self.config.min_capacity
-            + discharging_rate * self.my_simulation_parameters.seconds_per_timestep
+            > self.config.min_capacity + discharging_rate * self.my_simulation_parameters.seconds_per_timestep
         ):
             # has enough
-            self.state.fill -= (
-                discharging_rate * self.my_simulation_parameters.seconds_per_timestep
-            )
+            self.state.fill -= discharging_rate * self.my_simulation_parameters.seconds_per_timestep
 
         elif self.state.fill <= self.config.min_capacity:
             # empty
@@ -258,13 +236,8 @@ class GenericHydrogenStorage(cp.Component):
             # added recently :but in this case to simplify work of CHP, say that no hydrogen can be provided
             amount_released = self.state.fill - self.config.min_capacity
             self.state.fill -= amount_released
-            delta_not_released = (
-                discharging_rate
-                - amount_released / self.my_simulation_parameters.seconds_per_timestep
-            )
-            discharging_rate = (
-                amount_released / self.my_simulation_parameters.seconds_per_timestep
-            )
+            delta_not_released = discharging_rate - amount_released / self.my_simulation_parameters.seconds_per_timestep
+            discharging_rate = amount_released / self.my_simulation_parameters.seconds_per_timestep
 
         power_demand = discharging_rate * self.config.energy_for_discharge * 3.6e3
         return discharging_rate, power_demand, delta_not_released
@@ -281,9 +254,7 @@ class GenericHydrogenStorage(cp.Component):
         """Restores the state."""
         self.state = self.previous_state.clone()
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
 
         # get input values
@@ -291,13 +262,9 @@ class GenericHydrogenStorage(cp.Component):
         discharging_rate = stsv.get_input_value(self.hydrogen_output_channel)
 
         if charging_rate < 0:
-            raise Exception(
-                "trying to charge with negative amount" + str(charging_rate)
-            )
+            raise Exception("trying to charge with negative amount" + str(charging_rate))
         if discharging_rate < 0:
-            raise Exception(
-                "trying to discharge with negative amount: " + str(discharging_rate)
-            )
+            raise Exception("trying to discharge with negative amount: " + str(discharging_rate))
 
         if charging_rate > 0 and discharging_rate > 0:
             # simultaneous charging and discharging has to be prevented

--- a/hisim/components/generic_price_signal.py
+++ b/hisim/components/generic_price_signal.py
@@ -83,9 +83,7 @@ class PriceSignal(cp.Component):
     PricePurchase = "PricePurchase"
     PriceInjection = "PriceInjection"
 
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: PriceSignalConfig
-    ) -> None:
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: PriceSignalConfig) -> None:
         """Initialization of Price Signal class.
 
         :param my_simulation_parameters: _description_
@@ -141,28 +139,20 @@ class PriceSignal(cp.Component):
         """Doublechecks."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Outputs price signal of time step."""
         priceinjectionforecast = [0.1]
         pricepurchaseforecast = [0.5]
         if self.config.predictive_control and self.config.prediction_horizon:
             priceinjectionforecast = [0.1] * int(
-                self.config.prediction_horizon
-                / self.my_simulation_parameters.seconds_per_timestep
+                self.config.prediction_horizon / self.my_simulation_parameters.seconds_per_timestep
             )
             pricepurchaseforecast = [0.5] * int(
-                self.config.prediction_horizon
-                / self.my_simulation_parameters.seconds_per_timestep
+                self.config.prediction_horizon / self.my_simulation_parameters.seconds_per_timestep
             )
-        elif (
-            self.price_signal_config.price_signal_type
-            == "Prices at second half of 2021"
-        ):
+        elif self.price_signal_config.price_signal_type == "Prices at second half of 2021":
             priceinjectionforecast = [self.price_signal_config.price_injection] * int(
-                self.config.prediction_horizon
-                / self.my_simulation_parameters.seconds_per_timestep
+                self.config.prediction_horizon / self.my_simulation_parameters.seconds_per_timestep
             )
         elif self.price_signal_config.pricing_scheme == "dynamic":
             pricepurchaseforecast = self.price_signal_config.static_tou_price
@@ -170,12 +160,10 @@ class PriceSignal(cp.Component):
             pricepurchaseforecast = self.price_signal_config.fixed_price
         elif self.price_signal_config.price_signal_type == "dummy":
             priceinjectionforecast = [10] * int(
-                self.config.prediction_horizon
-                / self.my_simulation_parameters.seconds_per_timestep
+                self.config.prediction_horizon / self.my_simulation_parameters.seconds_per_timestep
             )
             pricepurchaseforecast = [50] * int(
-                self.config.prediction_horizon
-                / self.my_simulation_parameters.seconds_per_timestep
+                self.config.prediction_horizon / self.my_simulation_parameters.seconds_per_timestep
             )
             # pricepurchaseforecast = [ ]
             # for step in range( self.day ):
@@ -217,22 +205,16 @@ class PriceSignal(cp.Component):
 
         if "Fixed_Price_" + self.price_signal_config.country in price_purchase:
             self.price_signal_config.price_signal_type = "Prices at second half of 2021"
-            fixed_price = price_purchase[
-                "Fixed_Price_" + self.price_signal_config.country
-            ].tolist()
+            fixed_price = price_purchase["Fixed_Price_" + self.price_signal_config.country].tolist()
             # convert euro/kWh to cent/kW-timestep
-            p_conversion = 100 / (
-                1000 * 3600 / self.my_simulation_parameters.seconds_per_timestep
-            )
+            p_conversion = 100 / (1000 * 3600 / self.my_simulation_parameters.seconds_per_timestep)
             fixed_price = [element * p_conversion for element in fixed_price]
             self.price_signal_config.fixed_price = np.repeat(
                 fixed_price,
                 int(3600 / self.my_simulation_parameters.seconds_per_timestep),
             ).tolist()
 
-            static_tou_price = price_purchase[
-                "Static_TOU_Price_" + self.price_signal_config.country
-            ].tolist()
+            static_tou_price = price_purchase["Static_TOU_Price_" + self.price_signal_config.country].tolist()
             static_tou_price = [element * p_conversion for element in static_tou_price]
             self.price_signal_config.static_tou_price = np.repeat(
                 static_tou_price,
@@ -242,10 +224,8 @@ class PriceSignal(cp.Component):
             fit_data = feed_in_tarrif.loc[self.price_signal_config.country]
             for i in range(len(fit_data)):
                 if (
-                    fit_data["min_capacity (kW)"].values[i]
-                    < self.price_signal_config.installed_capacity
-                    and fit_data["max_capacity (kW)"].values[i]
-                    >= self.price_signal_config.installed_capacity
+                    fit_data["min_capacity (kW)"].values[i] < self.price_signal_config.installed_capacity
+                    and fit_data["max_capacity (kW)"].values[i] >= self.price_signal_config.installed_capacity
                 ):
                     price_injection = fit_data["FIT"].values[i]
             self.price_signal_config.price_injection = price_injection * p_conversion

--- a/hisim/components/generic_pv_system.py
+++ b/hisim/components/generic_pv_system.py
@@ -116,12 +116,8 @@ class PVSystemConfig(ConfigBase):
             tilt=30,
             source_weight=0,
             location="Aachen",
-            co2_footprint=power_in_watt
-            * 1e-3
-            * 330.51,  # value from emission_factros_and_costs_devices.csv
-            cost=power_in_watt
-            * 1e-3
-            * 794.41,  # value from emission_factros_and_costs_devices.csv
+            co2_footprint=power_in_watt * 1e-3 * 330.51,  # value from emission_factros_and_costs_devices.csv
+            cost=power_in_watt * 1e-3 * 794.41,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.01,  # source: https://solarenergie.de/stromspeicher/preise
             lifetime=25,  # value from emission_factros_and_costs_devices.csv
             predictive=False,
@@ -159,12 +155,8 @@ class PVSystemConfig(ConfigBase):
             tilt=30,
             source_weight=0,
             location="Aachen",
-            co2_footprint=total_pv_power_in_watt
-            * 1e-3
-            * 330.51,  # value from emission_factros_and_costs_devices.csv
-            cost=total_pv_power_in_watt
-            * 1e-3
-            * 794.41,  # value from emission_factros_and_costs_devices.csv
+            co2_footprint=total_pv_power_in_watt * 1e-3 * 330.51,  # value from emission_factros_and_costs_devices.csv
+            cost=total_pv_power_in_watt * 1e-3 * 794.41,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.01,  # source: https://solarenergie.de/stromspeicher/preise
             lifetime=25,  # value from emission_factros_and_costs_devices.csv
             predictive=False,
@@ -265,9 +257,7 @@ class PVSystem(cp.Component):
     # Similar components to connect to:
     # 1. Weather
     @utils.measure_execution_time
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: PVSystemConfig
-    ) -> None:
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: PVSystemConfig) -> None:
         """Initialize the class."""
         self.my_simulation_parameters = my_simulation_parameters
         self.pvconfig = config
@@ -280,11 +270,9 @@ class PVSystem(cp.Component):
         self.module: Any
         self.coordinates: Any
         self.data_length: int = self.my_simulation_parameters.timesteps
-        self.temperature_model_parameters = (
-            pvlib.temperature.TEMPERATURE_MODEL_PARAMETERS["sapm"][
-                "open_rack_glass_glass"
-            ]
-        )
+        self.temperature_model_parameters = pvlib.temperature.TEMPERATURE_MODEL_PARAMETERS["sapm"][
+            "open_rack_glass_glass"
+        ]
         super().__init__(
             self.pvconfig.name + "_w" + str(self.pvconfig.source_weight),
             my_simulation_parameters=my_simulation_parameters,
@@ -379,12 +367,8 @@ class PVSystem(cp.Component):
             tilt=30,
             load_module_data=False,
             source_weight=source_weight,
-            co2_footprint=power_in_watt
-            * 1e-3
-            * 130.7,  # value from emission_factros_and_costs_devices.csv
-            cost=power_in_watt
-            * 1e-3
-            * 535.81,  # value from emission_factros_and_costs_devices.csv
+            co2_footprint=power_in_watt * 1e-3 * 130.7,  # value from emission_factros_and_costs_devices.csv
+            cost=power_in_watt * 1e-3 * 535.81,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.01,  # source: https://solarenergie.de/stromspeicher/preise
             lifetime=25,  # value from emission_factros_and_costs_devices.csv
             prediction_horizon=None,
@@ -453,24 +437,12 @@ class PVSystem(cp.Component):
                 Weather.GlobalHorizontalIrradiance,
             )
         )
-        connections.append(
-            cp.ComponentConnection(PVSystem.Azimuth, weather_classname, Weather.Azimuth)
-        )
-        connections.append(
-            cp.ComponentConnection(
-                PVSystem.ApparentZenith, weather_classname, Weather.ApparentZenith
-            )
-        )
-        connections.append(
-            cp.ComponentConnection(
-                PVSystem.WindSpeed, weather_classname, Weather.WindSpeed
-            )
-        )
+        connections.append(cp.ComponentConnection(PVSystem.Azimuth, weather_classname, Weather.Azimuth))
+        connections.append(cp.ComponentConnection(PVSystem.ApparentZenith, weather_classname, Weather.ApparentZenith))
+        connections.append(cp.ComponentConnection(PVSystem.WindSpeed, weather_classname, Weather.WindSpeed))
         return connections
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
 
         # check if results could be found in cache and if the lists have the right length
@@ -478,16 +450,13 @@ class PVSystem(cp.Component):
             hasattr(self, "ac_power_ratios_for_all_timesteps_output")
             and len(self.ac_power_ratios_for_all_timesteps_output) == self.data_length
         ):
-
             stsv.set_output_value(
                 self.electricity_output_channel,
-                self.ac_power_ratios_for_all_timesteps_output[timestep]
-                * self.pvconfig.power_in_watt,
+                self.ac_power_ratios_for_all_timesteps_output[timestep] * self.pvconfig.power_in_watt,
             )
 
         # calculate pv system outputs with pvlib
         else:
-
             dni = stsv.get_input_value(self.dni_channel)
             dni_extra = stsv.get_input_value(self.dni_extra_channel)
             dhi = stsv.get_input_value(self.dhi_channel)
@@ -521,7 +490,6 @@ class PVSystem(cp.Component):
             self.ac_power_ratios_for_all_timesteps_data[timestep] = ac_power_ratio
 
             if timestep + 1 == self.data_length:
-
                 dict_with_results = {
                     "output_power": self.ac_power_ratios_for_all_timesteps_data,
                 }
@@ -535,24 +503,14 @@ class PVSystem(cp.Component):
 
                 database.to_csv(self.cache_filepath, sep=",", decimal=".", index=False)
 
-        if (
-            self.pvconfig.predictive_control
-            and self.pvconfig.prediction_horizon is not None
-        ):
+        if self.pvconfig.predictive_control and self.pvconfig.prediction_horizon is not None:
             last_forecast_timestep = int(
-                timestep
-                + self.pvconfig.prediction_horizon
-                / self.my_simulation_parameters.seconds_per_timestep
+                timestep + self.pvconfig.prediction_horizon / self.my_simulation_parameters.seconds_per_timestep
             )
-            if last_forecast_timestep > len(
-                self.ac_power_ratios_for_all_timesteps_output
-            ):
-                last_forecast_timestep = len(
-                    self.ac_power_ratios_for_all_timesteps_output
-                )
+            if last_forecast_timestep > len(self.ac_power_ratios_for_all_timesteps_output):
+                last_forecast_timestep = len(self.ac_power_ratios_for_all_timesteps_output)
             pvforecast = [
-                self.ac_power_ratios_for_all_timesteps_output[t]
-                * self.pvconfig.power_in_watt
+                self.ac_power_ratios_for_all_timesteps_output[t] * self.pvconfig.power_in_watt
                 for t in range(timestep, last_forecast_timestep)
             ]
             self.simulation_repository.set_dynamic_entry(
@@ -578,18 +536,12 @@ class PVSystem(cp.Component):
                     SingletonSimRepository().delete_entry(
                         key=SingletonDictKeyEnum.WEATHERGLOBALHORIZONTALIRRADIANCEYEARLYFORECAST
                     )
-                    SingletonSimRepository().delete_entry(
-                        key=SingletonDictKeyEnum.WEATHERAZIMUTHYEARLYFORECAST
-                    )
-                    SingletonSimRepository().delete_entry(
-                        key=SingletonDictKeyEnum.WEATHERAPPARENTZENITHYEARLYFORECAST
-                    )
+                    SingletonSimRepository().delete_entry(key=SingletonDictKeyEnum.WEATHERAZIMUTHYEARLYFORECAST)
+                    SingletonSimRepository().delete_entry(key=SingletonDictKeyEnum.WEATHERAPPARENTZENITHYEARLYFORECAST)
                     SingletonSimRepository().delete_entry(
                         key=SingletonDictKeyEnum.WEATHERTEMPERATUREOUTSIDEYEARLYFORECAST
                     )
-                    SingletonSimRepository().delete_entry(
-                        key=SingletonDictKeyEnum.WEATHERWINDSPEEDYEARLYFORECAST
-                    )
+                    SingletonSimRepository().delete_entry(key=SingletonDictKeyEnum.WEATHERWINDSPEEDYEARLYFORECAST)
 
     def i_save_state(self) -> None:
         """Saves the state."""
@@ -616,14 +568,11 @@ class PVSystem(cp.Component):
 
         if file_exists:
             log.information("Get PV results from cache.")
-            self.ac_power_ratios_for_all_timesteps_output = pd.read_csv(
-                self.cache_filepath, sep=",", decimal="."
-            )["output_power"].tolist()
+            self.ac_power_ratios_for_all_timesteps_output = pd.read_csv(self.cache_filepath, sep=",", decimal=".")[
+                "output_power"
+            ].tolist()
 
-            if (
-                len(self.ac_power_ratios_for_all_timesteps_output)
-                != self.my_simulation_parameters.timesteps
-            ):
+            if len(self.ac_power_ratios_for_all_timesteps_output) != self.my_simulation_parameters.timesteps:
                 raise Exception(
                     "Reading the cached PV values seems to have failed. Expected "
                     + str(self.my_simulation_parameters.timesteps)
@@ -632,9 +581,7 @@ class PVSystem(cp.Component):
                 )
         else:
             if self.simulation_repository.exist_entry("weather_location"):
-                self.coordinates = self.simulation_repository.get_entry(
-                    "weather_location"
-                )
+                self.coordinates = self.simulation_repository.get_entry("weather_location")
             else:
                 raise KeyError(
                     "The key weather_location was not found in the repository."
@@ -670,22 +617,17 @@ class PVSystem(cp.Component):
                 ghi = SingletonSimRepository().get_entry(
                     key=SingletonDictKeyEnum.WEATHERGLOBALHORIZONTALIRRADIANCEYEARLYFORECAST
                 )
-                azimuth = SingletonSimRepository().get_entry(
-                    key=SingletonDictKeyEnum.WEATHERAZIMUTHYEARLYFORECAST
-                )
+                azimuth = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.WEATHERAZIMUTHYEARLYFORECAST)
                 apparent_zenith = SingletonSimRepository().get_entry(
                     key=SingletonDictKeyEnum.WEATHERAPPARENTZENITHYEARLYFORECAST
                 )
                 temperature = SingletonSimRepository().get_entry(
                     key=SingletonDictKeyEnum.WEATHERTEMPERATUREOUTSIDEYEARLYFORECAST
                 )
-                wind_speed = SingletonSimRepository().get_entry(
-                    key=SingletonDictKeyEnum.WEATHERWINDSPEEDYEARLYFORECAST
-                )
+                wind_speed = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.WEATHERWINDSPEEDYEARLYFORECAST)
 
                 x_simplephotovoltaic = []
                 for i in range(self.my_simulation_parameters.timesteps):
-
                     # calculate outputs
                     ac_power_ratio = self.simphotovoltaic_two(
                         dni_extra=dni_extra[i],
@@ -703,9 +645,7 @@ class PVSystem(cp.Component):
                     # append lists
                     x_simplephotovoltaic.append(ac_power_ratio)
 
-                self.ac_power_ratios_for_all_timesteps_output = (
-                    x_simplephotovoltaic
-                )
+                self.ac_power_ratios_for_all_timesteps_output = x_simplephotovoltaic
 
                 # cache predictive control results
                 dict_with_results = {
@@ -724,51 +664,37 @@ class PVSystem(cp.Component):
             else:
                 # create empty result lists as a preparation for caching in i_simulate
 
-                self.ac_power_ratios_for_all_timesteps_data = [
-                    0
-                ] * self.my_simulation_parameters.timesteps
+                self.ac_power_ratios_for_all_timesteps_data = [0] * self.my_simulation_parameters.timesteps
 
         if self.pvconfig.predictive:
             pv_forecast_yearly = [
-                self.ac_power_ratios_for_all_timesteps_output[t]
-                * self.pvconfig.power_in_watt
+                self.ac_power_ratios_for_all_timesteps_output[t] * self.pvconfig.power_in_watt
                 for t in range(self.my_simulation_parameters.timesteps)
             ]
-            SingletonSimRepository().set_entry(
-                key=SingletonDictKeyEnum.PVFORECASTYEARLY, entry=pv_forecast_yearly
-            )
+            SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.PVFORECASTYEARLY, entry=pv_forecast_yearly)
 
     def interpolate(self, pd_database: Any, year: Any) -> Any:
         """Interpolates."""
         lastday = pd.Series(
             pd_database[-1],
-            index=[
-                pd.to_datetime(
-                    datetime.datetime(year, 12, 31, 22, 59), utc=True
-                ).tz_convert("Europe/Berlin")
-            ],
+            index=[pd.to_datetime(datetime.datetime(year, 12, 31, 22, 59), utc=True).tz_convert("Europe/Berlin")],
         )
 
         pd_database = pd_database.append(lastday)
         pd_database = pd_database.sort_index()
         return pd_database.resample("1T").asfreq().interpolate(method="linear").tolist()
 
-    def get_modules_from_database(
-        self, module_database: Any, load_module_data: bool, module_name: str
-    ) -> Any:
+    def get_modules_from_database(self, module_database: Any, load_module_data: bool, module_name: str) -> Any:
         """Get modules from pvlib module database."""
 
         # get modules from pvlib database online (TODO: test if this works, it has not been fully tested yet)
         if load_module_data is True:
-
             if module_database == PVLibModuleAndInverterEnum.SANDIA_MODULE_DATABASE:
                 modules = pvlib.pvsystem.retrieve_sam(name="SandiaMod")
             elif module_database == PVLibModuleAndInverterEnum.CEC_MODULE_DATABASE:
                 modules = pvlib.pvsystem.retrieve_sam(name="CECMod")
             else:
-                raise KeyError(
-                    f"The module database {module_database} is not integrated in the PV component here."
-                )
+                raise KeyError(f"The module database {module_database} is not integrated in the PV component here.")
 
             # choose module from modules database
             module = modules[module_name]
@@ -782,16 +708,12 @@ class PVSystem(cp.Component):
 
             # note that you can import cec module database but the calculations of the pv system can only be done with sandia!
             elif module_database == PVLibModuleAndInverterEnum.CEC_MODULE_DATABASE:
-                modules = pd.read_csv(
-                    os.path.join(utils.HISIMPATH["photovoltaic"]["cec_modules"])
-                )
+                modules = pd.read_csv(os.path.join(utils.HISIMPATH["photovoltaic"]["cec_modules"]))
                 log.warning(
                     "You can import pv cec modules but the pvlib calculations (simphotovoltaic_two) only work with the sandia modules unfortunately."
                 )
             else:
-                raise KeyError(
-                    f"The module database {module_database} is not integrated in the PV component here."
-                )
+                raise KeyError(f"The module database {module_database} is not integrated in the PV component here.")
 
             # choose module from modules database
             module = modules.loc[modules["Name"] == module_name]
@@ -805,9 +727,7 @@ class PVSystem(cp.Component):
 
         return module
 
-    def get_inverters_from_database(
-        self, inverter_database: Any, load_module_data: bool, inverter_name: str
-    ) -> Any:
+    def get_inverters_from_database(self, inverter_database: Any, load_module_data: bool, inverter_name: str) -> Any:
         """Get inverters from pvlib module database."""
 
         # get inverters from pvlib database online
@@ -816,21 +736,15 @@ class PVSystem(cp.Component):
                 PVLibModuleAndInverterEnum.SANDIA_INVERTER_DATABASE,
                 PVLibModuleAndInverterEnum.CEC_INVERTER_DATABASE,
             ):
-
                 # get inverter data (for both sandia and cec inverters the same database is taken):
                 # see docs: https://pvlib-python.readthedocs.io/en/v0.9.0/generated/pvlib.pvsystem.retrieve_sam.html
                 inverters = pvlib.pvsystem.retrieve_sam("CECInverter")
                 inverter = inverters[inverter_name]
-            elif (
-                inverter_database
-                == PVLibModuleAndInverterEnum.ANTON_DRIESSE_INVERTER_DATABASE
-            ):
+            elif inverter_database == PVLibModuleAndInverterEnum.ANTON_DRIESSE_INVERTER_DATABASE:
                 inverters = pvlib.pvsystem.retrieve_sam("ADRInverter")
                 inverter = inverters[inverter_name]
             else:
-                raise KeyError(
-                    f"The inverter database {inverter_database} is not integrated in the PV component here."
-                )
+                raise KeyError(f"The inverter database {inverter_database} is not integrated in the PV component here.")
 
         # get inverters from input data csv files
         else:
@@ -861,9 +775,7 @@ class PVSystem(cp.Component):
                 inverter = inverter.to_dict(orient="records")[0]
 
             else:
-                raise KeyError(
-                    f"The inverter database {inverter_database} is not integrated in the PV component here."
-                )
+                raise KeyError(f"The inverter database {inverter_database} is not integrated in the PV component here.")
 
         return inverter
 
@@ -950,17 +862,11 @@ class PVSystem(cp.Component):
             airmass,
         )
         # calculate ground diffuse with specified albedo
-        poa_ground_diffuse = pvlib.irradiance.get_ground_diffuse(
-            surface_tilt, ghi, albedo=albedo
-        )
+        poa_ground_diffuse = pvlib.irradiance.get_ground_diffuse(surface_tilt, ghi, albedo=albedo)
         # calculate angle of incidence
-        aoi = pvlib.irradiance.aoi(
-            surface_tilt, surface_azimuth, apparent_zenith, azimuth
-        )
+        aoi = pvlib.irradiance.aoi(surface_tilt, surface_azimuth, apparent_zenith, azimuth)
         # calculate plane of array irradiance
-        poa_irrad = pvlib.irradiance.poa_components(
-            aoi, np.float64(dni), poa_sky_diffuse, poa_ground_diffuse
-        )
+        poa_irrad = pvlib.irradiance.poa_components(aoi, np.float64(dni), poa_sky_diffuse, poa_ground_diffuse)
         # calculate pv cell and module temperature
 
         pvtemps = pvlib.temperature.sapm_cell(

--- a/hisim/components/generic_rsoc.py
+++ b/hisim/components/generic_rsoc.py
@@ -58,9 +58,7 @@ class RsocConfig(cp.ConfigBase):
     def read_config(rsoc_name):
         """Opens the according JSON-file, based on the rSOC_name."""
 
-        config_file = os.path.join(
-            utils.HISIMPATH["inputs"], "rSOC_manufacturer_config.json"
-        )
+        config_file = os.path.join(utils.HISIMPATH["inputs"], "rSOC_manufacturer_config.json")
         with open(config_file, "r", encoding="utf-8") as json_file:
             data = json.load(json_file)
             return data.get("rSOC variants", {}).get(rsoc_name, {})
@@ -119,9 +117,7 @@ class Rsoc(cp.Component):
 
     # SOFC Outputs
     SOFCState = "SOFCState"
-    SOFCCurrentOutput = (
-        "SOFCCurrentPowerOutput"  # current load regarding the ramp-up and -down process
-    )
+    SOFCCurrentOutput = "SOFCCurrentPowerOutput"  # current load regarding the ramp-up and -down process
     TotalEnergyProduced = "TotalEnergyProduced"
 
     SOFCCurrentHydrogenFlowRate = "SOFCCurrentHydrogenFlowRate"
@@ -349,12 +345,8 @@ class Rsoc(cp.Component):
         self.total_operating_time = 0.0
 
         self.current_state_soec_previous = self.current_state_soec
-        self.total_ramp_up_count_state_soec_previous = (
-            self.total_ramp_up_count_state_soec
-        )
-        self.total_ramp_down_count_state_soec_previous = (
-            self.total_ramp_down_count_state_soec
-        )
+        self.total_ramp_up_count_state_soec_previous = self.total_ramp_up_count_state_soec
+        self.total_ramp_down_count_state_soec_previous = self.total_ramp_down_count_state_soec
         self.total_warm_start_count_soec_previous = self.total_warm_start_count_soec
         self.total_cold_start_count_soec_previous = self.total_cold_start_count_soec
         self.total_warm_start_cycles_soec_previous = self.total_warm_start_cycles_soec
@@ -367,12 +359,8 @@ class Rsoc(cp.Component):
         self.total_energy_soec_previous = self.total_energy_soec
 
         self.current_state_sofc_previous = self.current_state_sofc
-        self.total_ramp_up_count_state_sofc_previous = (
-            self.total_ramp_up_count_state_sofc
-        )
-        self.total_ramp_down_count_state_sofc_previous = (
-            self.total_ramp_down_count_state_sofc
-        )
+        self.total_ramp_up_count_state_sofc_previous = self.total_ramp_up_count_state_sofc
+        self.total_ramp_down_count_state_sofc_previous = self.total_ramp_down_count_state_sofc
         self.total_warm_start_count_sofc_previous = self.total_warm_start_count_sofc
         self.total_cold_start_count_sofc_previous = self.total_cold_start_count_sofc
         self.total_warm_start_cycles_sofc_previous = self.total_warm_start_cycles_sofc
@@ -389,17 +377,13 @@ class Rsoc(cp.Component):
     def soec_efficiency(self, name, current_load, min_load, max_load):
         """Efficiency curve data is provided corresponding to the used rSOC system."""
         # Load data from the JSON file
-        data_file = os.path.join(
-            utils.HISIMPATH["inputs"], "rSOC_efficiency_curve_data.json"
-        )
+        data_file = os.path.join(utils.HISIMPATH["inputs"], "rSOC_efficiency_curve_data.json")
         with open(data_file, "r", encoding="utf-8") as file:
             data = json.load(file)
 
         # Check if the provided technology is valid
         if name not in data:
-            raise ValueError(
-                f"Invalid rSOC name. Supported names are: {', '.join(data.keys())}"
-            )
+            raise ValueError(f"Invalid rSOC name. Supported names are: {', '.join(data.keys())}")
 
         # Extract the x and y data points for the selected technology
         load_percentage = data[name]["load_percentage_soec"]
@@ -408,9 +392,7 @@ class Rsoc(cp.Component):
         if min_load <= current_load <= max_load:
             current_load_percentage = current_load / max_load
             # Interpolation
-            current_sys_eff_soec = float(
-                np.interp(current_load_percentage, load_percentage, sys_eff)
-            )
+            current_sys_eff_soec = float(np.interp(current_load_percentage, load_percentage, sys_eff))
 
         else:
             current_sys_eff_soec = 0.0
@@ -420,17 +402,13 @@ class Rsoc(cp.Component):
     def sofc_efficiency(self, name, current_demand, min_power, max_power):
         """Efficiency curve data is provided corresponding to the used rSOC system."""
         # Load data from the JSON file
-        data_file = os.path.join(
-            utils.HISIMPATH["inputs"], "rSOC_efficiency_curve_data.json"
-        )
+        data_file = os.path.join(utils.HISIMPATH["inputs"], "rSOC_efficiency_curve_data.json")
         with open(data_file, "r", encoding="utf-8") as file:
             data = json.load(file)
 
         # Check if the provided technology is valid
         if name not in data:
-            raise ValueError(
-                f"Invalid rSOC name. Supported names are: {', '.join(data.keys())}"
-            )
+            raise ValueError(f"Invalid rSOC name. Supported names are: {', '.join(data.keys())}")
 
         # Extract the x and y data points for the selected technology
         load_percentage = data[name]["load_percentage_sofc"]
@@ -439,9 +417,7 @@ class Rsoc(cp.Component):
         if min_power < current_demand <= max_power:
             current_demand_percentage = current_demand / max_power
             # Interpolation
-            current_sys_eff_sofc = float(
-                np.interp(current_demand_percentage, load_percentage, sys_eff)
-            )
+            current_sys_eff_sofc = float(np.interp(current_demand_percentage, load_percentage, sys_eff))
 
         else:
             current_sys_eff_sofc = 0.0
@@ -452,18 +428,14 @@ class Rsoc(cp.Component):
         """Based on the calculated efficiency the current h2 production rate is calculated."""
         lhv_h2 = 33.33  # [kWh/kg]
 
-        h2_production_rate = (current_sys_eff_soec * current_load) / (
-            lhv_h2 * 3600
-        )  # [kg/s]
+        h2_production_rate = (current_sys_eff_soec * current_load) / (lhv_h2 * 3600)  # [kg/s]
         return h2_production_rate
 
     def h2_consumption_rate(self, current_sys_eff_sofc, current_demand):
         """Based on the calculated efficiency the current h2 consumption rate is calculated."""
         lhv_h2 = 33.33  # [kWh/kg]
         if current_sys_eff_sofc > 0.0 and current_demand >= self.min_power_sofc:
-            h2_consumption_rate = current_demand / (
-                current_sys_eff_sofc * lhv_h2 * 3600
-            )  # [kg/s]
+            h2_consumption_rate = current_demand / (current_sys_eff_sofc * lhv_h2 * 3600)  # [kg/s]
         else:
             h2_consumption_rate = 0.0
         return h2_consumption_rate
@@ -489,12 +461,8 @@ class Rsoc(cp.Component):
     def i_save_state(self) -> None:
         """Saves the current state."""
         self.current_state_soec_previous = self.current_state_soec
-        self.total_ramp_up_count_state_soec_previous = (
-            self.total_ramp_up_count_state_soec
-        )
-        self.total_ramp_down_count_state_soec_previous = (
-            self.total_ramp_down_count_state_soec
-        )
+        self.total_ramp_up_count_state_soec_previous = self.total_ramp_up_count_state_soec
+        self.total_ramp_down_count_state_soec_previous = self.total_ramp_down_count_state_soec
         self.total_warm_start_count_soec_previous = self.total_warm_start_count_soec
         self.total_cold_start_count_soec_previous = self.total_cold_start_count_soec
         self.total_warm_start_cycles_soec_previous = self.total_warm_start_cycles_soec
@@ -507,12 +475,8 @@ class Rsoc(cp.Component):
         self.total_energy_soec_previous = self.total_energy_soec
 
         self.current_state_sofc_previous = self.current_state_sofc
-        self.total_ramp_up_count_state_sofc_previous = (
-            self.total_ramp_up_count_state_sofc
-        )
-        self.total_ramp_down_count_state_sofc_previous = (
-            self.total_ramp_down_count_state_sofc
-        )
+        self.total_ramp_up_count_state_sofc_previous = self.total_ramp_up_count_state_sofc
+        self.total_ramp_down_count_state_sofc_previous = self.total_ramp_down_count_state_sofc
         self.total_warm_start_count_sofc_previous = self.total_warm_start_count_sofc
         self.total_cold_start_count_sofc_previous = self.total_cold_start_count_sofc
         self.total_warm_start_cycles_sofc_previous = self.total_warm_start_cycles_sofc
@@ -533,12 +497,8 @@ class Rsoc(cp.Component):
     def i_restore_state(self) -> None:
         """Restores previous state."""
         self.current_state_soec = self.current_state_soec_previous
-        self.total_ramp_up_count_state_soec = (
-            self.total_ramp_up_count_state_soec_previous
-        )
-        self.total_ramp_down_count_state_soec = (
-            self.total_ramp_down_count_state_soec_previous
-        )
+        self.total_ramp_up_count_state_soec = self.total_ramp_up_count_state_soec_previous
+        self.total_ramp_down_count_state_soec = self.total_ramp_down_count_state_soec_previous
         self.total_warm_start_count_soec = self.total_warm_start_count_soec_previous
         self.total_cold_start_count_soec = self.total_cold_start_count_soec_previous
         self.total_warm_start_cycles_soec = self.total_warm_start_cycles_soec_previous
@@ -551,12 +511,8 @@ class Rsoc(cp.Component):
         self.total_energy_soec = self.total_energy_soec_previous
 
         self.current_state_sofc = self.current_state_sofc_previous
-        self.total_ramp_up_count_state_sofc = (
-            self.total_ramp_up_count_state_sofc_previous
-        )
-        self.total_ramp_down_count_state_sofc = (
-            self.total_ramp_down_count_state_sofc_previous
-        )
+        self.total_ramp_up_count_state_sofc = self.total_ramp_up_count_state_sofc_previous
+        self.total_ramp_down_count_state_sofc = self.total_ramp_down_count_state_sofc_previous
         self.total_warm_start_count_sofc = self.total_warm_start_count_sofc_previous
         self.total_cold_start_count_sofc = self.total_cold_start_count_sofc_previous
         self.total_warm_start_cycles_sofc = self.total_warm_start_cycles_sofc_previous
@@ -574,14 +530,10 @@ class Rsoc(cp.Component):
         """Prepares the simulation."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the component."""
 
-        seconds_per_timestep = (
-            self.my_simulation_parameters.seconds_per_timestep
-        )  # [s/timestep]
+        seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep  # [s/timestep]
 
         if stsv.get_input_value(self.power_input) < 0.0:
             power_to_soec = abs(stsv.get_input_value(self.power_input))
@@ -595,17 +547,11 @@ class Rsoc(cp.Component):
         rsoc_state = stsv.get_input_value(self.input_state_rsoc)
 
         if rsoc_state == 1:
-            self.total_operating_time += (
-                self.my_simulation_parameters.seconds_per_timestep / 3600
-            )
-            stsv.set_output_value(
-                self.total_operating_time_rsco, self.total_operating_time
-            )
+            self.total_operating_time += self.my_simulation_parameters.seconds_per_timestep / 3600
+            stsv.set_output_value(self.total_operating_time_rsco, self.total_operating_time)
         else:
             self.total_operating_time += 0.0
-            stsv.set_output_value(
-                self.total_operating_time_rsco, self.total_operating_time
-            )
+            stsv.set_output_value(self.total_operating_time_rsco, self.total_operating_time)
 
         if power_to_soec != 0.0:
             # SOEC operation
@@ -622,9 +568,7 @@ class Rsoc(cp.Component):
             total_ramp_up_per_timestep = ramp_up_per_timestep
 
             # ramp down per timestep calculation
-            ramp_down_per_timestep = (
-                nominal_load * ramp_down_rate * seconds_per_timestep
-            )
+            ramp_down_per_timestep = nominal_load * ramp_down_rate * seconds_per_timestep
             total_ramp_down_per_timestep = ramp_down_per_timestep
 
             # calculating load input
@@ -642,23 +586,13 @@ class Rsoc(cp.Component):
                     self.total_ramp_down_count_state_soec += 0
 
                 # Ramping up
-                if (
-                    new_load >= total_ramp_up_per_timestep
-                    and self.current_state_soec < power_to_soec
-                ):
+                if new_load >= total_ramp_up_per_timestep and self.current_state_soec < power_to_soec:
                     self.total_ramp_up_count_state_soec += seconds_per_timestep
                     self.current_state_soec += total_ramp_up_per_timestep
 
-                elif (
-                    self.current_state_soec < power_to_soec
-                    and new_load < total_ramp_up_per_timestep
-                ):
-                    percentage_ramp_up_per_timestep = (
-                        new_load / total_ramp_up_per_timestep
-                    )
-                    self.total_ramp_up_count_state_soec += (
-                        percentage_ramp_up_per_timestep * seconds_per_timestep
-                    )
+                elif self.current_state_soec < power_to_soec and new_load < total_ramp_up_per_timestep:
+                    percentage_ramp_up_per_timestep = new_load / total_ramp_up_per_timestep
+                    self.total_ramp_up_count_state_soec += percentage_ramp_up_per_timestep * seconds_per_timestep
 
                     if self.current_state_soec == 0:
                         self.current_state_soec += power_to_soec
@@ -667,31 +601,17 @@ class Rsoc(cp.Component):
                         self.current_state_soec += new_load
 
                 # Ramping down
-                elif (
-                    total_ramp_down_per_timestep <= new_load
-                    and power_to_soec < self.current_state_soec
-                ):
+                elif total_ramp_down_per_timestep <= new_load and power_to_soec < self.current_state_soec:
                     self.total_ramp_down_count_state_soec += seconds_per_timestep
                     self.current_state_soec -= new_load
 
-                elif (
-                    power_to_soec < self.current_state_soec
-                    and new_load < total_ramp_down_per_timestep
-                ):
-                    percentage_ramp_down_per_timestep = (
-                        new_load / total_ramp_down_per_timestep
-                    )
-                    self.total_ramp_down_count_state_soec += (
-                        percentage_ramp_down_per_timestep * seconds_per_timestep
-                    )
+                elif power_to_soec < self.current_state_soec and new_load < total_ramp_down_per_timestep:
+                    percentage_ramp_down_per_timestep = new_load / total_ramp_down_per_timestep
+                    self.total_ramp_down_count_state_soec += percentage_ramp_down_per_timestep * seconds_per_timestep
                     self.current_state_soec -= new_load
 
-                current_sys_eff_soec = self.soec_efficiency(
-                    name, self.current_state_soec, min_load, self.max_load_soec
-                )
-                h2_production_rate = self.h2_production_rate(
-                    current_sys_eff_soec, self.current_state_soec
-                )
+                current_sys_eff_soec = self.soec_efficiency(name, self.current_state_soec, min_load, self.max_load_soec)
+                h2_production_rate = self.h2_production_rate(current_sys_eff_soec, self.current_state_soec)
 
             elif rsoc_state == 0:
                 self.total_ramp_up_count_state_soec += 0
@@ -714,16 +634,12 @@ class Rsoc(cp.Component):
             o2_flow_rate_soec = self.oxygen_rate(h2_production_rate)
             h2o_flow_rate_soec = self.water_rate(h2_production_rate)
 
-            self.total_hydrogen_produced_soec += (
-                h2_production_rate * seconds_per_timestep
-            )
+            self.total_hydrogen_produced_soec += h2_production_rate * seconds_per_timestep
             self.total_oxygen_produced_soec += o2_flow_rate_soec * seconds_per_timestep
             self.total_water_demand_soec += h2o_flow_rate_soec * seconds_per_timestep
 
             stsv.set_output_value(self.soec_hydrogen_flow_rate, h2_production_rate)
-            stsv.set_output_value(
-                self.soec_current_efficiency_state, current_sys_eff_soec
-            )
+            stsv.set_output_value(self.soec_current_efficiency_state, current_sys_eff_soec)
 
             # self.total_hydrogen_consumed_sofc += 0.0
             self.total_oxygen_consumed_sofc += 0.0
@@ -740,20 +656,14 @@ class Rsoc(cp.Component):
 
             name = self.name
 
-            seconds_per_timestep = (
-                self.my_simulation_parameters.seconds_per_timestep
-            )  # [s/timestep]
+            seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep  # [s/timestep]
 
             # ramp up per timestep calculation
-            ramp_up_per_timestep = (
-                self.nom_power_sofc * self.ramp_up_rate_sofc * seconds_per_timestep
-            )
+            ramp_up_per_timestep = self.nom_power_sofc * self.ramp_up_rate_sofc * seconds_per_timestep
             total_ramp_up_per_timestep = ramp_up_per_timestep
 
             # ramp down per timestep calculation
-            ramp_down_per_timestep = (
-                self.nom_power_sofc * self.ramp_down_rate_sofc * seconds_per_timestep
-            )
+            ramp_down_per_timestep = self.nom_power_sofc * self.ramp_down_rate_sofc * seconds_per_timestep
             total_ramp_down_per_timestep = ramp_down_per_timestep
 
             # calculating load input
@@ -772,23 +682,13 @@ class Rsoc(cp.Component):
                     self.total_ramp_down_count_state_sofc += 0
 
                 # Ramping up
-                if (
-                    new_load >= total_ramp_up_per_timestep
-                    and self.current_state_sofc < demand_to_sofc
-                ):
+                if new_load >= total_ramp_up_per_timestep and self.current_state_sofc < demand_to_sofc:
                     self.total_ramp_up_count_state_sofc += seconds_per_timestep
                     self.current_state_sofc += total_ramp_up_per_timestep
 
-                elif (
-                    self.current_state_sofc < demand_to_sofc
-                    and new_load < total_ramp_up_per_timestep
-                ):
-                    percentage_ramp_up_per_timestep = (
-                        new_load / total_ramp_up_per_timestep
-                    )
-                    self.total_ramp_up_count_state_sofc += (
-                        percentage_ramp_up_per_timestep * seconds_per_timestep
-                    )
+                elif self.current_state_sofc < demand_to_sofc and new_load < total_ramp_up_per_timestep:
+                    percentage_ramp_up_per_timestep = new_load / total_ramp_up_per_timestep
+                    self.total_ramp_up_count_state_sofc += percentage_ramp_up_per_timestep * seconds_per_timestep
 
                     if self.current_state_sofc == 0:
                         self.current_state_sofc += demand_to_sofc
@@ -797,23 +697,13 @@ class Rsoc(cp.Component):
                         self.current_state_sofc += new_load
 
                 # Ramping down
-                elif (
-                    total_ramp_down_per_timestep <= new_load
-                    and demand_to_sofc < self.current_state_sofc
-                ):
+                elif total_ramp_down_per_timestep <= new_load and demand_to_sofc < self.current_state_sofc:
                     self.total_ramp_down_count_state_sofc += seconds_per_timestep
                     self.current_state_sofc -= new_load
 
-                elif (
-                    demand_to_sofc < self.current_state_sofc
-                    and new_load < total_ramp_down_per_timestep
-                ):
-                    percentage_ramp_down_per_timestep = (
-                        new_load / total_ramp_down_per_timestep
-                    )
-                    self.total_ramp_down_count_state_sofc += (
-                        percentage_ramp_down_per_timestep * seconds_per_timestep
-                    )
+                elif demand_to_sofc < self.current_state_sofc and new_load < total_ramp_down_per_timestep:
+                    percentage_ramp_down_per_timestep = new_load / total_ramp_down_per_timestep
+                    self.total_ramp_down_count_state_sofc += percentage_ramp_down_per_timestep * seconds_per_timestep
                     self.current_state_sofc -= new_load
 
             elif rsoc_state == 0:
@@ -831,9 +721,7 @@ class Rsoc(cp.Component):
             current_sys_eff_sofc = self.sofc_efficiency(
                 name, self.current_state_sofc, self.min_power_sofc, self.max_power_sofc
             )
-            h2_consumption_rate = self.h2_consumption_rate(
-                current_sys_eff_sofc, self.current_state_sofc
-            )
+            h2_consumption_rate = self.h2_consumption_rate(current_sys_eff_sofc, self.current_state_sofc)
             o2_flow_rate_sofc = self.oxygen_rate(h2_consumption_rate)
             h2o_flow_rate_sofc = self.water_rate(h2_consumption_rate)
 
@@ -842,9 +730,7 @@ class Rsoc(cp.Component):
             self.total_water_produced_sofc += h2o_flow_rate_sofc * seconds_per_timestep
 
             stsv.set_output_value(self.sofc_hydrogen_flow_rate, h2_consumption_rate)
-            stsv.set_output_value(
-                self.sofc_current_efficiency_state, current_sys_eff_sofc
-            )
+            stsv.set_output_value(self.sofc_current_efficiency_state, current_sys_eff_sofc)
 
             # end
 
@@ -890,13 +776,9 @@ class Rsoc(cp.Component):
             self.current_load_soec, (self.current_state_soec * 1000)
         )  # for WATT output in system setup
 
-        self.total_energy_soec += self.current_state_soec * (
-            seconds_per_timestep / 3600
-        )
+        self.total_energy_soec += self.current_state_soec * (seconds_per_timestep / 3600)
         stsv.set_output_value(self.total_energy_consumed, self.total_energy_soec)
-        self.total_energy_sofc += self.current_state_sofc * (
-            seconds_per_timestep / 3600
-        )
+        self.total_energy_sofc += self.current_state_sofc * (seconds_per_timestep / 3600)
         stsv.set_output_value(self.total_energy_produced, self.total_energy_sofc)
 
     def write_to_report(self):
@@ -905,69 +787,17 @@ class Rsoc(cp.Component):
         for config_string in self.rsocconfig.get_string_dict():
             lines.append(config_string)
         lines.append("Component Name" + str(self.component_name))
-        lines.append(
-            "Total operating time during simulation: "
-            + str(self.total_operating_time)
-            + " [h]"
-        )
-        lines.append(
-            "Total hydrogen produced during simulation: "
-            + str(self.total_hydrogen_produced_soec)
-            + " [kg]"
-        )
-        lines.append(
-            "Total hydrogen consumed during simulation: "
-            + str(self.total_hydrogen_consumed_sofc)
-            + " [kg]"
-        )
-        lines.append(
-            "Total oxygen produced during simulation: "
-            + str(self.total_oxygen_produced_soec)
-            + " [kg]"
-        )
-        lines.append(
-            "Total oxygen consumed during simulation: "
-            + str(self.total_oxygen_consumed_sofc)
-            + " [kg]"
-        )
-        lines.append(
-            "Total water demand during simulation: "
-            + str(self.total_water_demand_soec)
-            + " [kg]"
-        )
-        lines.append(
-            "Total water demand during simulation: "
-            + str(self.total_water_produced_sofc)
-            + " [kg]"
-        )
-        lines.append(
-            "Total energy consumed during simulation: "
-            + str(self.total_energy_soec)
-            + " [kg]"
-        )
-        lines.append(
-            "Total energy produced during simulation: "
-            + str(self.total_energy_sofc)
-            + " [kWh]"
-        )
-        lines.append(
-            "Total ramp-up time during simulation: "
-            + str(self.total_ramp_up_count_state_soec)
-            + " [sec]"
-        )
-        lines.append(
-            "Total ramp-up time during simulation: "
-            + str(self.total_ramp_up_count_state_sofc)
-            + " [sec]"
-        )
-        lines.append(
-            "Total ramp-down time during simulation: "
-            + str(self.total_ramp_down_count_state_soec)
-            + " [sec]"
-        )
-        lines.append(
-            "Total ramp-down time during simulation: "
-            + str(self.total_ramp_down_count_state_sofc)
-            + " [sec]"
-        )
+        lines.append("Total operating time during simulation: " + str(self.total_operating_time) + " [h]")
+        lines.append("Total hydrogen produced during simulation: " + str(self.total_hydrogen_produced_soec) + " [kg]")
+        lines.append("Total hydrogen consumed during simulation: " + str(self.total_hydrogen_consumed_sofc) + " [kg]")
+        lines.append("Total oxygen produced during simulation: " + str(self.total_oxygen_produced_soec) + " [kg]")
+        lines.append("Total oxygen consumed during simulation: " + str(self.total_oxygen_consumed_sofc) + " [kg]")
+        lines.append("Total water demand during simulation: " + str(self.total_water_demand_soec) + " [kg]")
+        lines.append("Total water demand during simulation: " + str(self.total_water_produced_sofc) + " [kg]")
+        lines.append("Total energy consumed during simulation: " + str(self.total_energy_soec) + " [kg]")
+        lines.append("Total energy produced during simulation: " + str(self.total_energy_sofc) + " [kWh]")
+        lines.append("Total ramp-up time during simulation: " + str(self.total_ramp_up_count_state_soec) + " [sec]")
+        lines.append("Total ramp-up time during simulation: " + str(self.total_ramp_up_count_state_sofc) + " [sec]")
+        lines.append("Total ramp-down time during simulation: " + str(self.total_ramp_down_count_state_soec) + " [sec]")
+        lines.append("Total ramp-down time during simulation: " + str(self.total_ramp_down_count_state_sofc) + " [sec]")
         return lines

--- a/hisim/components/heat_distribution_system.py
+++ b/hisim/components/heat_distribution_system.py
@@ -188,14 +188,12 @@ class HeatDistribution(cp.Component):
         self.state_channel: cp.ComponentInput = self.add_input(
             self.component_name, self.State, lt.LoadTypes.ANY, lt.Units.ANY, True
         )
-        self.theoretical_thermal_building_demand_channel: cp.ComponentInput = (
-            self.add_input(
-                self.component_name,
-                self.TheoreticalThermalBuildingDemand,
-                lt.LoadTypes.HEATING,
-                lt.Units.WATT,
-                True,
-            )
+        self.theoretical_thermal_building_demand_channel: cp.ComponentInput = self.add_input(
+            self.component_name,
+            self.TheoreticalThermalBuildingDemand,
+            lt.LoadTypes.HEATING,
+            lt.Units.WATT,
+            True,
         )
 
         self.water_temperature_input_channel: cp.ComponentInput = self.add_input(
@@ -230,13 +228,9 @@ class HeatDistribution(cp.Component):
             output_description=f"here a description for {self.ThermalPowerDelivered} will follow.",
         )
 
-        self.add_default_connections(
-            self.get_default_connections_from_heat_distribution_controller()
-        )
+        self.add_default_connections(self.get_default_connections_from_heat_distribution_controller())
         self.add_default_connections(self.get_default_connections_from_building())
-        self.add_default_connections(
-            self.get_default_connections_from_simple_hot_water_storage()
-        )
+        self.add_default_connections(self.get_default_connections_from_simple_hot_water_storage())
 
     def get_default_connections_from_heat_distribution_controller(
         self,
@@ -330,9 +324,7 @@ class HeatDistribution(cp.Component):
         """Write important variables to report."""
         return self.heat_distribution_system_config.get_string_dict()
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the heat distribution system."""
 
         # Get inputs ------------------------------------------------------------------------------------------------------------
@@ -341,13 +333,9 @@ class HeatDistribution(cp.Component):
             self.theoretical_thermal_building_demand_channel
         )
 
-        water_temperature_input_in_celsius = stsv.get_input_value(
-            self.water_temperature_input_channel
-        )
+        water_temperature_input_in_celsius = stsv.get_input_value(self.water_temperature_input_channel)
 
-        residence_temperature_input_in_celsius = stsv.get_input_value(
-            self.residence_temperature_input_channel
-        )
+        residence_temperature_input_in_celsius = stsv.get_input_value(self.residence_temperature_input_channel)
 
         # if state_controller == 1:
         if state_controller in (1, -1):
@@ -364,9 +352,7 @@ class HeatDistribution(cp.Component):
         elif state_controller == 0:
             self.thermal_power_delivered_in_watt = 0.0
 
-            self.water_temperature_output_in_celsius = (
-                water_temperature_input_in_celsius
-            )
+            self.water_temperature_output_in_celsius = water_temperature_input_in_celsius
 
         else:
             raise ValueError("unknown hds controller mode")
@@ -384,12 +370,8 @@ class HeatDistribution(cp.Component):
             # self.thermal_power_delivered_in_watt,
         )
 
-        self.state.water_output_temperature_in_celsius = (
-            self.water_temperature_output_in_celsius
-        )
-        self.state.thermal_power_delivered_in_watt = (
-            self.thermal_power_delivered_in_watt
-        )
+        self.state.water_output_temperature_in_celsius = self.water_temperature_output_in_celsius
+        self.state.thermal_power_delivered_in_watt = self.thermal_power_delivered_in_watt
 
     def determine_water_temperature_output_after_heat_exchange_with_building_and_effective_thermal_power(
         self,
@@ -420,10 +402,7 @@ class HeatDistribution(cp.Component):
                 thermal_power_delivered_effective_in_watt = (
                     self.specific_heat_capacity_of_water_in_joule_per_kilogram_per_celsius
                     * water_mass_flow_in_kg_per_second
-                    * (
-                        water_temperature_input_in_celsius
-                        - water_temperature_output_in_celsius
-                    )
+                    * (water_temperature_input_in_celsius - water_temperature_output_in_celsius)
                 )
             else:
                 # water in hds is not warmer than the building, therefore heat exchange is not possible
@@ -441,10 +420,7 @@ class HeatDistribution(cp.Component):
                 thermal_power_delivered_effective_in_watt = (
                     self.specific_heat_capacity_of_water_in_joule_per_kilogram_per_celsius
                     * water_mass_flow_in_kg_per_second
-                    * (
-                        water_temperature_input_in_celsius
-                        - water_temperature_output_in_celsius
-                    )
+                    * (water_temperature_input_in_celsius - water_temperature_output_in_celsius)
                 )
             else:
                 # water in hds is not colder than building and therefore cooling is not possible
@@ -498,9 +474,7 @@ class HeatDistributionController(cp.Component):
     # Inputs
     TheoreticalThermalBuildingDemand = "TheoreticalThermalBuildingDemand"
     DailyAverageOutsideTemperature = "DailyAverageOutsideTemperature"
-    WaterTemperatureInputFromHeatWaterStorage = (
-        "WaterTemperatureInputFromHeatWaterStorage"
-    )
+    WaterTemperatureInputFromHeatWaterStorage = "WaterTemperatureInputFromHeatWaterStorage"
     # Inputs -> energy management system
     BuildingTemperatureModifier = "BuildingTemperatureModifier"
 
@@ -525,8 +499,8 @@ class HeatDistributionController(cp.Component):
         )
         self.state_controller: int = 0
         self.building_temperature_modifier: float = 0
-        my_heat_distribution_controller_information = (
-            HeatDistributionControllerInformation(config=self.hsd_controller_config)
+        my_heat_distribution_controller_information = HeatDistributionControllerInformation(
+            config=self.hsd_controller_config
         )
 
         self.build(
@@ -543,23 +517,19 @@ class HeatDistributionController(cp.Component):
         )
 
         # Inputs
-        self.theoretical_thermal_building_demand_channel: cp.ComponentInput = (
-            self.add_input(
-                self.component_name,
-                self.TheoreticalThermalBuildingDemand,
-                lt.LoadTypes.HEATING,
-                lt.Units.WATT,
-                True,
-            )
+        self.theoretical_thermal_building_demand_channel: cp.ComponentInput = self.add_input(
+            self.component_name,
+            self.TheoreticalThermalBuildingDemand,
+            lt.LoadTypes.HEATING,
+            lt.Units.WATT,
+            True,
         )
-        self.daily_avg_outside_temperature_input_channel: cp.ComponentInput = (
-            self.add_input(
-                self.component_name,
-                self.DailyAverageOutsideTemperature,
-                lt.LoadTypes.TEMPERATURE,
-                lt.Units.CELSIUS,
-                True,
-            )
+        self.daily_avg_outside_temperature_input_channel: cp.ComponentInput = self.add_input(
+            self.component_name,
+            self.DailyAverageOutsideTemperature,
+            lt.LoadTypes.TEMPERATURE,
+            lt.Units.CELSIUS,
+            True,
         )
         self.water_temperature_input_from_heat_water_storage_channel: cp.ComponentInput = self.add_input(
             self.component_name,
@@ -595,9 +565,7 @@ class HeatDistributionController(cp.Component):
 
         self.add_default_connections(self.get_default_connections_from_building())
         self.add_default_connections(self.get_default_connections_from_weather())
-        self.add_default_connections(
-            self.get_default_connections_from_simple_hot_water_storage()
-        )
+        self.add_default_connections(self.get_default_connections_from_simple_hot_water_storage())
 
     def get_default_connections_from_weather(
         self,
@@ -665,27 +633,17 @@ class HeatDistributionController(cp.Component):
         The function sets important constants and parameters for the calculations.
         """
         # Configuration
-        self.set_heating_threshold_temperature_in_celsius = (
-            set_heating_threshold_temperature_in_celsius
-        )
-        self.heating_reference_temperature_in_celsius = (
-            heating_reference_temperature_in_celsius
-        )
+        self.set_heating_threshold_temperature_in_celsius = set_heating_threshold_temperature_in_celsius
+        self.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
         self.heat_distribution_system_type = heat_distribution_system_type
 
         self.max_flow_temperature_in_celsius = max_flow_temperature_in_celsius
         self.min_flow_temperature_in_celsius = min_flow_temperature_in_celsius
         self.max_return_temperature_in_celsius = max_return_temperature_in_celsius
         self.min_return_temperature_in_celsius = min_return_temperature_in_celsius
-        self.factor_of_oversizing_of_heat_distribution_system = (
-            factor_of_oversizing_of_heat_distribution_system
-        )
-        self.exponent_factor_of_heating_distribution_system = (
-            exponent_factor_of_heating_distribution_system
-        )
-        self.set_room_temperature_for_building_in_celsius = (
-            set_room_temperature_for_building_in_celsius
-        )
+        self.factor_of_oversizing_of_heat_distribution_system = factor_of_oversizing_of_heat_distribution_system
+        self.exponent_factor_of_heating_distribution_system = exponent_factor_of_heating_distribution_system
+        self.set_room_temperature_for_building_in_celsius = set_room_temperature_for_building_in_celsius
 
     def i_prepare_simulation(self) -> None:
         """Prepare the simulation."""
@@ -693,9 +651,7 @@ class HeatDistributionController(cp.Component):
 
     def i_save_state(self) -> None:
         """Save the current state."""
-        self.previous_controller_heat_distribution_mode = (
-            self.controller_heat_distribution_mode
-        )
+        self.previous_controller_heat_distribution_mode = self.controller_heat_distribution_mode
 
     def i_restore_state(self) -> None:
         """Restore the previous state."""
@@ -711,9 +667,7 @@ class HeatDistributionController(cp.Component):
         lines.append("Heat Distribution Controller")
         return lines
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the heat distribution controller."""
         if force_convergence:
             pass
@@ -725,12 +679,12 @@ class HeatDistributionController(cp.Component):
             daily_avg_outside_temperature_in_celsius = stsv.get_input_value(
                 self.daily_avg_outside_temperature_input_channel
             )
-            self.building_temperature_modifier = stsv.get_input_value(
-                self.building_temperature_modifier_channel
-            )
+            self.building_temperature_modifier = stsv.get_input_value(self.building_temperature_modifier_channel)
 
-            list_of_heating_distribution_system_flow_and_return_temperatures = self.calc_heat_distribution_flow_and_return_temperatures(
-                daily_avg_outside_temperature_in_celsius=daily_avg_outside_temperature_in_celsius
+            list_of_heating_distribution_system_flow_and_return_temperatures = (
+                self.calc_heat_distribution_flow_and_return_temperatures(
+                    daily_avg_outside_temperature_in_celsius=daily_avg_outside_temperature_in_celsius
+                )
             )
 
             self.conditions_for_opening_or_shutting_heat_distribution(
@@ -738,10 +692,7 @@ class HeatDistributionController(cp.Component):
             )
 
             # no heating threshold for the heat distribution system
-            if (
-                self.hsd_controller_config.set_heating_threshold_outside_temperature_in_celsius
-                is None
-            ):
+            if self.hsd_controller_config.set_heating_threshold_outside_temperature_in_celsius is None:
                 summer_heating_mode = "on"
 
             # turning heat distributon system off when the average daily outside temperature is above a certain threshold
@@ -764,9 +715,7 @@ class HeatDistributionController(cp.Component):
                 self.state_controller = 0
 
             else:
-                raise ValueError(
-                    "unknown hds controller mode or summer mode or dew point protection mode."
-                )
+                raise ValueError("unknown hds controller mode or summer mode or dew point protection mode.")
 
             stsv.set_output_value(self.state_channel, self.state_controller)
             stsv.set_output_value(
@@ -803,16 +752,10 @@ class HeatDistributionController(cp.Component):
     ) -> str:
         """Set conditions for the valve in heat distribution."""
 
-        if (
-            daily_average_outside_temperature_in_celsius
-            > set_heating_threshold_temperature_in_celsius
-        ):
+        if daily_average_outside_temperature_in_celsius > set_heating_threshold_temperature_in_celsius:
             heating_mode = "off"
 
-        elif (
-            daily_average_outside_temperature_in_celsius
-            < set_heating_threshold_temperature_in_celsius
-        ):
+        elif daily_average_outside_temperature_in_celsius < set_heating_threshold_temperature_in_celsius:
             heating_mode = "on"
 
         else:
@@ -838,8 +781,7 @@ class HeatDistributionController(cp.Component):
         # increase set_heating_temperature when connected to EnergyManagementSystem and surplus electricity available.
         # only used for heating case
         set_room_temperature_for_building_modified_in_celsius = (
-            self.set_room_temperature_for_building_in_celsius
-            + self.building_temperature_modifier
+            self.set_room_temperature_for_building_in_celsius + self.building_temperature_modifier
         )
         min_flow_temperature_modified_in_celsius = (
             self.min_flow_temperature_in_celsius + self.building_temperature_modifier
@@ -850,19 +792,12 @@ class HeatDistributionController(cp.Component):
 
         # cooling case, daily avg temperature is higher than set indoor temperature.
         # flow and return temperatures can not be lower than set indoor temperature (because number would be complex)
-        if (
-            self.set_room_temperature_for_building_in_celsius
-            < daily_avg_outside_temperature_in_celsius
-        ):
+        if self.set_room_temperature_for_building_in_celsius < daily_avg_outside_temperature_in_celsius:
             # prevent that flow and return temperatures get colder than 19 °C because this could cause condensation of the indoor air on the heating system
             # https://suissetec.ch/files/PDFs/Merkblaetter/Heizung/Deutsch/2021_11_MB_Kuehlung_mit_Fussbodenheizung_DE_Web.pdf
 
-            flow_temperature_in_celsius = max(
-                self.min_flow_temperature_in_celsius, 19.0
-            )
-            return_temperature_in_celsius = max(
-                self.min_return_temperature_in_celsius, 19.0
-            )
+            flow_temperature_in_celsius = max(self.min_flow_temperature_in_celsius, 19.0)
+            return_temperature_in_celsius = max(self.min_return_temperature_in_celsius, 19.0)
 
         else:
             # heating case, daily avg outside temperature is lower than indoor temperature
@@ -882,10 +817,7 @@ class HeatDistributionController(cp.Component):
                     )
                 )
                 ** (1 / self.exponent_factor_of_heating_distribution_system)
-                * (
-                    self.max_flow_temperature_in_celsius
-                    - min_flow_temperature_modified_in_celsius
-                )
+                * (self.max_flow_temperature_in_celsius - min_flow_temperature_modified_in_celsius)
             )
             return_temperature_in_celsius = float(
                 min_return_temperature_modified_in_celsius
@@ -903,10 +835,7 @@ class HeatDistributionController(cp.Component):
                     )
                 )
                 ** (1 / self.exponent_factor_of_heating_distribution_system)
-                * (
-                    self.max_return_temperature_in_celsius
-                    - min_return_temperature_modified_in_celsius
-                )
+                * (self.max_return_temperature_in_celsius - min_return_temperature_modified_in_celsius)
             )
 
         list_of_heating_flow_and_return_temperature_in_celsius = [
@@ -957,20 +886,12 @@ class HeatDistributionControllerInformation:
         The function sets important constants and parameters for the calculations.
         """
         # Configuration
-        self.set_heating_threshold_temperature_in_celsius = (
-            set_heating_threshold_temperature_in_celsius
-        )
-        self.heating_reference_temperature_in_celsius = (
-            heating_reference_temperature_in_celsius
-        )
+        self.set_heating_threshold_temperature_in_celsius = set_heating_threshold_temperature_in_celsius
+        self.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
         self.heat_distribution_system_type = heat_distribution_system_type
 
-        self.set_heating_temperature_for_building_in_celsius = (
-            set_heating_temperature_for_building_in_celsius
-        )
-        self.set_cooling_temperature_for_building_in_celsius = (
-            set_cooling_temperature_for_building_in_celsius
-        )
+        self.set_heating_temperature_for_building_in_celsius = set_heating_temperature_for_building_in_celsius
+        self.set_cooling_temperature_for_building_in_celsius = set_cooling_temperature_for_building_in_celsius
 
     def prepare_calc_heating_dist_temperature(
         self,
@@ -982,13 +903,8 @@ class HeatDistributionControllerInformation:
         This function is taken from the HeatingSystem class of hplib and slightly adapted here.
         """
 
-        self.set_room_temperature_for_building_in_celsius = (
-            set_room_temperature_for_building_in_celsius
-        )
-        if (
-            self.heat_distribution_system_type
-            == HeatDistributionSystemType.FLOORHEATING
-        ):
+        self.set_room_temperature_for_building_in_celsius = set_room_temperature_for_building_in_celsius
+        if self.heat_distribution_system_type == HeatDistributionSystemType.FLOORHEATING:
             list_of_maximum_flow_and_return_temperatures_in_celsius = [35, 28]
             exponent_factor_of_heating_distribution_system = 1.1
 
@@ -1000,28 +916,15 @@ class HeatDistributionControllerInformation:
                 "Heating System Type not defined here. Check your heat distribution controller config or your Heating System Type class."
             )
 
-        self.max_flow_temperature_in_celsius = (
-            list_of_maximum_flow_and_return_temperatures_in_celsius[0]
-        )
-        self.min_flow_temperature_in_celsius = (
-            set_room_temperature_for_building_in_celsius
-        )
-        self.max_return_temperature_in_celsius = (
-            list_of_maximum_flow_and_return_temperatures_in_celsius[1]
-        )
-        self.min_return_temperature_in_celsius = (
-            set_room_temperature_for_building_in_celsius
-        )
-        self.factor_of_oversizing_of_heat_distribution_system = (
-            factor_of_oversizing_of_heat_distribution_system
-        )
-        self.exponent_factor_of_heating_distribution_system = (
-            exponent_factor_of_heating_distribution_system
-        )
+        self.max_flow_temperature_in_celsius = list_of_maximum_flow_and_return_temperatures_in_celsius[0]
+        self.min_flow_temperature_in_celsius = set_room_temperature_for_building_in_celsius
+        self.max_return_temperature_in_celsius = list_of_maximum_flow_and_return_temperatures_in_celsius[1]
+        self.min_return_temperature_in_celsius = set_room_temperature_for_building_in_celsius
+        self.factor_of_oversizing_of_heat_distribution_system = factor_of_oversizing_of_heat_distribution_system
+        self.exponent_factor_of_heating_distribution_system = exponent_factor_of_heating_distribution_system
 
         self.temperature_difference_between_flow_and_return_in_celsius = (
-            self.max_flow_temperature_in_celsius
-            - self.max_return_temperature_in_celsius
+            self.max_flow_temperature_in_celsius - self.max_return_temperature_in_celsius
         )
 
     def calc_heating_distribution_system_water_mass_flow_rate(
@@ -1033,11 +936,8 @@ class HeatDistributionControllerInformation:
             PhysicsConfig.water_specific_heat_capacity_in_joule_per_kilogram_per_kelvin
         )
 
-        heating_distribution_system_water_mass_flow_in_kg_per_second = (
-            max_thermal_building_demand_in_watt
-            / (
-                specific_heat_capacity_of_water_in_joule_per_kg_per_celsius
-                * self.temperature_difference_between_flow_and_return_in_celsius
-            )
+        heating_distribution_system_water_mass_flow_in_kg_per_second = max_thermal_building_demand_in_watt / (
+            specific_heat_capacity_of_water_in_joule_per_kg_per_celsius
+            * self.temperature_difference_between_flow_and_return_in_celsius
         )
         return heating_distribution_system_water_mass_flow_in_kg_per_second

--- a/hisim/components/idealized_electric_heater.py
+++ b/hisim/components/idealized_electric_heater.py
@@ -74,12 +74,8 @@ class IdealizedElectricHeater(cp.Component):
         self.thermal_power_delivered_in_watt: float = 0
         self.theoretical_thermal_building_in_watt: float = 0
         self.heating_in_watt: float = 0
-        self.set_heating_temperature_for_building_in_celsius = (
-            config.set_heating_temperature_for_building_in_celsius
-        )
-        self.set_cooling_temperature_for_building_in_celsius = (
-            config.set_cooling_temperature_for_building_in_celsius
-        )
+        self.set_heating_temperature_for_building_in_celsius = config.set_heating_temperature_for_building_in_celsius
+        self.set_cooling_temperature_for_building_in_celsius = config.set_cooling_temperature_for_building_in_celsius
 
         # Inputs
 
@@ -139,15 +135,11 @@ class IdealizedElectricHeater(cp.Component):
         lines.append("Idealized Electric Heater")
         return lines
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the Idealized Electric Heater."""
 
         # Get inputs ------------------------------------------------------------------------------------------------------------
-        theoretical_thermal_building_in_watt = stsv.get_input_value(
-            self.theoretical_thermal_building_channel
-        )
+        theoretical_thermal_building_in_watt = stsv.get_input_value(self.theoretical_thermal_building_channel)
 
         # Calculations ----------------------------------------------------------------------------------------------------------
 

--- a/hisim/components/random_numbers.py
+++ b/hisim/components/random_numbers.py
@@ -81,9 +81,7 @@ class RandomNumbers(Component):
         """Restores the state."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the component."""
 
         val1: float = self.values[timestep]

--- a/hisim/components/simple_hot_water_storage.py
+++ b/hisim/components/simple_hot_water_storage.py
@@ -73,8 +73,7 @@ class SimpleHotWaterStorageConfig(cp.ConfigBase):
             heat_transfer_coefficient_in_watt_per_m2_per_kelvin=2.0,
             heat_exchanger_is_present=True,  # until now stratified mode is causing problems, so heat exchanger mode is recommended
             co2_footprint=100,  # Todo: check value
-            cost=volume_heating_water_storage_in_liter
-            * 14.51,  # value from emission_factros_and_costs_devices.csv
+            cost=volume_heating_water_storage_in_liter * 14.51,  # value from emission_factros_and_costs_devices.csv
             lifetime=100,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.0,  # Todo: set correct value
         )
@@ -107,7 +106,6 @@ class SimpleHotWaterStorageConfig(cp.ConfigBase):
 
         # if the used heating system is a heat pump use formular
         if "HeatPump" in heating_system_name:
-
             volume_heating_water_storage_in_liter: float = (
                 max_thermal_power_in_watt_of_heating_system
                 * 1e-3
@@ -119,9 +117,7 @@ class SimpleHotWaterStorageConfig(cp.ConfigBase):
 
         # otherwise use approximation: 60l per kw thermal power
         else:
-            volume_heating_water_storage_in_liter = (
-                max_thermal_power_in_watt_of_heating_system * 1e3 * 60
-            )
+            volume_heating_water_storage_in_liter = max_thermal_power_in_watt_of_heating_system * 1e3 * 60
 
         config = SimpleHotWaterStorageConfig(
             name="SimpleHotWaterStorage",
@@ -130,8 +126,7 @@ class SimpleHotWaterStorageConfig(cp.ConfigBase):
             heat_transfer_coefficient_in_watt_per_m2_per_kelvin=2.0,
             heat_exchanger_is_present=True,  # until now stratified mode is causing problems, so heat exchanger mode is recommended
             co2_footprint=100,  # Todo: check value
-            cost=volume_heating_water_storage_in_liter
-            * 14.51,  # value from emission_factros_and_costs_devices.csv
+            cost=volume_heating_water_storage_in_liter * 14.51,  # value from emission_factros_and_costs_devices.csv
             lifetime=100,  # value from emission_factros_and_costs_devices.csv
             maintenance_cost_as_percentage_of_investment=0.0,  # Todo: set correct value
         )
@@ -206,20 +201,14 @@ class SimpleHotWaterStorage(cp.Component):
             self.waterstorageconfig.water_mass_flow_rate_from_hds_in_kg_per_second
         )
 
-        if SingletonSimRepository().exist_entry(
-            key=SingletonDictKeyEnum.WATERMASSFLOWRATEOFHEATGENERATOR
-        ):
-            self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo = SingletonSimRepository().get_entry(
-                key=SingletonDictKeyEnum.WATERMASSFLOWRATEOFHEATGENERATOR
+        if SingletonSimRepository().exist_entry(key=SingletonDictKeyEnum.WATERMASSFLOWRATEOFHEATGENERATOR):
+            self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo = (
+                SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.WATERMASSFLOWRATEOFHEATGENERATOR)
             )
         else:
-            self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo = (
-                None
-            )
+            self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo = None
 
-        self.build(
-            heat_exchanger_is_present=self.waterstorageconfig.heat_exchanger_is_present
-        )
+        self.build(heat_exchanger_is_present=self.waterstorageconfig.heat_exchanger_is_present)
 
         self.state: SimpleHotWaterStorageState = SimpleHotWaterStorageState(
             mean_water_temperature_in_celsius=self.mean_water_temperature_in_water_storage_in_celsius,
@@ -237,23 +226,19 @@ class SimpleHotWaterStorage(cp.Component):
             lt.Units.CELSIUS,
             True,
         )
-        self.water_temperature_heat_generator_input_channel: ComponentInput = (
-            self.add_input(
-                self.component_name,
-                self.WaterTemperatureFromHeatGenerator,
-                lt.LoadTypes.TEMPERATURE,
-                lt.Units.CELSIUS,
-                True,
-            )
+        self.water_temperature_heat_generator_input_channel: ComponentInput = self.add_input(
+            self.component_name,
+            self.WaterTemperatureFromHeatGenerator,
+            lt.LoadTypes.TEMPERATURE,
+            lt.Units.CELSIUS,
+            True,
         )
-        self.water_mass_flow_rate_heat_generator_input_channel: ComponentInput = (
-            self.add_input(
-                self.component_name,
-                self.WaterMassFlowRateFromHeatGenerator,
-                lt.LoadTypes.WARM_WATER,
-                lt.Units.KG_PER_SEC,
-                False,
-            )
+        self.water_mass_flow_rate_heat_generator_input_channel: ComponentInput = self.add_input(
+            self.component_name,
+            self.WaterMassFlowRateFromHeatGenerator,
+            lt.LoadTypes.WARM_WATER,
+            lt.Units.KG_PER_SEC,
+            False,
         )
 
         self.state_channel: cp.ComponentInput = self.add_input(
@@ -323,12 +308,8 @@ class SimpleHotWaterStorage(cp.Component):
             lt.Units.WATT,
             output_description=f"here a description for {self.StandbyHeatLoss} will follow.",
         )
-        self.add_default_connections(
-            self.get_default_connections_from_heat_distribution_system()
-        )
-        self.add_default_connections(
-            self.get_default_connections_from_advanced_heat_pump()
-        )
+        self.add_default_connections(self.get_default_connections_from_heat_distribution_system())
+        self.add_default_connections(self.get_default_connections_from_advanced_heat_pump())
         self.add_default_connections(self.get_default_connections_from_gasheater())
 
     def get_default_connections_from_heat_distribution_system(
@@ -423,9 +404,7 @@ class SimpleHotWaterStorage(cp.Component):
         """Doublecheck."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the heating water storage."""
 
         # Get inputs --------------------------------------------------------------------------------------------------------
@@ -440,10 +419,7 @@ class SimpleHotWaterStorage(cp.Component):
         )
 
         # get water mass flow rate of heat generator either from singleton sim repo or from input value
-        if (
-            self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo
-            is not None
-        ):
+        if self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo is not None:
             water_mass_flow_rate_from_heat_generator_in_kg_per_second = (
                 self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo
             )
@@ -486,9 +462,11 @@ class SimpleHotWaterStorage(cp.Component):
             mean_water_temperature_in_storage_in_celsius=self.mean_water_temperature_in_water_storage_in_celsius,
             mass_in_storage_in_kg=self.water_mass_in_storage_in_kg,
         )
-        thermal_energy_increase_current_vs_previous_mean_temperature_in_watt_hour = self.calculate_thermal_energy_increase_or_decrease_in_storage(
-            current_thermal_energy_in_storage_in_watt_hour=current_thermal_energy_in_storage_in_watt_hour,
-            previous_thermal_energy_in_storage_in_watt_hour=previous_thermal_energy_in_storage_in_watt_hour,
+        thermal_energy_increase_current_vs_previous_mean_temperature_in_watt_hour = (
+            self.calculate_thermal_energy_increase_or_decrease_in_storage(
+                current_thermal_energy_in_storage_in_watt_hour=current_thermal_energy_in_storage_in_watt_hour,
+                previous_thermal_energy_in_storage_in_watt_hour=previous_thermal_energy_in_storage_in_watt_hour,
+            )
         )
 
         thermal_energy_input_from_heat_generator_in_watt_hour = self.calculate_thermal_energy_of_water_flow(
@@ -515,18 +493,13 @@ class SimpleHotWaterStorage(cp.Component):
 
         # with heat exchanger in water storage perfect heat exchange is possible
         if self.heat_exchanger_is_present is True:
-            water_temperature_to_heat_distribution_system_in_celsius = (
-                self.state.mean_water_temperature_in_celsius
-            )
-            water_temperature_to_heat_generator_in_celsius = (
-                self.state.mean_water_temperature_in_celsius
-            )
+            water_temperature_to_heat_distribution_system_in_celsius = self.state.mean_water_temperature_in_celsius
+            water_temperature_to_heat_generator_in_celsius = self.state.mean_water_temperature_in_celsius
 
         # otherwise the water in the water storage is more stratified, which demands some more calculations
         else:
             # state controller is 1 if the heat generator delivers a mass flow rate input
             if state_controller == 1:
-
                 # hds gets water from heat generator (if heat generator is not off, mass flow is not zero)
                 water_temperature_to_heat_distribution_system_in_celsius = self.calculate_water_output_temperature(
                     mean_water_temperature_in_water_storage_in_celsius=self.state.mean_water_temperature_in_celsius,
@@ -544,10 +517,7 @@ class SimpleHotWaterStorage(cp.Component):
 
             # no water coming from heat generator, hds gets mean water and heat generator gets still water from hds
             elif state_controller == 0:
-
-                water_temperature_to_heat_distribution_system_in_celsius = (
-                    self.state.mean_water_temperature_in_celsius
-                )
+                water_temperature_to_heat_distribution_system_in_celsius = self.state.mean_water_temperature_in_celsius
 
                 water_temperature_to_heat_generator_in_celsius = self.calculate_water_output_temperature(
                     mean_water_temperature_in_water_storage_in_celsius=self.state.mean_water_temperature_in_celsius,
@@ -639,7 +609,9 @@ class SimpleHotWaterStorage(cp.Component):
             self.density_water_at_40_degree_celsius_in_kg_per_liter
             * self.waterstorageconfig.volume_heating_water_storage_in_liter
         )
-        self.heat_transfer_coefficient_in_watt_per_m2_per_kelvin = self.config.heat_transfer_coefficient_in_watt_per_m2_per_kelvin
+        self.heat_transfer_coefficient_in_watt_per_m2_per_kelvin = (
+            self.config.heat_transfer_coefficient_in_watt_per_m2_per_kelvin
+        )
         self.storage_surface_in_m2 = self.calculate_surface_area_of_storage(
             storage_volume_in_liter=self.waterstorageconfig.volume_heating_water_storage_in_liter,
         )
@@ -671,12 +643,10 @@ class SimpleHotWaterStorage(cp.Component):
         """ "Calculate masses of the water flows in kg."""
 
         mass_of_input_water_flows_from_heat_generator_in_kg = (
-            water_mass_flow_rate_from_heat_generator_in_kg_per_second
-            * seconds_per_timestep
+            water_mass_flow_rate_from_heat_generator_in_kg_per_second * seconds_per_timestep
         )
         mass_of_input_water_flows_from_heat_distribution_system_in_kg = (
-            water_mass_flow_rate_from_heat_distribution_system_in_kg_per_second
-            * seconds_per_timestep
+            water_mass_flow_rate_from_heat_distribution_system_in_kg_per_second * seconds_per_timestep
         )
 
         return (
@@ -696,10 +666,8 @@ class SimpleHotWaterStorage(cp.Component):
         """Calculate the mean temperature of the water in the water boiler."""
 
         mean_water_temperature_in_water_storage_in_celsius = (
-            water_mass_in_storage_in_kg
-            * previous_mean_water_temperature_in_water_storage_in_celsius
-            + mass_of_input_water_flows_from_heat_generator_in_kg
-            * water_temperature_from_heat_generator_in_celsius
+            water_mass_in_storage_in_kg * previous_mean_water_temperature_in_water_storage_in_celsius
+            + mass_of_input_water_flows_from_heat_generator_in_kg * water_temperature_from_heat_generator_in_celsius
             + mass_of_input_water_flows_from_heat_distribution_system_in_kg
             * water_temperature_from_heat_distribution_system_in_celsius
         ) / (
@@ -717,7 +685,6 @@ class SimpleHotWaterStorage(cp.Component):
         # if one timestep = 1h (3600s) or more, the factor for the water storage portion is one
 
         if 0 <= self.seconds_per_timestep <= 3600:
-
             factor_for_water_storage_portion = self.seconds_per_timestep / 3600
             factor_for_water_input_portion = 1 - factor_for_water_storage_portion
 
@@ -741,8 +708,7 @@ class SimpleHotWaterStorage(cp.Component):
 
         water_temperature_output_in_celsius = (
             mixing_factor_water_input_portion * water_input_temperature_in_celsius
-            + mixing_factor_water_storage_portion
-            * mean_water_temperature_in_water_storage_in_celsius
+            + mixing_factor_water_storage_portion * mean_water_temperature_in_water_storage_in_celsius
         )
 
         return water_temperature_output_in_celsius
@@ -767,13 +733,12 @@ class SimpleHotWaterStorage(cp.Component):
 
         # basis here: Q = m * cw * delta temperature, temperature loss is another term for delta temperature here
         temperature_loss_of_water_in_celsius_per_hour = heat_loss_in_watt / (
-            self.specific_heat_capacity_of_water_in_watthour_per_kilogram_per_celsius
-            * mass_in_storage_in_kg
+            self.specific_heat_capacity_of_water_in_watthour_per_kilogram_per_celsius * mass_in_storage_in_kg
         )
 
         # transform from °C/h to °C/timestep
-        temperature_loss_in_celsius_per_timestep = (
-            temperature_loss_of_water_in_celsius_per_hour / (3600 / seconds_per_timestep)
+        temperature_loss_in_celsius_per_timestep = temperature_loss_of_water_in_celsius_per_hour / (
+            3600 / seconds_per_timestep
         )
 
         return heat_loss_in_watt, temperature_loss_in_celsius_per_timestep
@@ -798,21 +763,15 @@ class SimpleHotWaterStorage(cp.Component):
         )
         return heat_loss_in_watt
 
-    def calculate_surface_area_of_storage(
-        self, storage_volume_in_liter: float
-    ) -> float:
+    def calculate_surface_area_of_storage(self, storage_volume_in_liter: float) -> float:
         """Calculate the surface area of the storage which is assumed to be a cylinder."""
 
         storage_volume_in_m3 = storage_volume_in_liter * 1e-3
         # volume = r^2 * pi * h = r^2 * pi * 4r = 4 * r^3 * pi
-        radius_of_storage_in_m = (storage_volume_in_m3 / (4 * np.pi)) ** (
-            1 / 3
-        )
+        radius_of_storage_in_m = (storage_volume_in_m3 / (4 * np.pi)) ** (1 / 3)
 
         # lateral surface = 2 * pi * r * h (h=4*r here)
-        lateral_surface_in_m2 = (
-            2 * radius_of_storage_in_m * np.pi * (4 * radius_of_storage_in_m)
-        )
+        lateral_surface_in_m2 = 2 * radius_of_storage_in_m * np.pi * (4 * radius_of_storage_in_m)
         # circle surface
         circle_surface_in_m2 = np.pi * radius_of_storage_in_m**2
 
@@ -838,9 +797,7 @@ class SimpleHotWaterStorage(cp.Component):
             * (mean_water_temperature_in_storage_in_celsius)
         )  # T_mean - 0°C
         # 1Wh = J / 3600
-        thermal_energy_in_storage_in_watt_hour = (
-            thermal_energy_in_storage_in_joule / 3600
-        )
+        thermal_energy_in_storage_in_watt_hour = thermal_energy_in_storage_in_joule / 3600
 
         return thermal_energy_in_storage_in_watt_hour
 
@@ -865,8 +822,7 @@ class SimpleHotWaterStorage(cp.Component):
     ) -> float:
         """Calculate thermal energy difference of current and previous state."""
         thermal_energy_difference_in_watt_hour = (
-            current_thermal_energy_in_storage_in_watt_hour
-            - previous_thermal_energy_in_storage_in_watt_hour
+            current_thermal_energy_in_storage_in_watt_hour - previous_thermal_energy_in_storage_in_watt_hour
         )
 
         return thermal_energy_difference_in_watt_hour
@@ -879,12 +835,16 @@ class SimpleHotWaterStorage(cp.Component):
         return config.cost, config.co2_footprint, config.lifetime
 
     def get_cost_opex(
-        self, all_outputs: List, postprocessing_results: pd.DataFrame,
+        self,
+        all_outputs: List,
+        postprocessing_results: pd.DataFrame,
     ) -> OpexCostDataClass:
         # pylint: disable=unused-argument
         """Calculate OPEX costs, consisting of maintenance costs for Heat Distribution System."""
         opex_cost_data_class = OpexCostDataClass(
-            opex_cost=self.calc_maintenance_cost(), co2_footprint=0, consumption=0,
+            opex_cost=self.calc_maintenance_cost(),
+            co2_footprint=0,
+            consumption=0,
         )
 
         return opex_cost_data_class
@@ -904,7 +864,9 @@ class SimpleHotWaterStorageControllerConfig(cp.ConfigBase):
     name: str
 
     @classmethod
-    def get_default_simplehotwaterstoragecontroller_config(cls,) -> Any:
+    def get_default_simplehotwaterstoragecontroller_config(
+        cls,
+    ) -> Any:
         """Get a default simplehotwaterstorage controller config."""
         config = SimpleHotWaterStorageControllerConfig(
             name="SimpleHotWaterStorageController",
@@ -934,27 +896,21 @@ class SimpleHotWaterStorageController(cp.Component):
             my_simulation_parameters=my_simulation_parameters,
             my_config=config,
         )
-        if SingletonSimRepository().exist_entry(
-            key=SingletonDictKeyEnum.WATERMASSFLOWRATEOFHEATGENERATOR
-        ):
-            self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo = SingletonSimRepository().get_entry(
-                key=SingletonDictKeyEnum.WATERMASSFLOWRATEOFHEATGENERATOR
+        if SingletonSimRepository().exist_entry(key=SingletonDictKeyEnum.WATERMASSFLOWRATEOFHEATGENERATOR):
+            self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo = (
+                SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.WATERMASSFLOWRATEOFHEATGENERATOR)
             )
         else:
-            self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo = (
-                None
-            )
+            self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo = None
 
         self.controller_mode: str = "off"
         # Inputs
-        self.water_mass_flow_rate_heat_generator_input_channel: ComponentInput = (
-            self.add_input(
-                self.component_name,
-                self.WaterMassFlowRateFromHeatGenerator,
-                lt.LoadTypes.WARM_WATER,
-                lt.Units.KG_PER_SEC,
-                False,
-            )
+        self.water_mass_flow_rate_heat_generator_input_channel: ComponentInput = self.add_input(
+            self.component_name,
+            self.WaterMassFlowRateFromHeatGenerator,
+            lt.LoadTypes.WARM_WATER,
+            lt.Units.KG_PER_SEC,
+            False,
         )
         # Outputs
         self.state_channel: ComponentOutput = self.add_output(
@@ -992,9 +948,7 @@ class SimpleHotWaterStorageController(cp.Component):
         """Write important variables to report."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulate the heat pump comtroller."""
 
         if force_convergence:
@@ -1003,10 +957,7 @@ class SimpleHotWaterStorageController(cp.Component):
             # Retrieves inputs
 
             # get water mass flow rate of heat generator either from singleton sim repo or from input value
-            if (
-                self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo
-                is not None
-            ):
+            if self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo is not None:
                 water_mass_flow_rate_from_heat_generator_in_kg_per_second = (
                     self.water_mass_flow_rate_from_heat_generator_in_kg_per_second_from_singleton_sim_repo
                 )
@@ -1030,7 +981,8 @@ class SimpleHotWaterStorageController(cp.Component):
             stsv.set_output_value(self.state_channel, state)
 
     def conditions_on_off(
-        self, water_mass_flow_rate_from_heat_generator_in_kg_per_second: float,
+        self,
+        water_mass_flow_rate_from_heat_generator_in_kg_per_second: float,
     ) -> None:
         """Set conditions for the simple hot water storage controller mode."""
 

--- a/hisim/components/sumbuilder.py
+++ b/hisim/components/sumbuilder.py
@@ -29,9 +29,7 @@ class SumBuilderConfig(cp.ConfigBase):
     @classmethod
     def get_sumbuilder_default_config(cls):
         """Gets a default Sumbuilder."""
-        return SumBuilderConfig(
-            name="Sum", loadtype=lt.LoadTypes.ANY, unit=lt.Units.ANY
-        )
+        return SumBuilderConfig(name="Sum", loadtype=lt.LoadTypes.ANY, unit=lt.Units.ANY)
 
 
 class CalculateOperation(cp.Component):
@@ -64,15 +62,11 @@ class CalculateOperation(cp.Component):
         num_inputs = len(self.inputs)
         label = f"Input{num_inputs + 1}"
         vars(self)[label] = label
-        myinput = cp.ComponentInput(
-            self.component_name, label, self.loadtype, self.unit, True
-        )
+        myinput = cp.ComponentInput(self.component_name, label, self.loadtype, self.unit, True)
         self.inputs.append(myinput)
         return myinput
 
-    def connect_arbitrary_input(
-        self, src_object_name: str, src_field_name: str
-    ) -> None:
+    def connect_arbitrary_input(self, src_object_name: str, src_field_name: str) -> None:
         """Connect arbitrary inputs."""
         next_input = self.add_numbered_input()
         next_input.src_object_name = src_object_name
@@ -109,9 +103,7 @@ class CalculateOperation(cp.Component):
         """Double checks the results."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates."""
         total: float = 0
         for index, input_channel in enumerate(self.inputs):
@@ -188,9 +180,7 @@ class SumBuilderForTwoInputs(Component):
         """Prepares the simulation."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Adds the two values."""
         val1 = stsv.get_input_value(self.input1)
         val2 = stsv.get_input_value(self.input2)
@@ -268,9 +258,7 @@ class SumBuilderForThreeInputs(Component):
         """For double checking results."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
         """Performs the addition of the values."""
         val1 = stsv.get_input_value(self.input1)
         val2 = stsv.get_input_value(self.input2)

--- a/hisim/components/transformer_rectifier.py
+++ b/hisim/components/transformer_rectifier.py
@@ -38,9 +38,7 @@ class TransformerConfig(ConfigBase):
     @classmethod
     def get_default_transformer(cls):
         """Gets a default Transformer."""
-        return TransformerConfig(
-            name="Generic Transformer and rectifier Unit", efficiency=0.95
-        )
+        return TransformerConfig(name="Generic Transformer and rectifier Unit", efficiency=0.95)
 
 
 class Transformer(Component):
@@ -112,9 +110,7 @@ class Transformer(Component):
         """Prepares the simulation."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Simulates the transformer."""
         startval_1 = stsv.get_input_value(self.input1)
         # print(f"Input from CSV: {startval_1}")

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -433,9 +433,7 @@ class Weather(Component):
     Weather_WindSpeed_yearly_forecast = "Weather_WindSpeed_yearly_forecast"
 
     @utils.measure_execution_time
-    def __init__(
-        self, my_simulation_parameters: SimulationParameters, config: WeatherConfig
-    ):
+    def __init__(self, my_simulation_parameters: SimulationParameters, config: WeatherConfig):
         """Initializes the entire class."""
         super().__init__(
             name="Weather",
@@ -446,9 +444,7 @@ class Weather(Component):
             raise Exception("Simparameters was none")
         self.last_timestep_with_update = -1
         self.weather_config = config
-        SingletonSimRepository().set_entry(
-            key=SingletonDictKeyEnum.LOCATION, entry=self.weather_config.location
-        )
+        SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.LOCATION, entry=self.weather_config.location)
         self.parameter_string = my_simulation_parameters.get_unique_key()
 
         self.air_temperature_output: ComponentOutput = self.add_output(
@@ -559,18 +555,14 @@ class Weather(Component):
         """Double chekc."""
         pass
 
-    def i_simulate(
-        self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool
-    ) -> None:
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
         """Performs the simulation."""
         if self.last_timestep_with_update == timestep:
             return
         if force_convergence:
             return
         """ Performs the simulation. """
-        stsv.set_output_value(
-            self.air_temperature_output, self.temperature_list[timestep]
-        )
+        stsv.set_output_value(self.air_temperature_output, self.temperature_list[timestep])
         stsv.set_output_value(self.dni_output, self.dni_list[timestep])
         stsv.set_output_value(self.dni_extra_output, self.dniextra_list[timestep])
         stsv.set_output_value(self.dhi_output, self.dhi_list[timestep])
@@ -578,9 +570,7 @@ class Weather(Component):
         stsv.set_output_value(self.altitude_output, self.altitude_list[timestep])
         stsv.set_output_value(self.azimuth_output, self.azimuth_list[timestep])
         stsv.set_output_value(self.wind_speed_output, self.wind_speed_list[timestep])
-        stsv.set_output_value(
-            self.apparent_zenith_output, self.apparent_zenith_list[timestep]
-        )
+        stsv.set_output_value(self.apparent_zenith_output, self.apparent_zenith_list[timestep])
         stsv.set_output_value(
             self.daily_average_outside_temperature_output,
             self.daily_average_outside_temperature_list_in_celsius[timestep],
@@ -588,17 +578,13 @@ class Weather(Component):
 
         # set the temperature forecast
         if self.weather_config.predictive_control:
-            timesteps_24h = (
-                24 * 3600 / self.my_simulation_parameters.seconds_per_timestep
-            )
+            timesteps_24h = 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep
             last_forecast_timestep = int(timestep + timesteps_24h)
             if last_forecast_timestep > len(self.temperature_list):
                 last_forecast_timestep = len(self.temperature_list)
             # log.information( type(self.temperature))
             temperatureforecast = self.temperature_list[timestep:last_forecast_timestep]
-            self.simulation_repository.set_entry(
-                self.Weather_Temperature_Forecast_24h, temperatureforecast
-            )
+            self.simulation_repository.set_entry(self.Weather_Temperature_Forecast_24h, temperatureforecast)
         self.last_timestep_with_update = timestep
 
     def i_prepare_simulation(self) -> None:
@@ -611,23 +597,15 @@ class Weather(Component):
             source_enum=self.weather_config.data_source,
         )
         self.simulation_repository.set_entry("weather_location", location_dict)
-        cachefound, cache_filepath = utils.get_cache_file(
-            "Weather", self.weather_config, self.my_simulation_parameters
-        )
+        cachefound, cache_filepath = utils.get_cache_file("Weather", self.weather_config, self.my_simulation_parameters)
         if cachefound:
             # read cached files
-            my_weather = pd.read_csv(
-                cache_filepath, sep=",", decimal=".", encoding="cp1252"
-            )
+            my_weather = pd.read_csv(cache_filepath, sep=",", decimal=".", encoding="cp1252")
             self.temperature_list = my_weather["t_out"].tolist()
-            self.daily_average_outside_temperature_list_in_celsius = my_weather[
-                "t_out_daily_average"
-            ].tolist()
+            self.daily_average_outside_temperature_list_in_celsius = my_weather["t_out_daily_average"].tolist()
             self.dry_bulb_list = self.temperature_list
             self.dhi_list = my_weather["DHI"].tolist()
-            self.dni_list = my_weather[
-                "DNI"
-            ].tolist()  # self np.float64( maybe not needed? - Noah
+            self.dni_list = my_weather["DNI"].tolist()  # self np.float64( maybe not needed? - Noah
             self.dniextra_list = my_weather["DNIextra"].tolist()
             self.ghi_list = my_weather["GHI"].tolist()
             self.altitude_list = my_weather["altitude"].tolist()
@@ -640,40 +618,17 @@ class Weather(Component):
                 year=self.my_simulation_parameters.year,
             )
             if self.weather_config.data_source == WeatherDataSourceEnum.NSRDB_15MIN:
-                dni = (
-                    tmy_data["DNI"].resample("1T").asfreq().interpolate(method="linear")
-                )
-                temperature = (
-                    tmy_data["T"].resample("1T").asfreq().interpolate(method="linear")
-                )
-                dhi = (
-                    tmy_data["DHI"].resample("1T").asfreq().interpolate(method="linear")
-                )
-                ghi = (
-                    tmy_data["GHI"].resample("1T").asfreq().interpolate(method="linear")
-                )
-                wind_speed = (
-                    tmy_data["Wspd"]
-                    .resample("1T")
-                    .asfreq()
-                    .interpolate(method="linear")
-                )
+                dni = tmy_data["DNI"].resample("1T").asfreq().interpolate(method="linear")
+                temperature = tmy_data["T"].resample("1T").asfreq().interpolate(method="linear")
+                dhi = tmy_data["DHI"].resample("1T").asfreq().interpolate(method="linear")
+                ghi = tmy_data["GHI"].resample("1T").asfreq().interpolate(method="linear")
+                wind_speed = tmy_data["Wspd"].resample("1T").asfreq().interpolate(method="linear")
             else:
-                dni = self.interpolate(
-                    tmy_data["DNI"], self.my_simulation_parameters.year
-                )
-                temperature = self.interpolate(
-                    tmy_data["T"], self.my_simulation_parameters.year
-                )
-                dhi = self.interpolate(
-                    tmy_data["DHI"], self.my_simulation_parameters.year
-                )
-                ghi = self.interpolate(
-                    tmy_data["GHI"], self.my_simulation_parameters.year
-                )
-                wind_speed = self.interpolate(
-                    tmy_data["Wspd"], self.my_simulation_parameters.year
-                )
+                dni = self.interpolate(tmy_data["DNI"], self.my_simulation_parameters.year)
+                temperature = self.interpolate(tmy_data["T"], self.my_simulation_parameters.year)
+                dhi = self.interpolate(tmy_data["DHI"], self.my_simulation_parameters.year)
+                ghi = self.interpolate(tmy_data["GHI"], self.my_simulation_parameters.year)
+                wind_speed = self.interpolate(tmy_data["Wspd"], self.my_simulation_parameters.year)
             # calculate extra terrestrial radiation- n eeded for perez array diffuse irradiance models
             dni_extra = pd.Series(pvlib.irradiance.get_extra_radiation(dni.index), index=dni.index)  # type: ignore
 
@@ -683,48 +638,22 @@ class Weather(Component):
             apparent_zenith = solpos["apparent_zenith"]
 
             if seconds_per_timestep != 60:
-                self.temperature_list = (
-                    temperature.resample(str(seconds_per_timestep) + "S")
-                    .mean()
-                    .tolist()
-                )
-                self.dry_bulb_list = (
-                    temperature.resample(str(seconds_per_timestep) + "S")
-                    .mean()
-                    .to_list()
-                )
+                self.temperature_list = temperature.resample(str(seconds_per_timestep) + "S").mean().tolist()
+                self.dry_bulb_list = temperature.resample(str(seconds_per_timestep) + "S").mean().to_list()
                 self.calculate_daily_average_outside_temperature(
                     temperaturelist=self.temperature_list,
                     seconds_per_timestep=seconds_per_timestep,
                 )
 
-                self.dhi_list = (
-                    dhi.resample(str(seconds_per_timestep) + "S").mean().tolist()
-                )
+                self.dhi_list = dhi.resample(str(seconds_per_timestep) + "S").mean().tolist()
                 # np.float64( ## not sure what this is fore. python float and npfloat 64 are the same.
-                self.dni_list = (
-                    dni.resample(str(seconds_per_timestep) + "S").mean().tolist()
-                )  # )  # type: ignore
-                self.dniextra_list = (
-                    dni_extra.resample(str(seconds_per_timestep) + "S").mean().tolist()
-                )
-                self.ghi_list = (
-                    ghi.resample(str(seconds_per_timestep) + "S").mean().tolist()
-                )
-                self.altitude_list = (
-                    altitude.resample(str(seconds_per_timestep) + "S").mean().tolist()
-                )
-                self.azimuth_list = (
-                    azimuth.resample(str(seconds_per_timestep) + "S").mean().tolist()
-                )
-                self.apparent_zenith_list = (
-                    apparent_zenith.resample(str(seconds_per_timestep) + "S")
-                    .mean()
-                    .tolist()
-                )
-                self.wind_speed_list = (
-                    wind_speed.resample(str(seconds_per_timestep) + "S").mean().tolist()
-                )
+                self.dni_list = dni.resample(str(seconds_per_timestep) + "S").mean().tolist()  # )  # type: ignore
+                self.dniextra_list = dni_extra.resample(str(seconds_per_timestep) + "S").mean().tolist()
+                self.ghi_list = ghi.resample(str(seconds_per_timestep) + "S").mean().tolist()
+                self.altitude_list = altitude.resample(str(seconds_per_timestep) + "S").mean().tolist()
+                self.azimuth_list = azimuth.resample(str(seconds_per_timestep) + "S").mean().tolist()
+                self.apparent_zenith_list = apparent_zenith.resample(str(seconds_per_timestep) + "S").mean().tolist()
+                self.wind_speed_list = wind_speed.resample(str(seconds_per_timestep) + "S").mean().tolist()
             else:
                 self.temperature_list = temperature.tolist()
                 self.dry_bulb_list = temperature.to_list()
@@ -739,9 +668,7 @@ class Weather(Component):
                 self.altitude_list = altitude.tolist()
                 self.azimuth_list = azimuth.tolist()
                 self.apparent_zenith_list = apparent_zenith.tolist()
-                self.wind_speed_list = (
-                    wind_speed.resample(str(seconds_per_timestep) + "S").mean().tolist()
-                )
+                self.wind_speed_list = wind_speed.resample(str(seconds_per_timestep) + "S").mean().tolist()
 
             solardata = [
                 self.dni_list,
@@ -818,19 +745,11 @@ class Weather(Component):
         """Interpolates a time series."""
         firstday = pd.Series(
             [0.0],
-            index=[
-                pd.to_datetime(
-                    datetime.datetime(year - 1, 12, 31, 23, 0), utc=True
-                ).tz_convert(tz="Europe/Berlin")
-            ],
+            index=[pd.to_datetime(datetime.datetime(year - 1, 12, 31, 23, 0), utc=True).tz_convert(tz="Europe/Berlin")],
         )
         lastday = pd.Series(
             pd_database.iloc[-1],
-            index=[
-                pd.to_datetime(
-                    datetime.datetime(year, 12, 31, 22, 59), utc=True
-                ).tz_convert(tz="Europe/Berlin")
-            ],
+            index=[pd.to_datetime(datetime.datetime(year, 12, 31, 22, 59), utc=True).tz_convert(tz="Europe/Berlin")],
         )
         pd_database = pd.concat([pd_database, firstday, lastday])
         pd_database = pd_database.sort_index()
@@ -864,9 +783,7 @@ class Weather(Component):
 
         # Calculate the declination angle: The variation due to the earths tilt
         # http://www.pveducation.org/pvcdrom/properties-of-sunlight/declination-angle
-        declination_rad = math.radians(
-            23.45 * math.sin((2 * math.pi / 365.0) * (day_of_year - 81))
-        )
+        declination_rad = math.radians(23.45 * math.sin((2 * math.pi / 365.0) * (day_of_year - 81)))
 
         # Normalise the day to 2*pi
         # There is some reason as to why it is 364 and not 365.26
@@ -874,18 +791,11 @@ class Weather(Component):
 
         # The deviation between local standard time and true solar time
         equation_of_time = (
-            (9.87 * math.sin(2 * angle_of_day))
-            - (7.53 * math.cos(angle_of_day))
-            - (1.5 * math.sin(angle_of_day))
+            (9.87 * math.sin(2 * angle_of_day)) - (7.53 * math.cos(angle_of_day)) - (1.5 * math.sin(angle_of_day))
         )
 
         # True Solar Time
-        solar_time = (
-            (utc_datetime.hour * 60)
-            + utc_datetime.minute
-            + (4 * longitude_deg)
-            + equation_of_time
-        ) / 60.0
+        solar_time = ((utc_datetime.hour * 60) + utc_datetime.minute + (4 * longitude_deg) + equation_of_time) / 60.0
 
         # Angle between the local longitude and longitude where the sun is at
         # higher altitude
@@ -893,24 +803,16 @@ class Weather(Component):
 
         # Altitude Position of the Sun in Radians
         altitude_rad = math.asin(
-            math.cos(latitude_rad)
-            * math.cos(declination_rad)
-            * math.cos(hour_angle_rad)
+            math.cos(latitude_rad) * math.cos(declination_rad) * math.cos(hour_angle_rad)
             + math.sin(latitude_rad) * math.sin(declination_rad)
         )
 
         # Azimuth Position fo the sun in radians
-        azimuth_rad = math.asin(
-            math.cos(declination_rad)
-            * math.sin(hour_angle_rad)
-            / math.cos(altitude_rad)
-        )
+        azimuth_rad = math.asin(math.cos(declination_rad) * math.sin(hour_angle_rad) / math.cos(altitude_rad))
 
         # I don't really know what this code does, it has been imported from
         # PySolar
-        if math.cos(hour_angle_rad) >= (
-            math.tan(declination_rad) / math.tan(latitude_rad)
-        ):
+        if math.cos(hour_angle_rad) >= (math.tan(declination_rad) / math.tan(latitude_rad)):
             return math.degrees(altitude_rad), math.degrees(azimuth_rad)
         return math.degrees(altitude_rad), (180 - math.degrees(azimuth_rad))
 
@@ -927,14 +829,10 @@ class Weather(Component):
         self.daily_average_outside_temperature_list_in_celsius = []
         start_index = 0
         for index in range(0, total_number_of_timesteps_temperature_list):
-            daily_average_temperature = float(
-                np.mean(temperaturelist[start_index: start_index + timestep_24h])
-            )
+            daily_average_temperature = float(np.mean(temperaturelist[start_index : start_index + timestep_24h]))
             if index == start_index + timestep_24h:
                 start_index = index
-            self.daily_average_outside_temperature_list_in_celsius.append(
-                daily_average_temperature
-            )
+            self.daily_average_outside_temperature_list_in_celsius.append(daily_average_temperature)
         return self.daily_average_outside_temperature_list_in_celsius
 
 
@@ -993,17 +891,13 @@ def read_dwd_data(filepath: str, year: int) -> pd.DataFrame:
         lon = float(lines[2][15:30])
     # check if time series data already exists as .csv with DNI
     if os.path.isfile(filepath + ".csv"):
-        data = pd.read_csv(
-            filepath + ".csv", index_col=0, parse_dates=True, sep=";", decimal=","
-        )
+        data = pd.read_csv(filepath + ".csv", index_col=0, parse_dates=True, sep=";", decimal=",")
         data.index = pd.to_datetime(data.index, utc=True).tz_convert("Europe/Berlin")
     # else read from .dat and calculate DNI etc.
     else:
         # get data
         data = pd.read_csv(filepath + ".dat", sep=r"\s+", skiprows=list(range(0, 31)))
-        data.index = pd.date_range(
-            f"{year}-01-01 00:30:00", periods=8760, freq="H", tz="Europe/Berlin"
-        )
+        data.index = pd.date_range(f"{year}-01-01 00:30:00", periods=8760, freq="H", tz="Europe/Berlin")
         data["GHI"] = data["D"] + data["B"]
         data = data.rename(
             columns={
@@ -1028,9 +922,7 @@ def read_nsrdb_data(filepath: str, year: int) -> pd.DataFrame:
     # get data
     data = pd.read_csv(filepath + ".dat", sep=",", skiprows=list(range(0, 11)))
     data = data.drop(data.index[8761:8772])
-    data.index = pd.date_range(
-        f"{year}-01-01 00:30:00", periods=8760, freq="H", tz="Europe/Berlin"
-    )
+    data.index = pd.date_range(f"{year}-01-01 00:30:00", periods=8760, freq="H", tz="Europe/Berlin")
     data = data.rename(
         columns={
             "DHI": "DHI",
@@ -1052,9 +944,7 @@ def read_nsrdb_15min_data(filepath: str, year: int) -> pd.DataFrame:
     """Reads a set of NSRDB data in 15 min resolution."""
     data = pd.read_csv(filepath, encoding="utf-8", skiprows=[0, 1])
     # get data
-    data.index = pd.date_range(
-        f"{year}-01-01 00:00:00", periods=24 * 4 * 365, freq="900S", tz="UTC"
-    )
+    data.index = pd.date_range(f"{year}-01-01 00:00:00", periods=24 * 4 * 365, freq="900S", tz="UTC")
     data = data.rename(
         columns={
             "Temperature": "T",
@@ -1091,13 +981,9 @@ def calculate_direct_normal_radiation(
 
     """
 
-    solar_pos = pvlib.solarposition.get_solarposition(
-        direct_horizontal_irradation.index, lat, lon
-    )
+    solar_pos = pvlib.solarposition.get_solarposition(direct_horizontal_irradation.index, lat, lon)
     solar_pos["apparent_zenith"][solar_pos.apparent_zenith > zenith_tol] = zenith_tol
-    dni = direct_horizontal_irradation.div(
-        solar_pos["apparent_zenith"].apply(math.radians).apply(math.cos)
-    )
+    dni = direct_horizontal_irradation.div(solar_pos["apparent_zenith"].apply(math.radians).apply(math.cos))
     if sum(dni.isnull()) > 0:
         raise ValueError("Something went wrong...")
     return dni

--- a/hisim/dynamic_component.py
+++ b/hisim/dynamic_component.py
@@ -69,7 +69,6 @@ def search_and_compare(
         return False
 
     for tag_search in tags_to_search:
-
         if tag_search not in tags_of_component:
             return False
 
@@ -108,9 +107,7 @@ class DynamicComponent(Component):
 
         self.my_component_inputs = my_component_inputs
         self.my_component_outputs = my_component_outputs
-        self.dynamic_default_connections: Dict[
-            str, List[DynamicComponentConnection]
-        ] = {}
+        self.dynamic_default_connections: Dict[str, List[DynamicComponentConnection]] = {}
 
     def add_component_output(
         self,
@@ -167,16 +164,9 @@ class DynamicComponent(Component):
         label = f"Input{num_inputs}"
         vars(self)[label] = label
 
-        log.trace(
-            "Added component input and connect: "
-            + source_object_name
-            + " - "
-            + source_component_output
-        )
+        log.trace("Added component input and connect: " + source_object_name + " - " + source_component_output)
         # Define Input as Component Input and add it to inputs
-        myinput = ComponentInput(
-            self.component_name, label, source_load_type, source_unit, True
-        )
+        myinput = ComponentInput(self.component_name, label, source_load_type, source_unit, True)
         self.inputs.append(myinput)
         myinput.src_object_name = source_object_name
         myinput.src_field_name = str(source_component_output)
@@ -223,9 +213,7 @@ class DynamicComponent(Component):
                     vars(self)[label] = label
 
                     # Define Input as Component Input and add it to inputs
-                    myinput = ComponentInput(
-                        self.component_name, label, source_load_type, source_unit, True
-                    )
+                    myinput = ComponentInput(self.component_name, label, source_load_type, source_unit, True)
                     self.inputs.append(myinput)
                     myinput.src_object_name = component.component_name
                     myinput.src_field_name = str(source_component_output)
@@ -237,9 +225,7 @@ class DynamicComponent(Component):
                         + " - "
                         + myinput.src_field_name
                     )
-                    self.connect_input(
-                        label, component.component_name, output_var.field_name
-                    )
+                    self.connect_input(label, component.component_name, output_var.field_name)
                     self.my_component_inputs.append(
                         DynamicConnectionInput(
                             source_component_class=label,
@@ -267,17 +253,13 @@ class DynamicComponent(Component):
                 source_object_name=src_name,
             )
 
-    def add_dynamic_default_connections(
-        self, connections: List[DynamicComponentConnection]
-    ) -> None:
+    def add_dynamic_default_connections(self, connections: List[DynamicComponentConnection]) -> None:
         """Adds a dynamic default connection list definition."""
 
         component_name = connections[0].source_class_name
         for connection in connections:
             if connection.source_class_name != component_name:
-                raise ValueError(
-                    "Trying to add dynamic connections to different components in one go."
-                )
+                raise ValueError("Trying to add dynamic connections to different components in one go.")
         self.dynamic_default_connections[component_name] = connections
         log.trace(
             "added dynamic default connections for connections from : "
@@ -286,9 +268,7 @@ class DynamicComponent(Component):
             + str(self.dynamic_default_connections)
         )
 
-    def get_dynamic_default_connections(
-        self, source_component: Component
-    ) -> List[DynamicComponentConnection]:
+    def get_dynamic_default_connections(self, source_component: Component) -> List[DynamicComponentConnection]:
         """Gets the dynamic default connections for this component."""
         source_classname: str = source_component.get_classname()
 
@@ -328,9 +308,7 @@ class DynamicComponent(Component):
                 tags_to_search=tags,
                 tags_of_component=element.source_tags,
             ):
-                inputvalue = stsv.get_input_value(
-                    getattr(self, element.source_component_class)
-                )
+                inputvalue = stsv.get_input_value(getattr(self, element.source_component_class))
                 break
         return inputvalue
 
@@ -344,12 +322,8 @@ class DynamicComponent(Component):
 
         # check if component of component type is available
         for _, element in enumerate(self.my_component_inputs):  # loop over all inputs
-            if tags_search_and_compare(
-                tags_to_search=tags, tags_of_component=element.source_tags
-            ):
-                inputvalues.append(
-                    stsv.get_input_value(getattr(self, element.source_component_class))
-                )
+            if tags_search_and_compare(tags_to_search=tags, tags_of_component=element.source_tags):
+                inputvalues.append(stsv.get_input_value(getattr(self, element.source_component_class)))
             else:
                 continue
         return inputvalues
@@ -371,23 +345,17 @@ class DynamicComponent(Component):
                 tags_to_search=tags,
                 tags_of_component=element.source_tags,
             ):
-                stsv.set_output_value(
-                    getattr(self, element.source_component_class), output_value
-                )
+                stsv.set_output_value(getattr(self, element.source_component_class), output_value)
             else:
                 continue
 
-    def get_dynamic_inputs(
-        self, tags: List[Union[lt.ComponentType, lt.InandOutputType]]
-    ) -> List[ComponentInput]:
+    def get_dynamic_inputs(self, tags: List[Union[lt.ComponentType, lt.InandOutputType]]) -> List[ComponentInput]:
         """Returns inputs from all dynamic inputs with component type and weight."""
         inputs = []
 
         # check if component of component type is available
         for _, element in enumerate(self.my_component_inputs):  # loop over all inputs
-            if tags_search_and_compare(
-                tags_to_search=tags, tags_of_component=element.source_tags
-            ):
+            if tags_search_and_compare(tags_to_search=tags, tags_of_component=element.source_tags):
                 inputs.append(getattr(self, element.source_component_class))
             else:
                 continue

--- a/hisim/hisim_main.py
+++ b/hisim/hisim_main.py
@@ -23,7 +23,7 @@ def main(
 ) -> None:
     """Core function."""
     # filter warnings due to pvlib, pvlib generates warnings during simulation within pvlib package
-    warnings.filterwarnings('ignore')
+    warnings.filterwarnings("ignore")
     # before starting, delete old logging files if path and logging files exist
     logging_default_path = log.LOGGING_DEFAULT_PATH
     if os.path.exists(logging_default_path) and os.listdir(logging_default_path) != []:
@@ -32,18 +32,17 @@ def main(
                 try:
                     os.remove(os.path.join(logging_default_path, file))
                 except Exception:
-                    log.information("Logging default file could not be removed. This can occur when more than one simulation run simultaneously.")
+                    log.information(
+                        "Logging default file could not be removed. This can occur when more than one simulation run simultaneously."
+                    )
 
     function_in_module = "setup_function"
     log.information("#################################")
-    log.information(
-        "starting simulation of " + path_to_module)
+    log.information("starting simulation of " + path_to_module)
     starttime = datetime.now()
     starting_date_time_str = starttime.strftime("%d-%b-%Y %H:%M:%S")
     log.information("Start @ " + starting_date_time_str + " ")
-    log.profile(
-        path_to_module + " " + function_in_module + "Start @ " + starting_date_time_str
-    )
+    log.profile(path_to_module + " " + function_in_module + "Start @ " + starting_date_time_str)
     log.information("#################################")
     normalized_path = os.path.normpath(path_to_module)
     path_in_list = normalized_path.split(os.sep)
@@ -112,14 +111,7 @@ if __name__ == "__main__":
         main(path_to_module=FILE_NAME)
     if len(sys.argv) == 3:
         MODULE_CONFIG = sys.argv[2]
-        log.information(
-            "calling "
-            + FUNCTION_NAME
-            + " from "
-            + FILE_NAME
-            + " with module config "
-            + MODULE_CONFIG
-        )
+        log.information("calling " + FUNCTION_NAME + " from " + FILE_NAME + " with module config " + MODULE_CONFIG)
         main(
             path_to_module=FILE_NAME,
             my_module_config_path=MODULE_CONFIG,

--- a/hisim/json_executor.py
+++ b/hisim/json_executor.py
@@ -38,16 +38,13 @@ class JsonExecutor:
             self.my_obj: ConfigFile = ConfigFile.from_json(json_str)
             if self.my_obj.my_simulation_parameters is None:
                 raise ValueError("No simulation parameters object was found.")
-            self.my_simulation_parameters: SimulationParameters = (
-                self.my_obj.my_simulation_parameters
-            )
+            self.my_simulation_parameters: SimulationParameters = self.my_obj.my_simulation_parameters
 
     def component_importer(self, needed_classes: List[str]) -> Dict[str, Any]:
         """Imports a config."""
         package_dir = os.path.join(PathlibPath(__file__).resolve().parent, "components")
         class_dict = {}
-        for (_idx1, module_name, _idx2) in iter_modules([package_dir]):
-
+        for _idx1, module_name, _idx2 in iter_modules([package_dir]):
             # import the module and iterate through its attributes
             module = import_module(f"hisim.components.{module_name}")
 
@@ -82,9 +79,7 @@ class JsonExecutor:
         )
         component_dict = {}
         for component_entry in self.my_obj.component_entries:
-            component_instance = self.process_one_component_entry(
-                component_entry, class_dict, my_simulation_parameters
-            )
+            component_instance = self.process_one_component_entry(component_entry, class_dict, my_simulation_parameters)
             simulator.add_component(component_instance)
             component_dict[component_entry.component_name] = component_instance
         for component_entry in self.my_obj.component_entries:
@@ -121,23 +116,15 @@ class JsonExecutor:
                 )
         if not found_simulation_parameters:
             raise ValueError(
-                "The class "
-                + component_entry.component_full_classname
-                + " has no simulation parameters parameter"
+                "The class " + component_entry.component_full_classname + " has no simulation parameters parameter"
             )
         if not found_config:
-            raise ValueError(
-                "The class "
-                + component_entry.component_full_classname
-                + " has no config parameter"
-            )
+            raise ValueError("The class " + component_entry.component_full_classname + " has no config parameter")
         config_class = class_dict[component_entry.config_full_classname]
 
         config_instance = config_class.from_dict(component_entry.configuration)
 
-        class_instance = my_class(
-            config=config_instance, my_simulation_parameters=my_simulation_parameters
-        )
+        class_instance = my_class(config=config_instance, my_simulation_parameters=my_simulation_parameters)
         return class_instance
 
     def generate_list_of_needed_classes_for_import(self):

--- a/hisim/log.py
+++ b/hisim/log.py
@@ -9,7 +9,7 @@ LOGGING_DEFAULT_PATH: str = r"../logs/"
 
 class LogPrio(IntEnum):
 
-    """ Define a logging priority. """
+    """Define a logging priority."""
 
     ERROR = 1
     WARNING = 2
@@ -20,38 +20,38 @@ class LogPrio(IntEnum):
 
 
 def error(message: str, logging_message_path: str = LOGGING_DEFAULT_PATH) -> None:
-    """ Log an error message. """
+    """Log an error message."""
     log(LogPrio.ERROR, message, logging_message_path)
 
 
 def warning(message: str, logging_message_path: str = LOGGING_DEFAULT_PATH) -> None:
-    """ Log a warning message. """
+    """Log a warning message."""
     log(LogPrio.WARNING, message, logging_message_path)
 
 
 def information(message: str, logging_message_path: str = LOGGING_DEFAULT_PATH) -> None:
-    """ Log a information message. """
+    """Log a information message."""
     log(LogPrio.INFORMATION, message, logging_message_path)
 
 
 def trace(message: str, logging_message_path: str = LOGGING_DEFAULT_PATH) -> None:
-    """ Log a trace message. """
+    """Log a trace message."""
     log(LogPrio.TRACE, message, logging_message_path)
 
 
 def debug(message: str, logging_message_path: str = LOGGING_DEFAULT_PATH) -> None:
-    """ Log a debug message. """
+    """Log a debug message."""
     log(LogPrio.DEBUG, message, logging_message_path)
 
 
 def profile(message: str, logging_message_path: str = LOGGING_DEFAULT_PATH) -> None:
-    """ Log a profile message. """
+    """Log a profile message."""
     log(LogPrio.PROFILE, message, logging_message_path)
     log_profile_file(message, logging_message_path)
 
 
 def log(prio: int, message: str, logging_message_path: str = LOGGING_DEFAULT_PATH) -> None:
-    """ Write and print a log message. """
+    """Write and print a log message."""
     # if(prio < LogPrio.Debug):
     prio_string: str
     if prio == LogPrio.ERROR:
@@ -74,18 +74,18 @@ def log(prio: int, message: str, logging_message_path: str = LOGGING_DEFAULT_PAT
     if not os.path.exists(logging_message_path):
         os.makedirs(logging_message_path)
 
-    file_name = os.path.join(logging_message_path, 'hisim_simulation.log')
-    with open(file_name, 'a', encoding="utf-8") as filestream:
+    file_name = os.path.join(logging_message_path, "hisim_simulation.log")
+    with open(file_name, "a", encoding="utf-8") as filestream:
         filestream.write(message + "\n")
 
 
 def log_profile_file(message: str, logging_message_path: str = LOGGING_DEFAULT_PATH) -> None:
-    """ Write log message to logfile. """
+    """Write log message to logfile."""
 
     if not os.path.exists(logging_message_path):
         os.makedirs(logging_message_path)
 
-    file_name = os.path.join(logging_message_path, 'profiling_timeuse.log')
+    file_name = os.path.join(logging_message_path, "profiling_timeuse.log")
 
-    with open(file_name, 'a', encoding="utf-8") as filestream:
+    with open(file_name, "a", encoding="utf-8") as filestream:
         filestream.write(message + "\n")

--- a/hisim/modular_household/component_connections.py
+++ b/hisim/modular_household/component_connections.py
@@ -15,21 +15,27 @@ from utspclient.helpers.lpgpythonbindings import JsonReference
 import hisim.loadtypes as lt
 from hisim import utils
 from hisim.component import Component
-from hisim.components import (advanced_battery_bslib,
-                              advanced_ev_battery_bslib, building,
-                              controller_l1_building_heating,
-                              controller_l1_generic_ev_charge,
-                              controller_l1_heatpump,
-                              controller_l1_chp,
-                              controller_l1_electrolyzer,
-                              controller_l2_energy_management_system,
-                              generic_car,
-                              generic_chp, generic_electrolyzer,
-                              generic_heat_pump_modular, generic_heat_source,
-                              generic_hot_water_storage_modular,
-                              generic_hydrogen_storage, generic_pv_system,
-                              generic_smart_device,
-                              weather)
+from hisim.components import (
+    advanced_battery_bslib,
+    advanced_ev_battery_bslib,
+    building,
+    controller_l1_building_heating,
+    controller_l1_generic_ev_charge,
+    controller_l1_heatpump,
+    controller_l1_chp,
+    controller_l1_electrolyzer,
+    controller_l2_energy_management_system,
+    generic_car,
+    generic_chp,
+    generic_electrolyzer,
+    generic_heat_pump_modular,
+    generic_heat_source,
+    generic_hot_water_storage_modular,
+    generic_hydrogen_storage,
+    generic_pv_system,
+    generic_smart_device,
+    weather,
+)
 
 from hisim.components.configuration import HouseholdWarmWaterDemandConfig
 from hisim.simulator import SimulationParameters
@@ -37,7 +43,7 @@ from obsolete import loadprofilegenerator_connector
 
 
 def get_heating_system_efficiency(
-        heating_system_installed: lt.HeatingSystems, water_vs_heating: lt.InandOutputType
+    heating_system_installed: lt.HeatingSystems, water_vs_heating: lt.InandOutputType
 ) -> float:
     """Reads in type of heating system and returns related efficiency values.
 
@@ -82,7 +88,8 @@ def configure_pv_system(
     """
     if pv_peak_power is not None:
         my_pv_system_config = generic_pv_system.PVSystem.get_default_config(
-            power_in_watt=pv_peak_power, source_weight=count,
+            power_in_watt=pv_peak_power,
+            source_weight=count,
         )
     else:
         my_pv_system_config = generic_pv_system.PVSystem.get_default_config(
@@ -137,7 +144,12 @@ def configure_smart_devices(
     for device in device_collection:
         my_smart_devices.append(
             generic_smart_device.SmartDevice(
-                config=generic_smart_device.SmartDeviceConfig(name="SmartDevice", identifier=device, source_weight=count, smart_devices_included=smart_devices_included),
+                config=generic_smart_device.SmartDeviceConfig(
+                    name="SmartDevice",
+                    identifier=device,
+                    source_weight=count,
+                    smart_devices_included=smart_devices_included,
+                ),
                 my_simulation_parameters=my_simulation_parameters,
             )
         )
@@ -234,9 +246,7 @@ def configure_ev_batteries(
         raise Exception("For EV configuration mobility set is obligatory.")
 
     if charging_station_set is not None:
-        charging_power = float(
-            (charging_station_set.Name or "").split("with ")[1].split(" kW")[0]
-        )
+        charging_power = float((charging_station_set.Name or "").split("with ")[1].split(" kW")[0])
     else:
         raise Exception("For EV configuration charging station set is obligatory.")
 
@@ -249,17 +259,15 @@ def configure_ev_batteries(
         )
         ev_capacities.append(car_battery_config.e_bat_custom)
 
-        car_battery_controller_config = (
-            controller_l1_generic_ev_charge.ChargingStationConfig.get_default_config(
-                charging_station_set=charging_station_set
-            )
+        car_battery_controller_config = controller_l1_generic_ev_charge.ChargingStationConfig.get_default_config(
+            charging_station_set=charging_station_set
         )
         car_battery_controller_config.source_weight = car.config.source_weight
-        car_battery_controller_config.lower_threshold_charging_power = charging_power * 1e3 * 0.1  # 10 % of charging power for acceptable efficiencies
+        car_battery_controller_config.lower_threshold_charging_power = (
+            charging_power * 1e3 * 0.1
+        )  # 10 % of charging power for acceptable efficiencies
         if controllable:
-            car_battery_controller_config.battery_set = (
-                0.4  # lower threshold for soc of car battery in clever case
-            )
+            car_battery_controller_config.battery_set = 0.4  # lower threshold for soc of car battery in clever case
         my_controller_carbattery = controller_l1_generic_ev_charge.L1Controller(
             my_simulation_parameters=my_simulation_parameters,
             config=car_battery_controller_config,
@@ -329,7 +337,6 @@ def configure_smart_controller_for_smart_devices(
                 lt.InandOutputType.ELECTRICITY_REAL,
             ],
             source_weight=elem.source_weight,
-
         )
 
         electricity_to_smart_device = my_electricity_controller.add_component_output(
@@ -374,26 +381,22 @@ def configure_battery(
 
     """
     if battery_capacity is not None:
-        my_advanced_battery_config = (
-            advanced_battery_bslib.BatteryConfig(
-                custom_battery_capacity_generic_in_kilowatt_hour=battery_capacity,
-                custom_pv_inverter_power_generic_in_watt=battery_capacity * 0.5 * 1e3,
-                source_weight=count,
-                system_id='SG1',
-                name='Battery',
-                charge_in_kwh=0,
-                discharge_in_kwh=0,
-                co2_footprint=battery_capacity * 130.7,
-                cost=battery_capacity * 535.81,
-                lifetime=10,  # todo set correct values
-                lifetime_in_cycles=5e3,  # todo set correct values
-                maintenance_cost_as_percentage_of_investment=0.02,
-            )
+        my_advanced_battery_config = advanced_battery_bslib.BatteryConfig(
+            custom_battery_capacity_generic_in_kilowatt_hour=battery_capacity,
+            custom_pv_inverter_power_generic_in_watt=battery_capacity * 0.5 * 1e3,
+            source_weight=count,
+            system_id="SG1",
+            name="Battery",
+            charge_in_kwh=0,
+            discharge_in_kwh=0,
+            co2_footprint=battery_capacity * 130.7,
+            cost=battery_capacity * 535.81,
+            lifetime=10,  # todo set correct values
+            lifetime_in_cycles=5e3,  # todo set correct values
+            maintenance_cost_as_percentage_of_investment=0.02,
         )
     else:
-        my_advanced_battery_config = (
-            advanced_battery_bslib.BatteryConfig.get_default_config()
-        )
+        my_advanced_battery_config = advanced_battery_bslib.BatteryConfig.get_default_config()
         my_advanced_battery_config.source_weight = count
     count += 1
     my_advanced_battery = advanced_battery_bslib.Battery(
@@ -408,21 +411,18 @@ def configure_battery(
         source_unit=lt.Units.WATT,
         source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_REAL],
         source_weight=my_advanced_battery.source_weight,
-
     )
 
-    electricity_to_or_from_battery_target = (
-        my_electricity_controller.add_component_output(
-            source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.BATTERY,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
-            source_weight=my_advanced_battery.source_weight,
-            source_load_type=lt.LoadTypes.ELECTRICITY,
-            source_unit=lt.Units.WATT,
-            output_description="Target electricity for Battery Control. ",
-        )
+    electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
+        source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
+        source_tags=[
+            lt.ComponentType.BATTERY,
+            lt.InandOutputType.ELECTRICITY_TARGET,
+        ],
+        source_weight=my_advanced_battery.source_weight,
+        source_load_type=lt.LoadTypes.ELECTRICITY,
+        source_unit=lt.Units.WATT,
+        output_description="Target electricity for Battery Control. ",
     )
 
     my_advanced_battery.connect_dynamic_input(
@@ -440,7 +440,7 @@ def configure_water_heating(
     my_occupancy: loadprofilegenerator_connector.Occupancy,
     water_heating_system_installed: lt.HeatingSystems,
     count: int,
-    number_of_apartments: float
+    number_of_apartments: float,
 ) -> Tuple[generic_hot_water_storage_modular.HotWaterStorage, int]:
     """Sets Boiler with Heater, L1 Controller and L2 Controller for Water Heating System.
 
@@ -465,21 +465,25 @@ def configure_water_heating(
         lt.HeatingSystems.OIL_HEATING: lt.LoadTypes.OIL,
         lt.HeatingSystems.DISTRICT_HEATING: lt.LoadTypes.DISTRICTHEATING,
     }
-    heater_config = (
-        generic_heat_source.HeatSourceConfig.get_default_config_waterheating()
-    )
+    heater_config = generic_heat_source.HeatSourceConfig.get_default_config_waterheating()
     heater_config.fuel = fuel_translator[water_heating_system_installed]
     heater_config.efficiency = get_heating_system_efficiency(
-        heating_system_installed=water_heating_system_installed, water_vs_heating=lt.InandOutputType.HEATING)
+        heating_system_installed=water_heating_system_installed, water_vs_heating=lt.InandOutputType.HEATING
+    )
     heater_l1_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
         "DHW" + water_heating_system_installed.value
     )
     [heater_config.source_weight, heater_l1_config.source_weight] = [count] * 2
     count += 1
     boiler_config = (
-        generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(number_of_apartments=number_of_apartments)
+        generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
+            number_of_apartments=number_of_apartments
+        )
     )
-    boiler_config.compute_default_cycle(temperature_difference_in_kelvin=heater_l1_config.t_max_heating_in_celsius - heater_l1_config.t_min_heating_in_celsius)
+    boiler_config.compute_default_cycle(
+        temperature_difference_in_kelvin=heater_l1_config.t_max_heating_in_celsius
+        - heater_l1_config.t_min_heating_in_celsius
+    )
 
     heater_config.power_th = (
         my_occupancy.max_hot_water_demand
@@ -506,9 +510,7 @@ def configure_water_heating(
     my_heater_controller_l1.connect_only_predefined_connections(my_boiler)
     my_sim.add_component(my_heater_controller_l1)
 
-    my_heater = generic_heat_source.HeatSource(
-        config=heater_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_heater = generic_heat_source.HeatSource(config=heater_config, my_simulation_parameters=my_simulation_parameters)
     my_heater.connect_only_predefined_connections(my_heater_controller_l1)
 
     my_sim.add_component(my_heater)
@@ -526,7 +528,7 @@ def configure_water_heating_electric(
     water_heating_system_installed: lt.HeatingSystems,
     controllable: bool,
     count: int,
-    number_of_apartments: float
+    number_of_apartments: float,
 ) -> Tuple[generic_hot_water_storage_modular.HotWaterStorage, int]:
     """Sets Boiler with Heater, L1 Controller and L2 Controller for Water Heating System.
 
@@ -553,16 +555,12 @@ def configure_water_heating_electric(
 
     """
     if water_heating_system_installed == lt.HeatingSystems.HEAT_PUMP:
-        heatpump_config = (
-            generic_heat_pump_modular.HeatPumpConfig.get_default_config_waterheating()
-        )
+        heatpump_config = generic_heat_pump_modular.HeatPumpConfig.get_default_config_waterheating()
         heatpump_l1_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
             "DHWHeatPumpController"
         )
     elif water_heating_system_installed == lt.HeatingSystems.ELECTRIC_HEATING:
-        heatpump_config = (
-            generic_heat_pump_modular.HeatPumpConfig.get_default_config_waterheating_electric()
-        )
+        heatpump_config = generic_heat_pump_modular.HeatPumpConfig.get_default_config_waterheating_electric()
         heatpump_l1_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
             "BoilerHeatingController"
         )
@@ -583,9 +581,14 @@ def configure_water_heating_electric(
         * my_occupancy.scaling_factor_according_to_number_of_apartments
     )
     boiler_config = (
-        generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(number_of_apartments=number_of_apartments)
+        generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
+            number_of_apartments=number_of_apartments
+        )
     )
-    boiler_config.compute_default_cycle(temperature_difference_in_kelvin=heatpump_l1_config.t_max_heating_in_celsius - heatpump_l1_config.t_min_heating_in_celsius)
+    boiler_config.compute_default_cycle(
+        temperature_difference_in_kelvin=heatpump_l1_config.t_max_heating_in_celsius
+        - heatpump_l1_config.t_min_heating_in_celsius
+    )
 
     my_boiler = generic_hot_water_storage_modular.HotWaterStorage(
         my_simulation_parameters=my_simulation_parameters, config=boiler_config
@@ -683,7 +686,8 @@ def configure_heating(
     heater_config = generic_heat_source.HeatSourceConfig.get_default_config_heating()
     heater_config.fuel = fuel_translator[heating_system_installed]
     heater_config.efficiency = get_heating_system_efficiency(
-        heating_system_installed=heating_system_installed, water_vs_heating=lt.InandOutputType.HEATING)
+        heating_system_installed=heating_system_installed, water_vs_heating=lt.InandOutputType.HEATING
+    )
     heater_l1_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller(
         heating_system_installed.value
     )
@@ -703,20 +707,18 @@ def configure_heating(
     my_heater_controller_l1.connect_input(
         input_fieldname=my_heater_controller_l1.StorageTemperature,
         src_object_name=my_building.component_name,
-        src_field_name=my_building.TemperatureMeanThermalMass
+        src_field_name=my_building.TemperatureMeanThermalMass,
     )
     my_sim.add_component(my_heater_controller_l1)
 
-    my_heater = generic_heat_source.HeatSource(
-        config=heater_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_heater = generic_heat_source.HeatSource(config=heater_config, my_simulation_parameters=my_simulation_parameters)
     my_heater.connect_only_predefined_connections(my_heater_controller_l1)
     my_sim.add_component(my_heater)
 
     my_building.connect_input(
         input_fieldname=my_building.ThermalPowerDelivered,
         src_object_name=my_heater.component_name,
-        src_field_name=my_heater.ThermalPowerDelivered
+        src_field_name=my_heater.ThermalPowerDelivered,
     )
 
     return my_heater, count
@@ -761,16 +763,12 @@ def configure_heating_electric(
 
     """
     if heating_system_installed == lt.HeatingSystems.HEAT_PUMP:
-        heatpump_config = (
-            generic_heat_pump_modular.HeatPumpConfig.get_default_config_heating()
-        )
+        heatpump_config = generic_heat_pump_modular.HeatPumpConfig.get_default_config_heating()
         heatpump_l1_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller(
             "HeatigHeatPumpController"
         )
     elif heating_system_installed == lt.HeatingSystems.ELECTRIC_HEATING:
-        heatpump_config = (
-            generic_heat_pump_modular.HeatPumpConfig.get_default_config_heating_electric()
-        )
+        heatpump_config = generic_heat_pump_modular.HeatPumpConfig.get_default_config_heating_electric()
         heatpump_l1_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller(
             "ElectricHeatingController"
         )
@@ -836,7 +834,7 @@ def configure_heating_electric(
     my_building.connect_input(
         input_fieldname=my_building.ThermalPowerDelivered,
         src_object_name=my_heatpump.component_name,
-        src_field_name=my_heatpump.ThermalPowerDelivered
+        src_field_name=my_heatpump.ThermalPowerDelivered,
     )
 
     return my_heatpump, count
@@ -884,16 +882,12 @@ def configure_heating_with_buffer_electric(
 
     """
     if heating_system_installed == lt.HeatingSystems.HEAT_PUMP:
-        heatpump_config = (
-            generic_heat_pump_modular.HeatPumpConfig.get_default_config_heating()
-        )
+        heatpump_config = generic_heat_pump_modular.HeatPumpConfig.get_default_config_heating()
         heatpump_l1_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_buffer(
             "BufferHeatPumpController"
         )
     elif heating_system_installed == lt.HeatingSystems.ELECTRIC_HEATING:
-        heatpump_config = (
-            generic_heat_pump_modular.HeatPumpConfig.get_default_config_heating_electric()
-        )
+        heatpump_config = generic_heat_pump_modular.HeatPumpConfig.get_default_config_heating_electric()
         heatpump_l1_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_buffer(
             "BufferElectricHeatingController"
         )
@@ -904,25 +898,29 @@ def configure_heating_with_buffer_electric(
     [heatpump_config.source_weight, heatpump_l1_config.source_weight] = [count] * 2
     count += 1
 
-    buffer_config = (
-        generic_hot_water_storage_modular.StorageConfig.get_default_config_buffer(power=float(my_building.my_building_information.max_thermal_building_demand_in_watt))
+    buffer_config = generic_hot_water_storage_modular.StorageConfig.get_default_config_buffer(
+        power=float(my_building.my_building_information.max_thermal_building_demand_in_watt)
     )
     buffer_config.compute_default_volume(
         time_in_seconds=heatpump_l1_config.min_idle_time_in_seconds,
-        temperature_difference_in_kelvin=heatpump_l1_config.t_max_heating_in_celsius - heatpump_l1_config.t_min_heating_in_celsius,
-        multiplier=buffer_volume
+        temperature_difference_in_kelvin=heatpump_l1_config.t_max_heating_in_celsius
+        - heatpump_l1_config.t_min_heating_in_celsius,
+        multiplier=buffer_volume,
     )
-    buffer_config.compute_default_cycle(temperature_difference_in_kelvin=heatpump_l1_config.t_max_heating_in_celsius - heatpump_l1_config.t_min_heating_in_celsius)
+    buffer_config.compute_default_cycle(
+        temperature_difference_in_kelvin=heatpump_l1_config.t_max_heating_in_celsius
+        - heatpump_l1_config.t_min_heating_in_celsius
+    )
 
-    building_heating_controller_config = controller_l1_building_heating.L1BuildingHeatingConfig.get_default_config_heating(
-        "buffer"
+    building_heating_controller_config = (
+        controller_l1_building_heating.L1BuildingHeatingConfig.get_default_config_heating("buffer")
     )
     building_heating_controller_config.day_of_heating_season_end = heating_season[0]
     building_heating_controller_config.day_of_heating_season_begin = heating_season[1]
-    building_heating_controller_config.t_buffer_activation_threshold_in_celsius = heatpump_l1_config.t_max_heating_in_celsius
-    [buffer_config.source_weight, building_heating_controller_config.source_weight] = [
-        count
-    ] * 2
+    building_heating_controller_config.t_buffer_activation_threshold_in_celsius = (
+        heatpump_l1_config.t_max_heating_in_celsius
+    )
+    [buffer_config.source_weight, building_heating_controller_config.source_weight] = [count] * 2
     count += 1
 
     my_buffer = generic_hot_water_storage_modular.HotWaterStorage(
@@ -959,7 +957,7 @@ def configure_heating_with_buffer_electric(
         my_buffer_controller.connect_input(
             my_buffer_controller.BuildingTemperatureModifier,
             my_electricity_controller.component_name,
-            my_electricity_controller.BuildingTemperatureModifier
+            my_electricity_controller.BuildingTemperatureModifier,
         )
 
         my_electricity_controller.add_component_input_and_connect(
@@ -972,7 +970,6 @@ def configure_heating_with_buffer_electric(
                 lt.InandOutputType.ELECTRICITY_REAL,
             ],
             source_weight=my_heatpump.config.source_weight,
-
         )
 
         my_electricity_controller.add_component_output(
@@ -1003,7 +1000,7 @@ def configure_heating_with_buffer_electric(
     my_building.connect_input(
         input_fieldname=my_building.ThermalPowerDelivered,
         src_object_name=my_buffer.component_name,
-        src_field_name=my_buffer.PowerFromHotWaterStorage
+        src_field_name=my_buffer.PowerFromHotWaterStorage,
     )
 
     return my_heatpump, my_buffer, count
@@ -1049,7 +1046,8 @@ def configure_heating_with_buffer(
     heater_config.fuel = fuel_translator[heating_system_installed]
     heater_config.power_th = my_building.my_building_information.max_thermal_building_demand_in_watt
     heater_config.efficiency = get_heating_system_efficiency(
-        heating_system_installed=heating_system_installed, water_vs_heating=lt.InandOutputType.HEATING)
+        heating_system_installed=heating_system_installed, water_vs_heating=lt.InandOutputType.HEATING
+    )
     heater_l1_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_buffer(
         "Buffer" + heating_system_installed.value + "Controller"
     )
@@ -1059,25 +1057,29 @@ def configure_heating_with_buffer(
     [heater_config.source_weight, heater_l1_config.source_weight] = [count] * 2
     count += 1
 
-    buffer_config = (
-        generic_hot_water_storage_modular.StorageConfig.get_default_config_buffer(power=float(my_building.my_building_information.max_thermal_building_demand_in_watt))
+    buffer_config = generic_hot_water_storage_modular.StorageConfig.get_default_config_buffer(
+        power=float(my_building.my_building_information.max_thermal_building_demand_in_watt)
     )
     buffer_config.compute_default_volume(
         time_in_seconds=heater_l1_config.min_idle_time_in_seconds,
-        temperature_difference_in_kelvin=heater_l1_config.t_max_heating_in_celsius - heater_l1_config.t_min_heating_in_celsius,
-        multiplier=buffer_volume
+        temperature_difference_in_kelvin=heater_l1_config.t_max_heating_in_celsius
+        - heater_l1_config.t_min_heating_in_celsius,
+        multiplier=buffer_volume,
     )
-    buffer_config.compute_default_cycle(temperature_difference_in_kelvin=heater_l1_config.t_max_heating_in_celsius - heater_l1_config.t_min_heating_in_celsius)
+    buffer_config.compute_default_cycle(
+        temperature_difference_in_kelvin=heater_l1_config.t_max_heating_in_celsius
+        - heater_l1_config.t_min_heating_in_celsius
+    )
 
-    building_heating_controller_config = controller_l1_building_heating.L1BuildingHeatingConfig.get_default_config_heating(
-        "buffer"
+    building_heating_controller_config = (
+        controller_l1_building_heating.L1BuildingHeatingConfig.get_default_config_heating("buffer")
     )
     building_heating_controller_config.day_of_heating_season_end = heating_season[0]
     building_heating_controller_config.day_of_heating_season_begin = heating_season[1] - 1
-    building_heating_controller_config.t_buffer_activation_threshold_in_celsius = heater_l1_config.t_max_heating_in_celsius
-    [buffer_config.source_weight, building_heating_controller_config.source_weight] = [
-        count
-    ] * 2
+    building_heating_controller_config.t_buffer_activation_threshold_in_celsius = (
+        heater_l1_config.t_max_heating_in_celsius
+    )
+    [buffer_config.source_weight, building_heating_controller_config.source_weight] = [count] * 2
     count += 1
 
     my_buffer = generic_hot_water_storage_modular.HotWaterStorage(
@@ -1090,9 +1092,7 @@ def configure_heating_with_buffer(
     my_heater_controller_l1.connect_only_predefined_connections(my_buffer)
     my_sim.add_component(my_heater_controller_l1)
 
-    my_heater = generic_heat_source.HeatSource(
-        config=heater_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_heater = generic_heat_source.HeatSource(config=heater_config, my_simulation_parameters=my_simulation_parameters)
     my_heater.connect_only_predefined_connections(my_heater_controller_l1)
     my_sim.add_component(my_heater)
 
@@ -1107,16 +1107,22 @@ def configure_heating_with_buffer(
     my_building.connect_input(
         input_fieldname=my_building.ThermalPowerDelivered,
         src_object_name=my_buffer.component_name,
-        src_field_name=my_buffer.PowerFromHotWaterStorage
+        src_field_name=my_buffer.PowerFromHotWaterStorage,
     )
 
     return my_heater, my_buffer, count
 
 
-def configure_chp(my_sim: Any, my_simulation_parameters: SimulationParameters, my_building: building.Building,
-                  my_boiler: generic_hot_water_storage_modular.HotWaterStorage,
-                  my_electricity_controller: controller_l2_energy_management_system.L2GenericEnergyManagementSystem,
-                  chp_power: float, controllable: bool, count: int, ) -> int:
+def configure_chp(
+    my_sim: Any,
+    my_simulation_parameters: SimulationParameters,
+    my_building: building.Building,
+    my_boiler: generic_hot_water_storage_modular.HotWaterStorage,
+    my_electricity_controller: controller_l2_energy_management_system.L2GenericEnergyManagementSystem,
+    chp_power: float,
+    controllable: bool,
+    count: int,
+) -> int:
     """Sets up natural gas CHP. It heats the DHW storage and the building in winter.
 
     :param my_sim: Simulation class.
@@ -1145,15 +1151,21 @@ def configure_chp(my_sim: Any, my_simulation_parameters: SimulationParameters, m
 
     # size chp power to hot water storage size
     my_boiler.config.compute_default_cycle(
-        temperature_difference_in_kelvin=chp_controller_config.t_max_dhw_in_celsius - chp_controller_config.t_min_dhw_in_celsius)
-    chp_power = chp_power * (my_boiler.config.energy_full_cycle or 1) * 3.6e6 / chp_controller_config.min_operation_time_in_seconds or 1
+        temperature_difference_in_kelvin=chp_controller_config.t_max_dhw_in_celsius
+        - chp_controller_config.t_min_dhw_in_celsius
+    )
+    chp_power = (
+        chp_power
+        * (my_boiler.config.energy_full_cycle or 1)
+        * 3.6e6
+        / chp_controller_config.min_operation_time_in_seconds
+        or 1
+    )
 
     # configure and add chp
     chp_config = generic_chp.CHPConfig.get_default_config_chp(thermal_power=chp_power)
     chp_config.source_weight = count
-    my_chp = generic_chp.SimpleCHP(
-        my_simulation_parameters=my_simulation_parameters, config=chp_config
-    )
+    my_chp = generic_chp.SimpleCHP(my_simulation_parameters=my_simulation_parameters, config=chp_config)
 
     # add treshold electricity to chp controller and add it to simulation
     chp_controller_config.electricity_threshold = chp_config.p_el / 2
@@ -1170,10 +1182,11 @@ def configure_chp(my_sim: Any, my_simulation_parameters: SimulationParameters, m
 
     # connect thermal power output of CHP
     my_boiler.connect_only_predefined_connections(my_chp)
-    my_building.connect_input(input_fieldname=my_building.ThermalPowerCHP,
-                              src_object_name=my_chp.component_name,
-                              src_field_name=my_chp.ThermalPowerOutputBuilding,
-                              )
+    my_building.connect_input(
+        input_fieldname=my_building.ThermalPowerCHP,
+        src_object_name=my_chp.component_name,
+        src_field_name=my_chp.ThermalPowerOutputBuilding,
+    )
 
     my_electricity_controller.add_component_input_and_connect(
         source_object_name=my_chp.component_name,
@@ -1210,10 +1223,15 @@ def configure_chp(my_sim: Any, my_simulation_parameters: SimulationParameters, m
 
 
 def configure_chp_with_buffer(
-        my_sim: Any, my_simulation_parameters: SimulationParameters, my_buffer: generic_hot_water_storage_modular.HotWaterStorage,
-        my_boiler: generic_hot_water_storage_modular.HotWaterStorage,
-        my_electricity_controller: controller_l2_energy_management_system.L2GenericEnergyManagementSystem,
-        chp_power: float, controllable: bool, count: int, ) -> int:
+    my_sim: Any,
+    my_simulation_parameters: SimulationParameters,
+    my_buffer: generic_hot_water_storage_modular.HotWaterStorage,
+    my_boiler: generic_hot_water_storage_modular.HotWaterStorage,
+    my_electricity_controller: controller_l2_energy_management_system.L2GenericEnergyManagementSystem,
+    chp_power: float,
+    controllable: bool,
+    count: int,
+) -> int:
     """Sets up natural gas CHP. It heats the DHW storage and the buffer storage for heating.
 
     :param my_sim: Simulation class.
@@ -1242,24 +1260,34 @@ def configure_chp_with_buffer(
 
     # size chp power to hot water storage size
     my_boiler.config.compute_default_cycle(
-        temperature_difference_in_kelvin=chp_controller_config.t_max_dhw_in_celsius - chp_controller_config.t_min_dhw_in_celsius)
-    chp_power = chp_power * (my_boiler.config.energy_full_cycle or 1) * 3.6e6 / chp_controller_config.min_operation_time_in_seconds
+        temperature_difference_in_kelvin=chp_controller_config.t_max_dhw_in_celsius
+        - chp_controller_config.t_min_dhw_in_celsius
+    )
+    chp_power = (
+        chp_power
+        * (my_boiler.config.energy_full_cycle or 1)
+        * 3.6e6
+        / chp_controller_config.min_operation_time_in_seconds
+    )
 
     # configure and add chp
     chp_config = generic_chp.CHPConfig.get_default_config_chp(thermal_power=chp_power)
     chp_config.source_weight = count
     my_chp = generic_chp.SimpleCHP(
-        my_simulation_parameters=my_simulation_parameters, config=chp_config,
+        my_simulation_parameters=my_simulation_parameters,
+        config=chp_config,
     )
 
     # add chop controller and adopt electricity threshold
     chp_controller_config.electricity_threshold = chp_config.p_el / 2
     my_chp_controller = controller_l1_chp.L1CHPController(
-        my_simulation_parameters=my_simulation_parameters, config=chp_controller_config,
+        my_simulation_parameters=my_simulation_parameters,
+        config=chp_controller_config,
     )
     my_chp_controller.connect_only_predefined_connections(my_boiler)
     my_chp_controller.connect_input(
-        input_fieldname=my_chp_controller.BuildingTemperature, src_object_name=my_buffer.component_name,
+        input_fieldname=my_chp_controller.BuildingTemperature,
+        src_object_name=my_buffer.component_name,
         src_field_name=my_buffer.TemperatureMean,
     )
     my_sim.add_component(my_chp_controller)
@@ -1311,9 +1339,16 @@ def configure_chp_with_buffer(
 
 
 def configure_electrolyzer_and_h2_storage(
-        my_sim: Any, my_simulation_parameters: SimulationParameters, my_chp: generic_chp.SimpleCHP, my_chp_controller: controller_l1_chp.L1CHPController,
-        my_electricity_controller: controller_l2_energy_management_system.L2GenericEnergyManagementSystem, electrolyzer_power: float,
-        h2_storage_size: float, fuel_cell_power: float, count: int, ) -> int:
+    my_sim: Any,
+    my_simulation_parameters: SimulationParameters,
+    my_chp: generic_chp.SimpleCHP,
+    my_chp_controller: controller_l1_chp.L1CHPController,
+    my_electricity_controller: controller_l2_energy_management_system.L2GenericEnergyManagementSystem,
+    electrolyzer_power: float,
+    h2_storage_size: float,
+    fuel_cell_power: float,
+    count: int,
+) -> int:
     """Configures electrolyzer and h2 storage with fuel cell already defined.
 
     (in configure_elctrolysis_h2storage_fuelcell_system (_with_buffer))
@@ -1357,11 +1392,9 @@ def configure_electrolyzer_and_h2_storage(
     my_sim.add_component(my_electrolyzer)
 
     # run time controller of electrolyzer
-    my_electrolyzer_controller = (
-        controller_l1_electrolyzer.L1GenericElectrolyzerController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=electrolyzer_controller_config,
-        )
+    my_electrolyzer_controller = controller_l1_electrolyzer.L1GenericElectrolyzerController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=electrolyzer_controller_config,
     )
     my_sim.add_component(my_electrolyzer_controller)
     my_electrolyzer.connect_only_predefined_connections(my_electrolyzer_controller)
@@ -1416,9 +1449,17 @@ def configure_electrolyzer_and_h2_storage(
 
 
 def configure_elctrolysis_h2storage_fuelcell_system(
-        my_sim: Any, my_simulation_parameters: SimulationParameters, my_building: building.Building,
-        my_boiler: generic_hot_water_storage_modular.HotWaterStorage, my_electricity_controller: controller_l2_energy_management_system.L2GenericEnergyManagementSystem,
-        fuel_cell_power: float, h2_storage_size: float, electrolyzer_power: float, controllable: bool, count: int, ) -> int:
+    my_sim: Any,
+    my_simulation_parameters: SimulationParameters,
+    my_building: building.Building,
+    my_boiler: generic_hot_water_storage_modular.HotWaterStorage,
+    my_electricity_controller: controller_l2_energy_management_system.L2GenericEnergyManagementSystem,
+    fuel_cell_power: float,
+    h2_storage_size: float,
+    electrolyzer_power: float,
+    controllable: bool,
+    count: int,
+) -> int:
     """Sets electrolysis, H2-storage and chp system.
 
     :param my_sim: Simulation class.
@@ -1449,15 +1490,21 @@ def configure_elctrolysis_h2storage_fuelcell_system(
 
     # size chp power to hot water storage size
     my_boiler.config.compute_default_cycle(
-        temperature_difference_in_kelvin=chp_controller_config.t_max_dhw_in_celsius - chp_controller_config.t_min_dhw_in_celsius)
-    fuel_cell_power = fuel_cell_power * (my_boiler.config.energy_full_cycle or 1) * 3.6e6 / chp_controller_config.min_operation_time_in_seconds or 1
+        temperature_difference_in_kelvin=chp_controller_config.t_max_dhw_in_celsius
+        - chp_controller_config.t_min_dhw_in_celsius
+    )
+    fuel_cell_power = (
+        fuel_cell_power
+        * (my_boiler.config.energy_full_cycle or 1)
+        * 3.6e6
+        / chp_controller_config.min_operation_time_in_seconds
+        or 1
+    )
 
     # configure and add chp
     chp_config = generic_chp.CHPConfig.get_default_config_fuelcell(thermal_power=fuel_cell_power)
     chp_config.source_weight = count
-    my_chp = generic_chp.SimpleCHP(
-        my_simulation_parameters=my_simulation_parameters, config=chp_config
-    )
+    my_chp = generic_chp.SimpleCHP(my_simulation_parameters=my_simulation_parameters, config=chp_config)
 
     # add treshold electricity to chp controller and add it to simulation
     chp_controller_config.electricity_threshold = chp_config.p_el / 2
@@ -1487,7 +1534,6 @@ def configure_elctrolysis_h2storage_fuelcell_system(
         source_unit=lt.Units.WATT,
         source_tags=[lt.ComponentType.CHP, lt.InandOutputType.ELECTRICITY_PRODUCTION],
         source_weight=my_chp.config.source_weight,
-
     )
 
     # connect to EMS electricity controller
@@ -1513,17 +1559,32 @@ def configure_elctrolysis_h2storage_fuelcell_system(
     count += 1
 
     count = configure_electrolyzer_and_h2_storage(
-        my_sim=my_sim, my_simulation_parameters=my_simulation_parameters, my_chp=my_chp, my_chp_controller=my_chp_controller,
-        my_electricity_controller=my_electricity_controller, electrolyzer_power=electrolyzer_power, h2_storage_size=h2_storage_size,
-        fuel_cell_power=fuel_cell_power, count=count)
+        my_sim=my_sim,
+        my_simulation_parameters=my_simulation_parameters,
+        my_chp=my_chp,
+        my_chp_controller=my_chp_controller,
+        my_electricity_controller=my_electricity_controller,
+        electrolyzer_power=electrolyzer_power,
+        h2_storage_size=h2_storage_size,
+        fuel_cell_power=fuel_cell_power,
+        count=count,
+    )
 
     return count
 
 
 def configure_elctrolysis_h2storage_fuelcell_system_with_buffer(
-        my_sim: Any, my_simulation_parameters: SimulationParameters, my_buffer: generic_hot_water_storage_modular.HotWaterStorage,
-        my_boiler: generic_hot_water_storage_modular.HotWaterStorage, my_electricity_controller: controller_l2_energy_management_system.L2GenericEnergyManagementSystem,
-        fuel_cell_power: float, h2_storage_size: float, electrolyzer_power: float, controllable: bool, count: int, ) -> int:
+    my_sim: Any,
+    my_simulation_parameters: SimulationParameters,
+    my_buffer: generic_hot_water_storage_modular.HotWaterStorage,
+    my_boiler: generic_hot_water_storage_modular.HotWaterStorage,
+    my_electricity_controller: controller_l2_energy_management_system.L2GenericEnergyManagementSystem,
+    fuel_cell_power: float,
+    h2_storage_size: float,
+    electrolyzer_power: float,
+    controllable: bool,
+    count: int,
+) -> int:
     """Sets electrolysis, H2-storage and chp system.
 
     :param my_sim: Simulation class.
@@ -1554,15 +1615,21 @@ def configure_elctrolysis_h2storage_fuelcell_system_with_buffer(
 
     # size chp power to hot water storage size
     my_boiler.config.compute_default_cycle(
-        temperature_difference_in_kelvin=chp_controller_config.t_max_dhw_in_celsius - chp_controller_config.t_min_dhw_in_celsius)
-    fuel_cell_power = fuel_cell_power * (my_boiler.config.energy_full_cycle or 1) * 3.6e6 / chp_controller_config.min_operation_time_in_seconds or 1
+        temperature_difference_in_kelvin=chp_controller_config.t_max_dhw_in_celsius
+        - chp_controller_config.t_min_dhw_in_celsius
+    )
+    fuel_cell_power = (
+        fuel_cell_power
+        * (my_boiler.config.energy_full_cycle or 1)
+        * 3.6e6
+        / chp_controller_config.min_operation_time_in_seconds
+        or 1
+    )
 
     # configure and add chp
     chp_config = generic_chp.CHPConfig.get_default_config_fuelcell(thermal_power=fuel_cell_power)
     chp_config.source_weight = count
-    my_chp = generic_chp.SimpleCHP(
-        my_simulation_parameters=my_simulation_parameters, config=chp_config
-    )
+    my_chp = generic_chp.SimpleCHP(my_simulation_parameters=my_simulation_parameters, config=chp_config)
 
     # add treshold electricity to chp controller and add it to simulation
     chp_controller_config.electricity_threshold = chp_config.p_el / 2
@@ -1571,7 +1638,9 @@ def configure_elctrolysis_h2storage_fuelcell_system_with_buffer(
     )
     my_chp_controller.connect_only_predefined_connections(my_boiler)
     my_chp_controller.connect_input(
-        input_fieldname=my_chp_controller.BuildingTemperature, src_object_name=my_buffer.component_name, src_field_name=my_buffer.TemperatureMean,
+        input_fieldname=my_chp_controller.BuildingTemperature,
+        src_object_name=my_buffer.component_name,
+        src_field_name=my_buffer.TemperatureMean,
     )
     my_sim.add_component(my_chp_controller)
 
@@ -1581,10 +1650,11 @@ def configure_elctrolysis_h2storage_fuelcell_system_with_buffer(
 
     # connect thermal power output of CHP
     my_boiler.connect_only_predefined_connections(my_chp)
-    my_buffer.connect_input(input_fieldname=my_buffer.ThermalPowerCHP,
-                            src_object_name=my_chp.component_name,
-                            src_field_name=my_chp.ThermalPowerOutputBuilding,
-                            )
+    my_buffer.connect_input(
+        input_fieldname=my_buffer.ThermalPowerCHP,
+        src_object_name=my_chp.component_name,
+        src_field_name=my_chp.ThermalPowerOutputBuilding,
+    )
 
     my_electricity_controller.add_component_input_and_connect(
         source_object_name=my_chp.component_name,
@@ -1593,7 +1663,6 @@ def configure_elctrolysis_h2storage_fuelcell_system_with_buffer(
         source_unit=lt.Units.WATT,
         source_tags=[lt.ComponentType.CHP, lt.InandOutputType.ELECTRICITY_PRODUCTION],
         source_weight=my_chp.config.source_weight,
-
     )
 
     # connect to EMS electricity controller
@@ -1619,8 +1688,15 @@ def configure_elctrolysis_h2storage_fuelcell_system_with_buffer(
     count += 1
 
     count = configure_electrolyzer_and_h2_storage(
-        my_sim=my_sim, my_simulation_parameters=my_simulation_parameters, my_chp=my_chp, my_chp_controller=my_chp_controller,
-        my_electricity_controller=my_electricity_controller, electrolyzer_power=electrolyzer_power, h2_storage_size=h2_storage_size,
-        fuel_cell_power=fuel_cell_power, count=count)
+        my_sim=my_sim,
+        my_simulation_parameters=my_simulation_parameters,
+        my_chp=my_chp,
+        my_chp_controller=my_chp_controller,
+        my_electricity_controller=my_electricity_controller,
+        electrolyzer_power=electrolyzer_power,
+        h2_storage_size=h2_storage_size,
+        fuel_cell_power=fuel_cell_power,
+        count=count,
+    )
 
     return count

--- a/hisim/modular_household/interface_configs/archetype_config.py
+++ b/hisim/modular_household/interface_configs/archetype_config.py
@@ -45,7 +45,8 @@ class ArcheTypeConfig:
     #     )
     #: average daily commuting distance in kilometers, passed as input to the LoadProfileGenerator and considered to model consumption of cars
     mobility_distance: Optional[JsonReference] = field(
-        default_factory=lambda: TravelRouteSets.Travel_Route_Set_for_15km_Commuting_Distance)  # type: ignore
+        default_factory=lambda: TravelRouteSets.Travel_Route_Set_for_15km_Commuting_Distance
+    )  # type: ignore
     #: url of the UTSP (this is not needed for the config anymore. it is integrated in the tusp_connector build() function automatically)
     url: str = get_environment_variable("UTSP_URL")
     #: passwort to connect to the UTSP

--- a/hisim/modular_household/interface_configs/modular_household_config.py
+++ b/hisim/modular_household/interface_configs/modular_household_config.py
@@ -14,7 +14,7 @@ from hisim.system_setup_configuration import SystemSetupConfigBase
 @dataclass
 class ModularHouseholdOptions:
 
-    """ Set options for the system setup."""
+    """Set options for the system setup."""
 
     pass
 
@@ -34,9 +34,7 @@ class ModularHouseholdConfig(SystemSetupConfigBase):
         """Get default ModularHouseholdConfig."""
         system_config_ = system_config.SystemConfig()
         archetype_config_ = archetype_config.ArcheTypeConfig()
-        household_config = ModularHouseholdConfig(
-            system_config_=system_config_, archetype_config_=archetype_config_
-        )
+        household_config = ModularHouseholdConfig(system_config_=system_config_, archetype_config_=archetype_config_)
         return household_config
 
 
@@ -52,15 +50,14 @@ def read_in_configs(pathname: str) -> ModularHouseholdConfig:
         with open(pathname, encoding="utf8") as config_file:
             household_config_dict = json.load(config_file)  # type: ignore
             household_config: ModularHouseholdConfig = ModularHouseholdConfig.from_dict(
-                household_config_dict.get("system_setup_config"))  # type: ignore
+                household_config_dict.get("system_setup_config")
+            )  # type: ignore
         log.information(f"Read modular household config from {pathname}")
         if (household_config.system_config_ is None) and (household_config.archetype_config_ is None):
             raise ValueError()
     except Exception:
         household_config = ModularHouseholdConfig()
-        log.warning(
-            f"Could not read the modular household config from '{pathname}'. Using a default config instead."
-        )
+        log.warning(f"Could not read the modular household config from '{pathname}'. Using a default config instead.")
 
     # set default configs
     if household_config.system_config_ is None:

--- a/hisim/postprocessing/chart_singleday.py
+++ b/hisim/postprocessing/chart_singleday.py
@@ -68,9 +68,7 @@ class ChartSingleDay(Chart, ChartFontsAndSize):
 
     def get_day_data(self):
         """Extracts data for a single day."""
-        firstindex = (
-            (self.month * 30 + self.day) * 24 * int(1 / self.time_correction_factor)
-        )
+        firstindex = (self.month * 30 + self.day) * 24 * int(1 / self.time_correction_factor)
         lastindex = firstindex + 24 * int(1 / self.time_correction_factor)
         day_number = self.day + 1
         if day_number == 1:
@@ -114,9 +112,7 @@ class ChartSingleDay(Chart, ChartFontsAndSize):
         #  twin object for two different y-axis on the sample plot
         my_double.ax2 = my_double.axis.twinx()
         #  make a plot with different y-axis using second axis object
-        my_double.line2 = my_double.ax2.plot(
-            self.data.index, other.data, label=other.property, linewidth=5
-        )
+        my_double.line2 = my_double.ax2.plot(self.data.index, other.data, label=other.property, linewidth=5)
         return my_double
 
     def close(self):
@@ -136,9 +132,7 @@ class ChartSingleDay(Chart, ChartFontsAndSize):
         plt.xticks(fontsize=self.fontsize_ticks)
         plt.yticks(fontsize=self.fontsize_ticks)
 
-        single_day_data, self.units = self.rescale_y_axis(
-            y_values=single_day_data, units=self.units
-        )
+        single_day_data, self.units = self.rescale_y_axis(y_values=single_day_data, units=self.units)
         plt.title(self.title, fontsize=self.fontsize_title)
         plt.plot(
             single_day_data.index,

--- a/hisim/postprocessing/chartbase.py
+++ b/hisim/postprocessing/chartbase.py
@@ -69,9 +69,7 @@ class Chart:  # noqa: too-few-public-methods
         self.time_correction_factor = time_correction_factor
 
         self.title: str = ""
-        matches = re.finditer(
-            ".+?(?:(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|$|#)", self.output
-        )
+        matches = re.finditer(".+?(?:(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|$|#)", self.output)
         matches = [m.group(0) for m in matches]  # type: ignore
 
         pass_sign = False
@@ -96,15 +94,15 @@ class Chart:  # noqa: too-few-public-methods
         self.title.strip()
         self.directory_path = directory_path
         self.output_type = self.output.split(" # ", 2)[1]
-        self.component_output_folder_path = os.path.join(
-            self.directory_path, self.component_name, self.output_type
-        )
+        self.component_output_folder_path = os.path.join(self.directory_path, self.component_name, self.output_type)
         os.makedirs(self.component_output_folder_path, exist_ok=True)
         self.object_name = " "
         self.property = chart_property
         if output2 is not None:
             self.output2 = output2
-            self.filename = f"{self.type.lower()}_{self.component_name}_{self.output_type}_double{self.figure_format.value}"
+            self.filename = (
+                f"{self.type.lower()}_{self.component_name}_{self.output_type}_double{self.figure_format.value}"
+            )
         else:
             self.filename = f"{self.type.lower()}_{self.component_name}_{self.output_type}{self.figure_format.value}"
         self.filepath = os.path.join(self.directory_path, self.filename)

--- a/hisim/postprocessing/charts.py
+++ b/hisim/postprocessing/charts.py
@@ -117,9 +117,7 @@ class Line(Chart, ChartFontsAndSize):  # noqa: too-few-public-methods
     ):
         """Initializes a line chart."""
         if output_description is None:
-            raise ValueError(
-                "Output description was None for component " + component_name
-            )
+            raise ValueError("Output description was None for component " + component_name)
 
         super().__init__(
             output=output,

--- a/hisim/postprocessing/compute_kpis.py
+++ b/hisim/postprocessing/compute_kpis.py
@@ -58,16 +58,10 @@ def building_temperature_control_and_heating_load(
     specific_heating_load_in_watt_per_m2 = heating_load_in_watt / scaled_conditioned_floor_area_in_m2
 
     for column in results.columns:
-
         if "TemperatureIndoorAir" in column.split(sep=" "):
-
             for temperature in results[column].values:
-
                 if temperature < set_heating_temperature_in_celsius:
-
-                    temperature_difference_heating = (
-                        set_heating_temperature_in_celsius - temperature
-                    )
+                    temperature_difference_heating = set_heating_temperature_in_celsius - temperature
 
                     temperature_difference_of_building_being_below_heating_set_temperature = (
                         temperature_difference_of_building_being_below_heating_set_temperature
@@ -75,25 +69,18 @@ def building_temperature_control_and_heating_load(
                     )
 
                 elif temperature > set_cooling_temperature_in_celsius:
-
-                    temperature_difference_cooling = (
-                        temperature - set_cooling_temperature_in_celsius
-                    )
+                    temperature_difference_cooling = temperature - set_cooling_temperature_in_celsius
                     temperature_difference_of_building_being_below_cooling_set_temperature = (
                         temperature_difference_of_building_being_below_cooling_set_temperature
                         + temperature_difference_cooling
                     )
 
             temperature_hours_of_building_being_below_heating_set_temperature = (
-                temperature_difference_of_building_being_below_heating_set_temperature
-                * seconds_per_timestep
-                / 3600
+                temperature_difference_of_building_being_below_heating_set_temperature * seconds_per_timestep / 3600
             )
 
             temperature_hours_of_building_being_above_cooling_set_temperature = (
-                temperature_difference_of_building_being_below_cooling_set_temperature
-                * seconds_per_timestep
-                / 3600
+                temperature_difference_of_building_being_below_cooling_set_temperature * seconds_per_timestep / 3600
             )
 
             # get also max and min indoor air temperature
@@ -109,22 +96,20 @@ def building_temperature_control_and_heating_load(
         min_temperature_reached_in_celsius,
         max_temperature_reached_in_celsius,
         heating_load_in_watt,
-        specific_heating_load_in_watt_per_m2
+        specific_heating_load_in_watt_per_m2,
     )
 
 
-def get_heatpump_cycles(results: pd.DataFrame,) -> float:
+def get_heatpump_cycles(
+    results: pd.DataFrame,
+) -> float:
     """Get the number of cycles of the heat pump for the simulated period."""
     number_of_cycles = 0
     for column in results.columns:
-
         if "TimeOff" in column.split(sep=" "):
-
             for index, off_time in enumerate(results[column].values):
-
                 try:
                     if off_time != 0 and results[column].values[index + 1] == 0:
-
                         number_of_cycles = number_of_cycles + 1
 
                 except Exception:
@@ -133,9 +118,7 @@ def get_heatpump_cycles(results: pd.DataFrame,) -> float:
     return number_of_cycles
 
 
-def get_heat_pump_seasonal_performance_factor(
-    results: pd.DataFrame, seconds_per_timestep: int
-) -> float:
+def get_heat_pump_seasonal_performance_factor(results: pd.DataFrame, seconds_per_timestep: int) -> float:
     """Get SPF from heat pump over simulated period.
 
     Transform thermal and electrical power from heat pump in energies.
@@ -143,21 +126,14 @@ def get_heat_pump_seasonal_performance_factor(
     thermal_output_energy_in_watt_hour = 0.0
     electrical_energy_in_watt_hour = 1.0
     for column in results.columns:
-
         if "ThermalOutputPower" in column.split(sep=" "):
             # take only output values for heating
-            thermal_output_power_values_in_watt = [
-                value for value in results[column].values if value > 0.0
-            ]
+            thermal_output_power_values_in_watt = [value for value in results[column].values if value > 0.0]
             # get energy from power
-            thermal_output_energy_in_watt_hour = (
-                sum(thermal_output_power_values_in_watt) * seconds_per_timestep / 3600
-            )
+            thermal_output_energy_in_watt_hour = sum(thermal_output_power_values_in_watt) * seconds_per_timestep / 3600
         if "ElectricalInputPower" in column.split(sep=" "):
             # get electrical energie values
-            electrical_energy_in_watt_hour = (
-                sum(results[column].values) * seconds_per_timestep / 3600
-            )
+            electrical_energy_in_watt_hour = sum(results[column].values) * seconds_per_timestep / 3600
 
     # calculate SPF
     spf = thermal_output_energy_in_watt_hour / electrical_energy_in_watt_hour
@@ -176,9 +152,7 @@ def get_heat_pump_kpis(
             # get number of heat pump cycles over simulated period
             number_of_cycles = get_heatpump_cycles(results=results)
             # get SPF
-            spf = get_heat_pump_seasonal_performance_factor(
-                results=results, seconds_per_timestep=seconds_per_timestep
-            )
+            spf = get_heat_pump_seasonal_performance_factor(results=results, seconds_per_timestep=seconds_per_timestep)
         # heat pump was not used
         else:
             pass
@@ -193,13 +167,8 @@ def get_electricity_to_and_from_grid_from_electricty_meter(
     # go through all wrapped components and try to find electricity meter
     for wrapped_component in wrapped_components:
         if "ElectricityMeter" in wrapped_component.my_component.component_name:
-
-            total_energy_from_grid_in_kwh = (
-                wrapped_component.my_component.config.total_energy_from_grid_in_kwh
-            )
-            total_energy_to_grid_in_kwh = (
-                wrapped_component.my_component.config.total_energy_to_grid_in_kwh
-            )
+            total_energy_from_grid_in_kwh = wrapped_component.my_component.config.total_energy_from_grid_in_kwh
+            total_energy_to_grid_in_kwh = wrapped_component.my_component.config.total_energy_to_grid_in_kwh
 
             break
 
@@ -214,17 +183,13 @@ def read_in_fuel_costs() -> pd.DataFrame:
     return price_frame
 
 
-def get_euro_and_co2(
-    fuel_costs: pd.DataFrame, fuel: Union[LoadTypes, InandOutputType]
-) -> Tuple[float, float]:
+def get_euro_and_co2(fuel_costs: pd.DataFrame, fuel: Union[LoadTypes, InandOutputType]) -> Tuple[float, float]:
     """Returns cost (Euro) of kWh of fuel and CO2 consumption (kg) of kWh of fuel."""
     column = fuel_costs.iloc[fuel_costs.index == fuel.value]
     return (float(column["Cost"].iloc[0]), float(column["Footprint"].iloc[0]))
 
 
-def compute_consumption_production(
-    all_outputs: List, results: pd.DataFrame
-) -> pd.DataFrame:
+def compute_consumption_production(all_outputs: List, results: pd.DataFrame) -> pd.DataFrame:
     """Computes electricity consumption and production based on results of hisim simulation.
 
     Also evaluates battery charge and discharge, because it is relevant for self consumption rates.
@@ -248,10 +213,8 @@ def compute_consumption_production(
                 production_ids.append(index)
 
             elif (
-                InandOutputType.ELECTRICITY_CONSUMPTION_EMS_CONTROLLED
-                in output.postprocessing_flag
-                or InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED
-                in output.postprocessing_flag
+                InandOutputType.ELECTRICITY_CONSUMPTION_EMS_CONTROLLED in output.postprocessing_flag
+                or InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED in output.postprocessing_flag
             ):
                 consumption_ids.append(index)
 
@@ -264,21 +227,15 @@ def compute_consumption_production(
             continue
 
     postprocessing_results = pd.DataFrame()
-    postprocessing_results["consumption"] = (
-        pd.DataFrame(results.iloc[:, consumption_ids]).clip(lower=0).sum(axis=1)
-    )
-    postprocessing_results["production"] = (
-        pd.DataFrame(results.iloc[:, production_ids]).clip(lower=0).sum(axis=1)
-    )
+    postprocessing_results["consumption"] = pd.DataFrame(results.iloc[:, consumption_ids]).clip(lower=0).sum(axis=1)
+    postprocessing_results["production"] = pd.DataFrame(results.iloc[:, production_ids]).clip(lower=0).sum(axis=1)
 
     postprocessing_results["battery_charge"] = (
-        pd.DataFrame(results.iloc[:, battery_charge_discharge_ids])
-        .clip(lower=0)
-        .sum(axis=1)
+        pd.DataFrame(results.iloc[:, battery_charge_discharge_ids]).clip(lower=0).sum(axis=1)
     )
-    postprocessing_results["battery_discharge"] = pd.DataFrame(
-        results.iloc[:, battery_charge_discharge_ids]
-    ).clip(upper=0).sum(axis=1) * (-1)
+    postprocessing_results["battery_discharge"] = pd.DataFrame(results.iloc[:, battery_charge_discharge_ids]).clip(
+        upper=0
+    ).sum(axis=1) * (-1)
 
     return postprocessing_results
 
@@ -288,13 +245,8 @@ def compute_self_consumption_and_injection(
 ) -> Tuple[pd.Series, pd.Series]:
     """Computes the self consumption and the grid injection."""
     # account for battery
-    production_with_battery = (
-        postprocessing_results["production"]
-        + postprocessing_results["battery_discharge"]
-    )
-    consumption_with_battery = (
-        postprocessing_results["consumption"] + postprocessing_results["battery_charge"]
-    )
+    production_with_battery = postprocessing_results["production"] + postprocessing_results["battery_discharge"]
+    consumption_with_battery = postprocessing_results["consumption"] + postprocessing_results["battery_charge"]
 
     # evaluate injection and sum over time
     injection = production_with_battery - consumption_with_battery
@@ -306,12 +258,8 @@ def compute_self_consumption_and_injection(
     self_consumption = (
         pd.concat(
             (
-                production_with_battery[
-                    production_with_battery <= postprocessing_results["consumption"]
-                ],
-                postprocessing_results["consumption"][
-                    postprocessing_results["consumption"] < production_with_battery
-                ],
+                production_with_battery[production_with_battery <= postprocessing_results["consumption"]],
+                postprocessing_results["consumption"][postprocessing_results["consumption"] < production_with_battery],
             )
         )
         .groupby(level=0)
@@ -325,32 +273,21 @@ def search_electricity_prices_in_results(
     all_outputs: List, results: pd.DataFrame
 ) -> Tuple["pd.Series[float]", "pd.Series[float]"]:
     """Extracts electricity price consumption and electricity price production from results."""
-    electricity_price_consumption = pd.Series(
-        dtype=pd.Float64Dtype()
-    )  # type: pd.Series[float]
-    electricity_price_injection = pd.Series(
-        dtype=pd.Float64Dtype()
-    )  # type: pd.Series[float]
+    electricity_price_consumption = pd.Series(dtype=pd.Float64Dtype())  # type: pd.Series[float]
+    electricity_price_injection = pd.Series(dtype=pd.Float64Dtype())  # type: pd.Series[float]
     for index, output in enumerate(all_outputs):
         if output.postprocessing_flag is not None:
             if LoadTypes.PRICE in output.postprocessing_flag:
-                if (
-                    InandOutputType.ELECTRICITY_CONSUMPTION
-                    in output.postprocessing_flag
-                ):
+                if InandOutputType.ELECTRICITY_CONSUMPTION in output.postprocessing_flag:
                     electricity_price_consumption = results.iloc[:, index]
-                elif (
-                    InandOutputType.ELECTRICITY_INJECTION in output.postprocessing_flag
-                ):
+                elif InandOutputType.ELECTRICITY_INJECTION in output.postprocessing_flag:
                     electricity_price_injection = results.iloc[:, index]
                 else:
                     continue
     return electricity_price_consumption, electricity_price_injection
 
 
-def compute_energy_from_power(
-    power_timeseries: pd.Series, timeresolution: int
-) -> float:
+def compute_energy_from_power(power_timeseries: pd.Series, timeresolution: int) -> float:
     """Computes the energy from a power value."""
     if power_timeseries.empty:
         return 0.0
@@ -417,9 +354,7 @@ def compute_kpis(
     price_frame = read_in_fuel_costs()
 
     # compute consumption and production and extract price signals
-    postprocessing_results = compute_consumption_production(
-        all_outputs=all_outputs, results=results
-    )
+    postprocessing_results = compute_consumption_production(all_outputs=all_outputs, results=results)
     (
         electricity_price_consumption,
         electricity_price_injection,
@@ -476,21 +411,17 @@ def compute_kpis(
     electricity_price_constant, co2_price_constant = get_euro_and_co2(
         fuel_costs=price_frame, fuel=LoadTypes.ELECTRICITY
     )
-    electricity_inj_price_constant, _ = get_euro_and_co2(
-        fuel_costs=price_frame, fuel=LoadTypes.ELECTRICITY
-    )
+    electricity_inj_price_constant, _ = get_euro_and_co2(fuel_costs=price_frame, fuel=LoadTypes.ELECTRICITY)
 
     if production_sum > 0:
         # evaluate electricity price
         if not electricity_price_injection.empty:
             price = price - compute_energy_from_power(
-                power_timeseries=injection[injection > 0]
-                * electricity_price_injection[injection > 0],
+                power_timeseries=injection[injection > 0] * electricity_price_injection[injection > 0],
                 timeresolution=simulation_parameters.seconds_per_timestep,
             )
             price = price + compute_energy_from_power(
-                power_timeseries=postprocessing_results["consumption"]
-                - self_consumption,
+                power_timeseries=postprocessing_results["consumption"] - self_consumption,
                 timeresolution=simulation_parameters.seconds_per_timestep,
             )  # Todo: is this correct? (maybe not so important, only used if generic_price_signal is used
         else:
@@ -504,8 +435,7 @@ def compute_kpis(
         if not electricity_price_consumption.empty:
             # substract self consumption from consumption for bill calculation
             price = price + compute_energy_from_power(
-                power_timeseries=postprocessing_results["consumption"]
-                * electricity_price_consumption,
+                power_timeseries=postprocessing_results["consumption"] * electricity_price_consumption,
                 timeresolution=simulation_parameters.seconds_per_timestep,
             )
         else:
@@ -534,35 +464,23 @@ def compute_kpis(
     investment_cost, co2_footprint = compute_investment_cost(components=components)
 
     # get CAPEX and OPEX costs for simulated period
-    capex_results_path = os.path.join(
-        simulation_parameters.result_directory, "investment_cost_co2_footprint.csv"
-    )
-    opex_results_path = os.path.join(
-        simulation_parameters.result_directory, "operational_costs_co2_footprint.csv"
-    )
+    capex_results_path = os.path.join(simulation_parameters.result_directory, "investment_cost_co2_footprint.csv")
+    opex_results_path = os.path.join(simulation_parameters.result_directory, "operational_costs_co2_footprint.csv")
     if Path(opex_results_path).exists():
         opex_df = pd.read_csv(opex_results_path, index_col=0)
         total_operational_cost = opex_df["Operational Costs in EUR"].iloc[-1]
         total_operational_emisions = opex_df["Operational C02 footprint in kg"].iloc[-1]
     else:
-        log.warning(
-            "OPEX-costs for components are not calculated yet. Set PostProcessingOptions.COMPUTE_OPEX"
-        )
+        log.warning("OPEX-costs for components are not calculated yet. Set PostProcessingOptions.COMPUTE_OPEX")
         total_operational_cost = 0
         total_operational_emisions = 0
 
     if Path(capex_results_path).exists():
         capex_df = pd.read_csv(capex_results_path, index_col=0)
-        total_investment_cost_per_simulated_period = capex_df["Investment in EUR"].iloc[
-            -1
-        ]
-        total_device_co2_footprint_per_simulated_period = capex_df[
-            "Device CO2-footprint in kg"
-        ].iloc[-1]
+        total_investment_cost_per_simulated_period = capex_df["Investment in EUR"].iloc[-1]
+        total_device_co2_footprint_per_simulated_period = capex_df["Device CO2-footprint in kg"].iloc[-1]
     else:
-        log.warning(
-            "CAPEX-costs for components are not calculated yet. Set PostProcessingOptions.COMPUTE_CAPEX"
-        )
+        log.warning("CAPEX-costs for components are not calculated yet. Set PostProcessingOptions.COMPUTE_CAPEX")
         total_investment_cost_per_simulated_period = 0
         total_device_co2_footprint_per_simulated_period = 0
 
@@ -575,7 +493,7 @@ def compute_kpis(
         min_temperature_reached_in_celsius,
         max_temperature_reached_in_celsius,
         heating_load_in_watt,
-        specific_heating_load_in_watt_per_m2
+        specific_heating_load_in_watt_per_m2,
     ) = building_temperature_control_and_heating_load(
         results=results,
         seconds_per_timestep=simulation_parameters.seconds_per_timestep,
@@ -593,9 +511,7 @@ def compute_kpis(
     (
         total_energy_to_grid_in_kwh,
         total_energy_from_grid_in_kwh,
-    ) = get_electricity_to_and_from_grid_from_electricty_meter(
-        wrapped_components=components
-    )
+    ) = get_electricity_to_and_from_grid_from_electricty_meter(wrapped_components=components)
 
     # initialize table for report
     table: List = []
@@ -694,12 +610,8 @@ def compute_kpis(
             "°C",
         ]
     )
-    table.append(
-        ["Building heating load:", f"{(heating_load_in_watt):3.0f}", "W"]
-    )
-    table.append(
-        ["Specific heating load:", f"{(specific_heating_load_in_watt_per_m2):3.0f}", "W"]
-    )
+    table.append(["Building heating load:", f"{(heating_load_in_watt):3.0f}", "W"])
+    table.append(["Specific heating load:", f"{(specific_heating_load_in_watt_per_m2):3.0f}", "W"])
 
     table.append(["Number of heat pump cycles:", f"{number_of_cycles:3.0f}", "-"])
     table.append(["Seasonal performance factor of heat pump:", f"{spf:3.0f}", "-"])

--- a/hisim/postprocessing/generate_csv_for_housing_database.py
+++ b/hisim/postprocessing/generate_csv_for_housing_database.py
@@ -16,9 +16,7 @@ from hisim.simulationparameters import SimulationParameters
 from obsolete.loadprofilegenerator_connector import OccupancyConfig
 
 
-def compute_energy_from_power(
-    power_timeseries: pd.Series, seconds_per_timestep: int
-) -> float:
+def compute_energy_from_power(power_timeseries: pd.Series, seconds_per_timestep: int) -> float:
     """Computes energy from power value."""
     if power_timeseries.empty:
         return 0.0
@@ -41,9 +39,7 @@ def get_factor_cooking(occupancy_config: OccupancyConfig) -> float:
     else:
         scaling_factor_line = scaling_factors.loc["EU"]
         log.warning(
-            "Scaling Factor for "
-            + occupancy_config.country_name
-            + "is not available, EU average is used per default."
+            "Scaling Factor for " + occupancy_config.country_name + "is not available, EU average is used per default."
         )
     return float(scaling_factor_line["ratio cooking to total"])
 
@@ -78,10 +74,7 @@ def compute_seasonal(
         output_night[
             (
                 (output_night.index > dt.datetime(year=2019, month=6, day=21, hour=12))
-                & (
-                    output_night.index
-                    < dt.datetime(year=2019, month=9, day=23, hour=12)
-                )
+                & (output_night.index < dt.datetime(year=2019, month=9, day=23, hour=12))
             )
         ].sum()
         * factor
@@ -99,10 +92,7 @@ def compute_seasonal(
         output_night[
             (
                 (output_night.index > dt.datetime(year=2019, month=12, day=21, hour=12))
-                | (
-                    output_night.index
-                    < dt.datetime(year=2019, month=3, day=23, hour=12)
-                )
+                | (output_night.index < dt.datetime(year=2019, month=3, day=23, hour=12))
             )
         ].sum()
         * factor
@@ -124,17 +114,11 @@ def compute_seasonal(
         output_night[
             (
                 (output_night.index > dt.datetime(year=2019, month=3, day=23, hour=12))
-                & (
-                    output_night.index
-                    < dt.datetime(year=2019, month=6, day=21, hour=12)
-                )
+                & (output_night.index < dt.datetime(year=2019, month=6, day=21, hour=12))
             )
             | (
                 (output_night.index > dt.datetime(year=2019, month=9, day=23, hour=12))
-                & (
-                    output_night.index
-                    < dt.datetime(year=2019, month=12, day=21, hour=12)
-                )
+                & (output_night.index < dt.datetime(year=2019, month=12, day=21, hour=12))
             )
         ].sum()
         * factor
@@ -242,9 +226,7 @@ def generate_csv_for_database(
         if output.postprocessing_flag is not None:
             if InandOutputType.WATER_HEATING in output.postprocessing_flag:
                 if LoadTypes.DISTRICTHEATING in output.postprocessing_flag:
-                    csv_frame_annual[("WaterHeating", "Distributed Stream [kWh]")] = (
-                        sum(results.iloc[:, index]) * 1e-3
-                    )
+                    csv_frame_annual[("WaterHeating", "Distributed Stream [kWh]")] = sum(results.iloc[:, index]) * 1e-3
                     csv_frame_seasonal = compute_seasonal(
                         csv_frame_seasonal=csv_frame_seasonal,
                         index_in_seasonal_frame=(
@@ -257,9 +239,7 @@ def generate_csv_for_database(
                         night=night,
                     )
                 elif LoadTypes.GAS in output.postprocessing_flag:
-                    csv_frame_annual[("WaterHeating", "Gas [kWh]")] = (
-                        sum(results.iloc[:, index]) * 1e-3
-                    )
+                    csv_frame_annual[("WaterHeating", "Gas [kWh]")] = sum(results.iloc[:, index]) * 1e-3
                     csv_frame_seasonal = compute_seasonal(
                         csv_frame_seasonal=csv_frame_seasonal,
                         index_in_seasonal_frame=("WaterHeating", "Gas [kWh]"),
@@ -269,9 +249,7 @@ def generate_csv_for_database(
                         night=night,
                     )
                 elif LoadTypes.OIL in output.postprocessing_flag:
-                    csv_frame_annual[("WaterHeating", "Oil [l]")] = sum(
-                        results.iloc[:, index]
-                    )
+                    csv_frame_annual[("WaterHeating", "Oil [l]")] = sum(results.iloc[:, index])
                     csv_frame_seasonal = compute_seasonal(
                         csv_frame_seasonal=csv_frame_seasonal,
                         index_in_seasonal_frame=("WaterHeating", "Oil [l]"),
@@ -282,9 +260,7 @@ def generate_csv_for_database(
                     )
                 else:
                     if HeatingSystems.HEAT_PUMP in output.postprocessing_flag:
-                        csv_frame_annual[
-                            ("WaterHeating", "Electricity - HeatPump [kWh]")
-                        ] = compute_energy_from_power(
+                        csv_frame_annual[("WaterHeating", "Electricity - HeatPump [kWh]")] = compute_energy_from_power(
                             power_timeseries=results.iloc[:, index],
                             seconds_per_timestep=simulation_parameters.seconds_per_timestep,
                         )
@@ -300,9 +276,7 @@ def generate_csv_for_database(
                             night=night,
                         )
                     elif HeatingSystems.ELECTRIC_HEATING in output.postprocessing_flag:
-                        csv_frame_annual[
-                            ("WaterHeating", "Electricity [kWh]")
-                        ] = compute_energy_from_power(
+                        csv_frame_annual[("WaterHeating", "Electricity [kWh]")] = compute_energy_from_power(
                             power_timeseries=results.iloc[:, index],
                             seconds_per_timestep=simulation_parameters.seconds_per_timestep,
                         )
@@ -319,9 +293,7 @@ def generate_csv_for_database(
                         )
             elif InandOutputType.HEATING in output.postprocessing_flag:
                 if LoadTypes.DISTRICTHEATING in output.postprocessing_flag:
-                    csv_frame_annual[("SpaceHeating", "Distributed Stream [kWh]")] = (
-                        sum(results.iloc[:, index]) * 1e-3
-                    )
+                    csv_frame_annual[("SpaceHeating", "Distributed Stream [kWh]")] = sum(results.iloc[:, index]) * 1e-3
                     csv_frame_seasonal = compute_seasonal(
                         csv_frame_seasonal=csv_frame_seasonal,
                         index_in_seasonal_frame=(
@@ -334,9 +306,7 @@ def generate_csv_for_database(
                         night=night,
                     )
                 elif LoadTypes.GAS in output.postprocessing_flag:
-                    csv_frame_annual[("SpaceHeating", "Gas [kWh]")] = (
-                        sum(results.iloc[:, index]) * 1e-3
-                    )
+                    csv_frame_annual[("SpaceHeating", "Gas [kWh]")] = sum(results.iloc[:, index]) * 1e-3
                     csv_frame_seasonal = compute_seasonal(
                         csv_frame_seasonal=csv_frame_seasonal,
                         index_in_seasonal_frame=("SpaceHeating", "Gas [kWh]"),
@@ -346,9 +316,7 @@ def generate_csv_for_database(
                         night=night,
                     )
                 elif LoadTypes.OIL in output.postprocessing_flag:
-                    csv_frame_annual[("SpaceHeating", "Oil [l]")] = sum(
-                        results.iloc[:, index]
-                    )
+                    csv_frame_annual[("SpaceHeating", "Oil [l]")] = sum(results.iloc[:, index])
                     csv_frame_seasonal = compute_seasonal(
                         csv_frame_seasonal=csv_frame_seasonal,
                         index_in_seasonal_frame=("SpaceHeating", "Oil [l]"),
@@ -359,9 +327,7 @@ def generate_csv_for_database(
                     )
                 else:
                     if HeatingSystems.HEAT_PUMP in output.postprocessing_flag:
-                        csv_frame_annual[
-                            ("SpaceHeating", "Electricity - HeatPump [kWh]")
-                        ] = compute_energy_from_power(
+                        csv_frame_annual[("SpaceHeating", "Electricity - HeatPump [kWh]")] = compute_energy_from_power(
                             power_timeseries=results.iloc[:, index],
                             seconds_per_timestep=simulation_parameters.seconds_per_timestep,
                         )
@@ -377,9 +343,7 @@ def generate_csv_for_database(
                             night=night,
                         )
                     elif HeatingSystems.ELECTRIC_HEATING in output.postprocessing_flag:
-                        csv_frame_annual[
-                            ("SpaceHeating", "Electricity [kWh]")
-                        ] = compute_energy_from_power(
+                        csv_frame_annual[("SpaceHeating", "Electricity [kWh]")] = compute_energy_from_power(
                             power_timeseries=results.iloc[:, index],
                             seconds_per_timestep=simulation_parameters.seconds_per_timestep,
                         )
@@ -396,9 +360,7 @@ def generate_csv_for_database(
                         )
             elif ComponentType.CAR in output.postprocessing_flag:
                 if LoadTypes.DIESEL in output.postprocessing_flag:
-                    csv_frame_annual[("Transport", "Diesel [l]")] = sum(
-                        results.iloc[:, index]
-                    )
+                    csv_frame_annual[("Transport", "Diesel [l]")] = sum(results.iloc[:, index])
                     csv_frame_seasonal = compute_seasonal(
                         csv_frame_seasonal=csv_frame_seasonal,
                         index_in_seasonal_frame=("Transport", "Diesel [l]"),
@@ -408,9 +370,7 @@ def generate_csv_for_database(
                         night=night,
                     )
                 else:
-                    csv_frame_annual[
-                        ("Transport", "Electricity [kWh]")
-                    ] = compute_energy_from_power(
+                    csv_frame_annual[("Transport", "Electricity [kWh]")] = compute_energy_from_power(
                         power_timeseries=results.iloc[:, index],
                         seconds_per_timestep=simulation_parameters.seconds_per_timestep,
                     )
@@ -422,16 +382,10 @@ def generate_csv_for_database(
                         day=day,
                         night=night,
                     )
-            elif (
-                InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED
-                in output.postprocessing_flag
-            ):
-                remaining_electricity_annual = (
-                    remaining_electricity_annual
-                    + compute_energy_from_power(
-                        power_timeseries=results.iloc[:, index],
-                        seconds_per_timestep=simulation_parameters.seconds_per_timestep,
-                    )
+            elif InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED in output.postprocessing_flag:
+                remaining_electricity_annual = remaining_electricity_annual + compute_energy_from_power(
+                    power_timeseries=results.iloc[:, index],
+                    seconds_per_timestep=simulation_parameters.seconds_per_timestep,
                 )
                 remaining_electricity_seasonal_item = compute_seasonal(
                     csv_frame_seasonal=csv_frame_seasonal,
@@ -441,20 +395,13 @@ def generate_csv_for_database(
                     day=day,
                     night=night,
                 ).loc[("RemainingLoad", "Electricity [kWh]")]
-                remaining_electricity_seasonal = (
-                    remaining_electricity_seasonal
-                    + np.array(remaining_electricity_seasonal_item)
+                remaining_electricity_seasonal = remaining_electricity_seasonal + np.array(
+                    remaining_electricity_seasonal_item
                 )
-            elif (
-                InandOutputType.ELECTRICITY_CONSUMPTION_EMS_CONTROLLED
-                in output.postprocessing_flag
-            ):
-                remaining_electricity_annual = (
-                    remaining_electricity_annual
-                    + compute_energy_from_power(
-                        power_timeseries=results.iloc[:, index],
-                        seconds_per_timestep=simulation_parameters.seconds_per_timestep,
-                    )
+            elif InandOutputType.ELECTRICITY_CONSUMPTION_EMS_CONTROLLED in output.postprocessing_flag:
+                remaining_electricity_annual = remaining_electricity_annual + compute_energy_from_power(
+                    power_timeseries=results.iloc[:, index],
+                    seconds_per_timestep=simulation_parameters.seconds_per_timestep,
                 )
                 remaining_electricity_seasonal_item = compute_seasonal(
                     csv_frame_seasonal=csv_frame_seasonal,
@@ -464,9 +411,8 @@ def generate_csv_for_database(
                     day=day,
                     night=night,
                 ).loc[("RemainingLoad", "Electricity [kWh]")]
-                remaining_electricity_seasonal = (
-                    remaining_electricity_seasonal
-                    + np.array(remaining_electricity_seasonal_item)
+                remaining_electricity_seasonal = remaining_electricity_seasonal + np.array(
+                    remaining_electricity_seasonal_item
                 )
         else:
             continue
@@ -476,18 +422,12 @@ def generate_csv_for_database(
     else:
         factor_cooking = get_factor_cooking(occupancy_config)
 
-    csv_frame_annual[
-        ("RemainingLoad", "Electricity [kWh]")
-    ] = remaining_electricity_annual * (1 - factor_cooking)
-    csv_frame_annual[("Cooking", "Electricity [kWh]")] = (
-        remaining_electricity_annual * factor_cooking
+    csv_frame_annual[("RemainingLoad", "Electricity [kWh]")] = remaining_electricity_annual * (1 - factor_cooking)
+    csv_frame_annual[("Cooking", "Electricity [kWh]")] = remaining_electricity_annual * factor_cooking
+    csv_frame_seasonal.loc[("RemainingLoad", "Electricity [kWh]")] = remaining_electricity_seasonal * (
+        1 - factor_cooking
     )
-    csv_frame_seasonal.loc[
-        ("RemainingLoad", "Electricity [kWh]")
-    ] = remaining_electricity_seasonal * (1 - factor_cooking)
-    csv_frame_seasonal.loc[("Cooking", "Electricity [kWh]")] = (
-        remaining_electricity_seasonal * factor_cooking
-    )
+    csv_frame_seasonal.loc[("Cooking", "Electricity [kWh]")] = remaining_electricity_seasonal * factor_cooking
 
     # extract infos from used climate data to compare to climate information used for tabula evaluation
     building_code = building_data["Code_BuildingVariant"].to_list()[0]
@@ -495,52 +435,31 @@ def generate_csv_for_database(
     converting_data.index = converting_data["Location"]  # type: ignore
 
     # write all necesary data for building validation to csv file
-    csv_frame_annual[("Annual Heating Demand Tabula", "[kWh/(m*m*a)]")] = building_data[
-        "q_ht"
+    csv_frame_annual[("Annual Heating Demand Tabula", "[kWh/(m*m*a)]")] = building_data["q_ht"].to_list()[0]
+    csv_frame_annual[("HeatingDays Tabula", "Number of Days")] = building_data["HeatingDays"].to_list()[0]
+    csv_frame_annual[("AverageTemperatureInHeatingSeason Tabula", "Temperature [C]")] = building_data[
+        "Theta_e"
     ].to_list()[0]
-    csv_frame_annual[("HeatingDays Tabula", "Number of Days")] = building_data[
-        "HeatingDays"
-    ].to_list()[0]
-    csv_frame_annual[
-        ("AverageTemperatureInHeatingSeason Tabula", "Temperature [C]")
-    ] = building_data["Theta_e"].to_list()[0]
     csv_frame_annual[("Annual Heating Demand HiSIM", "[kWh/(m*m*a)]")] = (
-        csv_frame_annual[("SpaceHeating", "Distributed Stream [kWh]")]
-        / building_data["A_C_Ref"]
+        csv_frame_annual[("SpaceHeating", "Distributed Stream [kWh]")] / building_data["A_C_Ref"]
     ).iloc[0]
     csv_frame_annual[("HeatingDays HiSIM", "Number of Days")] = int(
         converting_data.loc[building_code.split(".")[0]]["NumberOfHeatingDays"]
     )
-    csv_frame_annual[
-        ("AverageTemperatureInHeatingSeason HiSIM", "Temperature [C]")
-    ] = float(converting_data.loc[building_code.split(".")[0]]["Average"])
+    csv_frame_annual[("AverageTemperatureInHeatingSeason HiSIM", "Temperature [C]")] = float(
+        converting_data.loc[building_code.split(".")[0]]["Average"]
+    )
     csv_frame_annual[("Building Size", "Area [m*m]")] = building_data["A_C_Ref"].iloc[0]
-    csv_frame_annual[("Construction Year", "Period start")] = building_data[
-        "Year1_Building"
-    ].iloc[0]
-    csv_frame_annual[("Construction Year", "Period end")] = building_data[
-        "Year2_Building"
-    ].iloc[0]
-    csv_frame_annual[
-        ("Annual Heating Demand Tabula with HiSIM climate", "[kWh/(m*m*a)]")
-    ] = (
+    csv_frame_annual[("Construction Year", "Period start")] = building_data["Year1_Building"].iloc[0]
+    csv_frame_annual[("Construction Year", "Period end")] = building_data["Year2_Building"].iloc[0]
+    csv_frame_annual[("Annual Heating Demand Tabula with HiSIM climate", "[kWh/(m*m*a)]")] = (
         building_data["q_ht"].to_list()[0]
         * (
-            (
-                20
-                - csv_frame_annual[
-                    ("AverageTemperatureInHeatingSeason HiSIM", "Temperature [C]")
-                ]
-            )
+            (20 - csv_frame_annual[("AverageTemperatureInHeatingSeason HiSIM", "Temperature [C]")])
             * csv_frame_annual[("HeatingDays HiSIM", "Number of Days")]
         )
         / (
-            (
-                20
-                - csv_frame_annual[
-                    ("AverageTemperatureInHeatingSeason Tabula", "Temperature [C]")
-                ]
-            )
+            (20 - csv_frame_annual[("AverageTemperatureInHeatingSeason Tabula", "Temperature [C]")])
             * csv_frame_annual[("HeatingDays Tabula", "Number of Days")]
         )
     )

--- a/hisim/postprocessing/investment_cost_co2.py
+++ b/hisim/postprocessing/investment_cost_co2.py
@@ -33,7 +33,9 @@ def read_in_component_costs() -> pd.DataFrame:
     return price_frame
 
 
-def compute_investment_cost(components: List[ComponentWrapper],) -> Tuple[float, float]:
+def compute_investment_cost(
+    components: List[ComponentWrapper],
+) -> Tuple[float, float]:
     """Iterates over all components and computes annual investment cost and annual C02 footprint respectively.
 
     :param components: List of all configured components in the HiSIM system setup.
@@ -48,19 +50,14 @@ def compute_investment_cost(components: List[ComponentWrapper],) -> Tuple[float,
 
     for component in components:
         if isinstance(component.my_component, generic_smart_device.SmartDevice):
-            column = price_frame.iloc[
-                price_frame.index
-                == "Washing machine (or domestic appliances in general)"
-            ]
+            column = price_frame.iloc[price_frame.index == "Washing machine (or domestic appliances in general)"]
             component_capacity = 1.0
         elif isinstance(component.my_component, generic_pv_system.PVSystem):
             column = price_frame.iloc[price_frame.index == "Photovoltaic panel"]
             component_capacity = component.my_component.pvconfig.power_in_watt * 1e-3
         elif isinstance(component.my_component, generic_heat_source.HeatSource):
             if component.my_component.config.fuel == LoadTypes.DISTRICTHEATING:
-                column = price_frame.iloc[
-                    price_frame.index == "Biomass district heating system"
-                ]
+                column = price_frame.iloc[price_frame.index == "Biomass district heating system"]
             elif component.my_component.config.fuel == LoadTypes.GAS:
                 column = price_frame.iloc[price_frame.index == "Gas boiler"]
             elif component.my_component.config.fuel == LoadTypes.OIL:
@@ -68,18 +65,12 @@ def compute_investment_cost(components: List[ComponentWrapper],) -> Tuple[float,
             elif component.my_component.config.fuel == LoadTypes.ELECTRICITY:
                 column = price_frame.iloc[price_frame.index == "Electric heating"]
             component_capacity = component.my_component.config.power_th * 1e-3
-        elif isinstance(
-            component.my_component, generic_hot_water_storage_modular.HotWaterStorage
-        ):
+        elif isinstance(component.my_component, generic_hot_water_storage_modular.HotWaterStorage):
             column = price_frame.iloc[price_frame.index == "Hot Water tank"]
             component_capacity = component.my_component.volume
         elif isinstance(component.my_component, advanced_battery_bslib.Battery):
-            column = price_frame.iloc[
-                price_frame.index == "Lithium iron phosphate battery"
-            ]
-            component_capacity = (
-                component.my_component.custom_battery_capacity_generic_in_kilowatt_hour
-            )
+            column = price_frame.iloc[price_frame.index == "Lithium iron phosphate battery"]
+            component_capacity = component.my_component.custom_battery_capacity_generic_in_kilowatt_hour
         elif isinstance(component.my_component, generic_car.Car):
             if component.my_component.config.fuel == LoadTypes.ELECTRICITY:
                 column = price_frame.iloc[price_frame.index == "Electric vehicle"]
@@ -88,30 +79,19 @@ def compute_investment_cost(components: List[ComponentWrapper],) -> Tuple[float,
             component_capacity = 1.0
         elif isinstance(component.my_component, generic_chp.SimpleCHP):
             if component.my_component.config.use == LoadTypes.GAS:
-                column = price_frame.iloc[
-                    price_frame.index == "Gas powered Combined Heat and Power"
-                ]
+                column = price_frame.iloc[price_frame.index == "Gas powered Combined Heat and Power"]
             elif component.my_component.config.use == LoadTypes.HYDROGEN:
                 column = price_frame.iloc[price_frame.index == "Hydrogen fuelcell"]
             component_capacity = component.my_component.config.p_fuel * 1e-3
-        elif isinstance(
-            component.my_component, generic_hydrogen_storage.GenericHydrogenStorage
-        ):
+        elif isinstance(component.my_component, generic_hydrogen_storage.GenericHydrogenStorage):
             column = price_frame.iloc[price_frame.index == "Hydrogen Storage"]
             component_capacity = component.my_component.config.max_capacity
-        elif isinstance(
-            component.my_component, generic_electrolyzer.GenericElectrolyzer
-        ):
+        elif isinstance(component.my_component, generic_electrolyzer.GenericElectrolyzer):
             column = price_frame.iloc[price_frame.index == "Electrolyzer"]
             component_capacity = component.my_component.config.max_power * 1e-3
         else:
             continue
-        co2_emissions = (
-            co2_emissions
-            + float(column["annual Footprint"].iloc[0]) * component_capacity
-        )
-        investment_cost = (
-            investment_cost + float(column["annual cost"].iloc[0]) * component_capacity
-        )
+        co2_emissions = co2_emissions + float(column["annual Footprint"].iloc[0]) * component_capacity
+        investment_cost = investment_cost + float(column["annual cost"].iloc[0]) * component_capacity
 
     return investment_cost, co2_emissions

--- a/hisim/postprocessing/opex_and_capex_cost_calculation.py
+++ b/hisim/postprocessing/opex_and_capex_cost_calculation.py
@@ -32,7 +32,8 @@ def opex_calculation(
         component_unwrapped = component.my_component
         # cost and co2_footprint are calculated per simulated period
         opex_cost_data_class: OpexCostDataClass = component_unwrapped.get_cost_opex(
-            all_outputs=all_outputs, postprocessing_results=postprocessing_results,
+            all_outputs=all_outputs,
+            postprocessing_results=postprocessing_results,
         )
         cost = opex_cost_data_class.opex_cost
         co2_footprint = opex_cost_data_class.co2_footprint
@@ -57,9 +58,7 @@ def opex_calculation(
             "---",
         ]
     )
-    pathname = os.path.join(
-        simulation_parameters.result_directory, "operational_costs_co2_footprint.csv"
-    )
+    pathname = os.path.join(simulation_parameters.result_directory, "operational_costs_co2_footprint.csv")
     opex_df = pd.DataFrame(opex_table_as_list_of_list, columns=headline)
     opex_df.to_csv(pathname, index=False, header=True, encoding="utf8")
 
@@ -69,7 +68,8 @@ def opex_calculation(
 
 
 def capex_calculation(
-    components: List[ComponentWrapper], simulation_parameters: SimulationParameters,
+    components: List[ComponentWrapper],
+    simulation_parameters: SimulationParameters,
 ) -> List:
     """Loops over all components and calls capex cost calculation."""
     seconds_per_year = 365 * 24 * 60 * 60
@@ -104,12 +104,10 @@ def capex_calculation(
                     lifetime_in_cycles,
                 ) = component_unwrapped.get_battery_aging_information()
                 if lifetime_in_cycles > 0:
-                    capex_per_simulated_period = (capex / lifetime_in_cycles) * (
+                    capex_per_simulated_period = (capex / lifetime_in_cycles) * (virtual_number_of_full_charge_cycles)
+                    device_co2_footprint_per_simulated_period = (co2_footprint / lifetime_in_cycles) * (
                         virtual_number_of_full_charge_cycles
                     )
-                    device_co2_footprint_per_simulated_period = (
-                        co2_footprint / lifetime_in_cycles
-                    ) * (virtual_number_of_full_charge_cycles)
                 else:
                     log.warning(
                         f"capex calculation not valid. Check lifetime_in_cycles in Configuration of {component}"
@@ -118,15 +116,13 @@ def capex_calculation(
                 capex_per_simulated_period = (capex / lifetime) * (
                     simulation_parameters.duration.total_seconds() / seconds_per_year
                 )
-                device_co2_footprint_per_simulated_period = (
-                    co2_footprint / lifetime
-                ) * (simulation_parameters.duration.total_seconds() / seconds_per_year)
+                device_co2_footprint_per_simulated_period = (co2_footprint / lifetime) * (
+                    simulation_parameters.duration.total_seconds() / seconds_per_year
+                )
             total_investment_cost += capex
             total_device_co2_footprint += co2_footprint
             total_investment_cost_per_simulated_period += capex_per_simulated_period
-            total_device_co2_footprint_per_simulated_period += (
-                device_co2_footprint_per_simulated_period
-            )
+            total_device_co2_footprint_per_simulated_period += device_co2_footprint_per_simulated_period
 
             capex_table_as_list_of_list.append(
                 [
@@ -137,9 +133,7 @@ def capex_calculation(
                 ]
             )
         else:
-            log.warning(
-                f"capex calculation not valid. Check lifetime in Configuration of {component}"
-            )
+            log.warning(f"capex calculation not valid. Check lifetime in Configuration of {component}")
 
     capex_table_as_list_of_list.append(
         [
@@ -158,9 +152,7 @@ def capex_calculation(
         ]
     )
 
-    pathname = os.path.join(
-        simulation_parameters.result_directory, "investment_cost_co2_footprint.csv"
-    )
+    pathname = os.path.join(simulation_parameters.result_directory, "investment_cost_co2_footprint.csv")
     capex_df = pd.DataFrame(capex_table_as_list_of_list, columns=headline)
     capex_df.to_csv(pathname, index=False, header=True, encoding="utf8")
 

--- a/hisim/postprocessing/postprocessing_datatransfer.py
+++ b/hisim/postprocessing/postprocessing_datatransfer.py
@@ -46,10 +46,6 @@ class PostProcessingDataTransfer:  # noqa: too-few-public-methods
         self.results_daily = results_daily
         self.post_processing_options = simulation_parameters.post_processing_options
 
-        log.information(
-            "Selected "
-            + str(len(self.post_processing_options))
-            + " post processing options:"
-        )
+        log.information("Selected " + str(len(self.post_processing_options)) + " post processing options:")
         for option in self.post_processing_options:
             log.information("Selected post processing option: " + str(option))

--- a/hisim/postprocessing/postprocessing_main.py
+++ b/hisim/postprocessing/postprocessing_main.py
@@ -78,19 +78,13 @@ class PostProcessor:
                 PostProcessingOptions.WRITE_COMPONENT_CONFIGS_TO_JSON,
             }
             # Of all specified options, select those that are allowed
-            valid_options = list(
-                set(ppdt.post_processing_options) & allowed_options_for_docker
-            )
+            valid_options = list(set(ppdt.post_processing_options) & allowed_options_for_docker)
             if len(valid_options) < len(ppdt.post_processing_options):
                 # At least one invalid option was set
                 ppdt.post_processing_options = valid_options
-                log.warning(
-                    "Hisim is running in a docker container. Disabled invalid postprocessing options."
-                )
+                log.warning("Hisim is running in a docker container. Disabled invalid postprocessing options.")
 
-        report = reportgenerator.ReportGenerator(
-            dirpath=ppdt.simulation_parameters.result_directory
-        )
+        report = reportgenerator.ReportGenerator(dirpath=ppdt.simulation_parameters.result_directory)
         days = {"month": 0, "day": 0}
         system_chart_entries: List[SystemChartEntry] = []
         # Make plots
@@ -111,24 +105,19 @@ class PostProcessor:
         if PostProcessingOptions.PLOT_SINGLE_DAYS in ppdt.post_processing_options:
             log.information("Making single day plots.")
             start = timer()
-            self.make_single_day_plots(
-                days, ppdt, report_image_entries=report_image_entries
-            )
+            self.make_single_day_plots(days, ppdt, report_image_entries=report_image_entries)
             end = timer()
             duration = end - start
             log.information("Making single day plots took " + f"{duration:1.2f}s.")
 
         # make monthly bar plots only if simulation duration approximately a year
         if (
-            PostProcessingOptions.PLOT_MONTHLY_BAR_CHARTS
-            in ppdt.post_processing_options
+            PostProcessingOptions.PLOT_MONTHLY_BAR_CHARTS in ppdt.post_processing_options
             and ppdt.simulation_parameters.duration.days >= 360
         ):
             log.information("Making monthly bar charts.")
             start = timer()
-            self.make_monthly_bar_charts(
-                ppdt, report_image_entries=report_image_entries
-            )
+            self.make_monthly_bar_charts(ppdt, report_image_entries=report_image_entries)
             end = timer()
             duration = end - start
             log.information("Making monthly bar plots took " + f"{duration:1.2f}s.")
@@ -150,22 +139,16 @@ class PostProcessor:
             log.information("Computing network charts took " + f"{duration:1.2f}s.")
         # Generate Pdf report
         if PostProcessingOptions.GENERATE_PDF_REPORT in ppdt.post_processing_options:
-            log.information(
-                "Making PDF report and writing simulation parameters to report."
-            )
+            log.information("Making PDF report and writing simulation parameters to report.")
             start = timer()
             self.write_simulation_parameters_to_report(ppdt, report)
             end = timer()
             duration = end - start
             log.information(
-                "Making PDF report and writing simulation parameters to report took "
-                + f"{duration:1.2f}s."
+                "Making PDF report and writing simulation parameters to report took " + f"{duration:1.2f}s."
             )
 
-        if (
-            PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT
-            in ppdt.post_processing_options
-        ):
+        if PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT in ppdt.post_processing_options:
             log.information("Writing components to report.")
             start = timer()
             self.write_components_to_report(ppdt, report, report_image_entries)
@@ -173,32 +156,20 @@ class PostProcessor:
             duration = end - start
             log.information("Writing components to report took " + f"{duration:1.2f}s.")
 
-        if (
-            PostProcessingOptions.WRITE_ALL_OUTPUTS_TO_REPORT
-            in ppdt.post_processing_options
-        ):
+        if PostProcessingOptions.WRITE_ALL_OUTPUTS_TO_REPORT in ppdt.post_processing_options:
             log.information("Writing all outputs to report.")
             start = timer()
             self.write_all_outputs_to_report(ppdt, report)
             end = timer()
             duration = end - start
-            log.information(
-                "Writing all outputs to report took " + f"{duration:1.2f}s."
-            )
-        if (
-            PostProcessingOptions.WRITE_NETWORK_CHARTS_TO_REPORT
-            in ppdt.post_processing_options
-        ):
+            log.information("Writing all outputs to report took " + f"{duration:1.2f}s.")
+        if PostProcessingOptions.WRITE_NETWORK_CHARTS_TO_REPORT in ppdt.post_processing_options:
             log.information("Writing network charts to report.")
             start = timer()
-            self.write_network_charts_to_report(
-                ppdt, report, system_chart_entries=system_chart_entries
-            )
+            self.write_network_charts_to_report(ppdt, report, system_chart_entries=system_chart_entries)
             end = timer()
             duration = end - start
-            log.information(
-                "Writing network charts toreport took " + f"{duration:1.2f}s."
-            )
+            log.information("Writing network charts toreport took " + f"{duration:1.2f}s.")
         if PostProcessingOptions.COMPUTE_OPEX in ppdt.post_processing_options:
             log.information(
                 "Computing and writing operational costs and C02 emissions produced in operation to report."
@@ -223,37 +194,23 @@ class PostProcessor:
                 "Computing and writing investment costs and C02 emissions from production of devices to report took "
                 + f"{duration:1.2f}s."
             )
-        if (
-            PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT
-            in ppdt.post_processing_options
-        ):
+        if PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT in ppdt.post_processing_options:
             log.information("Computing and writing KPIs to report.")
             start = timer()
             self.compute_and_write_kpis_to_report(ppdt, report)
             end = timer()
             duration = end - start
-            log.information(
-                "Computing and writing KPIs to report took " + f"{duration:1.2f}s."
-            )
-        if (
-            PostProcessingOptions.GENERATE_CSV_FOR_HOUSING_DATA_BASE
-            in ppdt.post_processing_options
-        ):
+            log.information("Computing and writing KPIs to report took " + f"{duration:1.2f}s.")
+        if PostProcessingOptions.GENERATE_CSV_FOR_HOUSING_DATA_BASE in ppdt.post_processing_options:
             building_data = pd.DataFrame()
             occupancy_config = None
             for elem in ppdt.wrapped_components:
                 if isinstance(elem.my_component, building.Building):
-                    building_data = (
-                        elem.my_component.my_building_information.buildingdata
-                    )
-                elif isinstance(
-                    elem.my_component, loadprofilegenerator_connector.Occupancy
-                ):
+                    building_data = elem.my_component.my_building_information.buildingdata
+                elif isinstance(elem.my_component, loadprofilegenerator_connector.Occupancy):
                     occupancy_config = elem.my_component.occupancy_config
             if len(building_data) == 0:
-                log.warning(
-                    "Building needs to be defined to generate csv for housing data base."
-                )
+                log.warning("Building needs to be defined to generate csv for housing data base.")
             else:
                 log.information("Generating csv for housing data base. ")
                 start = timer()
@@ -266,66 +223,44 @@ class PostProcessor:
                 )
                 end = timer()
                 duration = end - start
-                log.information(
-                    "Generating csv for housing data base took " + f"{duration:1.2f}s."
-                )
+                log.information("Generating csv for housing data base took " + f"{duration:1.2f}s.")
 
         # only a single day has been calculated. This gets special charts for debugging.
         if (
-            PostProcessingOptions.PLOT_SPECIAL_TESTING_SINGLE_DAY
-            in ppdt.post_processing_options
+            PostProcessingOptions.PLOT_SPECIAL_TESTING_SINGLE_DAY in ppdt.post_processing_options
             and len(ppdt.results) == 1440
         ):
-            log.information(
-                "Making special single day plots for a single day calculation for testing."
-            )
+            log.information("Making special single day plots for a single day calculation for testing.")
             start = timer()
-            self.make_special_one_day_debugging_plots(
-                ppdt, report_image_entries=report_image_entries
-            )
+            self.make_special_one_day_debugging_plots(ppdt, report_image_entries=report_image_entries)
             end = timer()
             duration = end - start
             log.information(
-                "Making special single day plots for a single day calculation for testing took "
-                + f"{duration:1.2f}s."
+                "Making special single day plots for a single day calculation for testing took " + f"{duration:1.2f}s."
             )
 
         # Write Outputs to specific format for scenario evaluation (idea for format from pyam package)
-        if (
-            PostProcessingOptions.PREPARE_OUTPUTS_FOR_SCENARIO_EVALUATION
-            in ppdt.post_processing_options
-        ):
+        if PostProcessingOptions.PREPARE_OUTPUTS_FOR_SCENARIO_EVALUATION in ppdt.post_processing_options:
             log.information("Prepare results for scenario evaluation.")
             self.prepare_results_for_scenario_evaluation(ppdt)
 
         # Open file explorer
-        if (
-            PostProcessingOptions.OPEN_DIRECTORY_IN_EXPLORER
-            in ppdt.post_processing_options
-        ):
+        if PostProcessingOptions.OPEN_DIRECTORY_IN_EXPLORER in ppdt.post_processing_options:
             log.information("Opening the explorer.")
             self.open_dir_in_file_explorer(ppdt)
 
         # Prepare webtool results
-        if (
-            PostProcessingOptions.MAKE_RESULT_JSON_WITH_KPI_FOR_WEBTOOL
-            in ppdt.post_processing_options
-        ):
+        if PostProcessingOptions.MAKE_RESULT_JSON_WITH_KPI_FOR_WEBTOOL in ppdt.post_processing_options:
             log.information("Make kpi json file for webtool.")
             self.write_kpis_for_webtool_to_json_file(ppdt)
 
-        if (
-            PostProcessingOptions.WRITE_COMPONENT_CONFIGS_TO_JSON
-            in ppdt.post_processing_options
-        ):
+        if PostProcessingOptions.WRITE_COMPONENT_CONFIGS_TO_JSON in ppdt.post_processing_options:
             log.information("Writing component configurations to JSON file.")
             self.write_component_configurations_to_json(ppdt)
 
         log.information("Finished main post processing function.")
 
-    def make_network_charts(
-        self, ppdt: PostProcessingDataTransfer
-    ) -> List[SystemChartEntry]:
+    def make_network_charts(self, ppdt: PostProcessingDataTransfer) -> List[SystemChartEntry]:
         """Generates the network charts that show the connection of the elements."""
         systemchart = SystemChart(ppdt)
         return systemchart.make_chart()
@@ -383,9 +318,7 @@ class PostProcessor:
                 output=output.full_name,
                 component_name=output.component_name,
                 units=output.unit,
-                directory_path=os.path.join(
-                    ppdt.simulation_parameters.result_directory
-                ),
+                directory_path=os.path.join(ppdt.simulation_parameters.result_directory),
                 time_correction_factor=ppdt.time_correction_factor,
                 output_description=output.output_description,
                 figure_format=ppdt.simulation_parameters.figure_format,
@@ -435,12 +368,7 @@ class PostProcessor:
             )
 
             my_entry = my_carpet.plot(
-                xdims=int(
-                    (
-                        ppdt.simulation_parameters.end_date
-                        - ppdt.simulation_parameters.start_date
-                    ).days
-                ),
+                xdims=int((ppdt.simulation_parameters.end_date - ppdt.simulation_parameters.start_date).days),
                 data=ppdt.results.iloc[:, index],
             )
             report_image_entries.append(my_entry)
@@ -454,9 +382,7 @@ class PostProcessor:
         """Makes the line plots."""
         for index, output in enumerate(ppdt.all_outputs):
             if output.output_description is None:
-                raise ValueError(
-                    "Output description was missing for " + output.full_name
-                )
+                raise ValueError("Output description was missing for " + output.full_name)
             my_line = charts.Line(
                 output=output.full_name,
                 component_name=output.component_name,
@@ -488,24 +414,20 @@ class PostProcessor:
                 ppdt.simulation_parameters.result_directory,
                 f"{column.split(' ', 3)[2]}_{column.split(' ', 3)[0]}_monthly.csv",
             )
-            header = [
-                f"{column.split('[', 1)[0]} - monthly [" f"{column.split('[', 1)[1]}"
-            ]
-            ppdt.results_monthly[column].to_csv(
-                csvfilename, sep=",", decimal=".", header=header
-            )
+            header = [f"{column.split('[', 1)[0]} - monthly [" f"{column.split('[', 1)[1]}"]
+            ppdt.results_monthly[column].to_csv(csvfilename, sep=",", decimal=".", header=header)
 
     def write_simulation_parameters_to_report(
         self, ppdt: PostProcessingDataTransfer, report: reportgenerator.ReportGenerator
     ) -> None:
         """Write simulation parameters to report."""
-        lines = [
-            "The following information was used to configure the HiSim Building Simulation."
-        ]
+        lines = ["The following information was used to configure the HiSim Building Simulation."]
         simulation_parameters_list = ppdt.simulation_parameters.get_unique_key_as_list()
         lines += simulation_parameters_list
         self.write_new_chapter_with_text_content_to_report(
-            report=report, lines=lines, headline=". Simulation Parameters",
+            report=report,
+            lines=lines,
+            headline=". Simulation Parameters",
         )
 
     def write_components_to_report(
@@ -528,29 +450,17 @@ class PostProcessor:
 
             output_type_counter = 1
             report.add_spacer()
-            report.write_heading_with_style_heading_one(
-                [str(self.chapter_counter) + ". " + component]
-            )
-            if (
-                PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT
-                in ppdt.post_processing_options
-            ):
+            report.write_heading_with_style_heading_one([str(self.chapter_counter) + ". " + component])
+            if PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT in ppdt.post_processing_options:
                 for wrapped_component in ppdt.wrapped_components:
                     if wrapped_component.my_component.component_name == component:
                         report.write_with_normal_alignment(
-                            [
-                                "The following information was used to configure the component."
-                            ]
+                            ["The following information was used to configure the component."]
                         )
-                        component_content = (
-                            wrapped_component.my_component.write_to_report()
-                        )
+                        component_content = wrapped_component.my_component.write_to_report()
                         report.write_with_normal_alignment(component_content)
 
-            if (
-                PostProcessingOptions.INCLUDE_IMAGES_IN_PDF_REPORT
-                in ppdt.post_processing_options
-            ):
+            if PostProcessingOptions.INCLUDE_IMAGES_IN_PDF_REPORT in ppdt.post_processing_options:
                 entry: ReportImageEntry
                 for entry in sorted_entries:
                     # write output description only once for each output type
@@ -568,22 +478,12 @@ class PostProcessor:
                             ]
                         )
                         if entry.output_description is None:
-                            raise ValueError(
-                                "Component had no description: "
-                                + str(entry.component_name)
-                            )
+                            raise ValueError("Component had no description: " + str(entry.component_name))
                         report.write_with_normal_alignment([entry.output_description])
                         output_type_counter = output_type_counter + 1
                     report.write_figures_to_report(entry.file_path)
                     report.write_with_center_alignment(
-                        [
-                            "Fig."
-                            + str(self.figure_counter)
-                            + ": "
-                            + entry.component_name
-                            + " "
-                            + entry.output_type
-                        ]
+                        ["Fig." + str(self.figure_counter) + ": " + entry.component_name + " " + entry.output_type]
                     )
                     report.add_spacer()
                     self.figure_counter = self.figure_counter + 1
@@ -606,9 +506,7 @@ class PostProcessor:
                     if report_image_entry.output_type not in output_types:
                         output_types.append(report_image_entry.output_type)
 
-            write_image_entry_to_report_for_one_component(
-                component, report_image_entries_for_component
-            )
+            write_image_entry_to_report_for_one_component(component, report_image_entries_for_component)
 
         report.close()
 
@@ -622,7 +520,9 @@ class PostProcessor:
         for output in ppdt.all_outputs:
             all_output_names.append(output.full_name + " [" + output.unit + "]")
         self.write_new_chapter_with_text_content_to_report(
-            report=report, lines=all_output_names, headline=". All Outputs",
+            report=report,
+            lines=all_output_names,
+            headline=". All Outputs",
         )
 
     def write_network_charts_to_report(
@@ -633,16 +533,12 @@ class PostProcessor:
     ) -> None:
         """Write network charts to report."""
         report.open()
-        report.write_heading_with_style_heading_one(
-            [str(self.chapter_counter) + ". System Network Charts"]
-        )
+        report.write_heading_with_style_heading_one([str(self.chapter_counter) + ". System Network Charts"])
         for entry in system_chart_entries:
             report.write_figures_to_report_with_size_four_six(
                 os.path.join(ppdt.simulation_parameters.result_directory, entry.path)
             )
-            report.write_with_center_alignment(
-                ["Fig." + str(self.figure_counter) + ": " + entry.caption]
-            )
+            report.write_with_center_alignment(["Fig." + str(self.figure_counter) + ": " + entry.caption])
             self.figure_counter = self.figure_counter + 1
         self.chapter_counter = self.chapter_counter + 1
         report.page_break()
@@ -700,9 +596,7 @@ class PostProcessor:
             report=report,
             table_as_list_of_list=capex_compute_return,
             headline=". Investment Cost and CO2-Emissions of devices for simulated period",
-            comment=[
-                "Values for Battery are calculated with lifetime in cycles instead of lifetime in years"
-            ],
+            comment=["Values for Battery are calculated with lifetime in cycles instead of lifetime in years"],
         )
 
     def write_new_chapter_with_text_content_to_report(
@@ -710,9 +604,7 @@ class PostProcessor:
     ) -> None:
         """Write new chapter with headline and some general information e.g. KPIs to report."""
         report.open()
-        report.write_heading_with_style_heading_one(
-            [str(self.chapter_counter) + headline]
-        )
+        report.write_heading_with_style_heading_one([str(self.chapter_counter) + headline])
         report.write_with_normal_alignment(lines)
         self.chapter_counter = self.chapter_counter + 1
         report.page_break()
@@ -727,9 +619,7 @@ class PostProcessor:
     ) -> None:
         """Write new chapter with headline and a table to report."""
         report.open()
-        report.write_heading_with_style_heading_one(
-            [str(self.chapter_counter) + headline]
-        )
+        report.write_heading_with_style_heading_one([str(self.chapter_counter) + headline])
         report.write_tables_to_report(table_as_list_of_list)
         report.write_with_normal_alignment(comment)
         self.chapter_counter = self.chapter_counter + 1
@@ -743,9 +633,7 @@ class PostProcessor:
         xdg-open will be available on any unix client running X.
         """
         if sys.platform == "win32":
-            os.startfile(
-                os.path.realpath(ppdt.simulation_parameters.result_directory)
-            )  # noqa: B606
+            os.startfile(os.path.realpath(ppdt.simulation_parameters.result_directory))  # noqa: B606
         else:
             log.information("Not on Windows. Can't open explorer.")
 
@@ -756,9 +644,7 @@ class PostProcessor:
         """
         pass  # noqa: unnecessary-pass
 
-    def prepare_results_for_scenario_evaluation(
-        self, ppdt: PostProcessingDataTransfer
-    ) -> None:
+    def prepare_results_for_scenario_evaluation(self, ppdt: PostProcessingDataTransfer) -> None:
         """Prepare the results for the scenario evaluation."""
 
         # create result data folder
@@ -768,9 +654,7 @@ class PostProcessor:
         if os.path.exists(self.result_data_folder_for_scenario_evaluation) is False:
             os.makedirs(self.result_data_folder_for_scenario_evaluation)
         else:
-            log.information(
-                "This result data path exists already: " + self.result_data_folder_for_scenario_evaluation
-            )
+            log.information("This result data path exists already: " + self.result_data_folder_for_scenario_evaluation)
 
         # --------------------------------------------------------------------------------------------------------------------------------------------------------------
         # make dictionaries with pyam data structure for hourly and yearly data
@@ -799,20 +683,14 @@ class PostProcessor:
         self.model = "".join(["HiSim_", ppdt.module_filename])
 
         # set pyam scenario name
-        if SingletonSimRepository().exist_entry(
-            key=SingletonDictKeyEnum.RESULT_SCENARIO_NAME
-        ):
-            self.scenario = SingletonSimRepository().get_entry(
-                key=SingletonDictKeyEnum.RESULT_SCENARIO_NAME
-            )
+        if SingletonSimRepository().exist_entry(key=SingletonDictKeyEnum.RESULT_SCENARIO_NAME):
+            self.scenario = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.RESULT_SCENARIO_NAME)
         else:
             self.scenario = ""
 
         # set region
         if SingletonSimRepository().exist_entry(key=SingletonDictKeyEnum.LOCATION):
-            self.region = SingletonSimRepository().get_entry(
-                key=SingletonDictKeyEnum.LOCATION
-            )
+            self.region = SingletonSimRepository().get_entry(key=SingletonDictKeyEnum.LOCATION)
         else:
             self.region = ""
 
@@ -822,21 +700,11 @@ class PostProcessor:
         timeseries_daily = ppdt.results_daily.index
         timeseries_monthly = ppdt.results_monthly.index
 
-        if (
-            PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT
-            in ppdt.post_processing_options
-        ):
-            self.write_kpis_in_dict(
-                ppdt=ppdt, simple_dict_cumulative_data=simple_dict_hourly_data)
-            self.write_kpis_in_dict(
-                ppdt=ppdt, simple_dict_cumulative_data=simple_dict_daily_data
-            )
-            self.write_kpis_in_dict(
-                ppdt=ppdt, simple_dict_cumulative_data=simple_dict_monthly_data
-            )
-            self.write_kpis_in_dict(
-                ppdt=ppdt, simple_dict_cumulative_data=simple_dict_cumulative_data
-            )
+        if PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT in ppdt.post_processing_options:
+            self.write_kpis_in_dict(ppdt=ppdt, simple_dict_cumulative_data=simple_dict_hourly_data)
+            self.write_kpis_in_dict(ppdt=ppdt, simple_dict_cumulative_data=simple_dict_daily_data)
+            self.write_kpis_in_dict(ppdt=ppdt, simple_dict_cumulative_data=simple_dict_monthly_data)
+            self.write_kpis_in_dict(ppdt=ppdt, simple_dict_cumulative_data=simple_dict_cumulative_data)
 
         # got through all components and read output values, variables and units
         # for hourly data
@@ -892,9 +760,7 @@ class PostProcessor:
             (
                 variable_name,
                 unit,
-            ) = self.get_variable_name_and_unit_from_ppdt_results_column(
-                column=str(column)
-            )
+            ) = self.get_variable_name_and_unit_from_ppdt_results_column(column=str(column))
 
             simple_dict_cumulative_data["model"].append(self.model)
             simple_dict_cumulative_data["scenario"].append(self.scenario)
@@ -928,16 +794,10 @@ class PostProcessor:
 
         # write json config with all component configs, module config, pyam information dict and simulation parameters
         json_generator_config = JsonConfigurationGenerator(name=f"{self.scenario}")
-        json_generator_config.set_simulation_parameters(
-            my_simulation_parameters=ppdt.simulation_parameters
-        )
+        json_generator_config.set_simulation_parameters(my_simulation_parameters=ppdt.simulation_parameters)
         if ppdt.my_module_config_path is not None:
-            json_generator_config.set_module_config(
-                my_module_config_path=ppdt.my_module_config_path
-            )
-        json_generator_config.set_scenario_data_information_dict(
-            scenario_data_information_dict=data_information_dict
-        )
+            json_generator_config.set_module_config(my_module_config_path=ppdt.my_module_config_path)
+        json_generator_config.set_scenario_data_information_dict(scenario_data_information_dict=data_information_dict)
         for component in ppdt.wrapped_components:
             json_generator_config.add_component(config=component.my_component.config)
 
@@ -948,9 +808,7 @@ class PostProcessor:
             )
         )
 
-    def write_component_configurations_to_json(
-        self, ppdt: PostProcessingDataTransfer
-    ) -> None:
+    def write_component_configurations_to_json(self, ppdt: PostProcessingDataTransfer) -> None:
         """Collect all component configurations and write into JSON file in result directory."""
         json_generator_config = JsonConfigurationGenerator(name="my_system")
         for component in ppdt.wrapped_components:
@@ -993,25 +851,14 @@ class PostProcessor:
                     simple_dict_cumulative_data["time"].append(self.year)
                 simple_dict_cumulative_data["value"].append(variable_value)
 
-    def get_variable_name_and_unit_from_ppdt_results_column(
-        self, column: str
-    ) -> Tuple[str, str]:
+    def get_variable_name_and_unit_from_ppdt_results_column(self, column: str) -> Tuple[str, str]:
         """Get variable name and unit for pyam dictionary."""
 
         column_splitted = str(
-            "".join(
-                [
-                    x
-                    for x in column
-                    if x
-                    in string.ascii_letters + "'- " + string.digits + "_" + "°" + "/"
-                ]
-            )
+            "".join([x for x in column if x in string.ascii_letters + "'- " + string.digits + "_" + "°" + "/"])
         ).split(sep=" ")
 
-        variable_name = "".join(
-            [column_splitted[0], "|", column_splitted[3], "|", column_splitted[2]]
-        )
+        variable_name = "".join([column_splitted[0], "|", column_splitted[3], "|", column_splitted[2]])
 
         unit = column_splitted[5]
 
@@ -1030,9 +877,7 @@ class PostProcessor:
                 (
                     variable_name,
                     unit,
-                ) = self.get_variable_name_and_unit_from_ppdt_results_column(
-                    column=str(column)
-                )
+                ) = self.get_variable_name_and_unit_from_ppdt_results_column(column=str(column))
 
                 dict_to_check["model"].append(self.model)
                 dict_to_check["scenario"].append(self.scenario)
@@ -1064,12 +909,11 @@ class PostProcessor:
         )
 
         dataframe.to_csv(
-            path_or_buf=filename, index=None,
+            path_or_buf=filename,
+            index=None,
         )  # type: ignore
 
-    def write_kpis_for_webtool_to_json_file(
-        self, ppdt: PostProcessingDataTransfer
-    ) -> None:
+    def write_kpis_for_webtool_to_json_file(self, ppdt: PostProcessingDataTransfer) -> None:
         """Collect important KPIs and write into json for webtool."""
 
         # check if important options were set
@@ -1088,9 +932,7 @@ class PostProcessor:
                 all_outputs=ppdt.all_outputs,
                 simulation_parameters=ppdt.simulation_parameters,
             )
-            dict_with_important_kpi = self.get_dict_from_kpi_lists(
-                value_list=kpi_compute_return
-            )
+            dict_with_important_kpi = self.get_dict_from_kpi_lists(value_list=kpi_compute_return)
 
             # caculate capex
             capex_compute_return = capex_calculation(
@@ -1098,9 +940,7 @@ class PostProcessor:
                 simulation_parameters=ppdt.simulation_parameters,
             )
 
-            dict_with_important_capex = self.get_dict_from_opex_capex_lists(
-                value_list=capex_compute_return
-            )
+            dict_with_important_capex = self.get_dict_from_opex_capex_lists(value_list=capex_compute_return)
 
             # caculate opex
             opex_compute_return = opex_calculation(
@@ -1110,9 +950,7 @@ class PostProcessor:
                 simulation_parameters=ppdt.simulation_parameters,
             )
 
-            dict_with_important_opex = self.get_dict_from_opex_capex_lists(
-                value_list=opex_compute_return
-            )
+            dict_with_important_opex = self.get_dict_from_opex_capex_lists(value_list=opex_compute_return)
 
             # initialize webtool kpi entries dataclass
             webtool_kpi_dataclass = WebtoolKpiEntries(
@@ -1124,9 +962,7 @@ class PostProcessor:
             # save dict as json file in results folder
             json_file = webtool_kpi_dataclass.to_json(indent=4)
             with open(
-                os.path.join(
-                    ppdt.simulation_parameters.result_directory, "webtool_kpis.json"
-                ),
+                os.path.join(ppdt.simulation_parameters.result_directory, "webtool_kpis.json"),
                 "w",
                 encoding="utf-8",
             ) as file:
@@ -1147,14 +983,10 @@ class PostProcessor:
         for kpi_value_unit in value_list:
             if "---" not in kpi_value_unit:
                 variable_name = "".join(x for x in kpi_value_unit[0] if x != ":")
-                variable_value = "".join(
-                    x for x in kpi_value_unit[1] if x in string.digits
-                )
+                variable_value = "".join(x for x in kpi_value_unit[1] if x in string.digits)
                 variable_unit = kpi_value_unit[2]
 
-                dict_with_values.update(
-                    {f"{variable_name} [{variable_unit}] ": variable_value}
-                )
+                dict_with_values.update({f"{variable_name} [{variable_unit}] ": variable_value})
 
         return dict_with_values
 
@@ -1176,15 +1008,9 @@ class PostProcessor:
                 variable_value_emissions = value_unit[2]
                 variable_value_lifetime = value_unit[3]
 
-                dict_with_cost_values.update(
-                    {f"{variable_name} [{name_one[1]}] ": variable_value_investment}
-                )
-                dict_with_emission_values.update(
-                    {f"{variable_name} [{name_one[2]}] ": variable_value_emissions}
-                )
-                dict_with_lifetime_values.update(
-                    {f"{variable_name} [{name_one[3]}] ": variable_value_lifetime}
-                )
+                dict_with_cost_values.update({f"{variable_name} [{name_one[1]}] ": variable_value_investment})
+                dict_with_emission_values.update({f"{variable_name} [{name_one[2]}] ": variable_value_emissions})
+                dict_with_lifetime_values.update({f"{variable_name} [{name_one[3]}] ": variable_value_lifetime})
 
                 total_dict.update(
                     {

--- a/hisim/postprocessing/report_image_entries.py
+++ b/hisim/postprocessing/report_image_entries.py
@@ -34,9 +34,7 @@ class ReportImageEntry:
         self.output_type = output_type
         self.category = category
         if output_description is None:
-            raise ValueError(
-                "Component description was none from component: " + component_name
-            )
+            raise ValueError("Component description was none from component: " + component_name)
         self.output_description = output_description
         self.unit = unit
         self.component_output_folder_path = component_output_folder_path

--- a/hisim/postprocessing/reportgenerator.py
+++ b/hisim/postprocessing/reportgenerator.py
@@ -23,9 +23,7 @@ class MyDocTemplate(BaseDocTemplate):
         """Initialize the doc template."""
         self.allow_splitting = 0
         super().__init__(filename, **kw)
-        self.template = PageTemplate(
-            "normal", [Frame(2.5 * cm, 2.5 * cm, 15 * cm, 25 * cm, id="F1")]
-        )
+        self.template = PageTemplate("normal", [Frame(2.5 * cm, 2.5 * cm, 15 * cm, 25 * cm, id="F1")])
         self.addPageTemplates(self.template)
 
     # Entries to the table of contents can be done either manually by
@@ -79,11 +77,7 @@ class ReportGenerator:
 
         self.styles = getSampleStyleSheet()
         self.styles.add(ParagraphStyle(name="Justify", alignment=TA_JUSTIFY))
-        self.styles.add(
-            ParagraphStyle(
-                name="Normal_CENTER", parent=self.styles["Normal"], alignment=TA_CENTER
-            )
-        )
+        self.styles.add(ParagraphStyle(name="Normal_CENTER", parent=self.styles["Normal"], alignment=TA_CENTER))
         self.styles.add(
             ParagraphStyle(
                 name="toc_centered",
@@ -94,12 +88,8 @@ class ReportGenerator:
                 spaceAfter=40,
             )
         )
-        self.style_h1 = ParagraphStyle(
-            name="Heading1", fontSize=12, leading=16, spaceBefore=20
-        )
-        self.style_h2 = ParagraphStyle(
-            name="Heading2", fontSize=12, leading=14, spaceBefore=10
-        )
+        self.style_h1 = ParagraphStyle(name="Heading1", fontSize=12, leading=16, spaceBefore=20)
+        self.style_h2 = ParagraphStyle(name="Heading2", fontSize=12, leading=14, spaceBefore=10)
 
     def write_table_of_content(self):
         """Write Table of Content."""
@@ -111,9 +101,7 @@ class ReportGenerator:
 
         self.toc.levelStyles = [self.style_h1, self.style_h2]
 
-        self.story.append(
-            Paragraph("<b>Table of contents</b>", self.styles["toc_centered"])
-        )
+        self.story.append(Paragraph("<b>Table of contents</b>", self.styles["toc_centered"]))
         self.story.append(self.toc)
         self.story.append(PageBreak())
 
@@ -191,9 +179,7 @@ class ReportGenerator:
         """Get the story."""
         self.story = copy.deepcopy(self.story)
 
-    def write_with_normal_alignment(
-        self, text: Union[List[str], List[Optional[str]]]
-    ) -> None:
+    def write_with_normal_alignment(self, text: Union[List[str], List[Optional[str]]]) -> None:
         """Write a paragraph."""
         if len(text) != 0:
             for part in text:
@@ -287,9 +273,7 @@ class ReportGenerator:
     def add_page_number(self, canvas, doc):
         """Add page number to report."""
         canvas.saveState()
-        canvas.setFont(
-            self.styles["Heading2"].fontName, self.styles["Heading2"].fontSize
-        )
+        canvas.setFont(self.styles["Heading2"].fontName, self.styles["Heading2"].fontSize)
         page_number_text = f"{doc.page}"
         canvas.drawRightString(200 * mm, 20 * mm, page_number_text)
         canvas.restoreState()

--- a/hisim/postprocessing/scenario_evaluation/result_data_collection.py
+++ b/hisim/postprocessing/scenario_evaluation/result_data_collection.py
@@ -32,7 +32,10 @@ class ResultDataCollection:
         """Initialize the class."""
         result_folder = folder_from_which_data_will_be_collected
         self.result_data_folder = os.path.join(
-            result_folder, os.pardir, "results_for_scenario_comparison", "data",
+            result_folder,
+            os.pardir,
+            "results_for_scenario_comparison",
+            "data",
         )
 
         # in each system_setups/results folder should be one system setup that was executed with the default config
@@ -40,54 +43,31 @@ class ResultDataCollection:
 
         log.information(f"Checking results from folder: {result_folder}")
 
-        list_with_result_data_folders = self.get_only_useful_data(
-            result_path=result_folder
-        )
+        list_with_result_data_folders = self.get_only_useful_data(result_path=result_folder)
 
         if data_processing_mode == ResultDataProcessingModeEnum.PROCESS_ALL_DATA:
-
             parameter_key = None
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_BUILDING_SIZES
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_BUILDING_SIZES:
             parameter_key = "conditioned_floor_area_in_m2"
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_BUILDING_CODES
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_BUILDING_CODES:
             parameter_key = "building_code"
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_PV_AZIMUTH_ANGLES
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_PV_AZIMUTH_ANGLES:
             parameter_key = "pv_azimuth"
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_PV_TILT_ANGLES
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_PV_TILT_ANGLES:
             parameter_key = "pv_tilt"
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_SHARE_OF_MAXIMUM_PV
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_SHARE_OF_MAXIMUM_PV:
             parameter_key = "share_of_maximum_pv_power"
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_NUMBER_OF_DWELLINGS
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_NUMBER_OF_DWELLINGS:
             parameter_key = "number_of_dwellings_per_building"
 
         else:
-            raise ValueError(
-                "Analysis mode is not part of the ResultDataProcessingModeEnum class."
-            )
+            raise ValueError("Analysis mode is not part of the ResultDataProcessingModeEnum class.")
 
         log.information(f"Data Collection Mode is {data_processing_mode}")
 
@@ -102,9 +82,7 @@ class ResultDataCollection:
         else:
             # path to default config is given (which means there should be also a module config dict in the json file in the result folder which has read the config)
 
-            default_config_dict = self.get_default_config(
-                path_to_default_config=path_to_default_config
-            )
+            default_config_dict = self.get_default_config(path_to_default_config=path_to_default_config)
 
             (
                 list_with_csv_files,
@@ -147,24 +125,26 @@ class ResultDataCollection:
         self.clean_result_directory_from_unfinished_results(result_path=result_path)
 
         # get result folders with result data folder
-        list_with_all_paths_to_check = self.get_list_of_all_relevant_scenario_data_folders(
-            result_path=result_path
-        )
+        list_with_all_paths_to_check = self.get_list_of_all_relevant_scenario_data_folders(result_path=result_path)
         print(
             "len of list with all paths to containing result data ",
             len(list_with_all_paths_to_check),
         )
         # filter out results that had buildings that were too hot or too cold
-        list_with_all_paths_to_check_after_filtering = self.filter_results_that_failed_to_heat_or_cool_building_sufficiently(
-            list_of_result_path_that_contain_scenario_data=list_with_all_paths_to_check
+        list_with_all_paths_to_check_after_filtering = (
+            self.filter_results_that_failed_to_heat_or_cool_building_sufficiently(
+                list_of_result_path_that_contain_scenario_data=list_with_all_paths_to_check
+            )
         )
         print(
             "len of list with all paths after filtering ",
             len(list_with_all_paths_to_check),
         )
         # check if duplicates are existing and ask for deletion
-        list_with_result_data_folders = self.go_through_all_scenario_data_folders_and_check_if_module_configs_are_double_somewhere(
-            list_of_result_folder_paths_to_check=list_with_all_paths_to_check_after_filtering
+        list_with_result_data_folders = (
+            self.go_through_all_scenario_data_folders_and_check_if_module_configs_are_double_somewhere(
+                list_of_result_folder_paths_to_check=list_with_all_paths_to_check_after_filtering
+            )
         )
         print(
             "len of list with all paths after double checking for duplicates ",
@@ -184,9 +164,7 @@ class ResultDataCollection:
             file.write("Failed simulations found in the following folders: \n")
 
             for folder in os.listdir(result_path):
-                if not os.path.exists(
-                    os.path.join(result_path, folder, "finished.flag")
-                ):
+                if not os.path.exists(os.path.join(result_path, folder, "finished.flag")):
                     file.write(os.path.join(result_path, folder) + "\n")
                     list_of_unfinished_folders.append(os.path.join(result_path, folder))
             file.write(
@@ -225,9 +203,7 @@ class ResultDataCollection:
             encoding="utf-8",
         ) as file:
             file.write(str(datetime.datetime.now()) + "\n")
-            file.write(
-                "Simulations with unsuccessful heating or cooling found in the following folders: \n"
-            )
+            file.write("Simulations with unsuccessful heating or cooling found in the following folders: \n")
             file.write(
                 "Building is too...,"
                 "set temperature heating [°C],"
@@ -238,53 +214,38 @@ class ResultDataCollection:
                 "temp deviation above set cooling [°C*h], folder \n"
             )
             for folder in list_of_result_path_that_contain_scenario_data:
-                scenario_data_information = os.path.join(
-                    folder, "data_information_for_scenario_evaluation.json"
-                )
+                scenario_data_information = os.path.join(folder, "data_information_for_scenario_evaluation.json")
                 main_folder = os.path.normpath(folder + os.sep + os.pardir)
                 webtool_kpis_file = os.path.join(main_folder, "webtool_kpis.json")
 
                 # get set temperatures used in the simulation
                 if os.path.exists(scenario_data_information):
-                    with open(
-                        scenario_data_information, "r", encoding="utf-8"
-                    ) as data_info_file:
+                    with open(scenario_data_information, "r", encoding="utf-8") as data_info_file:
                         json_file = json.load(data_info_file)
                         component_entries = json_file["componentEntries"]
                         for component in component_entries:
                             if "Building" in component["componentName"]:
                                 set_heating_temperature = float(
-                                    component["configuration"].get(
-                                        "set_heating_temperature_in_celsius"
-                                    )
+                                    component["configuration"].get("set_heating_temperature_in_celsius")
                                 )
                                 set_cooling_temperature = float(
-                                    component["configuration"].get(
-                                        "set_cooling_temperature_in_celsius"
-                                    )
+                                    component["configuration"].get("set_cooling_temperature_in_celsius")
                                 )
                                 break
                 else:
-                    raise FileNotFoundError(
-                        f"The file {scenario_data_information} could not be found. "
-                    )
+                    raise FileNotFoundError(f"The file {scenario_data_information} could not be found. ")
 
                 # open the webtool kpis and check if building got too hot or too cold
                 if os.path.exists(webtool_kpis_file):
-
                     with open(webtool_kpis_file, "r", encoding="utf-8") as kpi_file:
                         json_file = json.load(kpi_file)
                         kpi_data = json_file["kpiDict"]
                         # check if min and max temperatures are too low or too high
                         min_temperature = float(
-                            kpi_data.get(
-                                "Minimum building indoor air temperature reached [\u00b0C] "
-                            )
+                            kpi_data.get("Minimum building indoor air temperature reached [\u00b0C] ")
                         )
                         max_temperature = float(
-                            kpi_data.get(
-                                "Maximum building indoor air temperature reached [\u00b0C] "
-                            )
+                            kpi_data.get("Maximum building indoor air temperature reached [\u00b0C] ")
                         )
                         temp_deviation_below_set = kpi_data.get(
                             "Temperature deviation of building indoor air temperature being below set temperature 19.0 \u00b0C [\u00b0C*h] "
@@ -335,9 +296,7 @@ class ResultDataCollection:
                             )
                             list_of_unsuccessful_folders.append(folder)
                 else:
-                    raise FileNotFoundError(
-                        f"The file {webtool_kpis_file} could not be found. "
-                    )
+                    raise FileNotFoundError(f"The file {webtool_kpis_file} could not be found. ")
 
             file.write(
                 f"Total number of simulations that have building temperatures way below or above set temperatures: {len(list_of_unsuccessful_folders)}"
@@ -350,9 +309,7 @@ class ResultDataCollection:
         )
 
         # ask if these simulation results should be analyzed
-        answer = input(
-            "Do you want to take these simulation results into account for further analysis?"
-        )
+        answer = input("Do you want to take these simulation results into account for further analysis?")
         if answer.upper() in ["N", "NO"]:
             for folder in list_of_unsuccessful_folders:
                 list_of_result_path_that_contain_scenario_data.remove(folder)
@@ -360,9 +317,7 @@ class ResultDataCollection:
                 "The folders with too low or too high building temperatures will be discarded from the further analysis."
             )
         elif answer.upper() in ["Y", "YES"]:
-            print(
-                "The folders with too low or too high building temperatures will be kept for the further analysis."
-            )
+            print("The folders with too low or too high building temperatures will be kept for the further analysis.")
         else:
             print("The answer must be yes or no.")
 
@@ -384,16 +339,12 @@ class ResultDataCollection:
         list_of_paths_third_order = list(glob.glob(path_to_check))
 
         list_with_all_paths_to_check = (
-            list_of_paths_first_order
-            + list_of_paths_second_order
-            + list_of_paths_third_order
+            list_of_paths_first_order + list_of_paths_second_order + list_of_paths_third_order
         )
 
         return list_with_all_paths_to_check
 
-    def import_data_from_file(
-        self, paths_to_check: List[str], analyze_yearly_or_hourly_data: Any
-    ) -> List:
+    def import_data_from_file(self, paths_to_check: List[str], analyze_yearly_or_hourly_data: Any) -> List:
         """Import data from result files."""
         log.information("Importing result_data_for_scenario_evaluation from csv files.")
 
@@ -408,12 +359,9 @@ class ResultDataCollection:
         elif analyze_yearly_or_hourly_data == ResultDataTypeEnum.MONTHLY:
             kind_of_data_set = "monthly"
         else:
-            raise ValueError(
-                "analyze_yearly_or_hourly_data was not found in the datacollectorenum class."
-            )
+            raise ValueError("analyze_yearly_or_hourly_data was not found in the datacollectorenum class.")
 
         for folder in paths_to_check:  # type: ignore
-
             for file in os.listdir(folder):  # type: ignore
                 # get yearly or hourly data
                 if kind_of_data_set in file and file.endswith(".csv"):
@@ -422,7 +370,9 @@ class ResultDataCollection:
         return all_csv_files
 
     def make_dictionaries_with_simulation_duration_keys(
-        self, simulation_duration_to_check: str, all_csv_files: List[str],
+        self,
+        simulation_duration_to_check: str,
+        all_csv_files: List[str],
     ) -> Dict:
         """Make dictionaries containing csv files of hourly or yearly data and according to the simulation duration of the data."""
 
@@ -435,20 +385,16 @@ class ResultDataCollection:
             parent_folder = os.path.abspath(os.path.join(file, os.pardir))  # type: ignore
             for file1 in os.listdir(parent_folder):
                 if ".json" in file1:
-                    with open(
-                        os.path.join(parent_folder, file1), "r", encoding="utf-8"
-                    ) as openfile:
+                    with open(os.path.join(parent_folder, file1), "r", encoding="utf-8") as openfile:
                         json_file = json.load(openfile)
-                        simulation_duration = json_file["scenarioDataInformation"].get(
-                            "duration in days"
-                        )
-                        if int(simulation_duration_to_check) == int(
-                            simulation_duration
-                        ):
+                        simulation_duration = json_file["scenarioDataInformation"].get("duration in days")
+                        if int(simulation_duration_to_check) == int(simulation_duration):
                             dict_of_csv_data[f"{simulation_duration}"].append(file)
                         else:
-                            raise ValueError(f"The simulation_duration_to_check of {simulation_duration_to_check} is different,"
-                                             f"to the simulation duration of {simulation_duration} found in the scenario data information json in the result folders.")
+                            raise ValueError(
+                                f"The simulation_duration_to_check of {simulation_duration_to_check} is different,"
+                                f"to the simulation duration of {simulation_duration} found in the scenario data information json in the result folders."
+                            )
 
         # raise error if dict is empty
         if bool(dict_of_csv_data) is False:
@@ -472,16 +418,12 @@ class ResultDataCollection:
         dataframe["scenario"] = f"{parameter_key}_{value}"
         return dataframe["scenario"]
 
-    def rename_scenario_name_of_dataframe_with_index(
-        self, dataframe: pd.DataFrame, index: int
-    ) -> Any:
+    def rename_scenario_name_of_dataframe_with_index(self, dataframe: pd.DataFrame, index: int) -> Any:
         """Rename the scenario of the given dataframe adding an index."""
         dataframe["scenario"] = dataframe["scenario"] + f"_{index}"
         return dataframe["scenario"]
 
-    def sort_dataframe_according_to_scenario_values(
-        self, dataframe: pd.DataFrame
-    ) -> pd.DataFrame:
+    def sort_dataframe_according_to_scenario_values(self, dataframe: pd.DataFrame) -> pd.DataFrame:
         """Sort dataframe according to scenario values."""
 
         # get parameter key values from scenario name
@@ -501,7 +443,6 @@ class ResultDataCollection:
         # sort the order of the dataframe according to order of parameter key values
         new_df = pd.DataFrame()
         for sorted_value in ordered_values:
-
             for scenario in list(set(dataframe["scenario"])):
                 scenario_name_splitted = scenario.split("_")
                 number = float(scenario_name_splitted[-1])
@@ -522,9 +463,7 @@ class ResultDataCollection:
         list_with_module_config_dicts: Optional[List[Any]] = None,
     ) -> None:
         """Read the csv files and generate the result dataframe."""
-        log.information(
-            f"Read csv files and generate result dataframes for {time_resolution_of_data_set}."
-        )
+        log.information(f"Read csv files and generate result dataframes for {time_resolution_of_data_set}.")
 
         appended_dataframe = pd.DataFrame()
         index = 0
@@ -535,7 +474,6 @@ class ResultDataCollection:
             raise ValueError("csv_data_list is empty.")
 
         for csv_file in csv_data_list:
-
             dataframe = pd.read_csv(csv_file)
 
             # add hash colum to dataframe so hash does not get lost when scenario is renamed
@@ -550,9 +488,7 @@ class ResultDataCollection:
                     module_config_key,
                     module_config_value,
                 ) in module_config_dict.items():
-                    dataframe[module_config_key] = [module_config_value] * len(
-                        dataframe["scenario"]
-                    )
+                    dataframe[module_config_key] = [module_config_value] * len(dataframe["scenario"])
 
             if rename_scenario is True:
                 if (
@@ -561,9 +497,7 @@ class ResultDataCollection:
                     and list_with_parameter_key_values != []
                 ):
                     # rename scenario adding paramter key, value pair
-                    dataframe[
-                        "scenario"
-                    ] = self.rename_scenario_name_of_dataframe_with_parameter_key_and_value(
+                    dataframe["scenario"] = self.rename_scenario_name_of_dataframe_with_parameter_key_and_value(
                         dataframe=dataframe,
                         parameter_key=parameter_key,
                         list_with_parameter_values=list_with_parameter_key_values,
@@ -572,9 +506,7 @@ class ResultDataCollection:
 
                 else:
                     # rename scenario adding an index
-                    dataframe[
-                        "scenario"
-                    ] = self.rename_scenario_name_of_dataframe_with_index(
+                    dataframe["scenario"] = self.rename_scenario_name_of_dataframe_with_index(
                         dataframe=dataframe, index=index
                     )
 
@@ -585,9 +517,7 @@ class ResultDataCollection:
         # sort dataframe
         if appended_dataframe.empty:
             raise ValueError("The appended dataframe is empty")
-        appended_dataframe = self.sort_dataframe_according_to_scenario_values(
-            dataframe=appended_dataframe
-        )
+        appended_dataframe = self.sort_dataframe_according_to_scenario_values(dataframe=appended_dataframe)
 
         filename = self.store_scenario_data_with_the_right_name_and_in_the_right_path(
             result_data_folder=self.result_data_folder,
@@ -615,9 +545,7 @@ class ResultDataCollection:
         elif time_resolution_of_data_set == ResultDataTypeEnum.MONTHLY:
             kind_of_data_set = "monthly"
         else:
-            raise ValueError(
-                "This kind of data was not found in the datacollectorenum class."
-            )
+            raise ValueError("This kind of data was not found in the datacollectorenum class.")
 
         if parameter_key is not None:
             path_for_file = os.path.join(
@@ -666,7 +594,6 @@ class ResultDataCollection:
         """Read json config in result_data_for_scenario_evaluation folder and compare with default config."""
 
         for file in os.listdir(path_to_scenario_data_folder):
-
             if ".json" in file:
                 with open(os.path.join(path_to_scenario_data_folder, file), "r", encoding="utf-8") as openfile:  # type: ignore
                     config_dict = json.load(openfile)
@@ -686,17 +613,12 @@ class ResultDataCollection:
         if len(set(default_config_dict).intersection(my_module_config_dict)) == 0:
             raise KeyError(
                 f"The module config of the folder {path_to_scenario_data_folder} should contain the keys of the default config,",
-                "otherwise their values cannot be compared."
+                "otherwise their values cannot be compared.",
             )
         # check if there is a module config which is equal to default config
 
-        if all(
-            item in my_module_config_dict.items()
-            for item in default_config_dict.items()
-        ):
-            self.path_of_scenario_data_executed_with_default_config = (
-                path_to_scenario_data_folder
-            )
+        if all(item in my_module_config_dict.items() for item in default_config_dict.items()):
+            self.path_of_scenario_data_executed_with_default_config = path_to_scenario_data_folder
 
         # for each parameter different than the default config parameter, get the respective path to the folder
         # and also create a dict with the parameter, value pairs
@@ -711,9 +633,7 @@ class ResultDataCollection:
         # add to each item in the dict also the default system setup if the default system setup exists
 
         if self.path_of_scenario_data_executed_with_default_config != "":
-            list_with_csv_files.append(
-                self.path_of_scenario_data_executed_with_default_config
-            )
+            list_with_csv_files.append(self.path_of_scenario_data_executed_with_default_config)
             list_with_parameter_key_values.append(default_config_dict[parameter_key])
 
             list_with_module_configs.append(default_config_dict)
@@ -734,7 +654,6 @@ class ResultDataCollection:
         """Read module config if possible and write to dataframe."""
 
         for file in os.listdir(path_to_scenario_data_folder):
-
             if ".json" in file:
                 with open(os.path.join(path_to_scenario_data_folder, file), "r", encoding="utf-8") as openfile:  # type: ignore
                     config_dict = json.load(openfile)
@@ -744,7 +663,7 @@ class ResultDataCollection:
         if len(set(default_config_dict).intersection(my_module_config_dict)) == 0:
             raise KeyError(
                 f"The module config of the folder {path_to_scenario_data_folder} should contain the keys of the default config,",
-                "otherwise their values cannot be compared."
+                "otherwise their values cannot be compared.",
             )
 
         list_with_module_configs.append(my_module_config_dict)
@@ -768,7 +687,6 @@ class ResultDataCollection:
         list_with_parameter_key_values: List = []
 
         for folder in list_with_result_data_folders:  # type: ignore
-
             if parameter_key is None:
                 (
                     list_with_module_configs,
@@ -782,7 +700,6 @@ class ResultDataCollection:
                 list_with_parameter_key_values = []
 
             else:
-
                 (
                     list_with_csv_files,
                     list_with_parameter_key_values,
@@ -802,15 +719,11 @@ class ResultDataCollection:
             list_with_module_configs,
         )
 
-    def check_for_duplicates_in_dict(
-        self, dictionary_to_check: Dict[str, Any], key: str
-    ) -> List:
+    def check_for_duplicates_in_dict(self, dictionary_to_check: Dict[str, Any], key: str) -> List:
         """Check for duplicates and return index of where the duplicates are found."""
 
         indices_of_duplicates = [
-            index
-            for index, value in enumerate(dictionary_to_check[key])
-            if value in dictionary_to_check[key][:index]
+            index for index, value in enumerate(dictionary_to_check[key]) if value in dictionary_to_check[key][:index]
         ]
 
         return indices_of_duplicates
@@ -823,36 +736,21 @@ class ResultDataCollection:
         list_of_all_module_configs = []
         list_of_result_folders_which_have_only_unique_configs = []
         for folder in list_of_result_folder_paths_to_check:
-
             for file in os.listdir(folder):
                 if ".json" in file:
                     with open(os.path.join(folder, file), "r", encoding="utf-8") as openfile:  # type: ignore
                         config_dict = json.load(openfile)
                         my_module_config_dict = config_dict["myModuleConfig"]
                         my_module_config_dict.update(
-                            {
-                                "duration in days": config_dict[
-                                    "scenarioDataInformation"
-                                ].get("duration in days")
-                            }
+                            {"duration in days": config_dict["scenarioDataInformation"].get("duration in days")}
                         )
-                        my_module_config_dict.update(
-                            {"model": config_dict["scenarioDataInformation"].get("model")}
-                        )
-                        my_module_config_dict.update(
-                            {
-                                "model": config_dict["scenarioDataInformation"].get(
-                                    "scenario"
-                                )
-                            }
-                        )
+                        my_module_config_dict.update({"model": config_dict["scenarioDataInformation"].get("model")})
+                        my_module_config_dict.update({"model": config_dict["scenarioDataInformation"].get("scenario")})
 
                         # prevent to add modules with same module config and same simulation duration twice
                         if my_module_config_dict not in list_of_all_module_configs:
                             list_of_all_module_configs.append(my_module_config_dict)
-                            list_of_result_folders_which_have_only_unique_configs.append(
-                                os.path.join(folder)
-                            )
+                            list_of_result_folders_which_have_only_unique_configs.append(os.path.join(folder))
 
             # get folders with duplicates
             list_with_duplicates = []

--- a/hisim/postprocessing/scenario_evaluation/result_data_plotting.py
+++ b/hisim/postprocessing/scenario_evaluation/result_data_plotting.py
@@ -49,50 +49,31 @@ class ScenarioChartGeneration:
         self.show_plot_legend: bool = True
 
         if data_processing_mode == ResultDataProcessingModeEnum.PROCESS_ALL_DATA:
-
             data_path_strip = "data_with_all_parameters"
             result_path_strip = "results_for_all_parameters"
             self.show_plot_legend = False
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_BUILDING_CODES
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_BUILDING_CODES:
             data_path_strip = "data_with_different_building_codes"
             result_path_strip = "results_different_building_codes"
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_BUILDING_SIZES
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_BUILDING_SIZES:
             data_path_strip = "data_with_different_conditioned_floor_area_in_m2s"
             result_path_strip = "results_different_conditioned_floor_area_in_m2s"
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_PV_AZIMUTH_ANGLES
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_PV_AZIMUTH_ANGLES:
             data_path_strip = "data_with_different_pv_azimuths"
             result_path_strip = "results_different_pv_azimuths"
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_PV_TILT_ANGLES
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_PV_TILT_ANGLES:
             data_path_strip = "data_with_different_pv_tilts"
             result_path_strip = "results_different_pv_tilts"
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_SHARE_OF_MAXIMUM_PV
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_SHARE_OF_MAXIMUM_PV:
             data_path_strip = "data_with_different_share_of_maximum_pv_powers"
             result_path_strip = "results_different_share_of_maximum_pv_powers"
 
-        elif (
-            data_processing_mode
-            == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_NUMBER_OF_DWELLINGS
-        ):
+        elif data_processing_mode == ResultDataProcessingModeEnum.PROCESS_FOR_DIFFERENT_NUMBER_OF_DWELLINGS:
             data_path_strip = "data_with_different_number_of_dwellings_per_buildings"
             result_path_strip = "results_different_number_of_dwellings_per_buildings"
 
@@ -144,9 +125,7 @@ class ScenarioChartGeneration:
             )
 
         else:
-            log.information(
-                "Variable list for data is not given and will not be plotted or anaylzed."
-            )
+            log.information("Variable list for data is not given and will not be plotted or anaylzed.")
 
     def make_plots_with_specific_kind_of_data(
         self,
@@ -163,29 +142,19 @@ class ScenarioChartGeneration:
             raise ValueError("Dataframe is empty.")
 
         sub_results_folder = f"simulation_duration_of_{simulation_duration_key}_days"
-        sub_sub_results_folder = (
-            f"scenario_comparison_{time_resolution_of_data_set.value}_{self.datetime_string}"
-        )
+        sub_sub_results_folder = f"scenario_comparison_{time_resolution_of_data_set.value}_{self.datetime_string}"
 
-        self.path_for_plots = os.path.join(
-            self.result_folder, sub_results_folder, sub_sub_results_folder
-        )
+        self.path_for_plots = os.path.join(self.result_folder, sub_results_folder, sub_sub_results_folder)
 
         for variable_to_check in variables_to_check:
             log.information("Check variable " + str(variable_to_check))
 
             # prepare path for plots
             self.path_addition = "".join(
-                [
-                    x
-                    for x in variable_to_check
-                    if x in string.ascii_letters or x.isspace() or x == "2"
-                ]
+                [x for x in variable_to_check if x in string.ascii_letters or x.isspace() or x == "2"]
             )
 
-            self.plot_path_complete = os.path.join(
-                self.path_for_plots, self.path_addition
-            )
+            self.plot_path_complete = os.path.join(self.path_for_plots, self.path_addition)
             if os.path.exists(self.plot_path_complete) is False:
                 os.makedirs(self.plot_path_complete)
 
@@ -214,21 +183,18 @@ class ScenarioChartGeneration:
 
                 try:
                     self.make_box_plot_for_pandas_dataframe(
-                        filtered_data=filtered_data, title=self.path_addition,
+                        filtered_data=filtered_data,
+                        title=self.path_addition,
                     )
                 except Exception:
-                    log.information(
-                        f"{variable_to_check} could not be plotted as box plot."
-                    )
+                    log.information(f"{variable_to_check} could not be plotted as box plot.")
 
                 try:
                     self.make_bar_plot_for_pandas_dataframe(
                         filtered_data=filtered_data, title=self.path_addition, unit=unit
                     )
                 except Exception:
-                    log.information(
-                        f"{variable_to_check} could not be plotted as bar plot."
-                    )
+                    log.information(f"{variable_to_check} could not be plotted as bar plot.")
 
                 try:
                     self.make_scatter_plot_for_pandas_dataframe(
@@ -237,25 +203,20 @@ class ScenarioChartGeneration:
                         y_data_variable=self.path_addition,
                     )
                 except Exception:
-                    log.information(
-                        f"{variable_to_check} could not be plotted as scatter plot."
-                    )
+                    log.information(f"{variable_to_check} could not be plotted as scatter plot.")
 
                 try:
                     self.make_histogram_plot_for_pandas_dataframe(
                         filtered_data=filtered_data, title=self.path_addition, unit=unit
                     )
                 except Exception:
-                    log.information(
-                        f"{variable_to_check} could not be plotted as histogram."
-                    )
+                    log.information(f"{variable_to_check} could not be plotted as histogram.")
 
             elif time_resolution_of_data_set in (
                 ResultDataTypeEnum.HOURLY,
                 ResultDataTypeEnum.DAILY,
                 ResultDataTypeEnum.MONTHLY,
             ):
-
                 if time_resolution_of_data_set == ResultDataTypeEnum.HOURLY:
                     kind_of_data_set = "hourly"
                     line_plot_marker_size = 2
@@ -280,24 +241,15 @@ class ScenarioChartGeneration:
                         line_plot_marker_size=line_plot_marker_size,
                     )
                 except Exception:
-                    log.information(
-                        f"{variable_to_check} could not be plotted as line plot."
-                    )
+                    log.information(f"{variable_to_check} could not be plotted as line plot.")
                 try:
-
-                    self.make_box_plot_for_pandas_dataframe(
-                        filtered_data=filtered_data, title=self.path_addition
-                    )
+                    self.make_box_plot_for_pandas_dataframe(filtered_data=filtered_data, title=self.path_addition)
 
                 except Exception:
-                    log.information(
-                        f"{variable_to_check} could not be plotted as box plot."
-                    )
+                    log.information(f"{variable_to_check} could not be plotted as box plot.")
 
             else:
-                raise ValueError(
-                    "This kind of data was not found in the datacollectorenum class."
-                )
+                raise ValueError("This kind of data was not found in the datacollectorenum class.")
 
     def make_line_plot_for_pandas_dataframe(
         self, filtered_data: pd.DataFrame, title: str, line_plot_marker_size: int
@@ -305,35 +257,24 @@ class ScenarioChartGeneration:
         """Make line plot."""
         log.information("Make line plot with data.")
 
-        fig, a_x = plt.subplots(
-            figsize=self.hisim_chartbase.figsize, dpi=self.hisim_chartbase.dpi
-        )
+        fig, a_x = plt.subplots(figsize=self.hisim_chartbase.figsize, dpi=self.hisim_chartbase.dpi)
         x_data = list(OrderedSet(list(filtered_data.time)))
         if filtered_data.time.values[0] is not None:
             year = filtered_data.time.values[0].split("-")[0]
         else:
-            raise ValueError(
-                "year could not be determined because time value of filtered data was None."
-            )
+            raise ValueError("year could not be determined because time value of filtered data was None.")
 
         x_data_transformed = np.asarray(x_data, dtype="datetime64[D]")
 
         for scenario in list(OrderedSet(list(filtered_data.scenario))):
-            filtered_data_per_scenario = filtered_data.loc[
-                filtered_data["scenario"] == scenario
-            ]
+            filtered_data_per_scenario = filtered_data.loc[filtered_data["scenario"] == scenario]
             mean_values_aggregated_according_to_scenarios = []
             for time_value in x_data:
-
                 mean_value_per_scenario_per_timestep = np.mean(
-                    filtered_data_per_scenario.loc[
-                        filtered_data_per_scenario["time"] == time_value
-                    ]["value"]
+                    filtered_data_per_scenario.loc[filtered_data_per_scenario["time"] == time_value]["value"]
                 )
 
-                mean_values_aggregated_according_to_scenarios.append(
-                    mean_value_per_scenario_per_timestep
-                )
+                mean_values_aggregated_according_to_scenarios.append(mean_value_per_scenario_per_timestep)
 
             y_data = mean_values_aggregated_according_to_scenarios
 
@@ -345,9 +286,7 @@ class ScenarioChartGeneration:
                 label=scenario,
             )
 
-        y_tick_labels, unit, y_tick_locations = self.set_axis_scale(
-            a_x, x_or_y="y", unit=filtered_data.unit.values[0]
-        )
+        y_tick_labels, unit, y_tick_locations = self.set_axis_scale(a_x, x_or_y="y", unit=filtered_data.unit.values[0])
         plt.yticks(
             ticks=y_tick_locations,
             labels=y_tick_labels,
@@ -355,10 +294,12 @@ class ScenarioChartGeneration:
         )
 
         plt.ylabel(
-            ylabel=f"{unit}", fontsize=self.hisim_chartbase.fontsize_label,
+            ylabel=f"{unit}",
+            fontsize=self.hisim_chartbase.fontsize_label,
         )
         plt.xlabel(
-            xlabel=year, fontsize=self.hisim_chartbase.fontsize_label,
+            xlabel=year,
+            fontsize=self.hisim_chartbase.fontsize_label,
         )
         plt.title(label=title, fontsize=self.hisim_chartbase.fontsize_title)
         plt.tick_params(labelsize=self.hisim_chartbase.fontsize_ticks)
@@ -366,9 +307,7 @@ class ScenarioChartGeneration:
         if self.show_plot_legend:
             plt.legend(bbox_to_anchor=(1, 1), loc="upper left")
 
-        fig.savefig(
-            os.path.join(self.plot_path_complete, "line_plot.png"), bbox_inches="tight"
-        )
+        fig.savefig(os.path.join(self.plot_path_complete, "line_plot.png"), bbox_inches="tight")
         plt.close()
 
     def make_bar_plot_for_pandas_dataframe(
@@ -381,17 +320,13 @@ class ScenarioChartGeneration:
         """Make bar plot."""
         log.information("Make bar plot.")
 
-        fig, a_x = plt.subplots(
-            figsize=self.hisim_chartbase.figsize, dpi=self.hisim_chartbase.dpi
-        )
+        fig, a_x = plt.subplots(figsize=self.hisim_chartbase.figsize, dpi=self.hisim_chartbase.dpi)
 
         y_data = []
         bar_labels = []
 
         for scenario in list(OrderedSet(list(filtered_data.scenario))):
-            filtered_data_per_scenario = filtered_data.loc[
-                filtered_data["scenario"] == scenario
-            ]
+            filtered_data_per_scenario = filtered_data.loc[filtered_data["scenario"] == scenario]
 
             mean_value_per_scenario = np.mean(filtered_data_per_scenario.value.values)
 
@@ -409,7 +344,9 @@ class ScenarioChartGeneration:
         a_x.bar(x_data, y_data, label=bar_labels, color=colors)
 
         y_tick_labels, unit, y_tick_locations = self.set_axis_scale(
-            a_x, x_or_y="y", unit=unit,
+            a_x,
+            x_or_y="y",
+            unit=unit,
         )
         plt.yticks(
             ticks=y_tick_locations,
@@ -417,7 +354,8 @@ class ScenarioChartGeneration:
             fontsize=self.hisim_chartbase.fontsize_ticks,
         )
         plt.ylabel(
-            ylabel=f"{unit}", fontsize=self.hisim_chartbase.fontsize_label,
+            ylabel=f"{unit}",
+            fontsize=self.hisim_chartbase.fontsize_label,
         )
         plt.xlabel(
             xlabel=filtered_data.year.values[0],
@@ -444,24 +382,21 @@ class ScenarioChartGeneration:
         """Make box plot."""
         log.information("Make box plot.")
 
-        fig, a_x = plt.subplots(
-            figsize=self.hisim_chartbase.figsize, dpi=self.hisim_chartbase.dpi
-        )
+        fig, a_x = plt.subplots(figsize=self.hisim_chartbase.figsize, dpi=self.hisim_chartbase.dpi)
         if scenario_set is None:
             scenario_set = list(OrderedSet(filtered_data.scenario))
 
         sns.boxplot(data=filtered_data, x="scenario", y="value")
 
-        y_tick_labels, unit, y_tick_locations = self.set_axis_scale(
-            a_x, x_or_y="y", unit=filtered_data.unit.values[0]
-        )
+        y_tick_labels, unit, y_tick_locations = self.set_axis_scale(a_x, x_or_y="y", unit=filtered_data.unit.values[0])
         plt.yticks(
             ticks=y_tick_locations,
             labels=y_tick_labels,
             fontsize=self.hisim_chartbase.fontsize_ticks,
         )
         plt.ylabel(
-            ylabel=f"{unit}", fontsize=self.hisim_chartbase.fontsize_label,
+            ylabel=f"{unit}",
+            fontsize=self.hisim_chartbase.fontsize_label,
         )
         try:
             # this works for yearly data
@@ -473,7 +408,8 @@ class ScenarioChartGeneration:
             # take year from time colum
             year = filtered_data.time.values[0].split("-")[0]
             plt.xlabel(
-                xlabel=year, fontsize=self.hisim_chartbase.fontsize_label,
+                xlabel=year,
+                fontsize=self.hisim_chartbase.fontsize_label,
             )
         plt.title(label=title, fontsize=self.hisim_chartbase.fontsize_title)
         plt.tick_params(labelsize=self.hisim_chartbase.fontsize_ticks)
@@ -482,9 +418,7 @@ class ScenarioChartGeneration:
         if self.show_plot_legend:
             plt.legend(scenario_set, bbox_to_anchor=(1, 1), loc="upper left")
 
-        fig.savefig(
-            os.path.join(self.plot_path_complete, "box_plot.png"), bbox_inches="tight"
-        )
+        fig.savefig(os.path.join(self.plot_path_complete, "box_plot.png"), bbox_inches="tight")
         plt.close()
 
     def make_histogram_plot_for_pandas_dataframe(
@@ -506,10 +440,12 @@ class ScenarioChartGeneration:
         plt.hist(x=np.array(filtered_data.value.values), bins="auto")
 
         plt.ylabel(
-            ylabel="Count", fontsize=self.hisim_chartbase.fontsize_label,
+            ylabel="Count",
+            fontsize=self.hisim_chartbase.fontsize_label,
         )
         plt.xlabel(
-            xlabel=f"{unit}", fontsize=self.hisim_chartbase.fontsize_label,
+            xlabel=f"{unit}",
+            fontsize=self.hisim_chartbase.fontsize_label,
         )
         plt.title(label=title, fontsize=self.hisim_chartbase.fontsize_title)
         plt.tick_params(labelsize=self.hisim_chartbase.fontsize_ticks)
@@ -530,31 +466,22 @@ class ScenarioChartGeneration:
         """Make scatter plot."""
         log.information("Make scatter plot with data.")
 
-        fig, a_x = plt.subplots(
-            figsize=self.hisim_chartbase.figsize, dpi=self.hisim_chartbase.dpi
-        )
+        fig, a_x = plt.subplots(figsize=self.hisim_chartbase.figsize, dpi=self.hisim_chartbase.dpi)
 
         # iterate over all scenarios
         x_data_mean_value_list_for_all_scenarios = []
         y_data_mean_value_list_for_all_scenarios = []
         for scenario in list(OrderedSet(list(full_pandas_dataframe.scenario))):
-
-            full_data_per_scenario = full_pandas_dataframe.loc[
-                full_pandas_dataframe["scenario"] == scenario
-            ]
-            filtered_data_per_scenario = filtered_data.loc[
-                filtered_data["scenario"] == scenario
-            ]
+            full_data_per_scenario = full_pandas_dataframe.loc[full_pandas_dataframe["scenario"] == scenario]
+            filtered_data_per_scenario = filtered_data.loc[filtered_data["scenario"] == scenario]
 
             # get x_data_list by filtering the df according to x_data_variable and then by taking values from "value" column
             x_data_list = list(
-                full_data_per_scenario.loc[
-                    full_data_per_scenario["variable"] == x_data_variable
-                ]["value"].values
+                full_data_per_scenario.loc[full_data_per_scenario["variable"] == x_data_variable]["value"].values
             )
-            x_data_unit = full_data_per_scenario.loc[
-                full_data_per_scenario["variable"] == x_data_variable
-            ]["unit"].values[0]
+            x_data_unit = full_data_per_scenario.loc[full_data_per_scenario["variable"] == x_data_variable][
+                "unit"
+            ].values[0]
 
             # if x_data_list has more than 1 value (because more values for this scenario exist), then take mean value
             if len(x_data_list) > 1:
@@ -568,9 +495,7 @@ class ScenarioChartGeneration:
                 )
 
             # append to x_data_mean_value_list
-            x_data_mean_value_list_for_all_scenarios.append(
-                x_data_mean_value_per_scenario
-            )
+            x_data_mean_value_list_for_all_scenarios.append(x_data_mean_value_per_scenario)
 
             # get y values from filtered data per scenario (already filtered according to variable to check and scenario)
             y_data_list = list(filtered_data_per_scenario["value"].values)
@@ -587,9 +512,7 @@ class ScenarioChartGeneration:
                 )
 
             # append to y_data_mean_value_list
-            y_data_mean_value_list_for_all_scenarios.append(
-                y_data_mean_value_per_scenario
-            )
+            y_data_mean_value_list_for_all_scenarios.append(y_data_mean_value_per_scenario)
 
         # identify marker size accroding to data length
         data_length = len(x_data_mean_value_list_for_all_scenarios)
@@ -615,9 +538,7 @@ class ScenarioChartGeneration:
             s=scatter_plot_marker_size,
         )
 
-        y_tick_labels, y_unit, y_tick_locations = self.set_axis_scale(
-            a_x, x_or_y="y", unit=y_data_unit
-        )
+        y_tick_labels, y_unit, y_tick_locations = self.set_axis_scale(a_x, x_or_y="y", unit=y_data_unit)
         plt.yticks(
             ticks=y_tick_locations,
             labels=y_tick_labels,
@@ -644,9 +565,7 @@ class ScenarioChartGeneration:
         )
         plt.close()
 
-    def set_axis_scale(
-        self, a_x: Any, x_or_y: Any, unit: Any
-    ) -> Tuple[float, str, Any]:
+    def set_axis_scale(self, a_x: Any, x_or_y: Any, unit: Any) -> Tuple[float, str, Any]:
         """Get axis and unit and scale it properly."""
 
         if x_or_y == "x":
@@ -665,7 +584,6 @@ class ScenarioChartGeneration:
         scale = ""
 
         if unit not in ["-", "%"]:
-
             if max_scale >= 1e12:
                 new_tick_values = tick_values * 1e-12
                 scale = "T"

--- a/hisim/postprocessing/scenario_evaluation/result_data_processing.py
+++ b/hisim/postprocessing/scenario_evaluation/result_data_processing.py
@@ -35,17 +35,10 @@ class ScenarioDataProcessing:
         elif time_resolution_of_data_set == ResultDataTypeEnum.MONTHLY:
             kind_of_data_set = "monthly"
         else:
-            raise ValueError(
-                "This kind of data was not found in the datacollectorenum class."
-            )
-        log.information(
-            f"Read csv files and create one big dataframe for {kind_of_data_set} data."
-        )
+            raise ValueError("This kind of data was not found in the datacollectorenum class.")
+        log.information(f"Read csv files and create one big dataframe for {kind_of_data_set} data.")
 
-        for file in glob.glob(
-            os.path.join(data_folder_path, "**", f"*{kind_of_data_set}*.csv")
-        ):
-
+        for file in glob.glob(os.path.join(data_folder_path, "**", f"*{kind_of_data_set}*.csv")):
             file_df = pd.read_csv(filepath_or_buffer=file)
 
         # if scenario values are no strings, transform them
@@ -62,7 +55,6 @@ class ScenarioDataProcessing:
         #     variables_to_check.append("Relative Electricity Demand")
 
         if dict_of_scenarios_to_check is not None and dict_of_scenarios_to_check != {}:
-
             (
                 file_df,
                 key_for_scenario_one,
@@ -80,15 +72,11 @@ class ScenarioDataProcessing:
         )
 
     @staticmethod
-    def filter_pandas_dataframe(
-        dataframe: pd.DataFrame, variable_to_check: str
-    ) -> pd.DataFrame:
+    def filter_pandas_dataframe(dataframe: pd.DataFrame, variable_to_check: str) -> pd.DataFrame:
         """Filter pandas dataframe according to variable."""
         filtered_dataframe = dataframe.loc[dataframe["variable"] == variable_to_check]
         if filtered_dataframe.empty:
-            print(
-                f"The dataframe contains the following variables: {set(list(dataframe.variable))}"
-            )
+            print(f"The dataframe contains the following variables: {set(list(dataframe.variable))}")
             # raise ValueError(
             print(
                 f"The filtered dataframe is empty. The dataframe did not contain the variable {variable_to_check}. Check the list above."
@@ -97,7 +85,9 @@ class ScenarioDataProcessing:
 
     @staticmethod
     def get_statistics_of_data_and_write_to_excel(
-        filtered_data: pd.DataFrame, path_to_save: str, kind_of_data_set: str,
+        filtered_data: pd.DataFrame,
+        path_to_save: str,
+        kind_of_data_set: str,
     ) -> None:
         """Use pandas describe method to get statistical values of certain data."""
         # create a excel writer object
@@ -105,7 +95,6 @@ class ScenarioDataProcessing:
             path=os.path.join(path_to_save, f"{kind_of_data_set}_statistics.xlsx"),
             mode="w",
         ) as writer:
-
             filtered_data.to_excel(excel_writer=writer, sheet_name="filtered data")
             statistical_data = filtered_data.describe()
 
@@ -113,13 +102,12 @@ class ScenarioDataProcessing:
 
     @staticmethod
     def check_if_scenario_exists_and_filter_dataframe_for_scenarios(
-        data_frame: pd.DataFrame, dict_of_scenarios_to_check: Dict[str, List[str]],
+        data_frame: pd.DataFrame,
+        dict_of_scenarios_to_check: Dict[str, List[str]],
     ) -> pd.DataFrame:
         """Check if scenario exists and filter dataframe for scenario."""
         for (list_of_scenarios_to_check,) in dict_of_scenarios_to_check.values():
-            aggregated_scenario_dict: Dict = {
-                key: [] for key in list_of_scenarios_to_check
-            }
+            aggregated_scenario_dict: Dict = {key: [] for key in list_of_scenarios_to_check}
 
             for given_scenario in data_frame["scenario"]:
                 # string comparison
@@ -127,21 +115,16 @@ class ScenarioDataProcessing:
                 for scenario_to_check in list_of_scenarios_to_check:
                     if (
                         scenario_to_check in given_scenario
-                        and given_scenario
-                        not in aggregated_scenario_dict[scenario_to_check]
+                        and given_scenario not in aggregated_scenario_dict[scenario_to_check]
                     ):
-                        aggregated_scenario_dict[scenario_to_check].append(
-                            given_scenario
-                        )
+                        aggregated_scenario_dict[scenario_to_check].append(given_scenario)
             # raise error if dict is empty
             for (
                 key_scenario_to_check,
                 given_scenario,
             ) in aggregated_scenario_dict.items():
                 if given_scenario == []:
-                    raise ValueError(
-                        f"Scenarios containing {key_scenario_to_check} were not found in the dataframe."
-                    )
+                    raise ValueError(f"Scenarios containing {key_scenario_to_check} were not found in the dataframe.")
 
             concat_df = pd.DataFrame()
             # only take rows from dataframe which are in selected scenarios
@@ -149,13 +132,10 @@ class ScenarioDataProcessing:
                 key_scenario_to_check,
                 given_scenario,
             ) in aggregated_scenario_dict.items():
-
-                df_filtered_for_specific_scenarios = data_frame.loc[
-                    data_frame["scenario"].isin(given_scenario)
-                ]
-                df_filtered_for_specific_scenarios["scenario"] = [
-                    key_scenario_to_check
-                ] * len(df_filtered_for_specific_scenarios["scenario"])
+                df_filtered_for_specific_scenarios = data_frame.loc[data_frame["scenario"].isin(given_scenario)]
+                df_filtered_for_specific_scenarios["scenario"] = [key_scenario_to_check] * len(
+                    df_filtered_for_specific_scenarios["scenario"]
+                )
                 concat_df = pd.concat([concat_df, df_filtered_for_specific_scenarios])
                 concat_df["scenario_0"] = data_frame["scenario"]
 
@@ -186,7 +166,6 @@ class ScenarioDataProcessing:
                     and scenario_to_check == value
                     and value not in aggregated_scenario_dict[scenario_to_check]
                 ):
-
                     aggregated_scenario_dict[scenario_to_check].append(value)
 
         concat_df = pd.DataFrame()
@@ -195,18 +174,13 @@ class ScenarioDataProcessing:
             key_scenario_to_check,
             given_list_of_values,
         ) in aggregated_scenario_dict.items():
-
             df_filtered_for_specific_scenarios = dataframe.loc[
                 dataframe[column_name_to_check].isin(given_list_of_values)
             ]
 
-            df_filtered_for_specific_scenarios.loc[
-                :, "scenario"
-            ] = key_scenario_to_check
+            df_filtered_for_specific_scenarios.loc[:, "scenario"] = key_scenario_to_check
 
-            concat_df = pd.concat(
-                [concat_df, df_filtered_for_specific_scenarios], ignore_index=True
-            )
+            concat_df = pd.concat([concat_df, df_filtered_for_specific_scenarios], ignore_index=True)
 
             # concat_df[f"scenario_{filter_level_index}"] = dataframe.loc[:, "scenario"]
 
@@ -216,7 +190,8 @@ class ScenarioDataProcessing:
 
     @staticmethod
     def check_if_scenario_exists_and_filter_dataframe_for_scenarios_dict(
-        data_frame: pd.DataFrame, dict_of_scenarios_to_check: Dict[str, List[str]],
+        data_frame: pd.DataFrame,
+        dict_of_scenarios_to_check: Dict[str, List[str]],
     ) -> Tuple[pd.DataFrame, str, str]:
         """Check if scenario exists and filter dataframe for scenario."""
 
@@ -226,7 +201,6 @@ class ScenarioDataProcessing:
             scenario_to_check_key,
             list_of_scenarios_to_check,
         ) in dict_of_scenarios_to_check.items():
-
             concat_df = ScenarioDataProcessing.aggregate_all_values_for_one_scenario(
                 dataframe=concat_df,
                 list_of_scenarios_to_check=list_of_scenarios_to_check,
@@ -247,9 +221,7 @@ class ScenarioDataProcessing:
                 key_for_scenario_one = list(dict_of_scenarios_to_check.keys())[0]
                 key_for_current_scenario = list(dict_of_scenarios_to_check.keys())[1]
                 # concat_df.iloc[index, concat_df.columns.get_loc("scenario")] = f"{scenario_value_one}_{current_scenario_value}"
-                concat_df.loc[
-                    index, "scenario"
-                ] = f"{scenario_value_one}_{current_scenario_value}"
+                concat_df.loc[index, "scenario"] = f"{scenario_value_one}_{current_scenario_value}"
             elif filter_level_index == 1:
                 key_for_scenario_one = list(dict_of_scenarios_to_check.keys())[0]
                 key_for_current_scenario = ""
@@ -260,141 +232,87 @@ class ScenarioDataProcessing:
         """Calculate relative electricity demand."""
 
         # look for ElectricityMeter|Electricity|ElectrcityFromGrid output
-        if (
-            "ElectricityMeter|Electricity|ElectricityFromGrid"
-            not in dataframe.variable.values
-        ):
-            raise ValueError(
-                "ElectricityMeter|Electricity|ElectricityFromGrid was not found in variables."
-            )
+        if "ElectricityMeter|Electricity|ElectricityFromGrid" not in dataframe.variable.values:
+            raise ValueError("ElectricityMeter|Electricity|ElectricityFromGrid was not found in variables.")
 
         # filter again just to be shure
-        filtered_data = dataframe.loc[
-            dataframe.variable == "ElectricityMeter|Electricity|ElectricityFromGrid"
-        ]
+        filtered_data = dataframe.loc[dataframe.variable == "ElectricityMeter|Electricity|ElectricityFromGrid"]
 
         if "share_of_maximum_pv_power" not in filtered_data.columns:
-            raise ValueError(
-                "share_of_maximum_pv_power was not found in dataframe columns"
-            )
+            raise ValueError("share_of_maximum_pv_power was not found in dataframe columns")
         # sort df accrofing to share of pv
         filtered_data = filtered_data.sort_values("share_of_maximum_pv_power")
 
         # iterate over all scenarios
         for scenario in list(set(filtered_data.scenario.values)):
-
             if "share_of_maximum_pv_power" not in scenario:
-
-                df_for_one_scenario = filtered_data.loc[
-                    filtered_data.scenario == scenario
-                ]
+                df_for_one_scenario = filtered_data.loc[filtered_data.scenario == scenario]
 
                 df_for_one_scenario_and_for_share_zero = df_for_one_scenario.loc[
                     df_for_one_scenario.share_of_maximum_pv_power == 0
                 ]
 
-                reference_value_for_electricity_demand = (
-                    df_for_one_scenario_and_for_share_zero.value.values
-                )
-                relative_electricity_demand = [0] * len(
-                    reference_value_for_electricity_demand
-                )
+                reference_value_for_electricity_demand = df_for_one_scenario_and_for_share_zero.value.values
+                relative_electricity_demand = [0] * len(reference_value_for_electricity_demand)
 
                 # get reference value (when share of pv power is zero)
-                for share_of_maximum_pv_power in list(
-                    set(df_for_one_scenario.share_of_maximum_pv_power.values)
-                ):
-
+                for share_of_maximum_pv_power in list(set(df_for_one_scenario.share_of_maximum_pv_power.values)):
                     if share_of_maximum_pv_power != 0:
-
                         df_for_one_scenario_and_for_one_share = df_for_one_scenario.loc[
-                            df_for_one_scenario.share_of_maximum_pv_power
-                            == share_of_maximum_pv_power
+                            df_for_one_scenario.share_of_maximum_pv_power == share_of_maximum_pv_power
                         ]
 
-                        value_for_electricity_demand = (
-                            df_for_one_scenario_and_for_one_share.value.values
-                        )
+                        value_for_electricity_demand = df_for_one_scenario_and_for_one_share.value.values
 
                         # calculate reference electricity demand for each scenario and share of pv power
                         relative_electricity_demand = (
-                            value_for_electricity_demand
-                            / reference_value_for_electricity_demand
-                            * 100
+                            value_for_electricity_demand / reference_value_for_electricity_demand * 100
                         )
 
                         new_df_only_with_relative_electricity_demand = copy.deepcopy(
                             df_for_one_scenario_and_for_one_share
                         )
-                        new_df_only_with_relative_electricity_demand.loc[
-                            :, "variable"
-                        ] = "Relative Electricity Demand"
-                        new_df_only_with_relative_electricity_demand.loc[
-                            :, "unit"
-                        ] = "%"
-                        new_df_only_with_relative_electricity_demand.loc[
-                            :, "value"
-                        ] = relative_electricity_demand
+                        new_df_only_with_relative_electricity_demand.loc[:, "variable"] = "Relative Electricity Demand"
+                        new_df_only_with_relative_electricity_demand.loc[:, "unit"] = "%"
+                        new_df_only_with_relative_electricity_demand.loc[:, "value"] = relative_electricity_demand
 
                         del df_for_one_scenario_and_for_one_share
 
-                        dataframe = pd.concat(
-                            [dataframe, new_df_only_with_relative_electricity_demand]
-                        )
+                        dataframe = pd.concat([dataframe, new_df_only_with_relative_electricity_demand])
                         del dataframe["Unnamed: 0"]
                         del new_df_only_with_relative_electricity_demand
 
             else:
-
-                df_for_one_scenario = filtered_data.loc[
-                    filtered_data.scenario == scenario
-                ]
-                share_of_maximum_pv_power = df_for_one_scenario[
-                    "share_of_maximum_pv_power"
-                ].values[0]
+                df_for_one_scenario = filtered_data.loc[filtered_data.scenario == scenario]
+                share_of_maximum_pv_power = df_for_one_scenario["share_of_maximum_pv_power"].values[0]
 
                 if share_of_maximum_pv_power == 0:
-
                     relative_electricity_demand = [0] * len(df_for_one_scenario)
 
                 else:
-
                     value_for_electricity_demand = df_for_one_scenario.value.values
                     df_for_one_scenario_and_for_share_zero = filtered_data.loc[
                         filtered_data.share_of_maximum_pv_power == 0
                     ]
-                    reference_value_for_electricity_demand = (
-                        df_for_one_scenario_and_for_share_zero.value.values
-                    )
+                    reference_value_for_electricity_demand = df_for_one_scenario_and_for_share_zero.value.values
 
                     # calculate reference electricity demand for each scenario and share of pv power
                     relative_electricity_demand = (
                         1
                         - (
-                            (
-                                reference_value_for_electricity_demand
-                                - value_for_electricity_demand
-                            )
+                            (reference_value_for_electricity_demand - value_for_electricity_demand)
                             / reference_value_for_electricity_demand
                         )
                     ) * 100
 
-                new_df_only_with_relative_electricity_demand = copy.deepcopy(
-                    df_for_one_scenario
-                )
-                new_df_only_with_relative_electricity_demand.loc[
-                    :, "variable"
-                ] = "Relative Electricity Demand"
+                new_df_only_with_relative_electricity_demand = copy.deepcopy(df_for_one_scenario)
+                new_df_only_with_relative_electricity_demand.loc[:, "variable"] = "Relative Electricity Demand"
                 new_df_only_with_relative_electricity_demand.loc[:, "unit"] = "%"
-                new_df_only_with_relative_electricity_demand.loc[
-                    :, "value"
-                ] = relative_electricity_demand
+                new_df_only_with_relative_electricity_demand.loc[:, "value"] = relative_electricity_demand
 
                 del df_for_one_scenario
 
-                dataframe = pd.concat(
-                    [dataframe, new_df_only_with_relative_electricity_demand]
-                )
+                dataframe = pd.concat([dataframe, new_df_only_with_relative_electricity_demand])
 
                 del dataframe["Unnamed: 0"]
                 del new_df_only_with_relative_electricity_demand

--- a/hisim/postprocessing/scenario_evaluation/scenario_analysis_complete.py
+++ b/hisim/postprocessing/scenario_evaluation/scenario_analysis_complete.py
@@ -59,7 +59,8 @@ def main():
     )
 
     folder_from_which_data_will_be_collected = os.path.join(
-        cluster_storage_path, "repositories/HiSim/system_setups/results/",
+        cluster_storage_path,
+        "repositories/HiSim/system_setups/results/",
     )
 
     path_to_default_config = os.path.join(
@@ -68,9 +69,7 @@ def main():
     )
     simulation_duration_to_check = str(365)
 
-    data_processing_mode = (
-        result_data_collection.ResultDataProcessingModeEnum.PROCESS_ALL_DATA
-    )
+    data_processing_mode = result_data_collection.ResultDataProcessingModeEnum.PROCESS_ALL_DATA
 
     filterclass = result_data_processing.FilterClass()
     # list_with_variables_to_check = (

--- a/hisim/postprocessing/system_chart.py
+++ b/hisim/postprocessing/system_chart.py
@@ -69,9 +69,7 @@ class SystemChart:
     ) -> Optional[SystemChartEntry]:
         """Generates the system charts with graphviz."""
 
-        system_chart_entry: Optional[SystemChartEntry] = SystemChartEntry(
-            filename, caption
-        )
+        system_chart_entry: Optional[SystemChartEntry] = SystemChartEntry(filename, caption)
 
         try:
             """Visualizes the entire system with graphviz."""
@@ -87,9 +85,7 @@ class SystemChart:
             for component in self.ppdt.wrapped_components:
                 node_name = component.my_component.component_name
                 if with_class_names:
-                    node_name = (
-                        node_name + "\n" + component.my_component.__class__.__name__
-                    )
+                    node_name = node_name + "\n" + component.my_component.__class__.__name__
                 my_node = pydot.Node(node_name)
                 node_dict[component.my_component.component_name] = my_node
                 graph.add_node(my_node)
@@ -127,9 +123,7 @@ class SystemChart:
                     graph.add_edge(pydot.Edge(node_key[0], node_key[1], label=label))
                 else:
                     graph.add_edge(pydot.Edge(node_key[0], node_key[1]))
-            fullpath = os.path.join(
-                self.ppdt.simulation_parameters.result_directory, filename
-            )
+            fullpath = os.path.join(self.ppdt.simulation_parameters.result_directory, filename)
             graph.write_png(fullpath)  # noqa: no-member
         except Exception as exc:  # noqa
             log.error(

--- a/hisim/project_code_overview_generator.py
+++ b/hisim/project_code_overview_generator.py
@@ -36,7 +36,7 @@ BuiltInAttributes = [
 @dataclass
 class ClassInformation:
 
-    """ Stores information about classes. """
+    """Stores information about classes."""
 
     class_name: str = ""
     lines_of_code: int = 0
@@ -45,7 +45,7 @@ class ClassInformation:
 @dataclass
 class StringInformation:
 
-    """ Stores information for strings. """
+    """Stores information for strings."""
 
     string_name: str = ""
     string_value: str = ""
@@ -54,7 +54,7 @@ class StringInformation:
 @dataclass
 class MethodInformation:
 
-    """ Stores information about methods. """
+    """Stores information about methods."""
 
     method_name: str = ""
 
@@ -62,7 +62,7 @@ class MethodInformation:
 @dataclass
 class ListInformation:
 
-    """ Stores information for all lists. """
+    """Stores information for all lists."""
 
     list_name: str = ""
 
@@ -70,7 +70,7 @@ class ListInformation:
 @dataclass
 class DictInformation:
 
-    """ Stores information for all dictionaries. """
+    """Stores information for all dictionaries."""
 
     dict_name: str = ""
 
@@ -78,7 +78,7 @@ class DictInformation:
 @dataclass
 class OtherMembers:
 
-    """ Stores information for all other members of the files. """
+    """Stores information for all other members of the files."""
 
     member_name: str = ""
     variable_type: str = ""
@@ -87,7 +87,7 @@ class OtherMembers:
 @dataclass
 class FileInformation:
 
-    """ Stores the information about a single file. """
+    """Stores the information about a single file."""
 
     module_name: str = ""
     file_name: str = ""
@@ -113,21 +113,21 @@ class FileInformation:
 
 class OverviewGenerator:
 
-    """ Generates an overview of all modules. """
+    """Generates an overview of all modules."""
 
     def __init__(self):
-        """ Initializes the class. """
+        """Initializes the class."""
         self.existing_classes: List[str] = []
 
     def add_to_cell(self, column: int, row: int, value: Any, worksheet: Workbook) -> int:
-        """ Write data to the Excel sheet. """
+        """Write data to the Excel sheet."""
         worksheet.cell(column=column, row=row, value=value)
         column = column + 1
         return column
 
     def run(self):
-        """ Execute the components finder. """
-        dest_filename = 'components_information.xlsx'
+        """Execute the components finder."""
+        dest_filename = "components_information.xlsx"
 
         # collect file names
         python_files = self.collect_files()
@@ -155,14 +155,18 @@ class OverviewGenerator:
         self.write_clean_files(fis)
 
     def write_clean_files(self, fis: List[FileInformation]) -> None:
-        """ Writes files for calling flak8e and prospector. """
+        """Writes files for calling flak8e and prospector."""
         with open("../flake8_calls.txt", "w", encoding="utf8") as flake8:
             for myfi in fis:
                 if not myfi.cleaned:
                     continue
                 relative_name = myfi.file_name.replace("C:\\work\\hisim_github\\HiSim\\", "")
                 relative_name_slash = relative_name.replace("\\", "/")
-                flake8.write("        flake8 " + relative_name_slash + " --count --select=E9,F63,F7,F82,E800 --show-source --statistics\n")
+                flake8.write(
+                    "        flake8 "
+                    + relative_name_slash
+                    + " --count --select=E9,F63,F7,F82,E800 --show-source --statistics\n"
+                )
         with open("../prospector_calls.txt", "w", encoding="utf8") as prospector:
             for myfi in fis:
                 if not myfi.cleaned:
@@ -197,13 +201,14 @@ class OverviewGenerator:
                 flake8_cmd.write("if %errorlevel% neq 0 exit /b\n")
 
     def write_one_file_block(self, myfi, row, worksheet1):
-        """ Writes the block for a single file to excel. """
+        """Writes the block for a single file to excel."""
         column: int = 1
         column = self.add_to_cell(column=column, row=row, value=myfi.module_name, worksheet=worksheet1)
         column = self.add_to_cell(column=column, row=row, value=myfi.file_name, worksheet=worksheet1)
         column = self.add_to_cell(column=column, row=row, value=myfi.lines, worksheet=worksheet1)
-        column = self.add_to_cell(column=column, row=row, value=myfi.python_module_loading_possible,
-                                  worksheet=worksheet1)
+        column = self.add_to_cell(
+            column=column, row=row, value=myfi.python_module_loading_possible, worksheet=worksheet1
+        )
         column = self.add_to_cell(column=column, row=row, value=myfi.cleaned, worksheet=worksheet1)
         column = self.add_to_cell(column=column, row=row, value=myfi.authors, worksheet=worksheet1)
         column = self.add_to_cell(column=column, row=row, value=myfi.copyright, worksheet=worksheet1)
@@ -252,7 +257,7 @@ class OverviewGenerator:
         return row
 
     def process_one_file(self, filename):  # noqa
-        """ Import the module and iterate through its attributes. """
+        """Import the module and iterate through its attributes."""
         myfi: FileInformation = FileInformation()
 
         myfi.file_name = filename
@@ -305,7 +310,7 @@ class OverviewGenerator:
         return myfi
 
     def try_to_load_module(self, myfi):
-        """ Tries to load a file as python module. Returns None if it couldn't be loaded. """
+        """Tries to load a file as python module. Returns None if it couldn't be loaded."""
         try:
             spec = importlib.util.spec_from_file_location(myfi.module_name, myfi.file_name)
             module: Optional[ModuleType] = importlib.util.module_from_spec(spec)  # type: ignore
@@ -316,7 +321,7 @@ class OverviewGenerator:
         return module
 
     def process_string_attribute(self, myfi, strname, strval):
-        """ Processes all attributes that are of of the type string. """
+        """Processes all attributes that are of of the type string."""
         if strname == "__authors__":
             myfi.authors = strval
         elif strname == "__copyright__":
@@ -336,7 +341,7 @@ class OverviewGenerator:
             myfi.strings.append(sti)
 
     def analyze_file_directly(self, filename, myfi):
-        """ Analyze all the files and count the lines in each file. Could be expanded with more checks. """
+        """Analyze all the files and count the lines in each file. Could be expanded with more checks."""
         count = 0
         with open(filename, "r", encoding="utf8") as sourcefile:
             for count, line in enumerate(sourcefile):
@@ -349,7 +354,7 @@ class OverviewGenerator:
         myfi.lines = count
 
     def collect_files(self):
-        """ Iterate through the modules in the current package. """
+        """Iterate through the modules in the current package."""
         hisim_dir = Pathlibpath(__file__).resolve().parent.parent
         files = []
         for dirpath, _, filenames in os.walk(hisim_dir):

--- a/hisim/result_path_provider.py
+++ b/hisim/result_path_provider.py
@@ -17,7 +17,9 @@ class ResultPathProviderSingleton(metaclass=SingletonMeta):
     According to your storting options and your input information a result path is created.
     """
 
-    def __init__(self,):
+    def __init__(
+        self,
+    ):
         """Initialize the class."""
         self.base_path: Optional[str] = None
         self.model_name: Optional[str] = None
@@ -101,10 +103,7 @@ class ResultPathProviderSingleton(metaclass=SingletonMeta):
                     self.variant_name,
                     self.datetime_string,
                 )
-            elif (
-                self.sorting_option
-                == SortingOptionEnum.MASS_SIMULATION_WITH_INDEX_ENUMERATION
-            ):
+            elif self.sorting_option == SortingOptionEnum.MASS_SIMULATION_WITH_INDEX_ENUMERATION:
                 # schauen ob verzeichnis schon da und aufsteigende nummer anhängen
                 idx = 1
 
@@ -136,10 +135,7 @@ class ResultPathProviderSingleton(metaclass=SingletonMeta):
                             self.model_name,
                             self.variant_name + "_" + str(idx),
                         )
-            elif (
-                self.sorting_option
-                == SortingOptionEnum.MASS_SIMULATION_WITH_HASH_ENUMERATION
-            ):
+            elif self.sorting_option == SortingOptionEnum.MASS_SIMULATION_WITH_HASH_ENUMERATION:
                 if self.sampling_mode is not None:
                     path = os.path.join(
                         self.base_path,

--- a/hisim/sim_repository.py
+++ b/hisim/sim_repository.py
@@ -7,37 +7,37 @@ from hisim import loadtypes as lt
 
 class SimRepository:
 
-    """ Class for exchanging information across all components. """
+    """Class for exchanging information across all components."""
 
     def __init__(self) -> None:
-        """ Initializes the SimRepository. """
+        """Initializes the SimRepository."""
         self.my_dict: Dict[str, Any] = {}
         self.my_dynamic_dict: Dict[lt.ComponentType, Dict[int, Any]] = {elem: {} for elem in lt.ComponentType}
 
     def set_entry(self, key: str, entry: Any) -> None:
-        """ Sets an entry in the SimRepository. """
+        """Sets an entry in the SimRepository."""
         self.my_dict[key] = entry
 
     def get_entry(self, key: str) -> Any:
-        """ Gets an entry from the SimRepository. """
+        """Gets an entry from the SimRepository."""
         return self.my_dict[key]
 
     def exist_entry(self, key: str) -> bool:
-        """ Checks if an entry exists. """
+        """Checks if an entry exists."""
         if key in self.my_dict:
             return True
         return False
 
     def delete_entry(self, key: str) -> None:
-        """ Deletes an existing entry. """
+        """Deletes an existing entry."""
         self.my_dict.pop(key)
 
     def set_dynamic_entry(self, component_type: lt.ComponentType, source_weight: int, entry: Any) -> None:
-        """ Sets a dynamic entry. """
+        """Sets a dynamic entry."""
         self.my_dynamic_dict[component_type][source_weight] = entry
 
     def get_dynamic_entry(self, component_type: lt.ComponentType, source_weight: int) -> Any:
-        """ Gets a dynmaic entry. """
+        """Gets a dynmaic entry."""
         component = self.my_dynamic_dict.get(component_type, None)
         if component is None:
             return None
@@ -45,15 +45,15 @@ class SimRepository:
         return value
 
     def get_dynamic_component_weights(self, component_type: lt.ComponentType) -> list:
-        """ Gets weights for dynamic components. """
+        """Gets weights for dynamic components."""
         return list(self.my_dynamic_dict[component_type].keys())
 
     def delete_dynamic_entry(self, component_type: lt.ComponentType, source_weight: int) -> Any:
-        """ Deletes a dynamic component entry. """
+        """Deletes a dynamic component entry."""
         self.my_dynamic_dict[component_type].pop(source_weight)
 
     def clear(self):
-        """ Clears all dictionaries at the end of the simulation to enable garbage collection and reduce memory consumption. """
+        """Clears all dictionaries at the end of the simulation to enable garbage collection and reduce memory consumption."""
         self.my_dict.clear()
         del self.my_dict
         self.my_dynamic_dict.clear()

--- a/hisim/sim_repository_singleton.py
+++ b/hisim/sim_repository_singleton.py
@@ -44,9 +44,7 @@ class SingletonSimRepository(metaclass=SingletonMeta):
     def __init__(self) -> None:
         """Initializes the SimRepository."""
         self.my_dict: Dict[Any, Any] = {}
-        self.my_dynamic_dict: Dict[lt.ComponentType, Dict[int, Any]] = {
-            elem: {} for elem in lt.ComponentType
-        }
+        self.my_dynamic_dict: Dict[lt.ComponentType, Dict[int, Any]] = {elem: {} for elem in lt.ComponentType}
 
     def set_entry(self, key: Any, entry: Any) -> None:
         """Sets an entry in the SimRepository."""
@@ -66,15 +64,11 @@ class SingletonSimRepository(metaclass=SingletonMeta):
         """Deletes an existing entry."""
         self.my_dict.pop(key)
 
-    def set_dynamic_entry(
-        self, component_type: lt.ComponentType, source_weight: int, entry: Any
-    ) -> None:
+    def set_dynamic_entry(self, component_type: lt.ComponentType, source_weight: int, entry: Any) -> None:
         """Sets a dynamic entry."""
         self.my_dynamic_dict[component_type][source_weight] = entry
 
-    def get_dynamic_entry(
-        self, component_type: lt.ComponentType, source_weight: int
-    ) -> Any:
+    def get_dynamic_entry(self, component_type: lt.ComponentType, source_weight: int) -> Any:
         """Gets a dynmaic entry."""
         component = self.my_dynamic_dict.get(component_type, None)
         if component is None:
@@ -86,9 +80,7 @@ class SingletonSimRepository(metaclass=SingletonMeta):
         """Gets weights for dynamic components."""
         return list(self.my_dynamic_dict[component_type].keys())
 
-    def delete_dynamic_entry(
-        self, component_type: lt.ComponentType, source_weight: int
-    ) -> Any:
+    def delete_dynamic_entry(self, component_type: lt.ComponentType, source_weight: int) -> Any:
         """Deletes a dynamic component entry."""
         self.my_dynamic_dict[component_type].pop(source_weight)
 

--- a/hisim/simulationparameters.py
+++ b/hisim/simulationparameters.py
@@ -36,7 +36,6 @@ class SimulationParameters(JSONWizard):
         logging_level: int = log.LogPrio.INFORMATION,
         skip_finished_results: bool = False,
         surplus_control: bool = True,
-
     ):
         """Initializes the class."""
         self.start_date: datetime.datetime = start_date
@@ -78,14 +77,10 @@ class SimulationParameters(JSONWizard):
         # self.post_processing_options.append(PostProcessingOptions.PLOT_SANKEY)
         self.post_processing_options.append(PostProcessingOptions.PLOT_SINGLE_DAYS)
         self.post_processing_options.append(PostProcessingOptions.PLOT_MONTHLY_BAR_CHARTS)
-        self.post_processing_options.append(
-            PostProcessingOptions.OPEN_DIRECTORY_IN_EXPLORER
-        )
+        self.post_processing_options.append(PostProcessingOptions.OPEN_DIRECTORY_IN_EXPLORER)
 
     @classmethod
-    def full_year_all_options(
-        cls, year: int, seconds_per_timestep: int
-    ) -> SimulationParameters:
+    def full_year_all_options(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
         """Generates a parameter set for a full year with all the post processing, primarily for unit testing."""
         pars = cls(
             datetime.datetime(year, 1, 1),
@@ -97,9 +92,7 @@ class SimulationParameters(JSONWizard):
         return pars
 
     @classmethod
-    def full_year_with_only_plots(
-        cls, year: int, seconds_per_timestep: int
-    ) -> SimulationParameters:
+    def full_year_with_only_plots(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
         """Generates a parameter set for a full year with all the post processing, primarily for unit testing."""
         pars = cls(
             datetime.datetime(year, 1, 1),
@@ -111,9 +104,7 @@ class SimulationParameters(JSONWizard):
         return pars
 
     @classmethod
-    def january_only_with_all_options(
-        cls, year: int, seconds_per_timestep: int
-    ) -> SimulationParameters:
+    def january_only_with_all_options(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
         """Generates a parameter set for a single january, primarily for unit testing."""
         pars = cls(
             datetime.datetime(year, 1, 1),
@@ -125,9 +116,7 @@ class SimulationParameters(JSONWizard):
         return pars
 
     @classmethod
-    def january_only_with_only_plots(
-        cls, year: int, seconds_per_timestep: int
-    ) -> SimulationParameters:
+    def january_only_with_only_plots(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
         """Generates a parameter set for a single january, primarily for unit testing."""
         pars = cls(
             datetime.datetime(year, 1, 1),
@@ -139,9 +128,7 @@ class SimulationParameters(JSONWizard):
         return pars
 
     @classmethod
-    def three_months_only(
-        cls, year: int, seconds_per_timestep: int
-    ) -> SimulationParameters:
+    def three_months_only(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
         """Generates a parameter set for a three months, primarily for unit testing."""
         return cls(
             datetime.datetime(year, 3, 1),
@@ -151,9 +138,7 @@ class SimulationParameters(JSONWizard):
         )
 
     @classmethod
-    def three_months_with_plots_only(
-        cls, year: int, seconds_per_timestep: int
-    ) -> SimulationParameters:
+    def three_months_with_plots_only(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
         """Generates a parameter set for a three months, primarily for unit testing."""
         pars = cls(
             datetime.datetime(year, 6, 1),
@@ -165,9 +150,7 @@ class SimulationParameters(JSONWizard):
         return pars
 
     @classmethod
-    def one_week_only(
-        cls, year: int, seconds_per_timestep: int
-    ) -> SimulationParameters:
+    def one_week_only(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
         """Generates a parameter set for a single week, primarily for unit testing."""
         return cls(
             datetime.datetime(year, 1, 1),
@@ -177,9 +160,7 @@ class SimulationParameters(JSONWizard):
         )
 
     @classmethod
-    def one_week_with_only_plots(
-        cls, year: int, seconds_per_timestep: int
-    ) -> SimulationParameters:
+    def one_week_with_only_plots(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
         """Generates a parameter set for a single week, primarily for unit testing."""
         pars = cls(
             datetime.datetime(year, 1, 1),
@@ -192,9 +173,7 @@ class SimulationParameters(JSONWizard):
         return pars
 
     @classmethod
-    def one_day_only(
-        cls, year: int, seconds_per_timestep: int = 60
-    ) -> SimulationParameters:
+    def one_day_only(cls, year: int, seconds_per_timestep: int = 60) -> SimulationParameters:
         """Generates a parameter set for a single day, primarily for unit testing."""
         return cls(
             datetime.datetime(year, 1, 1),
@@ -204,9 +183,7 @@ class SimulationParameters(JSONWizard):
         )
 
     @classmethod
-    def one_day_only_with_all_options(
-        cls, year: int, seconds_per_timestep: int
-    ) -> SimulationParameters:
+    def one_day_only_with_all_options(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
         """Generates a parameter set for a single day, primarily for unit testing."""
         pars = cls(
             datetime.datetime(year, 1, 1),
@@ -218,9 +195,7 @@ class SimulationParameters(JSONWizard):
         return pars
 
     @classmethod
-    def one_day_only_with_only_plots(
-        cls, year: int, seconds_per_timestep: int
-    ) -> SimulationParameters:
+    def one_day_only_with_only_plots(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
         """Generates a parameter set for a single day, primarily for unit testing."""
         pars = cls(
             datetime.datetime(year, 1, 1),

--- a/hisim/simulator.py
+++ b/hisim/simulator.py
@@ -62,9 +62,7 @@ class Simulator:
         self.iteration_logging_path: str = ""
         self.config_dictionary: Dict[str, Any] = {}
 
-    def set_simulation_parameters(
-        self, my_simulation_parameters: SimulationParameters
-    ) -> None:
+    def set_simulation_parameters(self, my_simulation_parameters: SimulationParameters) -> None:
         """Sets the simulation parameters and the logging level at the same time."""
         self._simulation_parameters = my_simulation_parameters
         if self._simulation_parameters is not None:
@@ -83,9 +81,7 @@ class Simulator:
         component.set_sim_repo(self.simulation_repository)
 
         # set the wrapper
-        wrap = ComponentWrapper(
-            component, is_cachable, connect_automatically=connect_automatically
-        )
+        wrap = ComponentWrapper(component, is_cachable, connect_automatically=connect_automatically)
         wrap.register_component_outputs(self.all_outputs)
         self.wrapped_components.append(wrap)
         if component.component_name in self.config_dictionary:
@@ -102,13 +98,10 @@ class Simulator:
     def prepare_calculation(self) -> None:
         """Connects the inputs from every component to the corresponding outputs."""
         for wrapped_component in self.wrapped_components:
-
             # check if component should be connected to default connections automatically
             if wrapped_component.connect_automatically is True:
                 self.connect_everything_automatically(
-                    source_component_list=[
-                        wp.my_component for wp in self.wrapped_components
-                    ],
+                    source_component_list=[wp.my_component for wp in self.wrapped_components],
                     target_component=wrapped_component.my_component,
                 )
             wrapped_component.prepare_calculation()
@@ -164,25 +157,14 @@ class Simulator:
                 and postprocessingoptions.PostProcessingOptions.PROVIDE_DETAILED_ITERATION_LOGGING
                 in self._simulation_parameters.post_processing_options
             ):
-                myerr = stsv.get_differences_for_error_msg(
-                    previous_values, self.all_outputs
-                )
-                with open(
-                    self.iteration_logging_path, "a", encoding="utf-8"
-                ) as filestream:
+                myerr = stsv.get_differences_for_error_msg(previous_values, self.all_outputs)
+                with open(self.iteration_logging_path, "a", encoding="utf-8") as filestream:
                     filestream.write(myerr + "\n")
             if iterative_tries > 10:
                 force_convergence = True
             if iterative_tries > 100:
-                list_of_changed_values = stsv.get_differences_for_error_msg(
-                    previous_values, self.all_outputs
-                )
-                raise ValueError(
-                    "More than 100 tries in time step "
-                    + str(timestep)
-                    + "\n"
-                    + list_of_changed_values
-                )
+                list_of_changed_values = stsv.get_differences_for_error_msg(previous_values, self.all_outputs)
+                raise ValueError("More than 100 tries in time step " + str(timestep) + "\n" + list_of_changed_values)
             # Copies actual values to previous variable
             previous_values.copy_values_from_other(stsv)
             iterative_tries += 1
@@ -199,9 +181,7 @@ class Simulator:
         ):
             # check if result path is already set somewhere manually
             if ResultPathProviderSingleton().get_result_directory_name() is not None:
-                self._simulation_parameters.result_directory = (
-                    ResultPathProviderSingleton().get_result_directory_name()
-                )
+                self._simulation_parameters.result_directory = ResultPathProviderSingleton().get_result_directory_name()
                 log.information(
                     "Using result directory: "
                     + self._simulation_parameters.result_directory
@@ -216,9 +196,7 @@ class Simulator:
                     hash_number=None,
                     sorting_option=SortingOptionEnum.FLAT,
                 )
-                self._simulation_parameters.result_directory = (
-                    ResultPathProviderSingleton().get_result_directory_name()
-                )
+                self._simulation_parameters.result_directory = ResultPathProviderSingleton().get_result_directory_name()
                 log.information(
                     f"Using result directory:  {self._simulation_parameters.result_directory}"
                     + " which is set by the simulator."
@@ -248,15 +226,9 @@ class Simulator:
         # call again because it might not have gotten executed depending on how it's called.
         self.prepare_simulation_directory()
 
-        flagfile = os.path.join(
-            self._simulation_parameters.result_directory, "finished.flag"
-        )
-        if self._simulation_parameters.skip_finished_results and os.path.exists(
-            flagfile
-        ):
-            log.warning(
-                "Found " + flagfile + ". This calculation seems finished. Quitting."
-            )
+        flagfile = os.path.join(self._simulation_parameters.result_directory, "finished.flag")
+        if self._simulation_parameters.skip_finished_results and os.path.exists(flagfile):
+            log.warning("Found " + flagfile + ". This calculation seems finished. Quitting.")
             return
         # Starts time counter
         start_counter = time.perf_counter()
@@ -271,11 +243,7 @@ class Simulator:
             + " outputs."
         )
         all_result_lines = []
-        log.information(
-            "Starting simulation for "
-            + str(self._simulation_parameters.timesteps)
-            + " timesteps"
-        )
+        log.information("Starting simulation for " + str(self._simulation_parameters.timesteps) + " timesteps")
         lastmessage = datetime.datetime.now()
         last_step: int = 0
         starttime = datetime.datetime.now()
@@ -315,9 +283,7 @@ class Simulator:
                 )
                 last_step = step
                 total_iteration_tries_since_last_msg = 0
-        postprocessing_datatransfer = self.prepare_post_processing(
-            all_result_lines, start_counter
-        )
+        postprocessing_datatransfer = self.prepare_post_processing(all_result_lines, start_counter)
         log.information("Starting postprocessing")
         if postprocessing_datatransfer is None:
             raise ValueError("postprocessing_datatransfer was none")
@@ -349,13 +315,9 @@ class Simulator:
             column_name = entry.get_pretty_name()
             colum_names.append(column_name)
             log.debug("Output column: " + column_name)
-        self.results_data_frame = pd.DataFrame(
-            data=all_result_lines, columns=colum_names
-        )
+        self.results_data_frame = pd.DataFrame(data=all_result_lines, columns=colum_names)
         # todo: fix this constant
-        df_index = pd.date_range(
-            "2021-01-01 00:00:00", periods=len(self.results_data_frame), freq="T"
-        )
+        df_index = pd.date_range("2021-01-01 00:00:00", periods=len(self.results_data_frame), freq="T")
         self.results_data_frame.index = df_index
         end_counter = time.perf_counter()
         execution_time = end_counter - start_counter
@@ -405,15 +367,11 @@ class Simulator:
             average_iteration_tries: float = 1
         else:
             average_iteration_tries = total_iteration_tries / elapsed_steps
-        time_elapsed = datetime.timedelta(
-            seconds=(self._simulation_parameters.timesteps - step) / steps_per_second
-        )
+        time_elapsed = datetime.timedelta(seconds=(self._simulation_parameters.timesteps - step) / steps_per_second)
         time_left_minutes, time_left_seconds = divmod(time_elapsed.seconds, 60)
         time_left_seconds = str(time_left_seconds).zfill(2)  # type: ignore
         simulation_status = f"Simulating... {(step / self._simulation_parameters.timesteps) * 100:.1f}% "
-        simulation_status += (
-            f"| Elapsed Time: {elapsed_minutes}:{elapsed_seconds_str} min "
-        )
+        simulation_status += f"| Elapsed Time: {elapsed_minutes}:{elapsed_seconds_str} min "
         simulation_status += f"| Speed: {steps_per_second:.0f} step/s "
         simulation_status += f"| Time Left: {time_left_minutes}:{time_left_seconds} min"
         simulation_status += f"| Avg. iterations {average_iteration_tries:.1f}"
@@ -466,18 +424,14 @@ class Simulator:
                 temp_df_cumulative = temp_df.sum()
 
             # monthly results
-            results_merged_monthly[temp_df_monthly.columns[0]] = temp_df_monthly.values[
-                :, 0
-            ]
+            results_merged_monthly[temp_df_monthly.columns[0]] = temp_df_monthly.values[:, 0]
             results_merged_monthly.index = temp_df_monthly.index
             # daily results
             results_merged_daily[temp_df_daily.columns[0]] = temp_df_daily.values[:, 0]
             results_merged_daily.index = temp_df_daily.index
 
             # cumulative results
-            results_merged_cumulative[
-                temp_df_monthly.columns[0]
-            ] = temp_df_cumulative.values
+            results_merged_cumulative[temp_df_monthly.columns[0]] = temp_df_cumulative.values
 
             if self._simulation_parameters.seconds_per_timestep != 3600:
                 if self.all_outputs[i_column].unit in (
@@ -492,15 +446,11 @@ class Simulator:
                     Units.KG_PER_SEC,
                     Units.PERCENT,
                 ):
-                    temp_df_hourly = temp_df.resample(
-                        "60T"
-                    ).mean()  # .interpolate(method="linear")
+                    temp_df_hourly = temp_df.resample("60T").mean()  # .interpolate(method="linear")
                 else:
                     temp_df_hourly = temp_df.resample("60T").sum()
 
-                results_merged_hourly[
-                    temp_df_hourly.columns[0]
-                ] = temp_df_hourly.values[:, 0]
+                results_merged_hourly[temp_df_hourly.columns[0]] = temp_df_hourly.values[:, 0]
                 results_merged_hourly.index = temp_df_hourly.index
             else:
                 results_merged_hourly[temp_df.columns[0]] = temp_df.values[:, 0]
@@ -527,13 +477,9 @@ class Simulator:
 
         # check if target component is a normal or a dynamic component and get all default connections
         if isinstance(target_component, dcp.DynamicComponent):
-            target_default_connection_dict = (
-                target_component.dynamic_default_connections
-            )
+            target_default_connection_dict = target_component.dynamic_default_connections
 
-        elif isinstance(target_component, cp.Component) and not isinstance(
-            target_component, dcp.DynamicComponent
-        ):
+        elif isinstance(target_component, cp.Component) and not isinstance(target_component, dcp.DynamicComponent):
             target_default_connection_dict = target_component.default_connections
 
         else:
@@ -543,7 +489,6 @@ class Simulator:
 
         # check if target component has any default connections (otherwise automatic connection cannot be made)
         if bool(target_default_connection_dict) is True:
-
             # check if at least one source_component is in the target default connections
             if (
                 any(
@@ -562,13 +507,9 @@ class Simulator:
 
                 # if the source components' classname is found in the target components' default connection dict, a connection is made
                 if source_component_classname in target_default_connection_dict.keys():
-
                     if isinstance(target_component, dcp.DynamicComponent):
-
-                        dynamic_connections = (
-                            target_component.get_dynamic_default_connections(
-                                source_component=source_component
-                            )
+                        dynamic_connections = target_component.get_dynamic_default_connections(
+                            source_component=source_component
                         )
 
                         target_component.connect_with_dynamic_connections_list(
@@ -578,13 +519,8 @@ class Simulator:
                     if isinstance(target_component, cp.Component) and not isinstance(
                         target_component, dcp.DynamicComponent
                     ):
-
-                        connections = target_component.get_default_connections(
-                            source_component=source_component
-                        )
-                        target_component.connect_with_connections_list(
-                            connections=connections
-                        )
+                        connections = target_component.get_default_connections(source_component=source_component)
+                        target_component.connect_with_connections_list(connections=connections)
         else:
             raise KeyError(
                 f"Automatic connection does not work for {target_component.component_name} because no default connections were found. "

--- a/hisim/system_setup_configuration.py
+++ b/hisim/system_setup_configuration.py
@@ -45,10 +45,7 @@ class SystemSetupConfigBase(JSONWizard):
         if options_dict and not building_config:
             raise ValueError("Options for default setup not yet implemented.")
         if building_config:
-            my_config = cls.get_scaled_default(
-                building_config=building_config,
-                options=options
-            )
+            my_config = cls.get_scaled_default(building_config=building_config, options=options)
         else:
             my_config = cls.get_default()
 
@@ -58,9 +55,7 @@ class SystemSetupConfigBase(JSONWizard):
             log.information("Using `system_setup_config` to overwrite defaults.")
             utils.set_attributes_of_dataclass_from_dict(my_config, setup_config_dict)
         else:
-            log.information(
-                "Did not find `system_setup_config` in JSON. Using defaults."
-            )
+            log.information("Did not find `system_setup_config` in JSON. Using defaults.")
 
         return my_config
 
@@ -75,10 +70,6 @@ class SystemSetupConfigBase(JSONWizard):
         raise NotImplementedError
 
     @classmethod
-    def get_scaled_default(
-        cls,
-        building_config: building.BuildingConfig,
-        options: Any
-    ) -> Self:
+    def get_scaled_default(cls, building_config: building.BuildingConfig, options: Any) -> Self:
         """Get scaled default."""
         raise NotImplementedError

--- a/hisim/system_setup_starter.py
+++ b/hisim/system_setup_starter.py
@@ -37,9 +37,7 @@ def make_system_setup(
     The setup is simulated and result files are stored in `result_directory`.
     """
     if isinstance(parameters_json, list):
-        raise NotImplementedError(
-            "System Setup Starter can only handle one setup at a time for now."
-        )
+        raise NotImplementedError("System Setup Starter can only handle one setup at a time for now.")
 
     _parameters_json = deepcopy(parameters_json)
     Path(result_directory).mkdir(parents=True, exist_ok=True)  # pylint: disable=unexpected-keyword-arg
@@ -51,12 +49,14 @@ def make_system_setup(
     options = _parameters_json.pop("options", {})
     building_config = _parameters_json.pop("building_config", {})
     system_setup_config = _parameters_json.pop("system_setup_config", {})
-    module_config_dict = {"options": options, "building_config": building_config, "system_setup_config": system_setup_config}
+    module_config_dict = {
+        "options": options,
+        "building_config": building_config,
+        "system_setup_config": system_setup_config,
+    }
 
     if _parameters_json:
-        raise AttributeError(
-            f"There are unused attributes ({_parameters_json.keys()}) in parameters JSON."
-        )
+        raise AttributeError(f"There are unused attributes ({_parameters_json.keys()}) in parameters JSON.")
 
     # Set custom simulation parameters
     simulation_parameters = SimulationParameters(
@@ -87,9 +87,7 @@ if __name__ == "__main__":
         PARAMETERS_JSON_FILE = "input/request.json"
         RESULT_DIRECTORY = "results"
         if not Path(PARAMETERS_JSON_FILE).is_file():
-            log.information(
-                "Please specify an input JSON file or place it in `input/request.json`."
-            )
+            log.information("Please specify an input JSON file or place it in `input/request.json`.")
             sys.exit(1)
     elif len(sys.argv) == 2:
         PARAMETERS_JSON_FILE = sys.argv[1]
@@ -110,9 +108,7 @@ if __name__ == "__main__":
         my_path_to_module,
         my_simulation_parameters,
         my_module_config_path,
-    ) = make_system_setup(
-        parameters_json=my_parameters_json, result_directory=RESULT_DIRECTORY
-    )
+    ) = make_system_setup(parameters_json=my_parameters_json, result_directory=RESULT_DIRECTORY)
 
     main(
         my_path_to_module,

--- a/hisim/utils.py
+++ b/hisim/utils.py
@@ -36,27 +36,17 @@ def get_input_directory() -> str:
 hisim_abs_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))  # type: ignore
 hisim_inputs = os.path.join(hisim_abs_path, "inputs")
 hisim_results = os.path.join(hisim_abs_path, "results")
-hisim_postprocessing_img = os.path.join(
-    hisim_abs_path, "postprocessing", "report"
-)  # noqa
+hisim_postprocessing_img = os.path.join(hisim_abs_path, "postprocessing", "report")  # noqa
 
 HISIMPATH: Dict[str, Any] = {
     "inputs": hisim_inputs,
     "cache_dir": os.path.join(hisim_abs_path, "inputs", "cache"),
-    "cache_indices": os.path.join(
-        hisim_abs_path, "inputs", "cache", "cache_indices.json"
-    ),
+    "cache_indices": os.path.join(hisim_abs_path, "inputs", "cache", "cache_indices.json"),
     "cfg": os.path.join(hisim_abs_path, "inputs", "cfg.json"),
     "utsp_results": hisim_results,
-    "utsp_example_results": os.path.join(
-        hisim_inputs, "LPGResults_for_tests", "Results"
-    ),
-    "utsp_example_reports": os.path.join(
-        hisim_inputs, "LPGResults_for_tests", "Reports"
-    ),
-    "housing": os.path.join(
-        hisim_inputs, "housing", "data_processed", "episcope-tabula.csv"
-    ),
+    "utsp_example_results": os.path.join(hisim_inputs, "LPGResults_for_tests", "Results"),
+    "utsp_example_reports": os.path.join(hisim_inputs, "LPGResults_for_tests", "Reports"),
+    "housing": os.path.join(hisim_inputs, "housing", "data_processed", "episcope-tabula.csv"),
     "housing_reference_temperatures": os.path.join(
         hisim_inputs,
         "housing",
@@ -69,12 +59,8 @@ HISIMPATH: Dict[str, Any] = {
         "data_processed",
         "heater_efficiencies.csv",
     ),
-    "fuel_costs": os.path.join(
-        hisim_abs_path, "modular_household", "emission_factors_and_costs_fuels.csv"
-    ),
-    "component_costs": os.path.join(
-        hisim_abs_path, "modular_household", "emission_factors_and_costs_devices.csv"
-    ),
+    "fuel_costs": os.path.join(hisim_abs_path, "modular_household", "emission_factors_and_costs_fuels.csv"),
+    "component_costs": os.path.join(hisim_abs_path, "modular_household", "emission_factors_and_costs_devices.csv"),
     "occupancy_scaling_factors_per_country": os.path.join(
         hisim_inputs, "loadprofiles", "WHY_reference_data", "scaling_factors_demand.csv"
     ),
@@ -155,26 +141,14 @@ HISIMPATH: Dict[str, Any] = {
         },
     },
     "photovoltaic": {
-        "sandia_modules_new": os.path.join(
-            hisim_inputs, "photovoltaic", "data_processed", "sandia_modules_new.csv"
-        ),
-        "sandia_modules": os.path.join(
-            hisim_inputs, "photovoltaic", "data_processed", "sandia_modules.csv"
-        ),
-        "sandia_inverters": os.path.join(
-            hisim_inputs, "photovoltaic", "data_processed", "sandia_inverters.csv"
-        ),
-        "cec_modules": os.path.join(
-            hisim_inputs, "photovoltaic", "data_processed", "cec_modules.csv"
-        ),
-        "cec_inverters": os.path.join(
-            hisim_inputs, "photovoltaic", "data_processed", "cec_inverters.csv"
-        ),
+        "sandia_modules_new": os.path.join(hisim_inputs, "photovoltaic", "data_processed", "sandia_modules_new.csv"),
+        "sandia_modules": os.path.join(hisim_inputs, "photovoltaic", "data_processed", "sandia_modules.csv"),
+        "sandia_inverters": os.path.join(hisim_inputs, "photovoltaic", "data_processed", "sandia_inverters.csv"),
+        "cec_modules": os.path.join(hisim_inputs, "photovoltaic", "data_processed", "cec_modules.csv"),
+        "cec_inverters": os.path.join(hisim_inputs, "photovoltaic", "data_processed", "cec_inverters.csv"),
     },
     "chp_system": os.path.join(hisim_inputs, "chp_system"),
-    "smart_appliances": os.path.join(
-        hisim_inputs, "smart_devices", "data_processed", "smart_devices.json"
-    ),
+    "smart_appliances": os.path.join(hisim_inputs, "smart_devices", "data_processed", "smart_devices.json"),
     "frank_data": os.path.join(
         hisim_inputs,
         "loadprofiles",
@@ -184,9 +158,7 @@ HISIMPATH: Dict[str, Any] = {
     ),
     "report": os.path.join(hisim_abs_path, "results", "report.pdf"),
     "advanced_battery": {
-        "parameter": os.path.join(
-            hisim_abs_path, "inputs", "advanced_battery", "parameter", "PerModPAR.xlsx"
-        ),
+        "parameter": os.path.join(hisim_abs_path, "inputs", "advanced_battery", "parameter", "PerModPAR.xlsx"),
         "reference_case": os.path.join(
             hisim_abs_path,
             "inputs",
@@ -194,21 +166,13 @@ HISIMPATH: Dict[str, Any] = {
             "reference_case",
             "ref_case_data.npz",
         ),
-        "siemens_junelight": os.path.join(
-            hisim_abs_path, "inputs", "advanced_battery", "Siemens_Junelight.npy"
-        ),
+        "siemens_junelight": os.path.join(hisim_abs_path, "inputs", "advanced_battery", "Siemens_Junelight.npy"),
     },
-    "LoadProfileGenerator_export_directory": os.path.join(
-        os.path.join("D:", os.sep, "Work")
-    ),
-    "bat_parameter": os.path.join(
-        hisim_abs_path, "inputs", "advanced_battery", "Siemens_Junelight.npy"
-    ),
+    "LoadProfileGenerator_export_directory": os.path.join(os.path.join("D:", os.sep, "Work")),
+    "bat_parameter": os.path.join(hisim_abs_path, "inputs", "advanced_battery", "Siemens_Junelight.npy"),
     "modular_household": os.path.join(hisim_abs_path, "modular_household"),
     "price_signal": {
-        "PricePurchase": os.path.join(
-            hisim_inputs, "price_signal", "PricePurchase.csv"
-        ),
+        "PricePurchase": os.path.join(hisim_inputs, "price_signal", "PricePurchase.csv"),
         "FeedInTarrif": os.path.join(hisim_inputs, "price_signal", "FeedInTarrif.csv"),
     },
 }
@@ -221,26 +185,16 @@ def load_smart_appliance(name):  # noqa
     return data[name]
 
 
-def convert_lpg_timestep_to_utc(
-    data: List[int], year: int, seconds_per_timestep: int
-) -> List[int]:
+def convert_lpg_timestep_to_utc(data: List[int], year: int, seconds_per_timestep: int) -> List[int]:
     """Tranform LPG timesteps (list of integers) from local time to UTC."""
     timeshifts = pytz.timezone("Europe/Berlin")._utc_transition_times  # type: ignore # pylint: disable=W0212
     timeshifts = [elem for elem in timeshifts if elem.year == year]
     steps_per_hour = int(3600 / seconds_per_timestep)
     timeshift1_as_step = (
-        int(
-            (timeshifts[0] - dt.datetime(year=year, month=1, day=1)).seconds
-            / seconds_per_timestep
-        )
-        - 1
+        int((timeshifts[0] - dt.datetime(year=year, month=1, day=1)).seconds / seconds_per_timestep) - 1
     )
     timeshift2_as_step = (
-        int(
-            (timeshifts[1] - dt.datetime(year=year, month=1, day=1)).seconds
-            / seconds_per_timestep
-        )
-        - 1
+        int((timeshifts[1] - dt.datetime(year=year, month=1, day=1)).seconds / seconds_per_timestep) - 1
     )
 
     data_utc = []
@@ -287,8 +241,7 @@ def convert_lpg_data_to_utc(data: pd.DataFrame, year: int) -> pd.DataFrame:
 
     # add hour at end
     last_hour = data[
-        data.index
-        >= dt.datetime(year=year, month=lastdate.month, day=lastdate.day, hour=23)  # type: ignore
+        data.index >= dt.datetime(year=year, month=lastdate.month, day=lastdate.day, hour=23)  # type: ignore
     ]
     data = pd.concat([data, last_hour])  # type: ignore
 
@@ -296,9 +249,7 @@ def convert_lpg_data_to_utc(data: pd.DataFrame, year: int) -> pd.DataFrame:
     data.index = pd.Index(list(range(len(data))))
     data["Time"] = pd.date_range(
         start=dt.datetime(year=year, month=1, day=1, hour=0),
-        end=dt.datetime(
-            year=year, month=lastdate.month, day=lastdate.day, hour=23, minute=59  # type: ignore
-        ),
+        end=dt.datetime(year=year, month=lastdate.month, day=lastdate.day, hour=23, minute=59),  # type: ignore
         freq="T",
         tz="UTC",
     )
@@ -310,7 +261,7 @@ def get_cache_file(
     component_key: str,
     parameter_class: Any,
     my_simulation_parameters: SimulationParameters,
-    cache_dir_path: str = os.path.join(hisim_abs_path, "inputs", "cache")
+    cache_dir_path: str = os.path.join(hisim_abs_path, "inputs", "cache"),
 ) -> Tuple[bool, str]:  # noqa
     """Gets a cache path for a given parameter set.
 
@@ -341,9 +292,7 @@ def get_cache_file(
 
 def load_export_load_profile_generator(target):  # noqa
     """Returns the paths for the SQL exported files from the Load Profile Generator."""
-    targetpath = os.path.join(
-        HISIMPATH["LoadProfileGenerator_export_directory"], target
-    )
+    targetpath = os.path.join(HISIMPATH["LoadProfileGenerator_export_directory"], target)
     if os.path.exists(targetpath):
         lpg_export_path = {
             "electric_vehicle": [
@@ -366,13 +315,7 @@ def measure_execution_time(my_function):  # noqa
         end = timer()
         diff = end - start
         log.profile(
-            "Executing "
-            + my_function.__module__
-            + "."
-            + my_function.__name__
-            + " took "
-            + f"{diff:1.2f}"
-            + " seconds"
+            "Executing " + my_function.__module__ + "." + my_function.__name__ + " took " + f"{diff:1.2f}" + " seconds"
         )
         return result
 
@@ -392,13 +335,7 @@ def measure_memory_leak(my_function):  # noqa
         gc.collect()
         diff = rss_by_psutil_end - rss_by_psutil_start
         log.trace(
-            "Executing "
-            + my_function.__module__
-            + "."
-            + my_function.__name__
-            + " leaked "
-            + f"{diff:1.2f}"
-            + " MB"
+            "Executing " + my_function.__module__ + "." + my_function.__name__ + " leaked " + f"{diff:1.2f}" + " MB"
         )
         return result
 
@@ -418,13 +355,7 @@ def measure_memory_leak_with_error(my_function):  # noqa
         gc.collect()
         diff = rss_by_psutil_end - rss_by_psutil_start
         log.information(
-            "Executing "
-            + my_function.__module__
-            + "."
-            + my_function.__name__
-            + " leaked "
-            + f"{diff:1.2f}"
-            + " MB"
+            "Executing " + my_function.__module__ + "." + my_function.__name__ + " leaked " + f"{diff:1.2f}" + " MB"
         )
         if diff > 100:
             raise ValueError("Lost over 100MB of memory during the function call")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/system_setups/air_conditioned_house_a_with_mpc_controller.py
+++ b/system_setups/air_conditioned_house_a_with_mpc_controller.py
@@ -17,9 +17,7 @@ from hisim.components import generic_price_signal  # mpc
 
 
 __authors__ = "Marwa Alfouly, Sebastian Dickler"
-__copyright__ = (
-    "Copyright 2023, HiSim - Household Infrastructure and Building Simulator"
-)
+__copyright__ = "Copyright 2023, HiSim - Household Infrastructure and Building Simulator"
 __credits__ = ["Noah Pflugradt"]
 __license__ = "MIT"
 __version__ = "0.1"
@@ -28,9 +26,7 @@ __email__ = "s.dickler@fz-juelich.de"
 __status__ = "development"
 
 
-def setup_function(
-    my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters] = None
-) -> None:
+def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters] = None) -> None:
     """Simulates household with air-conditioner with MPC controller."""
 
     air_conditioned_house(my_sim, "MPC", my_simulation_parameters)
@@ -165,8 +161,12 @@ def air_conditioned_house(
     # offset = 0.5
 
     # Set MPC controller #mpc
-    mpc_scheme = "optimization_once_aday_only"  # The two options are: 'optimization_once_aday_only' or 'moving_horizon_control'
-    flexibility_element = "PV_and_Battery"  # The three options are: 'basic_buidling_configuration' or 'PV_only' or 'PV_and_Battery'
+    mpc_scheme = (
+        "optimization_once_aday_only"  # The two options are: 'optimization_once_aday_only' or 'moving_horizon_control'
+    )
+    flexibility_element = (
+        "PV_and_Battery"  # The three options are: 'basic_buidling_configuration' or 'PV_only' or 'PV_and_Battery'
+    )
     pricing_scheme = "dynamic"  # The two options are: 'dynamic' or 'fixed'
     optimizer_sampling_rate = 1
     # prediction_horizon = 24*3600
@@ -198,9 +198,7 @@ def air_conditioned_house(
     """System parameters"""
 
     if my_simulation_parameters is None:
-        my_simulation_parameters = SimulationParameters.one_day_only(
-            year, seconds_per_timestep
-        )
+        my_simulation_parameters = SimulationParameters.one_day_only(year, seconds_per_timestep)
         # my_simulation_parameters = SimulationParameters.one_day_only_with_only_plots(year, seconds_per_timestep)
         # my_simulation_parameters = SimulationParameters.one_day_only_with_all_options(year, seconds_per_timestep)
         # my_simulation_parameters = SimulationParameters.one_week_only(year, seconds_per_timestep)
@@ -226,7 +224,7 @@ def air_conditioned_house(
         total_base_area_in_m2=total_base_area_in_m2,
         number_of_apartments=number_of_apartments,
         predictive=predictive,
-        enable_opening_windows=enable_opening_windows
+        enable_opening_windows=enable_opening_windows,
     )
     my_building = building.Building(
         config=my_building_config,
@@ -235,7 +233,9 @@ def air_conditioned_house(
 
     """ Occupancy Profile """
     my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
-    my_occupancy_config.data_acquisition_mode = loadprofilegenerator_utsp_connector.LpgDataAcquisitionMode.USE_PREDEFINED_PROFILE
+    my_occupancy_config.data_acquisition_mode = (
+        loadprofilegenerator_utsp_connector.LpgDataAcquisitionMode.USE_PREDEFINED_PROFILE
+    )
     my_occupancy_config.predictive_control = predictive_control
     my_occupancy_config.predictive = predictive
 
@@ -246,9 +246,7 @@ def air_conditioned_house(
     my_sim.add_component(my_occupancy)
 
     """Weather"""
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum.SEVILLE
-    )
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.SEVILLE)
     my_weather_config.predictive_control = predictive_control
 
     my_weather = weather.Weather(
@@ -433,9 +431,7 @@ def air_conditioned_house(
 
     """PID controller"""  # pid
     if control == "PID":
-        my_pid_controller_config = (
-            controller_pid.PIDControllerConfig.get_default_config()
-        )
+        my_pid_controller_config = controller_pid.PIDControllerConfig.get_default_config()
         pid_controller = controller_pid.PIDController(
             config=my_pid_controller_config,
             my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/air_conditioned_house_b_with_pid_controller.py
+++ b/system_setups/air_conditioned_house_b_with_pid_controller.py
@@ -11,9 +11,7 @@ from hisim.simulator import SimulationParameters
 from hisim.simulator import Simulator
 
 __authors__ = "Marwa Alfouly, Sebastian Dickler"
-__copyright__ = (
-    "Copyright 2023, HiSim - Household Infrastructure and Building Simulator"
-)
+__copyright__ = "Copyright 2023, HiSim - Household Infrastructure and Building Simulator"
 __credits__ = ["Noah Pflugradt"]
 __license__ = "MIT"
 __version__ = "0.1"
@@ -22,9 +20,7 @@ __email__ = "s.dickler@fz-juelich.de"
 __status__ = "development"
 
 
-def setup_function(
-    my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters] = None
-) -> None:
+def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters] = None) -> None:
     """Simulates household with air-conditioner with PID controller."""
 
     air_conditioned_house(my_sim, "PID", my_simulation_parameters)

--- a/system_setups/air_conditioned_house_c_with_onoff_controller.py
+++ b/system_setups/air_conditioned_house_c_with_onoff_controller.py
@@ -12,9 +12,7 @@ from hisim.simulator import Simulator
 
 
 __authors__ = "Marwa Alfouly, Sebastian Dickler"
-__copyright__ = (
-    "Copyright 2023, HiSim - Household Infrastructure and Building Simulator"
-)
+__copyright__ = "Copyright 2023, HiSim - Household Infrastructure and Building Simulator"
 __credits__ = ["Noah Pflugradt"]
 __license__ = "MIT"
 __version__ = "0.1"
@@ -23,9 +21,7 @@ __email__ = "s.dickler@fz-juelich.de"
 __status__ = "development"
 
 
-def setup_function(
-    my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters] = None
-) -> None:
+def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters] = None) -> None:
     """Simulates household with air-conditioner with ON/OFF controller."""
 
     air_conditioned_house(my_sim, "on_off", my_simulation_parameters)

--- a/system_setups/automatic_default_connections.py
+++ b/system_setups/automatic_default_connections.py
@@ -19,9 +19,7 @@ from hisim.components import (
 )
 
 
-def setup_function(
-    my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None
-) -> Any:
+def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None) -> Any:
     """The setup function emulates an household including the basic components.
 
     Here the residents have their electricity and heating needs covered
@@ -60,20 +58,18 @@ def setup_function(
     # Set Fix System Parameters
 
     # Set Heat Pump
-    heating_reference_temperature_in_celsius: float = (
-        -7
-    )  # t_in #TODO: get real heating ref temps according to location
+    heating_reference_temperature_in_celsius: float = -7  # t_in #TODO: get real heating ref temps according to location
 
     # =================================================================================================================================
     # Build Basic Components
 
     # Build Building
-    my_building_config = building.BuildingConfig.get_default_german_single_family_home(heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius)
+    my_building_config = building.BuildingConfig.get_default_german_single_family_home(
+        heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+    )
 
     my_building_information = building.BuildingInformation(config=my_building_config)
-    my_building = building.Building(
-        config=my_building_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
 
     # Build Occupancy
     my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
@@ -82,18 +78,12 @@ def setup_function(
     )
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum.AACHEN
-    )
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
 
-    my_weather = weather.Weather(
-        config=my_weather_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Build PV
-    my_photovoltaic_system_config = (
-        generic_pv_system.PVSystemConfig.get_scaled_pv_system(
-            rooftop_area_in_m2=my_building_information.scaled_rooftop_area_in_m2
-        )
+    my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_scaled_pv_system(
+        rooftop_area_in_m2=my_building_information.scaled_rooftop_area_in_m2
     )
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
@@ -107,19 +97,15 @@ def setup_function(
         set_cooling_temperature_for_building_in_celsius=my_building_information.set_cooling_temperature_for_building_in_celsius,
         set_heating_temperature_for_building_in_celsius=my_building_information.set_heating_temperature_for_building_in_celsius,
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-        heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+        heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
     )
 
-    my_heat_distribution_controller = (
-        heat_distribution_system.HeatDistributionController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_heat_distribution_controller_config,
-        )
+    my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_distribution_controller_config,
     )
-    my_hds_controller_information = (
-        heat_distribution_system.HeatDistributionControllerInformation(
-            config=my_heat_distribution_controller_config
-        )
+    my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
+        config=my_heat_distribution_controller_config
     )
 
     # Build Heat Pump Controller
@@ -133,7 +119,7 @@ def setup_function(
     # Build Heat Pump
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-        heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+        heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
     )
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
@@ -168,12 +154,16 @@ def setup_function(
         number_of_apartments=my_building_information.number_of_apartments
     )
 
-    my_dhw_heatpump_controller_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
-        name="DHWHeatpumpController"
+    my_dhw_heatpump_controller_config = (
+        controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
+            name="DHWHeatpumpController"
+        )
     )
 
-    my_dhw_storage_config = generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
-        number_of_apartments=my_building_information.number_of_apartments
+    my_dhw_storage_config = (
+        generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
+            number_of_apartments=my_building_information.number_of_apartments
+        )
     )
     my_dhw_storage_config.compute_default_cycle(
         temperature_difference_in_kelvin=my_dhw_heatpump_controller_config.t_max_heating_in_celsius
@@ -184,11 +174,9 @@ def setup_function(
         my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
     )
 
-    my_domnestic_hot_water_heatpump_controller = (
-        controller_l1_heatpump.L1HeatPumpController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_dhw_heatpump_controller_config,
-        )
+    my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -213,8 +201,6 @@ def setup_function(
     my_sim.add_component(my_heat_distribution_controller, connect_automatically=True)
     my_sim.add_component(my_simple_hot_water_storage, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domnestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domnestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter, connect_automatically=True)

--- a/system_setups/basic_household.py
+++ b/system_setups/basic_household.py
@@ -66,9 +66,7 @@ def setup_function(
     # Build Building
     my_building_config = building.BuildingConfig.get_default_german_single_family_home()
 
-    my_building = building.Building(
-        config=my_building_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Build Occupancy
     my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
     my_occupancy = loadprofilegenerator_utsp_connector.UtspLpgConnector(
@@ -76,17 +74,11 @@ def setup_function(
     )
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum.AACHEN
-    )
-    my_weather = weather.Weather(
-        config=my_weather_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+    my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
     # Build PV
-    my_photovoltaic_system_config = (
-        generic_pv_system.PVSystemConfig.get_default_pv_system()
-    )
+    my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
 
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
@@ -171,9 +163,7 @@ def setup_function(
         my_electricity_meter.component_name,
         my_electricity_meter.ElectricityAvailable,
     )
-    my_heat_pump.connect_only_predefined_connections(
-        my_weather, my_heat_pump_controller
-    )
+    my_heat_pump.connect_only_predefined_connections(my_weather, my_heat_pump_controller)
     my_heat_pump.get_default_connections_heatpump_controller()
     # =================================================================================================================================
     # Add Components to Simulation Parameters

--- a/system_setups/basic_household_only_heating.py
+++ b/system_setups/basic_household_only_heating.py
@@ -19,9 +19,7 @@ __maintainer__ = "Noah Pflugradt"
 __status__ = "development"
 
 
-def setup_function(
-    my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None
-) -> None:
+def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None) -> None:
     """Gas heater + buffer storage.
 
     This setup function emulates an household including

--- a/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_pem.py
+++ b/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_pem.py
@@ -71,35 +71,17 @@ def setup_function(
     # Build Components
 
     if my_simulation_parameters is None:
-        my_simulation_parameters = SimulationParameters.full_year(
-            year=year, seconds_per_timestep=seconds_per_timestep
-        )
+        my_simulation_parameters = SimulationParameters.full_year(year=year, seconds_per_timestep=seconds_per_timestep)
 
     my_sim.set_simulation_parameters(my_simulation_parameters)
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_LINE
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_CARPET
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.MAKE_NETWORK_CHARTS
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.WRITE_ALL_OUTPUTS_TO_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.GENERATE_PDF_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.COMPUTE_OPEX
-    )
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_LINE)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_CARPET)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.WRITE_ALL_OUTPUTS_TO_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.GENERATE_PDF_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_OPEX)
     my_simulation_parameters.post_processing_options.append(
         PostProcessingOptions.PREPARE_OUTPUTS_FOR_SCENARIO_EVALUATION
     )
@@ -119,15 +101,11 @@ def setup_function(
 
     my_fuel_cell_controller_l2 = XTPController(
         my_simulation_parameters=my_simulation_parameters,
-        config=XTPControllerConfig.control_fuel_cell(
-            fuel_cell_name=fuel_cell_name, operation_mode=operation_mode
-        ),
+        config=XTPControllerConfig.control_fuel_cell(fuel_cell_name=fuel_cell_name, operation_mode=operation_mode),
     )
     my_fuel_cell_controller = FuelCellController(
         my_simulation_parameters=my_simulation_parameters,
-        config=FuelCellControllerConfig.control_fuel_cell(
-            fuel_cell_name=fuel_cell_name
-        ),
+        config=FuelCellControllerConfig.control_fuel_cell(fuel_cell_name=fuel_cell_name),
     )
     my_fuel_cell = FuelCell(
         my_simulation_parameters=my_simulation_parameters,
@@ -145,15 +123,11 @@ def setup_function(
 
     my_electrolyzer_controller = ElectrolyzerController(
         my_simulation_parameters=my_simulation_parameters,
-        config=ElectrolyzerControllerConfig.control_electrolyzer(
-            electrolyzer_name=electrolyzer_name
-        ),
+        config=ElectrolyzerControllerConfig.control_electrolyzer(electrolyzer_name=electrolyzer_name),
     )
     my_electrolyzer = Electrolyzer(
         my_simulation_parameters=my_simulation_parameters,
-        config=ElectrolyzerConfig.config_electrolyzer(
-            electrolyzer_name=electrolyzer_name
-        ),
+        config=ElectrolyzerConfig.config_electrolyzer(electrolyzer_name=electrolyzer_name),
     )
 
     my_cl2_config = cl2.EMSConfig.get_default_config_ems()
@@ -167,20 +141,12 @@ def setup_function(
         config=my_occupancy_config, my_simulation_parameters=my_simulation_parameters
     )
     # choose 1 to be the default for the number of apartments
-    SingletonSimRepository().set_entry(
-        key=SingletonDictKeyEnum.NUMBEROFAPARTMENTS, entry=number_of_apartments
-    )
+    SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.NUMBEROFAPARTMENTS, entry=number_of_apartments)
 
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum.AACHEN
-    )
-    my_weather = weather.Weather(
-        config=my_weather_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+    my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
-    my_photovoltaic_system_config = (
-        generic_pv_system.PVSystemConfig.get_default_pv_system()
-    )
+    my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
     my_photovoltaic_system_config.power_in_watt = pv_power
     my_photovoltaic_system_config.time = time
     my_photovoltaic_system_config.co2_footprint = pv_co2_footprint
@@ -212,15 +178,13 @@ def setup_function(
             predictive=False,
             set_heating_temperature_in_celsius=19.0,
             set_cooling_temperature_in_celsius=24.0,
-            enable_opening_windows=False
+            enable_opening_windows=False,
         ),
         my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Pump Controller Config
-    my_heat_pump_controller_config = (
-        GenericHeatPumpControllerConfig.get_default_generic_heat_pump_controller_config()
-    )
+    my_heat_pump_controller_config = GenericHeatPumpControllerConfig.get_default_generic_heat_pump_controller_config()
     my_heat_pump_controller_config.mode = hp_mode  # hp_mode
     # Build Heat Pump Controller
     my_heat_pump_controller = GenericHeatPumpController(
@@ -287,9 +251,7 @@ def setup_function(
         my_cl2.component_name,
         my_cl2.ElectricityToOrFromGrid,
     )
-    my_heat_pump.connect_only_predefined_connections(
-        my_weather, my_heat_pump_controller
-    )
+    my_heat_pump.connect_only_predefined_connections(my_weather, my_heat_pump_controller)
     my_heat_pump.get_default_connections_heatpump_controller()
     # hp test end
 

--- a/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_rsoc.py
+++ b/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_rsoc.py
@@ -27,9 +27,7 @@ from hisim.sim_repository_singleton import SingletonDictKeyEnum, SingletonSimRep
 from hisim.simulator import SimulationParameters
 
 
-def setup_function(
-    my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None
-) -> None:
+def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None) -> None:
     """Dynamic Components Demonstration.
 
     In this system setup a generic controller is added. The generic controller
@@ -64,48 +62,26 @@ def setup_function(
     # Build Components
 
     if my_simulation_parameters is None:
-        my_simulation_parameters = SimulationParameters.full_year(
-            year=year, seconds_per_timestep=seconds_per_timestep
-        )
+        my_simulation_parameters = SimulationParameters.full_year(year=year, seconds_per_timestep=seconds_per_timestep)
     # my_simulation_parameters = SimulationParameters.january_only(year=year, seconds_per_timestep=seconds_per_timestep)
     # my_simulation_parameters.enable_all_options( )
 
     my_sim.set_simulation_parameters(my_simulation_parameters)
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_LINE
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_CARPET
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.MAKE_NETWORK_CHARTS
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.WRITE_ALL_OUTPUTS_TO_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.GENERATE_PDF_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.COMPUTE_OPEX
-    )
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_LINE)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_CARPET)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.WRITE_ALL_OUTPUTS_TO_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.GENERATE_PDF_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_OPEX)
     my_simulation_parameters.post_processing_options.append(
         PostProcessingOptions.PREPARE_OUTPUTS_FOR_SCENARIO_EVALUATION
     )
 
-    my_advanced_battery_config_1 = (
-        advanced_battery_bslib.BatteryConfig.get_default_config()
-    )
+    my_advanced_battery_config_1 = advanced_battery_bslib.BatteryConfig.get_default_config()
     my_advanced_battery_config_1.system_id = "SG1"
-    my_advanced_battery_config_1.custom_battery_capacity_generic_in_kilowatt_hour = (
-        200.0
-    )
+    my_advanced_battery_config_1.custom_battery_capacity_generic_in_kilowatt_hour = 200.0
     my_advanced_battery_config_1.custom_pv_inverter_power_generic_in_watt = 110000.0
     my_advanced_battery_config_1.source_weight = 1
 
@@ -147,20 +123,12 @@ def setup_function(
         config=my_occupancy_config, my_simulation_parameters=my_simulation_parameters
     )
     # choose 1 to be the default for the number of apartments
-    SingletonSimRepository().set_entry(
-        key=SingletonDictKeyEnum.NUMBEROFAPARTMENTS, entry=number_of_apartments
-    )
+    SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.NUMBEROFAPARTMENTS, entry=number_of_apartments)
 
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum.AACHEN
-    )
-    my_weather = weather.Weather(
-        config=my_weather_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+    my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
-    my_photovoltaic_system_config = (
-        generic_pv_system.PVSystemConfig.get_default_pv_system()
-    )
+    my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
     my_photovoltaic_system_config.power_in_watt = pv_power
     my_photovoltaic_system_config.time = time
     my_photovoltaic_system_config.co2_footprint = pv_co2_footprint
@@ -185,7 +153,7 @@ def setup_function(
             predictive=False,
             set_heating_temperature_in_celsius=19.0,
             set_cooling_temperature_in_celsius=24.0,
-            enable_opening_windows=False
+            enable_opening_windows=False,
         ),
         my_simulation_parameters=my_simulation_parameters,
     )
@@ -259,9 +227,7 @@ def setup_function(
         my_cl2.component_name,
         my_cl2.ElectricityToOrFromGrid,
     )
-    my_heat_pump.connect_only_predefined_connections(
-        my_weather, my_heat_pump_controller
-    )
+    my_heat_pump.connect_only_predefined_connections(my_weather, my_heat_pump_controller)
     my_heat_pump.get_default_connections_heatpump_controller()
 
     my_cl2.add_component_input_and_connect(

--- a/system_setups/default_connections.py
+++ b/system_setups/default_connections.py
@@ -12,9 +12,7 @@ from hisim.components import electricity_meter
 from hisim import loadtypes
 
 
-def setup_function(
-    my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None
-) -> Any:
+def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None) -> Any:
     """The setup function emulates an household including the basic components.
 
     Here the residents have their electricity and heating needs covered
@@ -58,9 +56,7 @@ def setup_function(
 
     # Build Building
     my_building_config = building.BuildingConfig.get_default_german_single_family_home()
-    my_building = building.Building(
-        config=my_building_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
 
     # Build Occupancy
     my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
@@ -70,21 +66,15 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum.AACHEN
-    )
-    my_weather = weather.Weather(
-        config=my_weather_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+    my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     my_sim.add_component(my_weather)
 
     my_building.connect_only_predefined_connections(my_weather, my_occupancy)
     my_sim.add_component(my_building)
 
     # Build PV
-    my_photovoltaic_system_config = (
-        generic_pv_system.PVSystemConfig.get_default_pv_system()
-    )
+    my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,
@@ -122,9 +112,7 @@ def setup_function(
         config=generic_heat_pump.GenericHeatPumpConfig.get_default_generic_heat_pump_config(),
         my_simulation_parameters=my_simulation_parameters,
     )
-    my_heat_pump.connect_only_predefined_connections(
-        my_weather, my_heat_pump_controller
-    )
+    my_heat_pump.connect_only_predefined_connections(my_weather, my_heat_pump_controller)
 
     my_sim.add_component(my_heat_pump)
 

--- a/system_setups/dynamic_components.py
+++ b/system_setups/dynamic_components.py
@@ -27,9 +27,7 @@ from hisim import loadtypes as lt
 # from hisim import utils
 
 
-def setup_function(
-    my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None
-) -> None:
+def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None) -> None:
     """Dynamic Components Demonstration.
 
     In this system setup a generic controller is added. The generic controller
@@ -49,17 +47,13 @@ def setup_function(
 
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
-    my_advanced_battery_config_1 = (
-        advanced_battery_bslib.BatteryConfig.get_default_config()
-    )
+    my_advanced_battery_config_1 = advanced_battery_bslib.BatteryConfig.get_default_config()
     my_advanced_battery_config_1.system_id = "SG1"
     my_advanced_battery_config_1.custom_battery_capacity_generic_in_kilowatt_hour = 10.0
     my_advanced_battery_config_1.custom_pv_inverter_power_generic_in_watt = 5.0
     my_advanced_battery_config_1.source_weight = 1
 
-    my_advanced_battery_config_2 = (
-        advanced_battery_bslib.BatteryConfig.get_default_config()
-    )
+    my_advanced_battery_config_2 = advanced_battery_bslib.BatteryConfig.get_default_config()
     my_advanced_battery_config_2.system_id = "SG1"
     my_advanced_battery_config_2.custom_battery_capacity_generic_in_kilowatt_hour = 5.0
     my_advanced_battery_config_2.custom_pv_inverter_power_generic_in_watt = 2.5
@@ -98,16 +92,10 @@ def setup_function(
         config=my_occupancy_config, my_simulation_parameters=my_simulation_parameters
     )
 
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum.AACHEN
-    )
-    my_weather = weather.Weather(
-        config=my_weather_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+    my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
-    my_photovoltaic_system_config = (
-        generic_pv_system.PVSystemConfig.get_default_pv_system()
-    )
+    my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         my_simulation_parameters=my_simulation_parameters,
         config=my_photovoltaic_system_config,

--- a/system_setups/electrolyzer_with_renewables.py
+++ b/system_setups/electrolyzer_with_renewables.py
@@ -35,9 +35,7 @@ __maintainer__ = "Franz Oldopp"
 __status__ = "development"
 
 
-def setup_function(
-    my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]
-) -> None:
+def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]) -> None:
     """Electrolyzer system setup.
 
     In this system setup, a power input from a csv time series file is transformed
@@ -101,9 +99,7 @@ def setup_function(
     )
 
     # Create new CSV loader object
-    csv_loader = CSVLoader(
-        my_csv_loader, my_simulation_parameters=my_simulation_parameters
-    )
+    csv_loader = CSVLoader(my_csv_loader, my_simulation_parameters=my_simulation_parameters)
 
     # Setup the transformer and rectifier unit
     my_transformer = Transformer(
@@ -130,9 +126,7 @@ def setup_function(
     # Connect Component Inputs with Outputs
 
     # Connect output of csv_loader to input of the transformer
-    my_transformer.connect_input(
-        my_transformer.TransformerInput, csv_loader.component_name, csv_loader.Output1
-    )
+    my_transformer.connect_input(my_transformer.TransformerInput, csv_loader.component_name, csv_loader.Output1)
 
     my_controller.connect_input(
         my_controller.ProvidedLoad,

--- a/system_setups/household_1_advanced_hp_diesel_car.py
+++ b/system_setups/household_1_advanced_hp_diesel_car.py
@@ -44,7 +44,7 @@ __status__ = "development"
 @dataclass
 class HouseholdAdvancedHPDieselCarOptions:
 
-    """ Set options for the system setup."""
+    """Set options for the system setup."""
 
     pass
 
@@ -80,8 +80,8 @@ class HouseholdAdvancedHPDieselCarConfig(SystemSetupConfigBase):
 
         heating_reference_temperature_in_celsius: float = -7
 
-        building_config = (
-            building.BuildingConfig.get_default_german_single_family_home(heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius)
+        building_config = building.BuildingConfig.get_default_german_single_family_home(
+            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
         )
 
         household_config = cls.get_scaled_default(building_config)
@@ -89,9 +89,7 @@ class HouseholdAdvancedHPDieselCarConfig(SystemSetupConfigBase):
         household_config.hp_config.set_thermal_output_power_in_watt = (
             6000  # default value leads to switching on-off very often
         )
-        household_config.dhw_storage_config.volume = (
-            250  # default(volume = 230) leads to an error
-        )
+        household_config.dhw_storage_config.volume = 250  # default(volume = 230) leads to an error
 
         return household_config
 
@@ -99,7 +97,7 @@ class HouseholdAdvancedHPDieselCarConfig(SystemSetupConfigBase):
     def get_scaled_default(
         cls,
         building_config: building.BuildingConfig,
-        options: HouseholdAdvancedHPDieselCarOptions = HouseholdAdvancedHPDieselCarOptions()
+        options: HouseholdAdvancedHPDieselCarOptions = HouseholdAdvancedHPDieselCarOptions(),
     ) -> "HouseholdAdvancedHPDieselCarConfig":
         """Get scaled default HouseholdAdvancedHPDieselCarConfig."""
 
@@ -111,12 +109,10 @@ class HouseholdAdvancedHPDieselCarConfig(SystemSetupConfigBase):
             set_heating_temperature_for_building_in_celsius=my_building_information.set_heating_temperature_for_building_in_celsius,
             set_cooling_temperature_for_building_in_celsius=my_building_information.set_cooling_temperature_for_building_in_celsius,
             heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-            heating_reference_temperature_in_celsius=my_building_information.heating_reference_temperature_in_celsius
+            heating_reference_temperature_in_celsius=my_building_information.heating_reference_temperature_in_celsius,
         )
-        my_hds_controller_information = (
-            heat_distribution_system.HeatDistributionControllerInformation(
-                config=hds_controller_config
-            )
+        my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
+            config=hds_controller_config
         )
         household_config = HouseholdAdvancedHPDieselCarConfig(
             building_type="blub",
@@ -148,7 +144,7 @@ class HouseholdAdvancedHPDieselCarConfig(SystemSetupConfigBase):
             ),
             hp_config=advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                 heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-                heating_reference_temperature_in_celsius=my_building_information.heating_reference_temperature_in_celsius
+                heating_reference_temperature_in_celsius=my_building_information.heating_reference_temperature_in_celsius,
             ),
             simple_hot_water_storage_config=simple_hot_water_storage.SimpleHotWaterStorageConfig.get_scaled_hot_water_storage(
                 max_thermal_power_in_watt_of_heating_system=my_building_information.max_thermal_building_demand_in_watt,
@@ -171,9 +167,7 @@ class HouseholdAdvancedHPDieselCarConfig(SystemSetupConfigBase):
 
         # adjust HeatPump
         household_config.hp_config.group_id = 1  # use modulating heatpump as default
-        household_config.hp_controller_config.mode = (
-            2  # use heating and cooling as default
-        )
+        household_config.hp_controller_config.mode = 2  # use heating and cooling as default
         household_config.hp_config.minimum_idle_time_in_seconds = (
             900  # default value leads to switching on-off very often
         )
@@ -225,9 +219,7 @@ def setup_function(
         cleanup_old_lpg_requests()
 
     if my_sim.my_module_config_path:
-        my_config = HouseholdAdvancedHPDieselCarConfig.load_from_json(
-            my_sim.my_module_config_path
-        )
+        my_config = HouseholdAdvancedHPDieselCarConfig.load_from_json(my_sim.my_module_config_path)
     else:
         my_config = HouseholdAdvancedHPDieselCarConfig.get_default()
 
@@ -254,11 +246,9 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build heat Distribution System Controller
-    my_heat_distribution_controller = (
-        heat_distribution_system.HeatDistributionController(
-            config=my_config.hds_controller_config,
-            my_simulation_parameters=my_simulation_parameters,
-        )
+    my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
+        config=my_config.hds_controller_config,
+        my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -315,10 +305,7 @@ def setup_function(
         * (4180 / 3600)
         * 0.5
         * (3600 / my_simulation_parameters.seconds_per_timestep)
-        * (
-            HouseholdWarmWaterDemandConfig.ww_temperature_demand
-            - HouseholdWarmWaterDemandConfig.freshwater_temperature
-        )
+        * (HouseholdWarmWaterDemandConfig.ww_temperature_demand - HouseholdWarmWaterDemandConfig.freshwater_temperature)
     )
 
     my_dhw_heatpump_controller_config = my_config.dhw_heatpump_controller_config
@@ -334,11 +321,9 @@ def setup_function(
         my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
     )
 
-    my_domnestic_hot_water_heatpump_controller = (
-        controller_l1_heatpump.L1HeatPumpController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_dhw_heatpump_controller_config,
-        )
+    my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -383,9 +368,7 @@ def setup_function(
     my_sim.add_component(my_heat_distribution_controller, connect_automatically=True)
     my_sim.add_component(my_simple_hot_water_storage, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domnestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domnestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter, connect_automatically=True)
     for my_car in my_cars:

--- a/system_setups/household_2_advanced_hp_diesel_car_pv.py
+++ b/system_setups/household_2_advanced_hp_diesel_car_pv.py
@@ -78,20 +78,18 @@ class HouseholdAdvancedHPDieselCarPVConfig(SystemSetupConfigBase):
         heating_reference_temperature_in_celsius: float = -7
         set_heating_threshold_outside_temperature_in_celsius: float = 16.0
 
-        building_config = (
-            building.BuildingConfig.get_default_german_single_family_home(heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius)
+        building_config = building.BuildingConfig.get_default_german_single_family_home(
+            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
         )
         my_building_information = building.BuildingInformation(config=building_config)
         hds_controller_config = heat_distribution_system.HeatDistributionControllerConfig.get_default_heat_distribution_controller_config(
             set_heating_temperature_for_building_in_celsius=my_building_information.set_heating_temperature_for_building_in_celsius,
             set_cooling_temperature_for_building_in_celsius=my_building_information.set_cooling_temperature_for_building_in_celsius,
             heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
         )
-        my_hds_controller_information = (
-            heat_distribution_system.HeatDistributionControllerInformation(
-                config=hds_controller_config
-            )
+        my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
+            config=hds_controller_config
         )
 
         household_config = HouseholdAdvancedHPDieselCarPVConfig(
@@ -134,7 +132,7 @@ class HouseholdAdvancedHPDieselCarPVConfig(SystemSetupConfigBase):
             hp_config=(
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-                    heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+                    heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
                 )
             ),
             simple_hot_water_storage_config=(
@@ -160,15 +158,11 @@ class HouseholdAdvancedHPDieselCarPVConfig(SystemSetupConfigBase):
             ),
             car_config=generic_car.CarConfig.get_default_diesel_config(),
             electricity_meter_config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
-            electricity_controller_config=(
-                controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
-            ),
+            electricity_controller_config=(controller_l2_energy_management_system.EMSConfig.get_default_config_ems()),
         )
         # adjust HeatPump
         household_config.hp_config.group_id = 1  # use modulating heatpump as default
-        household_config.hp_controller_config.mode = (
-            2  # use heating and cooling as default
-        )
+        household_config.hp_controller_config.mode = 2  # use heating and cooling as default
         # household_config.hp_config.set_thermal_output_power_in_watt = (
         #     6000  # default value leads to switching on-off very often
         # )
@@ -230,9 +224,7 @@ def setup_function(
 
     # Todo: save file leads to use of file in next run. File was just produced to check how it looks like
     if my_sim.my_module_config_path:
-        my_config = HouseholdAdvancedHPDieselCarPVConfig.load_from_json(
-            my_sim.my_module_config_path
-        )
+        my_config = HouseholdAdvancedHPDieselCarPVConfig.load_from_json(my_sim.my_module_config_path)
     else:
         my_config = HouseholdAdvancedHPDieselCarPVConfig.get_default()
 
@@ -255,11 +247,9 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build heat Distribution System Controller
-    my_heat_distribution_controller = (
-        heat_distribution_system.HeatDistributionController(
-            config=my_config.hds_controller_config,
-            my_simulation_parameters=my_simulation_parameters,
-        )
+    my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
+        config=my_config.hds_controller_config,
+        my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -330,11 +320,9 @@ def setup_function(
         my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
     )
 
-    my_domnestic_hot_water_heatpump_controller = (
-        controller_l1_heatpump.L1HeatPumpController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_dhw_heatpump_controller_config,
-        )
+    my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -369,11 +357,9 @@ def setup_function(
     )
 
     # Build EMS
-    my_electricity_controller = (
-        controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_config.electricity_controller_config,
-        )
+    my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.electricity_controller_config,
     )
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -519,9 +505,7 @@ def setup_function(
     my_sim.add_component(my_heat_distribution_controller, connect_automatically=True)
     my_sim.add_component(my_simple_hot_water_storage, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domnestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domnestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter)
     my_sim.add_component(my_electricity_controller)

--- a/system_setups/household_3_advanced_hp_diesel_car_pv_battery.py
+++ b/system_setups/household_3_advanced_hp_diesel_car_pv_battery.py
@@ -79,20 +79,18 @@ class HouseholdAdvancedHPDieselCarPVBatteryConfig(SystemSetupConfigBase):
 
         heating_reference_temperature_in_celsius: float = -7
         set_heating_threshold_outside_temperature_in_celsius: float = 16.0
-        building_config = (
-            building.BuildingConfig.get_default_german_single_family_home(heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius)
+        building_config = building.BuildingConfig.get_default_german_single_family_home(
+            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
         )
         my_building_information = building.BuildingInformation(config=building_config)
         hds_controller_config = heat_distribution_system.HeatDistributionControllerConfig.get_default_heat_distribution_controller_config(
             set_heating_temperature_for_building_in_celsius=my_building_information.set_heating_temperature_for_building_in_celsius,
             set_cooling_temperature_for_building_in_celsius=my_building_information.set_cooling_temperature_for_building_in_celsius,
             heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
         )
-        my_hds_controller_information = (
-            heat_distribution_system.HeatDistributionControllerInformation(
-                config=hds_controller_config
-            )
+        my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
+            config=hds_controller_config
         )
 
         pv_config = generic_pv_system.PVSystemConfig.get_scaled_pv_system(
@@ -137,7 +135,7 @@ class HouseholdAdvancedHPDieselCarPVBatteryConfig(SystemSetupConfigBase):
             hp_config=(
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-                    heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+                    heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
                 )
             ),
             simple_hot_water_storage_config=(
@@ -166,15 +164,11 @@ class HouseholdAdvancedHPDieselCarPVBatteryConfig(SystemSetupConfigBase):
             advanced_battery_config=advanced_battery_bslib.BatteryConfig.get_scaled_battery(
                 total_pv_power_in_watt_peak=pv_config.power_in_watt
             ),
-            electricity_controller_config=(
-                controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
-            ),
+            electricity_controller_config=(controller_l2_energy_management_system.EMSConfig.get_default_config_ems()),
         )
         # adjust HeatPump
         household_config.hp_config.group_id = 1  # use modulating heatpump as default
-        household_config.hp_controller_config.mode = (
-            2  # use heating and cooling as default
-        )
+        household_config.hp_controller_config.mode = 2  # use heating and cooling as default
         # household_config.hp_config.set_thermal_output_power_in_watt = (
         #     6000  # default value leads to switching on-off very often
         # )
@@ -237,9 +231,7 @@ def setup_function(
 
     # Todo: save file leads to use of file in next run. File was just produced to check how it looks like
     if my_sim.my_module_config_path:
-        my_config = HouseholdAdvancedHPDieselCarPVBatteryConfig.load_from_json(
-            my_sim.my_module_config_path
-        )
+        my_config = HouseholdAdvancedHPDieselCarPVBatteryConfig.load_from_json(my_sim.my_module_config_path)
     else:
         my_config = HouseholdAdvancedHPDieselCarPVBatteryConfig.get_default()
     # =================================================================================================================================
@@ -261,11 +253,9 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build heat Distribution System Controller
-    my_heat_distribution_controller = (
-        heat_distribution_system.HeatDistributionController(
-            config=my_config.hds_controller_config,
-            my_simulation_parameters=my_simulation_parameters,
-        )
+    my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
+        config=my_config.hds_controller_config,
+        my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -336,11 +326,9 @@ def setup_function(
         my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
     )
 
-    my_domnestic_hot_water_heatpump_controller = (
-        controller_l1_heatpump.L1HeatPumpController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_dhw_heatpump_controller_config,
-        )
+    my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -375,11 +363,9 @@ def setup_function(
     )
 
     # Build EMS
-    my_electricity_controller = (
-        controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_config.electricity_controller_config,
-        )
+    my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.electricity_controller_config,
     )
 
     # Build Battery
@@ -518,18 +504,16 @@ def setup_function(
         source_weight=4,
     )
 
-    electricity_to_or_from_battery_target = (
-        my_electricity_controller.add_component_output(
-            source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.BATTERY,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
-            source_weight=4,
-            source_load_type=lt.LoadTypes.ELECTRICITY,
-            source_unit=lt.Units.WATT,
-            output_description="Target electricity for Battery Control. ",
-        )
+    electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
+        source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
+        source_tags=[
+            lt.ComponentType.BATTERY,
+            lt.InandOutputType.ELECTRICITY_TARGET,
+        ],
+        source_weight=4,
+        source_load_type=lt.LoadTypes.ELECTRICITY,
+        source_unit=lt.Units.WATT,
+        output_description="Target electricity for Battery Control. ",
     )
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -562,9 +546,7 @@ def setup_function(
     my_sim.add_component(my_heat_distribution_controller, connect_automatically=True)
     my_sim.add_component(my_simple_hot_water_storage, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domnestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domnestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter)
     my_sim.add_component(my_advanced_battery)

--- a/system_setups/household_4a_with_car_priority_advanced_hp_ev_pv.py
+++ b/system_setups/household_4a_with_car_priority_advanced_hp_ev_pv.py
@@ -81,25 +81,21 @@ class HouseholdAdvancedHPEvPvConfig(SystemSetupConfigBase):
         """Get default HouseholdAdvancedHPEvPvConfig."""
 
         charging_station_set = ChargingStationSets.Charging_At_Home_with_11_kW
-        charging_power = float(
-            (charging_station_set.Name or "").split("with ")[1].split(" kW")[0]
-        )
+        charging_power = float((charging_station_set.Name or "").split("with ")[1].split(" kW")[0])
         heating_reference_temperature_in_celsius: float = -7
         set_heating_threshold_outside_temperature_in_celsius: float = 16.0
-        building_config = (
-            building.BuildingConfig.get_default_german_single_family_home(heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius)
+        building_config = building.BuildingConfig.get_default_german_single_family_home(
+            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
         )
         my_building_information = building.BuildingInformation(config=building_config)
         hds_controller_config = heat_distribution_system.HeatDistributionControllerConfig.get_default_heat_distribution_controller_config(
             set_heating_temperature_for_building_in_celsius=my_building_information.set_heating_temperature_for_building_in_celsius,
             set_cooling_temperature_for_building_in_celsius=my_building_information.set_cooling_temperature_for_building_in_celsius,
             heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
         )
-        my_hds_controller_information = (
-            heat_distribution_system.HeatDistributionControllerInformation(
-                config=hds_controller_config
-            )
+        my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
+            config=hds_controller_config
         )
 
         household_config = HouseholdAdvancedHPEvPvConfig(
@@ -143,7 +139,7 @@ class HouseholdAdvancedHPEvPvConfig(SystemSetupConfigBase):
             hp_config=(
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-                    heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+                    heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
                 )
             ),
             simple_hot_water_storage_config=(
@@ -175,15 +171,11 @@ class HouseholdAdvancedHPEvPvConfig(SystemSetupConfigBase):
                 )
             ),
             electricity_meter_config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
-            electricity_controller_config=(
-                controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
-            ),
+            electricity_controller_config=(controller_l2_energy_management_system.EMSConfig.get_default_config_ems()),
         )
         # adjust HeatPump
         household_config.hp_config.group_id = 1  # use modulating heatpump as default
-        household_config.hp_controller_config.mode = (
-            2  # use heating and cooling as default
-        )
+        household_config.hp_controller_config.mode = 2  # use heating and cooling as default
         # household_config.hp_config.set_thermal_output_power_in_watt = (
         #     6000  # default value leads to switching on-off very often
         # )
@@ -254,9 +246,7 @@ def setup_function(
 
     # Todo: save file leads to use of file in next run. File was just produced to check how it looks like
     if my_sim.my_module_config_path:
-        my_config = HouseholdAdvancedHPEvPvConfig.load_from_json(
-            my_sim.my_module_config_path
-        )
+        my_config = HouseholdAdvancedHPEvPvConfig.load_from_json(my_sim.my_module_config_path)
     else:
         my_config = HouseholdAdvancedHPEvPvConfig.get_default()
     # =================================================================================================================================
@@ -281,11 +271,9 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build heat Distribution System Controller
-    my_heat_distribution_controller = (
-        heat_distribution_system.HeatDistributionController(
-            config=my_config.hds_controller_config,
-            my_simulation_parameters=my_simulation_parameters,
-        )
+    my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
+        config=my_config.hds_controller_config,
+        my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -356,11 +344,9 @@ def setup_function(
         my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
     )
 
-    my_domnestic_hot_water_heatpump_controller = (
-        controller_l1_heatpump.L1HeatPumpController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_dhw_heatpump_controller_config,
-        )
+    my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -373,9 +359,7 @@ def setup_function(
     filepaths_location = [elem for elem in filepaths if "CarLocation." in elem]
     names = [elem.partition(",")[0].partition(".")[2] for elem in filepaths_location]
 
-    my_car_config = (
-        my_config.car_config
-    )  # Todo: check source weight in case of 2 vehicles
+    my_car_config = my_config.car_config  # Todo: check source weight in case of 2 vehicles
     my_car_config.name = "ElectricCar"
 
     # create all cars
@@ -428,19 +412,15 @@ def setup_function(
     )
 
     # Build EMS
-    my_electricity_controller = (
-        controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_config.electricity_controller_config,
-        )
+    my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.electricity_controller_config,
     )
 
     # -----------------------------------------------------------------------------------------------------------------
     # connect Electric Vehicle
     # copied and adopted from modular_example
-    for car, car_battery, car_battery_controller in zip(
-        my_cars, my_car_batteries, my_car_battery_controllers
-    ):
+    for car, car_battery, car_battery_controller in zip(my_cars, my_car_batteries, my_car_battery_controllers):
         car_battery_controller.connect_only_predefined_connections(car)
         car_battery_controller.connect_only_predefined_connections(car_battery)
         car_battery.connect_only_predefined_connections(car_battery_controller)
@@ -631,9 +611,7 @@ def setup_function(
     my_sim.add_component(my_heat_distribution_controller, connect_automatically=True)
     my_sim.add_component(my_simple_hot_water_storage, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domnestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domnestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter)
     my_sim.add_component(my_electricity_controller)

--- a/system_setups/household_4b_with_heatpump_priority_advanced_hp_ev_pv.py
+++ b/system_setups/household_4b_with_heatpump_priority_advanced_hp_ev_pv.py
@@ -73,9 +73,7 @@ def setup_function(
 
     # Todo: save file leads to use of file in next run. File was just produced to check how it looks like
     if my_sim.my_module_config_path:
-        my_config = HouseholdAdvancedHPEvPvConfig.load_from_json(
-            my_sim.my_module_config_path
-        )
+        my_config = HouseholdAdvancedHPEvPvConfig.load_from_json(my_sim.my_module_config_path)
     else:
         my_config = HouseholdAdvancedHPEvPvConfig.get_default()
     # =================================================================================================================================
@@ -100,11 +98,9 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build heat Distribution System Controller
-    my_heat_distribution_controller = (
-        heat_distribution_system.HeatDistributionController(
-            config=my_config.hds_controller_config,
-            my_simulation_parameters=my_simulation_parameters,
-        )
+    my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
+        config=my_config.hds_controller_config,
+        my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -175,11 +171,9 @@ def setup_function(
         my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
     )
 
-    my_domnestic_hot_water_heatpump_controller = (
-        controller_l1_heatpump.L1HeatPumpController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_dhw_heatpump_controller_config,
-        )
+    my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -192,9 +186,7 @@ def setup_function(
     filepaths_location = [elem for elem in filepaths if "CarLocation." in elem]
     names = [elem.partition(",")[0].partition(".")[2] for elem in filepaths_location]
 
-    my_car_config = (
-        my_config.car_config
-    )  # Todo: check source weight in case of 2 vehicles
+    my_car_config = my_config.car_config  # Todo: check source weight in case of 2 vehicles
     my_car_config.name = "ElectricCar"
 
     # create all cars
@@ -247,19 +239,15 @@ def setup_function(
     )
 
     # Build EMS
-    my_electricity_controller = (
-        controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_config.electricity_controller_config,
-        )
+    my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.electricity_controller_config,
     )
 
     # -----------------------------------------------------------------------------------------------------------------
     # connect Electric Vehicle
     # copied and adopted from modular_example
-    for car, car_battery, car_battery_controller in zip(
-        my_cars, my_car_batteries, my_car_battery_controllers
-    ):
+    for car, car_battery, car_battery_controller in zip(my_cars, my_car_batteries, my_car_battery_controllers):
         car_battery_controller.connect_only_predefined_connections(car)
         car_battery_controller.connect_only_predefined_connections(car_battery)
         car_battery.connect_only_predefined_connections(car_battery_controller)
@@ -450,9 +438,7 @@ def setup_function(
     my_sim.add_component(my_heat_distribution_controller, connect_automatically=True)
     my_sim.add_component(my_simple_hot_water_storage, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domnestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domnestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter)
     my_sim.add_component(my_electricity_controller)

--- a/system_setups/household_5a_with_car_priority_advanced_hp_ev_pv_battery.py
+++ b/system_setups/household_5a_with_car_priority_advanced_hp_ev_pv_battery.py
@@ -84,25 +84,21 @@ class HouseholdAdvancedHpEvPvBatteryConfig(SystemSetupConfigBase):
         """Get default HouseholdAdvancedHpEvPvBatteryConfig."""
 
         charging_station_set = ChargingStationSets.Charging_At_Home_with_11_kW
-        charging_power = float(
-            (charging_station_set.Name or "").split("with ")[1].split(" kW")[0]
-        )
+        charging_power = float((charging_station_set.Name or "").split("with ")[1].split(" kW")[0])
         heating_reference_temperature_in_celsius: float = -7
         set_heating_threshold_outside_temperature_in_celsius: float = 16.0
-        building_config = (
-            building.BuildingConfig.get_default_german_single_family_home(heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius)
+        building_config = building.BuildingConfig.get_default_german_single_family_home(
+            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
         )
         my_building_information = building.BuildingInformation(config=building_config)
         hds_controller_config = heat_distribution_system.HeatDistributionControllerConfig.get_default_heat_distribution_controller_config(
             set_heating_temperature_for_building_in_celsius=my_building_information.set_heating_temperature_for_building_in_celsius,
             set_cooling_temperature_for_building_in_celsius=my_building_information.set_cooling_temperature_for_building_in_celsius,
             heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
         )
-        my_hds_controller_information = (
-            heat_distribution_system.HeatDistributionControllerInformation(
-                config=hds_controller_config
-            )
+        my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
+            config=hds_controller_config
         )
 
         pv_config = generic_pv_system.PVSystemConfig.get_scaled_pv_system(
@@ -148,7 +144,7 @@ class HouseholdAdvancedHpEvPvBatteryConfig(SystemSetupConfigBase):
             hp_config=(
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-                    heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+                    heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
                 )
             ),
             simple_hot_water_storage_config=(
@@ -183,15 +179,11 @@ class HouseholdAdvancedHpEvPvBatteryConfig(SystemSetupConfigBase):
             advanced_battery_config=advanced_battery_bslib.BatteryConfig.get_scaled_battery(
                 total_pv_power_in_watt_peak=pv_config.power_in_watt
             ),
-            electricity_controller_config=(
-                controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
-            ),
+            electricity_controller_config=(controller_l2_energy_management_system.EMSConfig.get_default_config_ems()),
         )
         # adjust HeatPump
         household_config.hp_config.group_id = 1  # use modulating heatpump as default
-        household_config.hp_controller_config.mode = (
-            2  # use heating and cooling as default
-        )
+        household_config.hp_controller_config.mode = 2  # use heating and cooling as default
         # household_config.hp_config.set_thermal_output_power_in_watt = (
         #     6000  # default value leads to switching on-off very often
         # )
@@ -263,9 +255,7 @@ def setup_function(
 
     # Todo: save file leads to use of file in next run. File was just produced to check how it looks like
     if my_sim.my_module_config_path:
-        my_config = HouseholdAdvancedHpEvPvBatteryConfig.load_from_json(
-            my_sim.my_module_config_path
-        )
+        my_config = HouseholdAdvancedHpEvPvBatteryConfig.load_from_json(my_sim.my_module_config_path)
     else:
         my_config = HouseholdAdvancedHpEvPvBatteryConfig.get_default()
     # =================================================================================================================================
@@ -290,11 +280,9 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build heat Distribution System Controller
-    my_heat_distribution_controller = (
-        heat_distribution_system.HeatDistributionController(
-            config=my_config.hds_controller_config,
-            my_simulation_parameters=my_simulation_parameters,
-        )
+    my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
+        config=my_config.hds_controller_config,
+        my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -365,11 +353,9 @@ def setup_function(
         my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
     )
 
-    my_domnestic_hot_water_heatpump_controller = (
-        controller_l1_heatpump.L1HeatPumpController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_dhw_heatpump_controller_config,
-        )
+    my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -382,9 +368,7 @@ def setup_function(
     filepaths_location = [elem for elem in filepaths if "CarLocation." in elem]
     names = [elem.partition(",")[0].partition(".")[2] for elem in filepaths_location]
 
-    my_car_config = (
-        my_config.car_config
-    )  # Todo: check source weight in case of 2 vehicles
+    my_car_config = my_config.car_config  # Todo: check source weight in case of 2 vehicles
     my_car_config.name = "ElectricCar"
 
     # create all cars
@@ -437,11 +421,9 @@ def setup_function(
     )
 
     # Build EMS
-    my_electricity_controller = (
-        controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_config.electricity_controller_config,
-        )
+    my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.electricity_controller_config,
     )
 
     # Build Battery
@@ -453,9 +435,7 @@ def setup_function(
     # -----------------------------------------------------------------------------------------------------------------
     # connect Electric Vehicle
     # copied and adopted from modular_example
-    for car, car_battery, car_battery_controller in zip(
-        my_cars, my_car_batteries, my_car_battery_controllers
-    ):
+    for car, car_battery, car_battery_controller in zip(my_cars, my_car_batteries, my_car_battery_controllers):
         car_battery_controller.connect_only_predefined_connections(car)
         car_battery_controller.connect_only_predefined_connections(car_battery)
         car_battery.connect_only_predefined_connections(car_battery_controller)
@@ -633,18 +613,16 @@ def setup_function(
         source_weight=4,
     )
 
-    electricity_to_or_from_battery_target = (
-        my_electricity_controller.add_component_output(
-            source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.BATTERY,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
-            source_weight=4,
-            source_load_type=lt.LoadTypes.ELECTRICITY,
-            source_unit=lt.Units.WATT,
-            output_description="Target electricity for Battery Control. ",
-        )
+    electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
+        source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
+        source_tags=[
+            lt.ComponentType.BATTERY,
+            lt.InandOutputType.ELECTRICITY_TARGET,
+        ],
+        source_weight=4,
+        source_load_type=lt.LoadTypes.ELECTRICITY,
+        source_unit=lt.Units.WATT,
+        output_description="Target electricity for Battery Control. ",
     )
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -677,9 +655,7 @@ def setup_function(
     my_sim.add_component(my_heat_distribution_controller, connect_automatically=True)
     my_sim.add_component(my_simple_hot_water_storage, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domnestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domnestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter)
     my_sim.add_component(my_advanced_battery)

--- a/system_setups/household_5b_with_battery_priority_advanced_hp_ev_pv_battery.py
+++ b/system_setups/household_5b_with_battery_priority_advanced_hp_ev_pv_battery.py
@@ -75,9 +75,7 @@ def setup_function(
 
     # Todo: save file leads to use of file in next run. File was just produced to check how it looks like
     if my_sim.my_module_config_path:
-        my_config = HouseholdAdvancedHpEvPvBatteryConfig.load_from_json(
-            my_sim.my_module_config_path
-        )
+        my_config = HouseholdAdvancedHpEvPvBatteryConfig.load_from_json(my_sim.my_module_config_path)
     else:
         my_config = HouseholdAdvancedHpEvPvBatteryConfig.get_default()
     # =================================================================================================================================
@@ -102,11 +100,9 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build heat Distribution System Controller
-    my_heat_distribution_controller = (
-        heat_distribution_system.HeatDistributionController(
-            config=my_config.hds_controller_config,
-            my_simulation_parameters=my_simulation_parameters,
-        )
+    my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
+        config=my_config.hds_controller_config,
+        my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -177,11 +173,9 @@ def setup_function(
         my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
     )
 
-    my_domnestic_hot_water_heatpump_controller = (
-        controller_l1_heatpump.L1HeatPumpController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_dhw_heatpump_controller_config,
-        )
+    my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -194,9 +188,7 @@ def setup_function(
     filepaths_location = [elem for elem in filepaths if "CarLocation." in elem]
     names = [elem.partition(",")[0].partition(".")[2] for elem in filepaths_location]
 
-    my_car_config = (
-        my_config.car_config
-    )  # Todo: check source weight in case of 2 vehicles
+    my_car_config = my_config.car_config  # Todo: check source weight in case of 2 vehicles
     my_car_config.name = "ElectricCar"
 
     # create all cars
@@ -249,11 +241,9 @@ def setup_function(
     )
 
     # Build EMS
-    my_electricity_controller = (
-        controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_config.electricity_controller_config,
-        )
+    my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.electricity_controller_config,
     )
 
     # Build Battery
@@ -265,9 +255,7 @@ def setup_function(
     # -----------------------------------------------------------------------------------------------------------------
     # connect Electric Vehicle
     # copied and adopted from modular_example
-    for car, car_battery, car_battery_controller in zip(
-        my_cars, my_car_batteries, my_car_battery_controllers
-    ):
+    for car, car_battery, car_battery_controller in zip(my_cars, my_car_batteries, my_car_battery_controllers):
         car_battery_controller.connect_only_predefined_connections(car)
         car_battery_controller.connect_only_predefined_connections(car_battery)
         car_battery.connect_only_predefined_connections(car_battery_controller)
@@ -445,18 +433,16 @@ def setup_function(
         source_weight=1,
     )
 
-    electricity_to_or_from_battery_target = (
-        my_electricity_controller.add_component_output(
-            source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.BATTERY,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
-            source_weight=1,
-            source_load_type=lt.LoadTypes.ELECTRICITY,
-            source_unit=lt.Units.WATT,
-            output_description="Target electricity for Battery Control. ",
-        )
+    electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
+        source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
+        source_tags=[
+            lt.ComponentType.BATTERY,
+            lt.InandOutputType.ELECTRICITY_TARGET,
+        ],
+        source_weight=1,
+        source_load_type=lt.LoadTypes.ELECTRICITY,
+        source_unit=lt.Units.WATT,
+        output_description="Target electricity for Battery Control. ",
     )
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -489,9 +475,7 @@ def setup_function(
     my_sim.add_component(my_heat_distribution_controller, connect_automatically=True)
     my_sim.add_component(my_simple_hot_water_storage, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domnestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domnestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter)
     my_sim.add_component(my_advanced_battery)

--- a/system_setups/household_cluster_advanced_hp_pv_battery_ems.py
+++ b/system_setups/household_cluster_advanced_hp_pv_battery_ems.py
@@ -72,48 +72,32 @@ def setup_function(
     config_filename = my_sim.my_module_config_path
 
     my_config: BuildingPVWeatherConfig
-    if isinstance(config_filename, str) and os.path.exists(
-        config_filename.rstrip("\r")
-    ):
-        with open(
-            config_filename.rstrip("\r"), encoding="unicode_escape"
-        ) as system_config_file:
+    if isinstance(config_filename, str) and os.path.exists(config_filename.rstrip("\r")):
+        with open(config_filename.rstrip("\r"), encoding="unicode_escape") as system_config_file:
             my_config = BuildingPVWeatherConfig.from_json(system_config_file.read())  # type: ignore
 
         log.information(f"Read system config from {config_filename}")
         log.information("Config values: " + f"{my_config.to_dict}" + "\n")
     else:
         my_config = BuildingPVWeatherConfig.get_default()
-        log.information(
-            "No module config path from the simulator was given. Use default config."
-        )
+        log.information("No module config path from the simulator was given. Use default config.")
 
     # Set Simulation Parameters
     year = 2021
     seconds_per_timestep = 60
 
     if my_simulation_parameters is None:
-        my_simulation_parameters = SimulationParameters.full_year(
-            year=year, seconds_per_timestep=seconds_per_timestep
-        )
+        my_simulation_parameters = SimulationParameters.full_year(year=year, seconds_per_timestep=seconds_per_timestep)
         my_simulation_parameters.post_processing_options.append(
             PostProcessingOptions.PREPARE_OUTPUTS_FOR_SCENARIO_EVALUATION
         )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.COMPUTE_OPEX
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.COMPUTE_CAPEX
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT
-        )
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_OPEX)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_CAPEX)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT)
         my_simulation_parameters.post_processing_options.append(
             PostProcessingOptions.MAKE_RESULT_JSON_WITH_KPI_FOR_WEBTOOL
         )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.OPEN_DIRECTORY_IN_EXPLORER
-        )
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.OPEN_DIRECTORY_IN_EXPLORER)
 
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
@@ -138,7 +122,6 @@ def setup_function(
     lpg_households: Union[JsonReference, List[JsonReference]]
 
     if isinstance(my_config.lpg_households, List):
-
         if len(my_config.lpg_households) == 1:
             lpg_households = getattr(Households, my_config.lpg_households[0])
         elif len(my_config.lpg_households) > 1:
@@ -151,26 +134,20 @@ def setup_function(
             raise ValueError("Config list with lpg household is empty.")
 
     else:
-        raise TypeError(
-            f"Type {type(my_config.lpg_households)} is incompatible. Should be List[str]."
-        )
+        raise TypeError(f"Type {type(my_config.lpg_households)} is incompatible. Should be List[str].")
 
     # =================================================================================================================================
     # Set Fix System Parameters
 
     # Set Heat Pump Controller
-    hp_controller_mode = (
-        2  # mode 1 for on/off and mode 2 for heating/cooling/off (regulated)
-    )
+    hp_controller_mode = 2  # mode 1 for on/off and mode 2 for heating/cooling/off (regulated)
     set_heating_threshold_outside_temperature_for_heat_pump_in_celsius = 16.0
     set_cooling_threshold_outside_temperature_for_heat_pump_in_celsius = 22.0
     temperature_offset_for_state_conditions_in_celsius = 5.0
 
     # Set Heat Pump
     group_id: int = 1  # outdoor/air heat pump (choose 1 for regulated or 4 for on/off)
-    heating_reference_temperature_in_celsius: float = (
-        -7
-    )  # t_in #TODO: get real heating ref temps according to location
+    heating_reference_temperature_in_celsius: float = -7  # t_in #TODO: get real heating ref temps according to location
     flow_temperature_in_celsius = 21  # t_out_val
 
     # =================================================================================================================================
@@ -182,20 +159,14 @@ def setup_function(
     )
     my_building_config.building_code = building_code
     my_building_config.total_base_area_in_m2 = total_base_area_in_m2
-    my_building_config.absolute_conditioned_floor_area_in_m2 = (
-        absolute_conditioned_floor_area_in_m2
-    )
+    my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
     my_building_information = building.BuildingInformation(config=my_building_config)
-    my_building = building.Building(
-        config=my_building_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
 
     # Build Occupancy
-    my_occupancy_config = (
-        loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
-    )
+    my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
     my_occupancy_config.household = lpg_households
     my_occupancy_config.cache_dir_path = cache_dir_path
 
@@ -204,13 +175,9 @@ def setup_function(
     )
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum.AACHEN
-    )
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
 
-    my_weather = weather.Weather(
-        config=my_weather_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
     # Build PV
     my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_scaled_pv_system(
@@ -261,7 +228,8 @@ def setup_function(
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config,
+        my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -287,9 +255,7 @@ def setup_function(
     )
 
     # Build EMS
-    my_electricity_controller_config = (
-        controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
-    )
+    my_electricity_controller_config = controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
     my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
         my_simulation_parameters=my_simulation_parameters,
         config=my_electricity_controller_config,
@@ -310,13 +276,17 @@ def setup_function(
         default_power_in_watt=6000,
     )
 
-    my_dhw_heatpump_controller_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
-        name="DHWHeatpumpController"
+    my_dhw_heatpump_controller_config = (
+        controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
+            name="DHWHeatpumpController"
+        )
     )
 
-    my_dhw_storage_config = generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
-        number_of_apartments=my_building_information.number_of_apartments,
-        default_volume_in_liter=450,
+    my_dhw_storage_config = (
+        generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
+            number_of_apartments=my_building_information.number_of_apartments,
+            default_volume_in_liter=450,
+        )
     )
     my_dhw_storage_config.compute_default_cycle(
         temperature_difference_in_kelvin=my_dhw_heatpump_controller_config.t_max_heating_in_celsius
@@ -533,15 +503,11 @@ def setup_function(
     my_sim.add_component(my_heat_pump_controller, connect_automatically=True)
     my_sim.add_component(my_heat_pump, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domnestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domnestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter)
     my_sim.add_component(my_advanced_battery)
-    my_sim.add_component(
-        my_electricity_controller, connect_automatically=connect_automatically
-    )
+    my_sim.add_component(my_electricity_controller, connect_automatically=connect_automatically)
 
     # Set Results Path
     # if config_filename is given, get hash number and sampling mode for result path

--- a/system_setups/household_cluster_reference_advanced_hp.py
+++ b/system_setups/household_cluster_reference_advanced_hp.py
@@ -98,48 +98,32 @@ def setup_function(
     config_filename = my_sim.my_module_config_path
 
     my_config: BuildingPVWeatherConfig
-    if isinstance(config_filename, str) and os.path.exists(
-        config_filename.rstrip("\r")
-    ):
-        with open(
-            config_filename.rstrip("\r"), encoding="unicode_escape"
-        ) as system_config_file:
+    if isinstance(config_filename, str) and os.path.exists(config_filename.rstrip("\r")):
+        with open(config_filename.rstrip("\r"), encoding="unicode_escape") as system_config_file:
             my_config = BuildingPVWeatherConfig.from_json(system_config_file.read())  # type: ignore
 
         log.information(f"Read system config from {config_filename}")
         log.information("Config values: " + f"{my_config.to_dict}" + "\n")
     else:
         my_config = BuildingPVWeatherConfig.get_default()
-        log.information(
-            "No module config path from the simulator was given. Use default config."
-        )
+        log.information("No module config path from the simulator was given. Use default config.")
 
     # Set Simulation Parameters
     year = 2021
     seconds_per_timestep = 60
 
     if my_simulation_parameters is None:
-        my_simulation_parameters = SimulationParameters.full_year(
-            year=year, seconds_per_timestep=seconds_per_timestep
-        )
+        my_simulation_parameters = SimulationParameters.full_year(year=year, seconds_per_timestep=seconds_per_timestep)
         my_simulation_parameters.post_processing_options.append(
             PostProcessingOptions.PREPARE_OUTPUTS_FOR_SCENARIO_EVALUATION
         )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.COMPUTE_OPEX
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.COMPUTE_CAPEX
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT
-        )
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_OPEX)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_CAPEX)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT)
         my_simulation_parameters.post_processing_options.append(
             PostProcessingOptions.MAKE_RESULT_JSON_WITH_KPI_FOR_WEBTOOL
         )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.OPEN_DIRECTORY_IN_EXPLORER
-        )
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.OPEN_DIRECTORY_IN_EXPLORER)
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Set Building (scale building according to total base area and not absolute floor area)
@@ -155,7 +139,6 @@ def setup_function(
     lpg_households: Union[JsonReference, List[JsonReference]]
 
     if isinstance(my_config.lpg_households, List):
-
         if len(my_config.lpg_households) == 1:
             lpg_households = getattr(Households, my_config.lpg_households[0])
         elif len(my_config.lpg_households) > 1:
@@ -168,26 +151,20 @@ def setup_function(
             raise ValueError("Config list with lpg household is empty.")
 
     else:
-        raise TypeError(
-            f"Type {type(my_config.lpg_households)} is incompatible. Should be List[str]."
-        )
+        raise TypeError(f"Type {type(my_config.lpg_households)} is incompatible. Should be List[str].")
 
     # =================================================================================================================================
     # Set Fix System Parameters
 
     # Set Heat Pump Controller
-    hp_controller_mode = (
-        2  # mode 1 for on/off and mode 2 for heating/cooling/off (regulated)
-    )
+    hp_controller_mode = 2  # mode 1 for on/off and mode 2 for heating/cooling/off (regulated)
     set_heating_threshold_outside_temperature_for_heat_pump_in_celsius = 16.0
     set_cooling_threshold_outside_temperature_for_heat_pump_in_celsius = 20.0
     temperature_offset_for_state_conditions_in_celsius = 5.0
 
     # Set Heat Pump
     group_id: int = 1  # outdoor/air heat pump (choose 1 for regulated or 4 for on/off)
-    heating_reference_temperature_in_celsius: float = (
-        -7
-    )  # t_in #TODO: get real heating ref temps according to location
+    heating_reference_temperature_in_celsius: float = -7  # t_in #TODO: get real heating ref temps according to location
     flow_temperature_in_celsius = 21  # t_out_val
 
     # =================================================================================================================================
@@ -199,21 +176,15 @@ def setup_function(
     )
     my_building_config.building_code = building_code
     my_building_config.total_base_area_in_m2 = total_base_area_in_m2
-    my_building_config.absolute_conditioned_floor_area_in_m2 = (
-        absolute_conditioned_floor_area_in_m2
-    )
+    my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
 
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
     my_building_information = building.BuildingInformation(config=my_building_config)
-    my_building = building.Building(
-        config=my_building_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
 
     # Build Occupancy
-    my_occupancy_config = (
-        loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
-    )
+    my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
     my_occupancy_config.household = lpg_households
     my_occupancy_config.cache_dir_path = cache_dir_path
 
@@ -222,13 +193,9 @@ def setup_function(
     )
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum.AACHEN
-    )
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
 
-    my_weather = weather.Weather(
-        config=my_weather_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
     # =================================================================================================================================
     # Build Energy System Components
@@ -270,7 +237,8 @@ def setup_function(
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config,
+        my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -300,13 +268,17 @@ def setup_function(
         default_power_in_watt=6000,
     )
 
-    my_dhw_heatpump_controller_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
-        name="DHWHeatpumpController"
+    my_dhw_heatpump_controller_config = (
+        controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
+            name="DHWHeatpumpController"
+        )
     )
 
-    my_dhw_storage_config = generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
-        number_of_apartments=my_building_information.number_of_apartments,
-        default_volume_in_liter=450,
+    my_dhw_storage_config = (
+        generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
+            number_of_apartments=my_building_information.number_of_apartments,
+            default_volume_in_liter=450,
+        )
     )
     my_dhw_storage_config.compute_default_cycle(
         temperature_difference_in_kelvin=my_dhw_heatpump_controller_config.t_max_heating_in_celsius
@@ -343,9 +315,7 @@ def setup_function(
     my_sim.add_component(my_heat_distribution_controller, connect_automatically=True)
     my_sim.add_component(my_simple_hot_water_storage, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domnestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domnestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter, connect_automatically=True)
 

--- a/system_setups/household_gas_heater.py
+++ b/system_setups/household_gas_heater.py
@@ -87,7 +87,9 @@ class HouseholdGasHeaterConfig(SystemSetupConfigBase):
         return household_config
 
     @classmethod
-    def get_scaled_default(cls, building_config: building.BuildingConfig, options: HouseholdGasHeaterOptions = HouseholdGasHeaterOptions()) -> "HouseholdGasHeaterConfig":
+    def get_scaled_default(
+        cls, building_config: building.BuildingConfig, options: HouseholdGasHeaterOptions = HouseholdGasHeaterOptions()
+    ) -> "HouseholdGasHeaterConfig":
         """Get scaled HouseholdGasHeaterConfig.
 
         - Simulation Parameters
@@ -113,7 +115,9 @@ class HouseholdGasHeaterConfig(SystemSetupConfigBase):
             heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
             heating_reference_temperature_in_celsius=my_building_information.heating_reference_temperature_in_celsius,
         )
-        my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(config=hds_controller_config)
+        my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
+            config=hds_controller_config
+        )
 
         household_config = HouseholdGasHeaterConfig(
             building_type="residential",
@@ -132,7 +136,9 @@ class HouseholdGasHeaterConfig(SystemSetupConfigBase):
                 predictive_control=False,
                 predictive=False,
             ),
-            pv_config=generic_pv_system.PVSystemConfig.get_scaled_pv_system(rooftop_area_in_m2=my_building_information.scaled_rooftop_area_in_m2),
+            pv_config=generic_pv_system.PVSystemConfig.get_scaled_pv_system(
+                rooftop_area_in_m2=my_building_information.scaled_rooftop_area_in_m2
+            ),
             options=options,
             building_config=building_config,
             hds_controller_config=hds_controller_config,
@@ -185,7 +191,9 @@ class HouseholdGasHeaterConfig(SystemSetupConfigBase):
         return household_config
 
 
-def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None) -> None:  # noqa: too-many-statements
+def setup_function(
+    my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None
+) -> None:  # noqa: too-many-statements
     """Generates a household with gas heater."""
 
     """
@@ -202,7 +210,9 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     year = 2021
     seconds_per_timestep = 60
     if my_simulation_parameters is None:
-        my_simulation_parameters = SimulationParameters.full_year_all_options(year=year, seconds_per_timestep=seconds_per_timestep)
+        my_simulation_parameters = SimulationParameters.full_year_all_options(
+            year=year, seconds_per_timestep=seconds_per_timestep
+        )
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     """
@@ -216,7 +226,9 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
 
     # Occupancy
     my_occupancy_config = my_config.occupancy_config
-    my_occupancy = loadprofilegenerator_utsp_connector.UtspLpgConnector(config=my_occupancy_config, my_simulation_parameters=my_simulation_parameters)
+    my_occupancy = loadprofilegenerator_utsp_connector.UtspLpgConnector(
+        config=my_occupancy_config, my_simulation_parameters=my_simulation_parameters
+    )
 
     # Weather
     my_weather = weather.Weather(
@@ -249,7 +261,9 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     )
 
     # BHeat Distribution System
-    my_heat_distribution = heat_distribution_system.HeatDistribution(my_simulation_parameters=my_simulation_parameters, config=my_config.hds_config)
+    my_heat_distribution = heat_distribution_system.HeatDistribution(
+        my_simulation_parameters=my_simulation_parameters, config=my_config.hds_config
+    )
 
     # Heat Water Storage
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(

--- a/system_setups/household_heat_pump.py
+++ b/system_setups/household_heat_pump.py
@@ -81,12 +81,8 @@ class HouseholdHeatPumpConfig(SystemSetupConfigBase):
     @classmethod
     def get_default(cls) -> "HouseholdHeatPumpConfig":
         """Get default HouseholdHeatPumpConfig."""
-        building_config = (
-            building.BuildingConfig.get_default_german_single_family_home()
-        )
-        household_config = cls.get_scaled_default(
-            building_config, options=HouseholdHeatPumpOptions()
-        )
+        building_config = building.BuildingConfig.get_default_german_single_family_home()
+        household_config = cls.get_scaled_default(building_config, options=HouseholdHeatPumpOptions())
         return household_config
 
     @classmethod
@@ -121,10 +117,8 @@ class HouseholdHeatPumpConfig(SystemSetupConfigBase):
             heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
             heating_reference_temperature_in_celsius=my_building_information.heating_reference_temperature_in_celsius,
         )
-        my_hds_controller_information = (
-            heat_distribution_system.HeatDistributionControllerInformation(
-                config=hds_controller_config
-            )
+        my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
+            config=hds_controller_config
         )
 
         household_config = HouseholdHeatPumpConfig(
@@ -185,9 +179,7 @@ class HouseholdHeatPumpConfig(SystemSetupConfigBase):
                     number_of_apartments=my_building_information.number_of_apartments
                 )
             ),
-            car_config=generic_car.CarConfig.get_default_diesel_config()
-            if options.diesel_car
-            else None,
+            car_config=generic_car.CarConfig.get_default_diesel_config() if options.diesel_car else None,
             electricity_meter_config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
         )
 
@@ -230,11 +222,9 @@ def setup_function(
     Build system
     """
     # Heat Distribution System Controller
-    my_heat_distribution_controller = (
-        heat_distribution_system.HeatDistributionController(
-            config=my_config.hds_controller_config,
-            my_simulation_parameters=my_simulation_parameters,
-        )
+    my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
+        config=my_config.hds_controller_config,
+        my_simulation_parameters=my_simulation_parameters,
     )
 
     # Occupancy
@@ -296,11 +286,9 @@ def setup_function(
     my_domestic_hot_water_storage = generic_hot_water_storage_modular.HotWaterStorage(
         my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
     )
-    my_domestic_hot_water_heatpump_controller = (
-        controller_l1_heatpump.L1HeatPumpController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_dhw_heatpump_controller_config,
-        )
+    my_domestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_heatpump_controller_config,
     )
     my_domestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
         config=my_dhw_heatpump_config, my_simulation_parameters=my_simulation_parameters
@@ -311,9 +299,7 @@ def setup_function(
         # get names of all available cars
         filepaths = listdir(utils.HISIMPATH["utsp_results"])
         filepaths_location = [elem for elem in filepaths if "CarLocation." in elem]
-        names = [
-            elem.partition(",")[0].partition(".")[2] for elem in filepaths_location
-        ]
+        names = [elem.partition(",")[0].partition(".")[2] for elem in filepaths_location]
 
         my_car_config = my_config.car_config
         my_car_config.name = "DieselCar"
@@ -350,9 +336,7 @@ def setup_function(
     my_sim.add_component(my_heat_distribution_controller, connect_automatically=True)
     my_sim.add_component(my_simple_hot_water_storage, connect_automatically=True)
     my_sim.add_component(my_domestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter, connect_automatically=True)
 

--- a/system_setups/household_reference_gas_heater_diesel_car.py
+++ b/system_setups/household_reference_gas_heater_diesel_car.py
@@ -70,20 +70,18 @@ class ReferenceHouseholdConfig(SystemSetupConfigBase):
 
         heating_reference_temperature_in_celsius: float = -7
         set_heating_threshold_outside_temperature_in_celsius: float = 16.0
-        building_config = (
-            building.BuildingConfig.get_default_german_single_family_home(heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius)
+        building_config = building.BuildingConfig.get_default_german_single_family_home(
+            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
         )
         my_building_information = building.BuildingInformation(config=building_config)
         hds_controller_config = heat_distribution_system.HeatDistributionControllerConfig.get_default_heat_distribution_controller_config(
             set_heating_temperature_for_building_in_celsius=my_building_information.set_heating_temperature_for_building_in_celsius,
             set_cooling_temperature_for_building_in_celsius=my_building_information.set_cooling_temperature_for_building_in_celsius,
             heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+            heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
         )
-        my_hds_controller_information = (
-            heat_distribution_system.HeatDistributionControllerInformation(
-                config=hds_controller_config
-            )
+        my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
+            config=hds_controller_config
         )
 
         household_config = ReferenceHouseholdConfig(
@@ -104,7 +102,6 @@ class ReferenceHouseholdConfig(SystemSetupConfigBase):
                 profile_with_washing_machine_and_dishwasher=True,
                 predictive_control=False,
                 predictive=False,
-
             ),
             building_config=building_config,
             hds_controller_config=hds_controller_config,
@@ -192,9 +189,7 @@ def setup_function(
 
     # Todo: save file leads to use of file in next run. File was just produced to check how it looks like
     if my_sim.my_module_config_path:
-        my_config = ReferenceHouseholdConfig.load_from_json(
-            my_sim.my_module_config_path
-        )
+        my_config = ReferenceHouseholdConfig.load_from_json(my_sim.my_module_config_path)
     else:
         my_config = ReferenceHouseholdConfig.get_default()
     # =================================================================================
@@ -215,11 +210,9 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build heat Distribution System Controller
-    my_heat_distribution_controller = (
-        heat_distribution_system.HeatDistributionController(
-            config=my_config.hds_controller_config,
-            my_simulation_parameters=my_simulation_parameters,
-        )
+    my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
+        config=my_config.hds_controller_config,
+        my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -241,11 +234,9 @@ def setup_function(
     )
 
     # Build Gas Heater Controller
-    my_gasheater_controller = (
-        controller_l1_generic_gas_heater.GenericGasHeaterControllerL1(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_config.gasheater_controller_config,
-        )
+    my_gasheater_controller = controller_l1_generic_gas_heater.GenericGasHeaterControllerL1(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.gasheater_controller_config,
     )
 
     # Build Gasheater
@@ -280,11 +271,9 @@ def setup_function(
         my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
     )
 
-    my_domnestic_hot_water_heatpump_controller = (
-        controller_l1_heatpump.L1HeatPumpController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_dhw_heatpump_controller_config,
-        )
+    my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -329,9 +318,7 @@ def setup_function(
     my_sim.add_component(my_heat_distribution_controller, connect_automatically=True)
     my_sim.add_component(my_simple_hot_water_storage, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_storage, connect_automatically=True)
-    my_sim.add_component(
-        my_domnestic_hot_water_heatpump_controller, connect_automatically=True
-    )
+    my_sim.add_component(my_domnestic_hot_water_heatpump_controller, connect_automatically=True)
     my_sim.add_component(my_domnestic_hot_water_heatpump, connect_automatically=True)
     my_sim.add_component(my_electricity_meter, connect_automatically=True)
     for my_car in my_cars:

--- a/system_setups/household_with_advanced_hp_hws_hds_pv_battery_ems.py
+++ b/system_setups/household_with_advanced_hp_hws_hds_pv_battery_ems.py
@@ -57,9 +57,7 @@ def setup_function(
     seconds_per_timestep = 60
 
     # Set Heat Pump Controller
-    hp_controller_mode = (
-        2  # mode 1 for on/off and mode 2 for heating/cooling/off (regulated)
-    )
+    hp_controller_mode = 2  # mode 1 for on/off and mode 2 for heating/cooling/off (regulated)
     set_heating_threshold_outside_temperature_for_heat_pump_in_celsius = 16.0
     set_cooling_threshold_outside_temperature_for_heat_pump_in_celsius = 22.0
     temperature_offset_for_state_conditions_in_celsius = 5.0
@@ -85,9 +83,7 @@ def setup_function(
         heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
     )
     my_building_information = building.BuildingInformation(config=my_building_config)
-    my_building = building.Building(
-        config=my_building_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Build Occupancy
     my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
     my_occupancy = loadprofilegenerator_utsp_connector.UtspLpgConnector(
@@ -95,18 +91,12 @@ def setup_function(
     )
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum.AACHEN
-    )
-    my_weather = weather.Weather(
-        config=my_weather_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+    my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
     # Build PV
-    my_photovoltaic_system_config = (
-        generic_pv_system.PVSystemConfig.get_scaled_pv_system(
-            rooftop_area_in_m2=my_building_information.scaled_rooftop_area_in_m2
-        )
+    my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_scaled_pv_system(
+        rooftop_area_in_m2=my_building_information.scaled_rooftop_area_in_m2
     )
 
     my_photovoltaic_system = generic_pv_system.PVSystem(
@@ -118,19 +108,15 @@ def setup_function(
         set_heating_temperature_for_building_in_celsius=my_building_information.set_heating_temperature_for_building_in_celsius,
         set_cooling_temperature_for_building_in_celsius=my_building_information.set_cooling_temperature_for_building_in_celsius,
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-        heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+        heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
     )
 
-    my_heat_distribution_controller = (
-        heat_distribution_system.HeatDistributionController(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_heat_distribution_controller_config,
-        )
+    my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_distribution_controller_config,
     )
-    my_hds_controller_information = (
-        heat_distribution_system.HeatDistributionControllerInformation(
-            config=my_heat_distribution_controller_config
-        )
+    my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
+        config=my_heat_distribution_controller_config
     )
 
     # Build Heat Pump Controller
@@ -149,7 +135,7 @@ def setup_function(
     # Build Heat Pump
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-        heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+        heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
     )
     my_heat_pump_config.group_id = group_id
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius
@@ -182,21 +168,15 @@ def setup_function(
     )
 
     # Build EMS
-    my_electricity_controller_config = (
-        controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
-    )
-    my_electricity_controller = (
-        controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_electricity_controller_config,
-        )
+    my_electricity_controller_config = controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
+    my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_electricity_controller_config,
     )
 
     # Build Battery
-    my_advanced_battery_config = (
-        advanced_battery_bslib.BatteryConfig.get_scaled_battery(
-            total_pv_power_in_watt_peak=my_photovoltaic_system_config.power_in_watt
-        )
+    my_advanced_battery_config = advanced_battery_bslib.BatteryConfig.get_scaled_battery(
+        total_pv_power_in_watt_peak=my_photovoltaic_system_config.power_in_watt
     )
     my_advanced_battery = advanced_battery_bslib.Battery(
         my_simulation_parameters=my_simulation_parameters,
@@ -230,18 +210,16 @@ def setup_function(
         output_description="Target electricity for Heat Pump. ",
     )
 
-    electricity_to_or_from_battery_target = (
-        my_electricity_controller.add_component_output(
-            source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.BATTERY,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
-            source_weight=3,
-            source_load_type=lt.LoadTypes.ELECTRICITY,
-            source_unit=lt.Units.WATT,
-            output_description="Target electricity for Battery Control. ",
-        )
+    electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
+        source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
+        source_tags=[
+            lt.ComponentType.BATTERY,
+            lt.InandOutputType.ELECTRICITY_TARGET,
+        ],
+        source_weight=3,
+        source_load_type=lt.LoadTypes.ELECTRICITY,
+        source_unit=lt.Units.WATT,
+        output_description="Target electricity for Battery Control. ",
     )
 
     # -----------------------------------------------------------------------------------------------------------------

--- a/system_setups/modular_example.py
+++ b/system_setups/modular_example.py
@@ -33,9 +33,7 @@ from obsolete import loadprofilegenerator_connector
 
 def cleanup_old_result_folders():
     """Removes old result folders of previous setup_function simulations."""
-    base_path = os.path.join(
-        hisim.utils.hisim_abs_path, os.path.pardir, "system_setups", "results"
-    )
+    base_path = os.path.join(hisim.utils.hisim_abs_path, os.path.pardir, "system_setups", "results")
     files_in_folder = os.listdir(base_path)
     for file in files_in_folder:
         if file.startswith("setup_function"):
@@ -70,9 +68,7 @@ def get_heating_reference_temperature_and_season_from_location(
     :rtype: Tuple[float, List[int]]
     """
 
-    converting_data = pd.read_csv(
-        hisim.utils.HISIMPATH["housing_reference_temperatures"]
-    )
+    converting_data = pd.read_csv(hisim.utils.HISIMPATH["housing_reference_temperatures"])
     # converting_data.index = converting_data["Location"]
     converting_data.set_index(inplace=True, keys="Location")
 
@@ -112,39 +108,19 @@ def setup_function(
 
     # Build system parameters
     if my_simulation_parameters is None:
-        my_simulation_parameters = SimulationParameters.full_year(
-            year=year, seconds_per_timestep=seconds_per_timestep
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.PLOT_CARPET
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.GENERATE_PDF_REPORT
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT
-        )
+        my_simulation_parameters = SimulationParameters.full_year(year=year, seconds_per_timestep=seconds_per_timestep)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_CARPET)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.GENERATE_PDF_REPORT)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT)
         # my_simulation_parameters.post_processing_options.append(
         #     PostProcessingOptions.GENERATE_CSV_FOR_HOUSING_DATA_BASE
         # )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.EXPORT_TO_CSV
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.MAKE_NETWORK_CHARTS
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.COMPUTE_OPEX
-        )
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.EXPORT_TO_CSV)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_AND_WRITE_KPIS_TO_REPORT)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_OPEX)
 
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
@@ -154,9 +130,7 @@ def setup_function(
     occupancy_profile = arche_type_config_.occupancy_profile
     building_code = arche_type_config_.building_code
     floor_area = arche_type_config_.absolute_conditioned_floor_area
-    water_heating_system_installed = (
-        arche_type_config_.water_heating_system_installed
-    )  # Electricity, Hydrogen or False
+    water_heating_system_installed = arche_type_config_.water_heating_system_installed  # Electricity, Hydrogen or False
     heating_system_installed = arche_type_config_.heating_system_installed
     mobility_set = arche_type_config_.mobility_set
     mobility_distance = arche_type_config_.mobility_distance
@@ -183,9 +157,7 @@ def setup_function(
         heatpump_power = 1
         hisim.log.information("Default power is used for heat pump. ")
     if heatpump_power < 1:
-        raise Exception(
-            "Heat pump power cannot be smaller than default: choose values greater than one"
-        )
+        raise Exception("Heat pump power cannot be smaller than default: choose values greater than one")
     controllable = system_config_.surplus_control_considered
     pv_included = system_config_.pv_included  # True or False
     pv_peak_power = system_config_.pv_peak_power or 5e3  # set default
@@ -193,9 +165,7 @@ def setup_function(
     buffer_included = system_config_.buffer_included
     buffer_volume = system_config_.buffer_volume or 1  # set default
     if buffer_volume < 1:
-        raise Exception(
-            "Buffer volume cannot be smaller than default: choose values greater than one"
-        )
+        raise Exception("Buffer volume cannot be smaller than default: choose values greater than one")
     battery_included = system_config_.battery_included
     battery_capacity = system_config_.battery_capacity or 5  # set default
     chp_included = system_config_.chp_included
@@ -209,12 +179,8 @@ def setup_function(
 
     # BASICS
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum[location]
-    )
-    my_weather = weather.Weather(
-        config=my_weather_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum[location])
+    my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     my_sim.add_component(my_weather)
 
     # Build building
@@ -235,48 +201,38 @@ def setup_function(
         predictive=False,
         set_heating_temperature_in_celsius=19.0,
         set_cooling_temperature_in_celsius=24.0,
-        enable_opening_windows=False
+        enable_opening_windows=False,
     )
     my_building_information = building.BuildingInformation(config=my_building_config)
-    my_building = building.Building(
-        config=my_building_config, my_simulation_parameters=my_simulation_parameters
-    )
+    my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     my_sim.add_component(my_building)
 
     # build occupancy
     if utsp_connected:
         if mobility_set is None:
             this_mobility_set = TransportationDeviceSets.Bus_and_one_30_km_h_Car
-            hisim.log.information(
-                "Default is used for mobility set, because None was defined."
-            )
+            hisim.log.information("Default is used for mobility set, because None was defined.")
         else:
             this_mobility_set = mobility_set
         if mobility_distance is None:
-            this_mobility_distance = (
-                TravelRouteSets.Travel_Route_Set_for_10km_Commuting_Distance
-            )
-            hisim.log.information(
-                "Default is used for mobility distance, because None was defined."
-            )
+            this_mobility_distance = TravelRouteSets.Travel_Route_Set_for_10km_Commuting_Distance
+            hisim.log.information("Default is used for mobility distance, because None was defined.")
         else:
             this_mobility_distance = mobility_distance
 
-        my_occupancy_config = (
-            loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig(
-                name="UTSPConnector",
-                data_acquisition_mode=loadprofilegenerator_utsp_connector.LpgDataAcquisitionMode.USE_UTSP,
-                household=occupancy_profile_utsp,  # type: ignore
-                energy_intensity=EnergyIntensityType.EnergySaving,
-                result_dir_path=hisim.utils.HISIMPATH["utsp_results"],
-                travel_route_set=this_mobility_distance,
-                transportation_device_set=this_mobility_set,
-                charging_station_set=charging_station,
-                consumption=0,
-                profile_with_washing_machine_and_dishwasher=not smart_devices_included,
-                predictive_control=False,
-                predictive=False,
-            )
+        my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig(
+            name="UTSPConnector",
+            data_acquisition_mode=loadprofilegenerator_utsp_connector.LpgDataAcquisitionMode.USE_UTSP,
+            household=occupancy_profile_utsp,  # type: ignore
+            energy_intensity=EnergyIntensityType.EnergySaving,
+            result_dir_path=hisim.utils.HISIMPATH["utsp_results"],
+            travel_route_set=this_mobility_distance,
+            transportation_device_set=this_mobility_set,
+            charging_station_set=charging_station,
+            consumption=0,
+            profile_with_washing_machine_and_dishwasher=not smart_devices_included,
+            predictive_control=False,
+            predictive=False,
         )
 
         my_occupancy = loadprofilegenerator_utsp_connector.UtspLpgConnector(
@@ -357,14 +313,10 @@ def setup_function(
         smart_devices_included,
         water_heating_system_installed,
     ):
-        my_electricity_controller_config = (
-            controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
-        )
-        my_electricity_controller = (
-            controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-                my_simulation_parameters=my_simulation_parameters,
-                config=my_electricity_controller_config,
-            )
+        my_electricity_controller_config = controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
+        my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
+            my_simulation_parameters=my_simulation_parameters,
+            config=my_electricity_controller_config,
         )
 
         my_electricity_controller.add_component_inputs_and_connect(
@@ -387,9 +339,7 @@ def setup_function(
     # """ EV BATTERY """
     if ev_included:
         if mobility_set is None:
-            raise Exception(
-                "If EV should be simulated mobility set needs to be defined."
-            )
+            raise Exception("If EV should be simulated mobility set needs to be defined.")
         _ = component_connections.configure_ev_batteries(
             my_sim=my_sim,
             my_simulation_parameters=my_simulation_parameters,  # noqa

--- a/system_setups/power_to_x_transformation_battery_electrolyzer_grid.py
+++ b/system_setups/power_to_x_transformation_battery_electrolyzer_grid.py
@@ -43,9 +43,7 @@ __maintainer__ = "Franz Oldopp"
 __status__ = "development"
 
 
-def setup_function(
-    my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]
-) -> None:
+def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]) -> None:
     """Setup function."""
     log.information("Starting basic electrolyzer system setup")
     # =================================================================================================================================
@@ -86,36 +84,18 @@ def setup_function(
             year=year, seconds_per_timestep=seconds_per_timestep
         )  # use a full year for testing
     my_sim.set_simulation_parameters(my_simulation_parameters)
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_LINE
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_SINGLE_DAYS
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_CARPET
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_MONTHLY_BAR_CHARTS
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.MAKE_NETWORK_CHARTS
-    )
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_LINE)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_SINGLE_DAYS)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_CARPET)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_MONTHLY_BAR_CHARTS)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     my_simulation_parameters.post_processing_options.append(
         PostProcessingOptions.PREPARE_OUTPUTS_FOR_SCENARIO_EVALUATION
     )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.GENERATE_PDF_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.WRITE_ALL_OUTPUTS_TO_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT
-    )
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.GENERATE_PDF_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.WRITE_ALL_OUTPUTS_TO_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT)
     # =================================================================================================================================
     # Build Components
 
@@ -135,9 +115,7 @@ def setup_function(
     )
 
     # Create new CSV loader object
-    csv_loader = CSVLoader(
-        my_csv_loader, my_simulation_parameters=my_simulation_parameters
-    )
+    csv_loader = CSVLoader(my_csv_loader, my_simulation_parameters=my_simulation_parameters)
 
     my_transformer = Transformer(
         my_simulation_parameters=my_simulation_parameters,
@@ -182,9 +160,7 @@ def setup_function(
     # Connect Component Inputs with Outputs
 
     # Connect output of csv_loader to input of the transformer (wind to battery)
-    my_transformer.connect_input(
-        my_transformer.TransformerInput, csv_loader.component_name, csv_loader.Output1
-    )
+    my_transformer.connect_input(my_transformer.TransformerInput, csv_loader.component_name, csv_loader.Output1)
 
     my_ptx_controller.connect_input(
         my_ptx_controller.RESLoad,

--- a/system_setups/power_to_x_transformation_battery_electrolyzer_no_grid.py
+++ b/system_setups/power_to_x_transformation_battery_electrolyzer_no_grid.py
@@ -42,9 +42,7 @@ __maintainer__ = "Franz Oldopp"
 __status__ = "development"
 
 
-def setup_function(
-    my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]
-) -> None:
+def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]) -> None:
     """Setup function."""
     log.information("Starting basic electrolyzer system setup")
     # =================================================================================================================================
@@ -85,36 +83,18 @@ def setup_function(
             year=year, seconds_per_timestep=seconds_per_timestep
         )  # use a full year for testing
     my_sim.set_simulation_parameters(my_simulation_parameters)
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_LINE
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_SINGLE_DAYS
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_CARPET
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.PLOT_MONTHLY_BAR_CHARTS
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.MAKE_NETWORK_CHARTS
-    )
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_LINE)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_SINGLE_DAYS)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_CARPET)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_MONTHLY_BAR_CHARTS)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     my_simulation_parameters.post_processing_options.append(
         PostProcessingOptions.PREPARE_OUTPUTS_FOR_SCENARIO_EVALUATION
     )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.GENERATE_PDF_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.WRITE_ALL_OUTPUTS_TO_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT
-    )
-    my_simulation_parameters.post_processing_options.append(
-        PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT
-    )
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.GENERATE_PDF_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.WRITE_ALL_OUTPUTS_TO_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.WRITE_COMPONENTS_TO_REPORT)
+    my_simulation_parameters.post_processing_options.append(PostProcessingOptions.INCLUDE_CONFIGS_IN_PDF_REPORT)
     # =================================================================================================================================
     # Build Components
 
@@ -134,9 +114,7 @@ def setup_function(
     )
 
     # Create new CSV loader object
-    csv_loader = CSVLoader(
-        my_csv_loader, my_simulation_parameters=my_simulation_parameters
-    )
+    csv_loader = CSVLoader(my_csv_loader, my_simulation_parameters=my_simulation_parameters)
 
     my_transformer = Transformer(
         my_simulation_parameters=my_simulation_parameters,
@@ -181,9 +159,7 @@ def setup_function(
     # Connect Component Inputs with Outputs
 
     # Connect output of csv_loader to input of the transformer (wind to battery)
-    my_transformer.connect_input(
-        my_transformer.TransformerInput, csv_loader.component_name, csv_loader.Output1
-    )
+    my_transformer.connect_input(my_transformer.TransformerInput, csv_loader.component_name, csv_loader.Output1)
 
     my_ptx_controller.connect_input(
         my_ptx_controller.RESLoad,

--- a/system_setups/simple_system_setup_one.py
+++ b/system_setups/simple_system_setup_one.py
@@ -14,9 +14,7 @@ from hisim.components.random_numbers import RandomNumbers, RandomNumbersConfig
 from hisim.components.sumbuilder import SumBuilderForTwoInputs, SumBuilderConfig
 
 
-def setup_function(
-    my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]
-) -> None:
+def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]) -> None:
     """First system setup.
 
     In this first system setup, a series (my_rn1) of random numbers in a range between 100 and 200 is
@@ -27,12 +25,8 @@ def setup_function(
 
     # Set the simulation parameters for the simulation
     if my_simulation_parameters is None:
-        my_simulation_parameters = SimulationParameters.full_year(
-            year=2021, seconds_per_timestep=60
-        )
-        my_simulation_parameters.post_processing_options.append(
-            PostProcessingOptions.PLOT_CARPET
-        )
+        my_simulation_parameters = SimulationParameters.full_year(year=2021, seconds_per_timestep=60)
+        my_simulation_parameters.post_processing_options.append(PostProcessingOptions.PLOT_CARPET)
 
     # testmy_sim = copy.deepcopy(my_sim)
     my_sim.set_simulation_parameters(my_simulation_parameters)

--- a/system_setups/simple_system_setup_two.py
+++ b/system_setups/simple_system_setup_two.py
@@ -17,9 +17,7 @@ from hisim.components.example_transformer import (
 from hisim.components.sumbuilder import SumBuilderForTwoInputs, SumBuilderConfig
 
 
-def setup_function(
-    my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]
-) -> None:
+def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]) -> None:
     """Second system setup.
 
     In this second system setup, two series (my_rn1 and my_transformer) are summed up.


### PR DESCRIPTION
The line-length has not been consistennt througout the files. I am suggesting to use 120 as a default because 150 is to wide for side by side comparisons.

Formatted the folders `hisim` and `system_setups` with `black --line-length 120`.

Pycodestyle error E203 is disable according to the [Black documentation](https://black.readthedocs.io/en/stable/faq.html#why-are-flake8-s-e203-and-w503-violated).

Renamed `.pyproject.toml` to `pyproject.toml` to load the settings for black within the project.

We should transition the information in `setup.py` and `setup.cfg` to the `proproject.toml` because this is the [new standard for Python packaging](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html).