### PR TITLE
Add postprocessing flags for webtool to relevant outputs

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -57,7 +57,7 @@ pydocstyle:
     - D213
     - W293
     - D211
-
+    - D203
 
 mypy:
   run: true

--- a/hisim/components/advanced_heat_pump_hplib.py
+++ b/hisim/components/advanced_heat_pump_hplib.py
@@ -159,7 +159,7 @@ class HeatPumpHplib(Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: HeatPumpHplibConfig,
-        my_display_config: DisplayConfig = DisplayConfig(display_in_webtool=True),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ):
         """Loads the parameters of the specified heat pump.
 

--- a/hisim/components/advanced_heat_pump_hplib.py
+++ b/hisim/components/advanced_heat_pump_hplib.py
@@ -200,8 +200,6 @@ class HeatPumpHplib(Component):
 
         self.minimum_idle_time_in_seconds = config.minimum_idle_time_in_seconds
 
-        postprocessing_flag = [InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED]
-
         # Component has states
         self.state = HeatPumpState(time_on=0, time_off=0, time_on_cooling=0, on_off_previous=0)
         self.previous_state = self.state.self_copy()

--- a/hisim/components/advanced_heat_pump_hplib.py
+++ b/hisim/components/advanced_heat_pump_hplib.py
@@ -3,16 +3,15 @@
 See library on https://github.com/FZJ-IEK3-VSA/hplib/tree/main/hplib
 """
 
+import hashlib
 # clean
 import importlib
-from typing import Any, List, Optional, Tuple, Dict
-import hashlib
 from dataclasses import dataclass
-from dataclasses_json import dataclass_json
-from dataclass_wizard import JSONWizard
+from typing import Any, List, Optional, Tuple, Dict
 
 import pandas as pd
-
+from dataclass_wizard import JSONWizard
+from dataclasses_json import dataclass_json
 from hplib import hplib as hpl
 
 # Import modules from HiSim
@@ -27,10 +26,9 @@ from hisim.component import (
     DisplayConfig,
 )
 from hisim.components import weather, simple_hot_water_storage, heat_distribution_system
+from hisim.components.heat_distribution_system import HeatDistributionSystemType
 from hisim.loadtypes import LoadTypes, Units, InandOutputType, OutputPostprocessingRules
 from hisim.simulationparameters import SimulationParameters
-from hisim.components.heat_distribution_system import HeatDistributionSystemType
-
 
 __authors__ = "Tjarko Tjaden, Hauke Hoops, Kai Rösken"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -45,7 +43,6 @@ __status__ = "development"
 @dataclass_json
 @dataclass
 class HeatPumpHplibConfig(ConfigBase):
-
     """HeatPumpHPLibConfig."""
 
     @classmethod
@@ -134,7 +131,6 @@ class HeatPumpHplibConfig(ConfigBase):
 
 
 class HeatPumpHplib(Component):
-
     """Simulate the heat pump.
 
     Outputs are heat pump efficiency (cop) as well as electrical (p_el) and
@@ -253,7 +249,10 @@ class HeatPumpHplib(Component):
             load_type=LoadTypes.HEATING,
             unit=Units.WATT,
             output_description=("Thermal output power in Watt"),
-            postprocessing_flag=[OutputPostprocessingRules.DISPLAY_IN_WEBTOOL],
+            postprocessing_flag=[
+                InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,
+                OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
+            ],
         )
 
         self.p_el: ComponentOutput = self.add_output(
@@ -261,7 +260,10 @@ class HeatPumpHplib(Component):
             field_name=self.ElectricalInputPower,
             load_type=LoadTypes.ELECTRICITY,
             unit=Units.WATT,
-            postprocessing_flag=postprocessing_flag,
+            postprocessing_flag=[
+                InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,
+                OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
+            ],
             output_description="Electricity input power in Watt",
         )
 
@@ -271,6 +273,9 @@ class HeatPumpHplib(Component):
             load_type=LoadTypes.ANY,
             unit=Units.ANY,
             output_description="COP",
+            postprocessing_flag=[
+                OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
+            ],
         )
         self.eer: ComponentOutput = self.add_output(
             object_name=self.component_name,
@@ -278,6 +283,9 @@ class HeatPumpHplib(Component):
             load_type=LoadTypes.ANY,
             unit=Units.ANY,
             output_description="EER",
+            postprocessing_flag=[
+                OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
+            ],
         )
         self.t_out: ComponentOutput = self.add_output(
             object_name=self.component_name,
@@ -285,6 +293,9 @@ class HeatPumpHplib(Component):
             load_type=LoadTypes.HEATING,
             unit=Units.CELSIUS,
             output_description="Temperature Output in °C",
+            postprocessing_flag=[
+                OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
+            ],
         )
 
         self.m_dot: ComponentOutput = self.add_output(
@@ -301,6 +312,9 @@ class HeatPumpHplib(Component):
             load_type=LoadTypes.TIME,
             unit=Units.SECONDS,
             output_description="Time turned on",
+            postprocessing_flag=[
+                OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
+            ],
         )
 
         self.time_off: ComponentOutput = self.add_output(
@@ -579,7 +593,6 @@ class HeatPumpHplib(Component):
 
 @dataclass
 class HeatPumpState:
-
     """HeatPumpState class."""
 
     time_on: int = 0
@@ -599,7 +612,6 @@ class HeatPumpState:
 @dataclass_json
 @dataclass
 class HeatPumpHplibControllerL1Config(ConfigBase):
-
     """HeatPump Controller Config Class."""
 
     @classmethod
@@ -630,7 +642,6 @@ class HeatPumpHplibControllerL1Config(ConfigBase):
 
 
 class HeatPumpHplibController(Component):
-
     """Heat Pump Controller.
 
     It takes data from other
@@ -1040,7 +1051,6 @@ class HeatPumpHplibController(Component):
 
 @dataclass
 class CalculationRequest(JSONWizard):
-
     """Class for caching hplib parameters so that hplib.simulate does not need to run so often."""
 
     t_in_primary: float

--- a/hisim/components/electricity_meter.py
+++ b/hisim/components/electricity_meter.py
@@ -1,29 +1,29 @@
 """Electricity meter module should replace the sumbuilder. """
+
 # clean
 from dataclasses import dataclass
 from typing import List
 
-from dataclasses_json import dataclass_json
 import pandas as pd
+from dataclasses_json import dataclass_json
 
 from hisim import component as cp
 from hisim import dynamic_component
 from hisim import loadtypes as lt
 from hisim.component import ComponentInput, OpexCostDataClass
+from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim.dynamic_component import (
     DynamicComponent,
     DynamicConnectionInput,
     DynamicConnectionOutput,
     DynamicComponentConnection,
 )
-from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim.simulationparameters import SimulationParameters
 
 
 @dataclass_json
 @dataclass
 class ElectricityMeterConfig(cp.ConfigBase):
-
     """Electricity Meter Config."""
 
     @classmethod
@@ -46,7 +46,6 @@ class ElectricityMeterConfig(cp.ConfigBase):
 
 
 class ElectricityMeter(DynamicComponent):
-
     """Electricity meter class.
 
     It calculates the electricity production and consumption dynamically for all components.
@@ -65,7 +64,7 @@ class ElectricityMeter(DynamicComponent):
         self,
         my_simulation_parameters: SimulationParameters,
         config: ElectricityMeterConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: cp.DisplayConfig = cp.DisplayConfig(display_in_webtool=True),
     ):
         """Initialize the component."""
         self.grid_energy_balancer_config = config
@@ -105,6 +104,7 @@ class ElectricityMeter(DynamicComponent):
             unit=lt.Units.WATT_HOUR,
             sankey_flow_direction=False,
             output_description=f"here a description for {self.ElectricityToGrid} will follow.",
+            postprocessing_flag=[lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL],
         )
         self.electricity_from_grid: cp.ComponentOutput = self.add_output(
             object_name=self.component_name,
@@ -113,6 +113,7 @@ class ElectricityMeter(DynamicComponent):
             unit=lt.Units.WATT_HOUR,
             sankey_flow_direction=False,
             output_description=f"here a description for {self.ElectricityFromGrid} will follow.",
+            postprocessing_flag=[lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL],
         )
 
         self.electricity_consumption_channel: cp.ComponentOutput = self.add_output(
@@ -122,6 +123,7 @@ class ElectricityMeter(DynamicComponent):
             unit=lt.Units.WATT_HOUR,
             sankey_flow_direction=False,
             output_description=f"here a description for {self.ElectricityConsumption} will follow.",
+            postprocessing_flag=[lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL],
         )
 
         self.electricity_production_channel: cp.ComponentOutput = self.add_output(
@@ -131,6 +133,7 @@ class ElectricityMeter(DynamicComponent):
             unit=lt.Units.WATT_HOUR,
             sankey_flow_direction=False,
             output_description=f"here a description for {self.ElectricityProduction} will follow.",
+            postprocessing_flag=[lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL],
         )
 
         self.cumulative_electricity_consumption_channel: cp.ComponentOutput = self.add_output(
@@ -140,6 +143,7 @@ class ElectricityMeter(DynamicComponent):
             unit=lt.Units.WATT_HOUR,
             sankey_flow_direction=False,
             output_description=f"here a description for {self.CumulativeConsumption} will follow.",
+            postprocessing_flag=[lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL],
         )
 
         self.cumulative_electricity_production_channel: cp.ComponentOutput = self.add_output(
@@ -149,6 +153,7 @@ class ElectricityMeter(DynamicComponent):
             unit=lt.Units.WATT_HOUR,
             sankey_flow_direction=False,
             output_description=f"here a description for {self.CumulativeProduction} will follow.",
+            postprocessing_flag=[lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL],
         )
         self.add_dynamic_default_connections(self.get_default_connections_from_utsp_occupancy())
         self.add_dynamic_default_connections(self.get_default_connections_from_pv_system())
@@ -393,7 +398,6 @@ class ElectricityMeter(DynamicComponent):
 
 @dataclass
 class ElectricityMeterState:
-
     """ElectricityMeterState class."""
 
     cumulative_production_in_watt_hour: float

--- a/hisim/components/generic_car.py
+++ b/hisim/components/generic_car.py
@@ -2,24 +2,25 @@
 
 Evaluates diesel or electricity consumption based on driven kilometers and processes Car Location for charging stations.
 """
+
 # clean
 
-# -*- coding: utf-8 -*-
-from typing import List, Any, Tuple
-from os import listdir, path
-from dataclasses import dataclass
 import datetime as dt
 import json
-from dataclasses_json import dataclass_json
+from dataclasses import dataclass
+from os import listdir, path
+# -*- coding: utf-8 -*-
+from typing import List, Any, Tuple
 
 import pandas as pd
+from dataclasses_json import dataclass_json
 
 from hisim import component as cp
 from hisim import loadtypes as lt
-from hisim.simulationparameters import SimulationParameters
-from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim import utils
 from hisim.component import OpexCostDataClass
+from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
+from hisim.simulationparameters import SimulationParameters
 
 __authors__ = "Johanna Ganglbauer"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -34,7 +35,6 @@ __status__ = "development"
 @dataclass_json
 @dataclass
 class CarConfig(cp.ConfigBase):
-
     """Definition of configuration of Car."""
 
     #: name of the car
@@ -108,7 +108,6 @@ def most_frequent(input_list: List) -> Any:
 
 
 class Car(cp.Component):
-
     """Simulates car with constant consumption. Car usage (driven kilometers and state) orginate from LPG."""
 
     # Outputs
@@ -126,7 +125,7 @@ class Car(cp.Component):
         my_simulation_parameters: SimulationParameters,
         config: CarConfig,
         occupancy_config: Any,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: cp.DisplayConfig = cp.DisplayConfig(display_in_webtool=True),
     ) -> None:
         """Initializes Car."""
         super().__init__(
@@ -143,7 +142,7 @@ class Car(cp.Component):
                 field_name=self.ElectricityOutput,
                 load_type=lt.LoadTypes.ELECTRICITY,
                 unit=lt.Units.WATT,
-                postprocessing_flag=[lt.ComponentType.CAR],
+                postprocessing_flag=[lt.ComponentType.CAR, lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL],
                 output_description="Electricity Consumption of the car while driving. [W]",
             )
             self.car_location_output: cp.ComponentOutput = self.add_output(
@@ -163,6 +162,7 @@ class Car(cp.Component):
                     lt.InandOutputType.FUEL_CONSUMPTION,
                     lt.LoadTypes.DIESEL,
                     lt.ComponentType.CAR,
+                    lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
                 ],
                 output_description="Diesel Consumption of the car while driving [l].",
             )

--- a/hisim/components/generic_gas_heater.py
+++ b/hisim/components/generic_gas_heater.py
@@ -1,13 +1,15 @@
 """Gas Heater Module."""
+
 # clean
 # Owned
 import importlib
-from typing import List, Any, Tuple
 from dataclasses import dataclass
-from dataclasses_json import dataclass_json
+from typing import List, Any, Tuple
 
 import pandas as pd
+from dataclasses_json import dataclass_json
 
+from hisim import loadtypes as lt
 from hisim.component import (
     Component,
     ComponentConnection,
@@ -18,11 +20,8 @@ from hisim.component import (
     OpexCostDataClass,
     DisplayConfig,
 )
-
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim.simulationparameters import SimulationParameters
-from hisim import loadtypes as lt
-
 
 __authors__ = "Frank Burkrad, Maximilian Hillen"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -37,7 +36,6 @@ __status__ = ""
 @dataclass_json
 @dataclass
 class GenericGasHeaterConfig(ConfigBase):
-
     """Configuration of the GasHeater class."""
 
     @classmethod
@@ -121,7 +119,6 @@ class GenericGasHeaterConfig(ConfigBase):
 
 
 class GasHeater(Component):
-
     """GasHeater class.
 
     Get Control Signal and calculate on base of it Massflow and Temperature of Massflow.
@@ -142,7 +139,7 @@ class GasHeater(Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: GenericGasHeaterConfig,
-        my_display_config: DisplayConfig = DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(display_in_webtool=True),
     ) -> None:
         """Construct all the neccessary attributes."""
         self.gasheater_config = config
@@ -187,6 +184,9 @@ class GasHeater(Component):
             lt.LoadTypes.GAS,
             lt.Units.KWH,
             output_description=f"here a description for {self.GasDemand} will follow.",
+            postprocessing_flag=[
+                lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
+            ],
         )
         self.thermal_output_power_channel: ComponentOutput = self.add_output(
             object_name=self.component_name,
@@ -194,6 +194,9 @@ class GasHeater(Component):
             load_type=lt.LoadTypes.HEATING,
             unit=lt.Units.WATT,
             output_description=f"here a description for {self.ThermalOutputPower} will follow.",
+            postprocessing_flag=[
+                lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
+            ],
         )
 
         self.minimal_thermal_power_in_watt = self.gasheater_config.minimal_thermal_power_in_watt

--- a/hisim/components/generic_hot_water_storage_modular.py
+++ b/hisim/components/generic_hot_water_storage_modular.py
@@ -4,19 +4,21 @@ Energy bucket model: extracts energy, adds energy and converts back to temperate
 The hot water storage simulates only storage and demand and needs to be connnected to a heat source. It can act as
 DHW hot water storage or as buffer storage.
 """
-from dataclasses import dataclass
 
+from dataclasses import dataclass
 # clean
 # Generic/Built-in
 from typing import Any, List, Optional, Tuple
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 from dataclasses_json import dataclass_json
 
 # Owned
 import hisim.component as cp
 import hisim.log
 from hisim import loadtypes as lt
+from hisim.component import OpexCostDataClass
 from hisim.components import (
     controller_l1_building_heating,
     generic_chp,
@@ -24,10 +26,8 @@ from hisim.components import (
     generic_heat_source,
     configuration,
 )
-
 from hisim.components.loadprofilegenerator_utsp_connector import UtspLpgConnector
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import OpexCostDataClass
 from obsolete.loadprofilegenerator_connector import Occupancy
 
 __authors__ = "Johanna Ganglbauer - johanna.ganglbauer@4wardenergy.at"
@@ -43,7 +43,6 @@ __status__ = "development"
 @dataclass_json
 @dataclass
 class StorageConfig(cp.ConfigBase):
-
     """Used in the HotWaterStorageClass defining the basics."""
 
     #: name of the hot water storage
@@ -170,7 +169,6 @@ class StorageConfig(cp.ConfigBase):
 
 
 class StorageState:
-
     """Data class saves the state of the simulation results."""
 
     def __init__(
@@ -229,7 +227,6 @@ class StorageState:
 
 # class HotWaterStorage(dycp.DynamicComponent):
 class HotWaterStorage(cp.Component):
-
     """Simple hot water storage implementation.
 
     Energy bucket model: extracts energy, adds energy and converts back to temperatere.
@@ -263,7 +260,7 @@ class HotWaterStorage(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: StorageConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: cp.DisplayConfig = cp.DisplayConfig(display_in_webtool=True),
     ):
         """Initializes instance of HotWaterStorage class."""
 
@@ -339,7 +336,11 @@ class HotWaterStorage(cp.Component):
             self.PowerFromHotWaterStorage,
             lt.LoadTypes.HEATING,
             lt.Units.WATT,
-            postprocessing_flag=[lt.InandOutputType.DISCHARGE, self.use],
+            postprocessing_flag=[
+                lt.InandOutputType.DISCHARGE,
+                self.use,
+                lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
+            ],
             output_description="Power transfered to Building or Hot Water Pipe.",
         )
 

--- a/hisim/components/generic_pv_system.py
+++ b/hisim/components/generic_pv_system.py
@@ -4,11 +4,11 @@
 
 # Generic/Built-in
 import datetime
+import enum
 import math
 import os
 from dataclasses import dataclass
 from typing import Any, List, Tuple, Optional
-import enum
 
 import numpy as np
 import pandas as pd
@@ -22,8 +22,8 @@ from hisim import log
 from hisim import utils
 from hisim.component import ConfigBase, OpexCostDataClass
 from hisim.components.weather import Weather
-from hisim.simulationparameters import SimulationParameters
 from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
+from hisim.simulationparameters import SimulationParameters
 
 __authors__ = "Vitor Hugo Bellotto Zago"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -49,7 +49,6 @@ https://github.com/FZJ-IEK3-VSA/tsib
 
 
 class PVLibModuleAndInverterEnum(enum.Enum):
-
     """Class to determine what pvlib database for phtotovoltaic modules and inverters should be used.
 
     https://pvlib-python.readthedocs.io/en/v0.9.0/generated/pvlib.pvsystem.retrieve_sam.html.
@@ -65,7 +64,6 @@ class PVLibModuleAndInverterEnum(enum.Enum):
 @dataclass_json
 @dataclass
 class PVSystemConfig(ConfigBase):
-
     """PVSystemConfig class."""
 
     @classmethod
@@ -211,7 +209,6 @@ class PVSystemConfig(ConfigBase):
 
 
 class PVSystem(cp.Component):
-
     """Simulates PV Output based on weather data and peak power.
 
     Parameters
@@ -261,7 +258,7 @@ class PVSystem(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: PVSystemConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: cp.DisplayConfig = cp.DisplayConfig(display_in_webtool=True),
     ) -> None:
         """Initialize the class."""
         self.my_simulation_parameters = my_simulation_parameters
@@ -350,7 +347,10 @@ class PVSystem(cp.Component):
             field_name=self.ElectricityOutput,
             load_type=lt.LoadTypes.ELECTRICITY,
             unit=lt.Units.WATT,
-            postprocessing_flag=[lt.InandOutputType.ELECTRICITY_PRODUCTION],
+            postprocessing_flag=[
+                lt.InandOutputType.ELECTRICITY_PRODUCTION,
+                lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
+            ],
             output_description=f"here a description for PV {self.ElectricityOutput} will follow.",
         )
 

--- a/hisim/components/simple_hot_water_storage.py
+++ b/hisim/components/simple_hot_water_storage.py
@@ -3,20 +3,20 @@
 # clean
 # Owned
 import importlib
-from typing import List, Any, Tuple
 from dataclasses import dataclass
+from typing import List, Any, Tuple
+
+import numpy as np
+import pandas as pd
 from dataclasses_json import dataclass_json
 
-import pandas as pd
-import numpy as np
 import hisim.component as cp
-from hisim.component import SingleTimeStepValues, ComponentInput, ComponentOutput, OpexCostDataClass, DisplayConfig
-
-from hisim.simulationparameters import SimulationParameters
-from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
-from hisim.components.configuration import PhysicsConfig
 from hisim import loadtypes as lt
 from hisim import utils
+from hisim.component import SingleTimeStepValues, ComponentInput, ComponentOutput, OpexCostDataClass, DisplayConfig
+from hisim.components.configuration import PhysicsConfig
+from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
+from hisim.simulationparameters import SimulationParameters
 
 __authors__ = "Katharina Rieck, Noah Pflugradt"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -31,7 +31,6 @@ __status__ = "dev"
 @dataclass_json
 @dataclass
 class SimpleHotWaterStorageConfig(cp.ConfigBase):
-
     """Configuration of the SimpleHotWaterStorage class."""
 
     @classmethod
@@ -130,7 +129,6 @@ class SimpleHotWaterStorageConfig(cp.ConfigBase):
 
 @dataclass
 class SimpleHotWaterStorageState:
-
     """SimpleHotWaterStorageState class."""
 
     mean_water_temperature_in_celsius: float = 25.0
@@ -147,7 +145,6 @@ class SimpleHotWaterStorageState:
 
 
 class SimpleHotWaterStorage(cp.Component):
-
     """SimpleHotWaterStorage class."""
 
     # Input
@@ -267,7 +264,7 @@ class SimpleHotWaterStorage(cp.Component):
             lt.Units.CELSIUS,
             output_description=f"here a description for {self.WaterMeanTemperatureInStorage} will follow.",
         )
-        #########################
+
         self.thermal_energy_in_storage_channel: ComponentOutput = self.add_output(
             self.component_name,
             self.ThermalEnergyInStorage,
@@ -281,6 +278,7 @@ class SimpleHotWaterStorage(cp.Component):
             lt.LoadTypes.HEATING,
             lt.Units.WATT_HOUR,
             output_description=f"here a description for {self.ThermalEnergyFromHeatGenerator} will follow.",
+            postprocessing_flag=[lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL],
         )
         self.thermal_energy_input_heat_distribution_system_channel: ComponentOutput = self.add_output(
             self.component_name,
@@ -288,6 +286,7 @@ class SimpleHotWaterStorage(cp.Component):
             lt.LoadTypes.HEATING,
             lt.Units.WATT_HOUR,
             output_description=f"here a description for {self.ThermalEnergyFromHeatDistribution} will follow.",
+            postprocessing_flag=[lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL],
         )
 
         self.thermal_energy_increase_in_storage_channel: ComponentOutput = self.add_output(
@@ -850,7 +849,6 @@ class SimpleHotWaterStorage(cp.Component):
 @dataclass_json
 @dataclass
 class SimpleHotWaterStorageControllerConfig(cp.ConfigBase):
-
     """Configuration of the SimpleHotWaterStorageController class."""
 
     @classmethod
@@ -872,7 +870,6 @@ class SimpleHotWaterStorageControllerConfig(cp.ConfigBase):
 
 
 class SimpleHotWaterStorageController(cp.Component):
-
     """SimpleHotWaterStorageController Class."""
 
     # Inputs

--- a/hisim/postprocessing/webtool_entries.py
+++ b/hisim/postprocessing/webtool_entries.py
@@ -6,14 +6,13 @@ from typing import Dict, List, Optional
 import pandas as pd
 from dataclass_wizard import JSONWizard
 
-from hisim.postprocessing.postprocessing_datatransfer import PostProcessingDataTransfer
 from hisim.component import ComponentOutput
 from hisim.loadtypes import OutputPostprocessingRules
+from hisim.postprocessing.postprocessing_datatransfer import PostProcessingDataTransfer
 
 
 @dataclass
 class ResultEntry(JSONWizard):
-
     """Class for storing one result entry for hisim webtool."""
 
     name: str
@@ -24,7 +23,6 @@ class ResultEntry(JSONWizard):
 
 @dataclass
 class WebtoolDict(JSONWizard):
-
     """Class for storing results for hisim webtool."""
 
     kpis: Dict
@@ -56,7 +54,6 @@ class WebtoolDict(JSONWizard):
                 self.components[this_name] = {
                     "prettyName": this_pretty_name,
                     "class": this_component_class,
-                    "sizing": {},
                     "technical": {},
                     "economical": {},
                 }
@@ -105,9 +102,9 @@ class WebtoolDict(JSONWizard):
         # Get bools that tells if the components should be displayed in webtool
         component_display_in_webtool_dict: Dict[str, bool] = {}
         for component in post_processing_data_transfer.wrapped_components:
-            component_display_in_webtool_dict[
-                component.my_component.component_name
-            ] = component.my_component.my_display_config.display_in_webtool
+            component_display_in_webtool_dict[component.my_component.component_name] = (
+                component.my_component.my_display_config.display_in_webtool
+            )
 
         # Read data from PostProcessingDataTransfer and save to results
         data: pd.DataFrame = post_processing_data_transfer.results_cumulative

--- a/system_setups/household_gas_heater.py
+++ b/system_setups/household_gas_heater.py
@@ -13,6 +13,7 @@ from utspclient.helpers.lpgdata import (
 )
 from hisim.system_setup_configuration import SystemSetupConfigBase
 from hisim.simulator import SimulationParameters
+from hisim.component import DisplayConfig
 from hisim.components import loadprofilegenerator_utsp_connector
 from hisim.components import weather
 from hisim.components import generic_gas_heater
@@ -40,7 +41,6 @@ __status__ = "development"
 
 @dataclass
 class HouseholdGasHeaterOptions:
-
     """Set options for the system setup."""
 
     photovoltaic: bool = False
@@ -50,7 +50,6 @@ class HouseholdGasHeaterOptions:
 @dataclass_json
 @dataclass
 class HouseholdGasHeaterConfig(SystemSetupConfigBase):
-
     """Configuration for household with gas heater."""
 
     building_type: str
@@ -234,18 +233,21 @@ def setup_function(
     my_weather = weather.Weather(
         config=weather.WeatherConfig.get_default(weather.LocationEnum.AACHEN),
         my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Wetter"),
     )
 
     # Photovoltaic
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_config.pv_config,
         my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Photovoltaik"),
     )
 
     # Building
     my_building = building.Building(
         config=my_config.building_config,
         my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Gebäude"),
     )
 
     # Gas Heater Controller
@@ -258,6 +260,7 @@ def setup_function(
     my_gas_heater = generic_gas_heater.GasHeater(
         config=my_config.gas_heater_config,
         my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Gastherme"),
     )
 
     # BHeat Distribution System
@@ -269,6 +272,7 @@ def setup_function(
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
         config=my_config.simple_hot_water_storage_config,
         my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Wärmespeicher"),
     )
 
     # DHW
@@ -281,14 +285,18 @@ def setup_function(
         - my_dhw_heatpump_controller_config.t_min_heating_in_celsius
     )
     my_domestic_hot_water_storage = generic_hot_water_storage_modular.HotWaterStorage(
-        my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_storage_config,
+        my_display_config=DisplayConfig.show("Warmwasserspeicher"),
     )
     my_domestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
         my_simulation_parameters=my_simulation_parameters,
         config=my_dhw_heatpump_controller_config,
     )
     my_domestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
-        config=my_dhw_heatpump_config, my_simulation_parameters=my_simulation_parameters
+        config=my_dhw_heatpump_config,
+        my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Warmwasser-Wärmepumpe"),
     )
 
     if my_config.car_config:
@@ -303,13 +311,14 @@ def setup_function(
 
         # create all cars
         my_cars: List[generic_car.Car] = []
-        for car in names:
+        for idx, car in enumerate(names):
             my_car_config.name = car
             my_cars.append(
                 generic_car.Car(
                     my_simulation_parameters=my_simulation_parameters,
                     config=my_car_config,
                     occupancy_config=my_occupancy_config,
+                    my_display_config=DisplayConfig.show(f"Diesel-PKW {idx}"),
                 )
             )
     else:
@@ -319,6 +328,7 @@ def setup_function(
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
         config=my_config.electricity_meter_config,
+        my_display_config=DisplayConfig.show("Stromzähler"),
     )
 
     # =================================================================================================================================

--- a/system_setups/household_heat_pump.py
+++ b/system_setups/household_heat_pump.py
@@ -13,6 +13,7 @@ from utspclient.helpers.lpgdata import (
 )
 from hisim.system_setup_configuration import SystemSetupConfigBase
 from hisim.simulator import SimulationParameters
+from hisim.component import DisplayConfig
 from hisim.components import loadprofilegenerator_utsp_connector
 from hisim.components import weather
 from hisim.components import advanced_heat_pump_hplib
@@ -39,7 +40,6 @@ __status__ = "development"
 
 @dataclass
 class HouseholdHeatPumpOptions:
-
     """Set options for the system setup."""
 
     photovoltaic: bool = False
@@ -49,7 +49,6 @@ class HouseholdHeatPumpOptions:
 @dataclass_json
 @dataclass
 class HouseholdHeatPumpConfig(SystemSetupConfigBase):
-
     """Configuration for household with advanced heat pump."""
 
     building_type: str
@@ -237,18 +236,21 @@ def setup_function(
     my_weather = weather.Weather(
         config=weather.WeatherConfig.get_default(weather.LocationEnum.AACHEN),
         my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Wetter"),
     )
 
     # Photovoltaic
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_config.pv_config,
         my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Photovoltaik"),
     )
 
     # Building
     my_building = building.Building(
         config=my_config.building_config,
         my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Gebäude"),
     )
 
     # Advanced Heat Pump Controller
@@ -261,6 +263,7 @@ def setup_function(
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
         config=my_config.hp_config,
         my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Wärmepumpe"),
     )
 
     # Heat Distribution System
@@ -272,6 +275,7 @@ def setup_function(
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
         config=my_config.simple_hot_water_storage_config,
         my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Wärmespeicher"),
     )
 
     # DHW
@@ -284,14 +288,18 @@ def setup_function(
         - my_dhw_heatpump_controller_config.t_min_heating_in_celsius
     )
     my_domestic_hot_water_storage = generic_hot_water_storage_modular.HotWaterStorage(
-        my_simulation_parameters=my_simulation_parameters, config=my_dhw_storage_config
+        my_simulation_parameters=my_simulation_parameters,
+        config=my_dhw_storage_config,
+        my_display_config=DisplayConfig.show("Warmwasserspeicher"),
     )
     my_domestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
         my_simulation_parameters=my_simulation_parameters,
         config=my_dhw_heatpump_controller_config,
     )
     my_domestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
-        config=my_dhw_heatpump_config, my_simulation_parameters=my_simulation_parameters
+        config=my_dhw_heatpump_config,
+        my_simulation_parameters=my_simulation_parameters,
+        my_display_config=DisplayConfig.show("Warmwasser-Wärmepumpe"),
     )
 
     if my_config.car_config:
@@ -306,13 +314,14 @@ def setup_function(
 
         # create all cars
         my_cars: List[generic_car.Car] = []
-        for car in names:
+        for idx, car in enumerate(names):
             my_car_config.name = car
             my_cars.append(
                 generic_car.Car(
                     my_simulation_parameters=my_simulation_parameters,
                     config=my_car_config,
                     occupancy_config=my_occupancy_config,
+                    my_display_config=DisplayConfig.show(f"Diesel-PKW {idx}"),
                 )
             )
     else:
@@ -322,6 +331,7 @@ def setup_function(
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
         config=my_config.electricity_meter_config,
+        my_display_config=DisplayConfig.show("Stromzähler"),
     )
 
     # =================================================================================================================================

--- a/tests/test_webtool_results.py
+++ b/tests/test_webtool_results.py
@@ -1,4 +1,9 @@
 """Test for webtool results."""
+
+import json
+from numbers import Number
+from pathlib import Path
+
 import pytest
 
 from hisim.component import SimulationParameters
@@ -19,9 +24,10 @@ def test_webtool_results():
     ]
     main(path, my_simulation_parameters)
 
-    # with open(Path(my_simulation_parameters.result_directory).joinpath("results_for_webtool.json"), "rb") as handle:
-    #     results_for_webtool = json.load(handle)
+    with open(Path(my_simulation_parameters.result_directory).joinpath("results_for_webtool.json"), "rb") as handle:
+        results_for_webtool = json.load(handle)
 
-    # assert isinstance(
-    #     results_for_webtool["components"]["AdvancedHeatPumpHPLib"]["economical"]["Operational Costs [EUR]"], Number
-    # )
+    assert isinstance(
+        results_for_webtool["components"]["AdvancedHeatPumpHPLib"]["technical"]["ThermalOutputPower"]["value"],
+        Number,
+    )


### PR DESCRIPTION
- Add postprocessing flags to component output in order to show them in the webtool
- Add `DisplayConfig.show()` to components in system setups
- Add D203 to disabled errors in pydocstyle, see https://hg.python.org/peps/rev/9b715d8246db
- Optimize imports