### PR TITLE
Fix energy performance for mass simus

### DIFF
--- a/hisim/components/advanced_heat_pump_hplib.py
+++ b/hisim/components/advanced_heat_pump_hplib.py
@@ -248,7 +248,6 @@ class HeatPumpHplib(Component):
             unit=Units.WATT,
             output_description=("Thermal output power in Watt"),
             postprocessing_flag=[
-                InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,
                 OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
             ],
         )

--- a/hisim/components/advanced_heat_pump_hplib.py
+++ b/hisim/components/advanced_heat_pump_hplib.py
@@ -104,7 +104,7 @@ class HeatPumpHplibConfig(ConfigBase):
     def get_scaled_advanced_hp_lib(
         cls,
         heating_load_of_building_in_watt: float,
-        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year: float,
+        building_heating_demand_in_kilowatt_hour_per_m2_per_year: float,
         heating_reference_temperature_in_celsius: float = -7.0,
     ) -> "HeatPumpHplibConfig":
         """Gets a default heat pump with scaling according to heating load of the building.
@@ -115,16 +115,16 @@ class HeatPumpHplibConfig(ConfigBase):
 
         # scale heat pump power up if the energy efficiency of building is low or very low
         # if building heating demand is in energy efficiency class A+ - D, additional scaling factor = 1
-        if 0 < annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year <= 130.0:
+        if 0 < building_heating_demand_in_kilowatt_hour_per_m2_per_year <= 130.0:
             additional_scaling_factor = 1
         # if building heating demand is in energy efficiency class E - F, additional scaling factor = 2
-        elif 130.0 < annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year <= 200.0:
+        elif 130.0 < building_heating_demand_in_kilowatt_hour_per_m2_per_year <= 200.0:
             additional_scaling_factor = 2
         # if building heating demand is in energy efficiency class G - H, additional scaling factor = 3
-        elif annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year > 200.0:
+        elif building_heating_demand_in_kilowatt_hour_per_m2_per_year > 200.0:
             additional_scaling_factor = 3
         else:
-            raise ValueError(f"The annual building heating demand of {annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year} kWh/m2a seems incorrect.")
+            raise ValueError(f"The annual building heating demand of {building_heating_demand_in_kilowatt_hour_per_m2_per_year} kWh/m2a seems incorrect.")
 
         set_thermal_output_power_in_watt = heating_load_of_building_in_watt * additional_scaling_factor
 

--- a/hisim/components/generic_pv_system.py
+++ b/hisim/components/generic_pv_system.py
@@ -350,6 +350,7 @@ class PVSystem(cp.Component):
             postprocessing_flag=[
                 lt.InandOutputType.ELECTRICITY_PRODUCTION,
                 lt.OutputPostprocessingRules.DISPLAY_IN_WEBTOOL,
+                lt.ComponentType.PV,
             ],
             output_description=f"here a description for PV {self.ElectricityOutput} will follow.",
         )

--- a/hisim/postprocessing/postprocessing_main.py
+++ b/hisim/postprocessing/postprocessing_main.py
@@ -1002,7 +1002,7 @@ class PostProcessor:
 
             self_consumption_rate = kpi_collection_dict["Self-consumption rate"]["value"]
             autarky_rate = kpi_collection_dict["Autarky rate"]["value"]
-            grid_injection_in_kilowatt_hour = kpi_collection_dict["Injection"]["value"]
+            grid_injection_in_kilowatt_hour = kpi_collection_dict["Grid injection"]["value"]
             economic_cost = kpi_collection_dict["Total costs for simulated period"]["value"]
             co2_cost = kpi_collection_dict["Total CO2 emissions for simulated period"]["value"]
 

--- a/hisim/postprocessing/scenario_evaluation/result_data_processing.py
+++ b/hisim/postprocessing/scenario_evaluation/result_data_processing.py
@@ -281,7 +281,7 @@ class FilterClass:
             "Building heating load",
             "Specific heating load",
             "Specific heating demand according to TABULA",
-            "Thermal output energy of heat distribution system"
+            "Thermal output energy of heat distribution system",
             "Number of heat pump cycles",
             "Seasonal performance factor of heat pump",
             "Thermal output energy of heat pump",

--- a/hisim/postprocessing/scenario_evaluation/result_data_processing.py
+++ b/hisim/postprocessing/scenario_evaluation/result_data_processing.py
@@ -255,10 +255,9 @@ class FilterClass:
         # system_setups for variables to check (check names of your variables before your evaluation, if they are correct)
         # kpi data has no time series, so only choose when you analyze yearly data
         kpi_data = [
-            "Production",
-            "Consumption",
-            "Ratio between energy production and consumption",
-            "Injection",
+            "Total electricity consumption",
+            "Total electricity production",
+            "Ratio between total production and total consumption",
             "Self-consumption",
             "Self-consumption rate",
             "Self-consumption rate according to mydualsun",
@@ -266,6 +265,8 @@ class FilterClass:
             "Total energy from grid",
             "Total energy to grid",
             "Relative electricity demand from grid",
+            "Self-consumption rate according to solar htw berlin",
+            "Autarky rate according to solar htw berlin",
             "Investment costs for equipment per simulated period",
             "CO2 footprint for equipment per simulated period",
             "System operational costs for simulated period",
@@ -275,16 +276,17 @@ class FilterClass:
             "Temperature deviation of building indoor air temperature being below set temperature 19.0 Celsius",
             "Minimum building indoor air temperature reached",
             "Temperature deviation of building indoor air temperature being above set temperature 24.0 Celsius",
+            "Temperature deviation of building indoor air temperature being above set temperature 24.0 Celsius",
             "Maximum building indoor air temperature reached",
             "Building heating load",
             "Specific heating load",
             "Specific heating demand according to TABULA",
-            "Thermal output energy of heat distribution system",
+            "Thermal output energy of heat distribution system"
             "Number of heat pump cycles",
             "Seasonal performance factor of heat pump",
             "Thermal output energy of heat pump",
             "Specific thermal output energy of heat pump",
-            "Electrical input energy of heat pump"
+            "Electrical input energy of heat pump",
         ]
 
         electricity_data = [

--- a/obsolete/household_with_advanced_hp_hws_hds_pv.py
+++ b/obsolete/household_with_advanced_hp_hws_hds_pv.py
@@ -159,7 +159,8 @@ def setup_function(
     # Build Heat Pump
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
-        heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius
+        heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
+        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
     )
     my_heat_pump_config.group_id = group_id
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius

--- a/system_setups/air_conditioned_house_a_with_mpc_controller.py
+++ b/system_setups/air_conditioned_house_a_with_mpc_controller.py
@@ -33,9 +33,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
 
 
 def air_conditioned_house(
-    my_sim: Simulator,
-    control: str,
-    my_simulation_parameters: Optional[SimulationParameters] = None,
+    my_sim: Simulator, control: str, my_simulation_parameters: Optional[SimulationParameters] = None,
 ) -> None:
     """Household Model.
 
@@ -226,10 +224,7 @@ def air_conditioned_house(
         predictive=predictive,
         enable_opening_windows=enable_opening_windows,
     )
-    my_building = building.Building(
-        config=my_building_config,
-        my_simulation_parameters=my_simulation_parameters,
-    )
+    my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters,)
 
     """ Occupancy Profile """
     my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
@@ -240,8 +235,7 @@ def air_conditioned_house(
     my_occupancy_config.predictive = predictive
 
     my_occupancy = loadprofilegenerator_utsp_connector.UtspLpgConnector(
-        config=my_occupancy_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_occupancy_config, my_simulation_parameters=my_simulation_parameters,
     )
     my_sim.add_component(my_occupancy)
 
@@ -249,10 +243,7 @@ def air_conditioned_house(
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.SEVILLE)
     my_weather_config.predictive_control = predictive_control
 
-    my_weather = weather.Weather(
-        config=my_weather_config,
-        my_simulation_parameters=my_simulation_parameters,
-    )
+    my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters,)
     my_sim.add_component(my_weather)
 
     """Photovoltaic System"""
@@ -279,8 +270,7 @@ def air_conditioned_house(
         predictive_control=predictive_control,
     )
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_photovoltaic_system_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_photovoltaic_system_config, my_simulation_parameters=my_simulation_parameters,
     )
     my_photovoltaic_system.connect_only_predefined_connections(my_weather)
     my_sim.add_component(my_photovoltaic_system)
@@ -303,8 +293,7 @@ def air_conditioned_house(
         predictive_control=predictive_control,
     )
     my_price_signal = generic_price_signal.PriceSignal(
-        config=my_price_signal_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_price_signal_config, my_simulation_parameters=my_simulation_parameters,
     )
     my_sim.add_component(my_price_signal)
 
@@ -318,18 +307,13 @@ def air_conditioned_house(
         control=control,
     )
     my_air_conditioner = air_conditioner.AirConditioner(
-        config=my_air_conditioner_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_air_conditioner_config, my_simulation_parameters=my_simulation_parameters,
     )
     my_air_conditioner.connect_input(
-        my_air_conditioner.TemperatureOutside,
-        my_weather.component_name,
-        my_weather.TemperatureOutside,
+        my_air_conditioner.TemperatureOutside, my_weather.component_name, my_weather.TemperatureOutside,
     )
     my_air_conditioner.connect_input(
-        my_air_conditioner.TemperatureMean,
-        my_building.component_name,
-        my_building.TemperatureMeanThermalMass,
+        my_air_conditioner.TemperatureMean, my_building.component_name, my_building.TemperatureMeanThermalMass,
     )
     my_sim.add_component(my_air_conditioner)
 
@@ -344,8 +328,7 @@ def air_conditioned_house(
             predictive=predictive,
         )
         my_battery = generic_battery.GenericBattery(
-            config=my_battery_config,
-            my_simulation_parameters=my_simulation_parameters,
+            config=my_battery_config, my_simulation_parameters=my_simulation_parameters,
         )
         my_sim.add_component(my_battery)
 
@@ -404,19 +387,14 @@ def air_conditioned_house(
         )
 
         my_mpc_controller = controller_mpc.MpcController(
-            config=my_mpc_controller_config,
-            my_simulation_parameters=my_simulation_parameters,
+            config=my_mpc_controller_config, my_simulation_parameters=my_simulation_parameters,
         )
         my_mpc_controller.connect_input(
-            my_mpc_controller.TemperatureMean,
-            my_building.component_name,
-            my_building.TemperatureMeanThermalMass,
+            my_mpc_controller.TemperatureMean, my_building.component_name, my_building.TemperatureMeanThermalMass,
         )
         my_sim.add_component(my_mpc_controller)
         my_battery.connect_input(
-            my_battery.State,
-            my_mpc_controller.component_name,
-            my_mpc_controller.BatteryControlState,
+            my_battery.State, my_mpc_controller.component_name, my_mpc_controller.BatteryControlState,
         )
         my_battery.connect_input(
             my_battery.ElectricityInput,
@@ -424,42 +402,29 @@ def air_conditioned_house(
             my_mpc_controller.BatteryChargingDischargingPower,
         )
         my_battery.connect_input(
-            my_battery.ElectricityInput,
-            my_mpc_controller.component_name,
-            my_mpc_controller.Battery2Load,
+            my_battery.ElectricityInput, my_mpc_controller.component_name, my_mpc_controller.Battery2Load,
         )
 
     """PID controller"""  # pid
     if control == "PID":
         my_pid_controller_config = controller_pid.PIDControllerConfig.get_default_config()
         pid_controller = controller_pid.PIDController(
-            config=my_pid_controller_config,
-            my_simulation_parameters=my_simulation_parameters,
+            config=my_pid_controller_config, my_simulation_parameters=my_simulation_parameters,
         )
         pid_controller.connect_input(
-            pid_controller.TemperatureMean,
-            my_building.component_name,
-            my_building.TemperatureMeanThermalMass,
+            pid_controller.TemperatureMean, my_building.component_name, my_building.TemperatureMeanThermalMass,
         )
         pid_controller.connect_input(
-            pid_controller.HeatFluxThermalMassNode,
-            my_building.component_name,
-            my_building.HeatFluxThermalMassNode,
+            pid_controller.HeatFluxThermalMassNode, my_building.component_name, my_building.HeatFluxThermalMassNode,
         )
         pid_controller.connect_input(
-            pid_controller.HeatFluxWallNode,
-            my_building.component_name,
-            my_building.HeatFluxWallNode,
+            pid_controller.HeatFluxWallNode, my_building.component_name, my_building.HeatFluxWallNode,
         )
         my_air_conditioner.connect_input(
-            my_air_conditioner.FeedForwardSignal,
-            pid_controller.component_name,
-            pid_controller.FeedForwardSignal,
+            my_air_conditioner.FeedForwardSignal, pid_controller.component_name, pid_controller.FeedForwardSignal,
         )
         my_air_conditioner.connect_input(
-            my_air_conditioner.ThermalPowerPID,
-            pid_controller.component_name,
-            pid_controller.ThermalPowerPID,
+            my_air_conditioner.ThermalPowerPID, pid_controller.component_name, pid_controller.ThermalPowerPID,
         )
         my_sim.add_component(pid_controller)
 
@@ -511,7 +476,5 @@ def air_conditioned_house(
     # )
 
     my_building.connect_input(
-        my_building.ThermalPowerDelivered,
-        my_air_conditioner.component_name,
-        my_air_conditioner.ThermalEnergyDelivered,
+        my_building.ThermalPowerDelivered, my_air_conditioner.component_name, my_air_conditioner.ThermalEnergyDelivered,
     )

--- a/system_setups/air_conditioned_house_b_with_pid_controller.py
+++ b/system_setups/air_conditioned_house_b_with_pid_controller.py
@@ -3,9 +3,7 @@
 # clean
 from typing import Optional
 
-from system_setups.air_conditioned_house_a_with_mpc_controller import (
-    air_conditioned_house,
-)
+from system_setups.air_conditioned_house_a_with_mpc_controller import air_conditioned_house
 
 from hisim.simulator import SimulationParameters
 from hisim.simulator import Simulator

--- a/system_setups/air_conditioned_house_c_with_onoff_controller.py
+++ b/system_setups/air_conditioned_house_c_with_onoff_controller.py
@@ -3,9 +3,7 @@
 # clean
 from typing import Optional
 
-from system_setups.air_conditioned_house_a_with_mpc_controller import (
-    air_conditioned_house,
-)
+from system_setups.air_conditioned_house_a_with_mpc_controller import air_conditioned_house
 
 from hisim.simulator import SimulationParameters
 from hisim.simulator import Simulator

--- a/system_setups/automatic_default_connections.py
+++ b/system_setups/automatic_default_connections.py
@@ -118,7 +118,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
         heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
-        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
+        building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
     )
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(

--- a/system_setups/automatic_default_connections.py
+++ b/system_setups/automatic_default_connections.py
@@ -86,8 +86,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         rooftop_area_in_m2=my_building_information.scaled_rooftop_area_in_m2
     )
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_photovoltaic_system_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_photovoltaic_system_config, my_simulation_parameters=my_simulation_parameters,
     )
     # =================================================================================================================================
     # Build Energy System Components
@@ -101,8 +100,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     )
 
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_heat_distribution_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_heat_distribution_controller_config,
     )
     my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
         config=my_heat_distribution_controller_config
@@ -124,8 +122,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     )
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -134,8 +131,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         temperature_difference_between_flow_and_return_in_celsius=my_hds_controller_information.temperature_difference_between_flow_and_return_in_celsius,
     )
     my_heat_distribution_system = heat_distribution_system.HeatDistribution(
-        config=my_heat_distribution_system_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_distribution_system_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Water Storage
@@ -146,8 +142,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         water_mass_flow_rate_from_hds_in_kg_per_second=my_hds_controller_information.water_mass_flow_rate_in_kp_per_second,
     )
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_simple_heat_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_simple_heat_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build DHW (this is taken from household_3_advanced_hp_diesel-car_pv_battery.py)
@@ -155,16 +150,12 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         number_of_apartments=my_building_information.number_of_apartments
     )
 
-    my_dhw_heatpump_controller_config = (
-        controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
-            name="DHWHeatpumpController"
-        )
+    my_dhw_heatpump_controller_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
+        name="DHWHeatpumpController"
     )
 
-    my_dhw_storage_config = (
-        generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
-            number_of_apartments=my_building_information.number_of_apartments
-        )
+    my_dhw_storage_config = generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
+        number_of_apartments=my_building_information.number_of_apartments
     )
     my_dhw_storage_config.compute_default_cycle(
         temperature_difference_in_kelvin=my_dhw_heatpump_controller_config.t_max_heating_in_celsius
@@ -176,8 +167,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     )
 
     my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(

--- a/system_setups/automatic_default_connections.py
+++ b/system_setups/automatic_default_connections.py
@@ -120,6 +120,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
         heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
+        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
     )
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(

--- a/system_setups/basic_household.py
+++ b/system_setups/basic_household.py
@@ -119,7 +119,7 @@ def setup_function(
         source_component_output=my_photovoltaic_system.ElectricityOutput,
         source_load_type=loadtypes.LoadTypes.ELECTRICITY,
         source_unit=loadtypes.Units.WATT,
-        source_tags=[loadtypes.ComponentType.PV, loadtypes.InandOutputType.ELECTRICITY_PRODUCTION,],
+        source_tags=[loadtypes.ComponentType.PV, loadtypes.InandOutputType.ELECTRICITY_PRODUCTION],
         source_weight=999,
     )
 

--- a/system_setups/basic_household.py
+++ b/system_setups/basic_household.py
@@ -81,8 +81,7 @@ def setup_function(
     my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
 
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_photovoltaic_system_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_photovoltaic_system_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Electricity Meter
@@ -120,10 +119,7 @@ def setup_function(
         source_component_output=my_photovoltaic_system.ElectricityOutput,
         source_load_type=loadtypes.LoadTypes.ELECTRICITY,
         source_unit=loadtypes.Units.WATT,
-        source_tags=[
-            loadtypes.ComponentType.PV,
-            loadtypes.InandOutputType.ELECTRICITY_PRODUCTION,
-        ],
+        source_tags=[loadtypes.ComponentType.PV, loadtypes.InandOutputType.ELECTRICITY_PRODUCTION,],
         source_weight=999,
     )
 
@@ -151,9 +147,7 @@ def setup_function(
     my_building.connect_only_predefined_connections(my_weather, my_occupancy)
 
     my_building.connect_input(
-        my_building.ThermalPowerDelivered,
-        my_heat_pump.component_name,
-        my_heat_pump.ThermalPowerDelivered,
+        my_building.ThermalPowerDelivered, my_heat_pump.component_name, my_heat_pump.ThermalPowerDelivered,
     )
 
     my_heat_pump_controller.connect_only_predefined_connections(my_building)

--- a/system_setups/basic_household_only_heating.py
+++ b/system_setups/basic_household_only_heating.py
@@ -104,9 +104,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
 
     my_building.connect_only_predefined_connections(my_weather, my_occupancy)
     my_building.connect_input(
-        my_building.ThermalPowerDelivered,
-        my_storage.component_name,
-        my_storage.RealHeatForBuilding,
+        my_building.ThermalPowerDelivered, my_storage.component_name, my_storage.RealHeatForBuilding,
     )
 
     my_storage.connect_input(
@@ -120,9 +118,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         my_controller_heat.ControlSignalChooseStorage,
     )
     my_storage.connect_input(
-        my_storage.ThermalInputPower1,
-        my_gas_heater.component_name,
-        my_gas_heater.ThermalOutputPower,
+        my_storage.ThermalInputPower1, my_gas_heater.component_name, my_gas_heater.ThermalOutputPower,
     )
 
     my_storage_controller.connect_input(
@@ -131,9 +127,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         my_storage.WaterOutputTemperatureHeatingWater,
     )
     my_storage_controller.connect_input(
-        my_storage_controller.BuildingTemperature,
-        my_building.component_name,
-        my_building.TemperatureMeanThermalMass,
+        my_storage_controller.BuildingTemperature, my_building.component_name, my_building.TemperatureMeanThermalMass,
     )
     # my_storage_controller.connect_input(
     #     my_storage_controller.ReferenceMaxHeatBuildingDemand,
@@ -150,20 +144,14 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     )
 
     my_controller_heat.connect_input(
-        my_controller_heat.ResidenceTemperature,
-        my_building.component_name,
-        my_building.TemperatureMeanThermalMass,
+        my_controller_heat.ResidenceTemperature, my_building.component_name, my_building.TemperatureMeanThermalMass,
     )
 
     my_gas_heater.connect_input(
-        my_gas_heater.ControlSignal,
-        my_controller_heat.component_name,
-        my_controller_heat.ControlSignalGasHeater,
+        my_gas_heater.ControlSignal, my_controller_heat.component_name, my_controller_heat.ControlSignalGasHeater,
     )
     my_gas_heater.connect_input(
-        my_gas_heater.MassflowInputTemperature,
-        my_storage.component_name,
-        my_storage.WaterOutputStorageforHeaters,
+        my_gas_heater.MassflowInputTemperature, my_storage.component_name, my_storage.WaterOutputStorageforHeaters,
     )
 
     # =================================================================================================================================

--- a/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_pem.py
+++ b/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_pem.py
@@ -115,8 +115,7 @@ def setup_function(
     my_electrolyzer_controller_l2 = PTXController(
         my_simulation_parameters=my_simulation_parameters,
         config=PTXControllerConfig.control_electrolyzer(
-            electrolyzer_name=electrolyzer_name,
-            operation_mode=operation_mode,
+            electrolyzer_name=electrolyzer_name, operation_mode=operation_mode,
         ),
     )
     # buffer bat test end
@@ -153,8 +152,7 @@ def setup_function(
     my_photovoltaic_system_config.cost = pv_cost
 
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_photovoltaic_system_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_photovoltaic_system_config,
     )
     my_photovoltaic_system.connect_only_predefined_connections(my_weather)
     # hp test start
@@ -229,10 +227,7 @@ def setup_function(
         source_component_output=my_heat_pump.ElectricityOutput,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
-        source_tags=[
-            lt.ComponentType.HEAT_PUMP,
-            lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,
-        ],
+        source_tags=[lt.ComponentType.HEAT_PUMP, lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
         source_weight=999,
     )
 
@@ -240,16 +235,12 @@ def setup_function(
     my_building.connect_only_predefined_connections(my_occupancy)
 
     my_building.connect_input(
-        my_building.ThermalPowerDelivered,
-        my_heat_pump.component_name,
-        my_heat_pump.ThermalPowerDelivered,
+        my_building.ThermalPowerDelivered, my_heat_pump.component_name, my_heat_pump.ThermalPowerDelivered,
     )
 
     my_heat_pump_controller.connect_only_predefined_connections(my_building)
     my_heat_pump_controller.connect_input(
-        my_heat_pump_controller.ElectricityInput,
-        my_cl2.component_name,
-        my_cl2.ElectricityToOrFromGrid,
+        my_heat_pump_controller.ElectricityInput, my_cl2.component_name, my_cl2.ElectricityToOrFromGrid,
     )
     my_heat_pump.connect_only_predefined_connections(my_weather, my_heat_pump_controller)
     my_heat_pump.get_default_connections_heatpump_controller()
@@ -269,10 +260,7 @@ def setup_function(
         source_component_output=my_electrolyzer.CurrentLoad,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
-        source_tags=[
-            lt.ComponentType.ELECTROLYZER,
-            lt.InandOutputType.ELECTRICITY_REAL,
-        ],
+        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_REAL,],
         source_weight=1,
     )
 
@@ -286,18 +274,14 @@ def setup_function(
     )
     electricity_to_electrolyzer_target = my_cl2.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[
-            lt.ComponentType.ELECTROLYZER,
-            lt.InandOutputType.ELECTRICITY_TARGET,
-        ],
+        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_TARGET,],
         source_weight=1,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
         output_description="Target electricity to electrolyzer. ",
     )
     my_fuel_cell_controller_l2.connect_dynamic_input(
-        input_fieldname=my_fuel_cell_controller_l2.DemandLoad,
-        src_object=electricity_from_fuel_cell_target_1,
+        input_fieldname=my_fuel_cell_controller_l2.DemandLoad, src_object=electricity_from_fuel_cell_target_1,
     )
     my_fuel_cell_controller.connect_input(
         input_fieldname=my_fuel_cell_controller.DemandProfile,
@@ -306,8 +290,7 @@ def setup_function(
     )
     # buffer bat test start
     my_electrolyzer_controller_l2.connect_dynamic_input(
-        input_fieldname=my_electrolyzer_controller_l2.RESLoad,
-        src_object=electricity_to_electrolyzer_target,
+        input_fieldname=my_electrolyzer_controller_l2.RESLoad, src_object=electricity_to_electrolyzer_target,
     )
     my_electrolyzer_controller.connect_input(
         input_fieldname=my_electrolyzer_controller.ProvidedLoad,
@@ -318,14 +301,10 @@ def setup_function(
     # buffer bat test end
 
     my_fuel_cell.connect_input(
-        my_fuel_cell.DemandProfile,
-        my_fuel_cell_controller.component_name,
-        my_fuel_cell_controller.PowerTarger,
+        my_fuel_cell.DemandProfile, my_fuel_cell_controller.component_name, my_fuel_cell_controller.PowerTarger,
     )
     my_fuel_cell.connect_input(
-        my_fuel_cell.ControlSignal,
-        my_fuel_cell_controller.component_name,
-        my_fuel_cell_controller.CurrentMode,
+        my_fuel_cell.ControlSignal, my_fuel_cell_controller.component_name, my_fuel_cell_controller.CurrentMode,
     )
 
     my_electrolyzer.connect_input(
@@ -335,9 +314,7 @@ def setup_function(
     )
 
     my_electrolyzer.connect_input(
-        my_electrolyzer.InputState,
-        my_electrolyzer_controller.component_name,
-        my_electrolyzer_controller.CurrentMode,
+        my_electrolyzer.InputState, my_electrolyzer_controller.component_name, my_electrolyzer_controller.CurrentMode,
     )
     """
     my_cl2.add_component_input_and_connect(

--- a/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_pem.py
+++ b/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_pem.py
@@ -227,7 +227,7 @@ def setup_function(
         source_component_output=my_heat_pump.ElectricityOutput,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
-        source_tags=[lt.ComponentType.HEAT_PUMP, lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
+        source_tags=[lt.ComponentType.HEAT_PUMP, lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
         source_weight=999,
     )
 
@@ -260,7 +260,7 @@ def setup_function(
         source_component_output=my_electrolyzer.CurrentLoad,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
-        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_REAL,],
+        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_REAL],
         source_weight=1,
     )
 
@@ -274,7 +274,7 @@ def setup_function(
     )
     electricity_to_electrolyzer_target = my_cl2.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_TARGET,],
+        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_TARGET],
         source_weight=1,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,

--- a/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_rsoc.py
+++ b/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_rsoc.py
@@ -86,29 +86,20 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     my_advanced_battery_config_1.source_weight = 1
 
     my_advanced_battery_1 = advanced_battery_bslib.Battery(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_advanced_battery_config_1,
+        my_simulation_parameters=my_simulation_parameters, config=my_advanced_battery_config_1,
     )
 
     # buffer bat test start
     my_rsoc_controller_l2 = RsocBatteryController(
         my_simulation_parameters=my_simulation_parameters,
-        config=RsocBatteryControllerConfig.confic_rsoc_name(
-            rsoc_name=rsoc_name,
-            operation_mode=operation_mode_rsoc,
-        ),
+        config=RsocBatteryControllerConfig.confic_rsoc_name(rsoc_name=rsoc_name, operation_mode=operation_mode_rsoc,),
     )
     my_rsoc_controller_l1 = RsocController(
         my_simulation_parameters=my_simulation_parameters,
-        config=RsocControllerConfig.config_rsoc(
-            rsoc_name=rsoc_name,
-        ),
+        config=RsocControllerConfig.config_rsoc(rsoc_name=rsoc_name,),
     )
     my_rsoc = Rsoc(
-        my_simulation_parameters=my_simulation_parameters,
-        config=RsocConfig.config_rsoc(
-            rsoc_name=rsoc_name,
-        ),
+        my_simulation_parameters=my_simulation_parameters, config=RsocConfig.config_rsoc(rsoc_name=rsoc_name,),
     )
     # buffer bat test end
 
@@ -135,8 +126,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     my_photovoltaic_system_config.cost = pv_cost
 
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_photovoltaic_system_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_photovoltaic_system_config,
     )
     my_photovoltaic_system.connect_only_predefined_connections(my_weather)
 
@@ -205,27 +195,20 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         source_component_output=my_heat_pump.ElectricityOutput,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
-        source_tags=[
-            lt.ComponentType.HEAT_PUMP,
-            lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,
-        ],
+        source_tags=[lt.ComponentType.HEAT_PUMP, lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
         source_weight=999,
     )
     my_building.connect_only_predefined_connections(my_weather)
     my_building.connect_only_predefined_connections(my_occupancy)
 
     my_building.connect_input(
-        my_building.ThermalPowerDelivered,
-        my_heat_pump.component_name,
-        my_heat_pump.ThermalPowerDelivered,
+        my_building.ThermalPowerDelivered, my_heat_pump.component_name, my_heat_pump.ThermalPowerDelivered,
     )
 
     my_heat_pump_controller.connect_only_predefined_connections(my_building)
 
     my_heat_pump_controller.connect_input(
-        my_heat_pump_controller.ElectricityInput,
-        my_cl2.component_name,
-        my_cl2.ElectricityToOrFromGrid,
+        my_heat_pump_controller.ElectricityInput, my_cl2.component_name, my_cl2.ElectricityToOrFromGrid,
     )
     my_heat_pump.connect_only_predefined_connections(my_weather, my_heat_pump_controller)
     my_heat_pump.get_default_connections_heatpump_controller()
@@ -235,10 +218,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         source_component_output=my_rsoc.SOFCCurrentOutput,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
-        source_tags=[
-            lt.ComponentType.FUEL_CELL,
-            lt.InandOutputType.ELECTRICITY_PRODUCTION,
-        ],
+        source_tags=[lt.ComponentType.FUEL_CELL, lt.InandOutputType.ELECTRICITY_PRODUCTION,],
         source_weight=2,
     )
 
@@ -247,10 +227,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         source_component_output=my_rsoc.SOECCurrentLoad,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
-        source_tags=[
-            lt.ComponentType.ELECTROLYZER,
-            lt.InandOutputType.ELECTRICITY_REAL,
-        ],
+        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_REAL,],
         source_weight=1,  # maybe change the weigth
     )
 
@@ -264,10 +241,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     )
     electricity_to_electrolyzer_target = my_cl2.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[
-            lt.ComponentType.ELECTROLYZER,
-            lt.InandOutputType.ELECTRICITY_TARGET,
-        ],
+        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_TARGET,],
         source_weight=1,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
@@ -275,12 +249,10 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     )
 
     my_rsoc_controller_l2.connect_dynamic_input(
-        input_fieldname=my_rsoc_controller_l2.Demand,
-        src_object=electricity_from_rsofc_target_1,
+        input_fieldname=my_rsoc_controller_l2.Demand, src_object=electricity_from_rsofc_target_1,
     )
     my_rsoc_controller_l2.connect_dynamic_input(
-        input_fieldname=my_rsoc_controller_l2.RESLoad,
-        src_object=electricity_to_electrolyzer_target,
+        input_fieldname=my_rsoc_controller_l2.RESLoad, src_object=electricity_to_electrolyzer_target,
     )
 
     my_rsoc_controller_l1.connect_input(
@@ -291,14 +263,10 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
 
     # buffer bat test end
     my_rsoc.connect_input(
-        my_rsoc.PowerInput,
-        my_rsoc_controller_l1.component_name,
-        my_rsoc_controller_l1.PowerVsDemand,
+        my_rsoc.PowerInput, my_rsoc_controller_l1.component_name, my_rsoc_controller_l1.PowerVsDemand,
     )
     my_rsoc.connect_input(
-        my_rsoc.RSOCInputState,
-        my_rsoc_controller_l1.component_name,
-        my_rsoc_controller_l1.StateToRSOC,
+        my_rsoc.RSOCInputState, my_rsoc_controller_l1.component_name, my_rsoc_controller_l1.StateToRSOC,
     )
 
     my_cl2.add_component_input_and_connect(

--- a/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_rsoc.py
+++ b/system_setups/decentralized_energy_netw_pv_bat_hydro_system_hp_rsoc.py
@@ -195,7 +195,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         source_component_output=my_heat_pump.ElectricityOutput,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
-        source_tags=[lt.ComponentType.HEAT_PUMP, lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
+        source_tags=[lt.ComponentType.HEAT_PUMP, lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
         source_weight=999,
     )
     my_building.connect_only_predefined_connections(my_weather)
@@ -218,7 +218,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         source_component_output=my_rsoc.SOFCCurrentOutput,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
-        source_tags=[lt.ComponentType.FUEL_CELL, lt.InandOutputType.ELECTRICITY_PRODUCTION,],
+        source_tags=[lt.ComponentType.FUEL_CELL, lt.InandOutputType.ELECTRICITY_PRODUCTION],
         source_weight=2,
     )
 
@@ -227,7 +227,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         source_component_output=my_rsoc.SOECCurrentLoad,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
-        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_REAL,],
+        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_REAL],
         source_weight=1,  # maybe change the weigth
     )
 
@@ -241,7 +241,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     )
     electricity_to_electrolyzer_target = my_cl2.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_TARGET,],
+        source_tags=[lt.ComponentType.ELECTROLYZER, lt.InandOutputType.ELECTRICITY_TARGET],
         source_weight=1,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,

--- a/system_setups/default_connections.py
+++ b/system_setups/default_connections.py
@@ -76,8 +76,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     # Build PV
     my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_photovoltaic_system_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_photovoltaic_system_config, my_simulation_parameters=my_simulation_parameters,
     )
     my_sim.add_component(my_photovoltaic_system)
     my_photovoltaic_system.connect_only_predefined_connections(my_weather)
@@ -122,10 +121,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         source_component_output=my_photovoltaic_system.ElectricityOutput,
         source_load_type=loadtypes.LoadTypes.ELECTRICITY,
         source_unit=loadtypes.Units.WATT,
-        source_tags=[
-            loadtypes.ComponentType.PV,
-            loadtypes.InandOutputType.ELECTRICITY_PRODUCTION,
-        ],
+        source_tags=[loadtypes.ComponentType.PV, loadtypes.InandOutputType.ELECTRICITY_PRODUCTION,],
         source_weight=999,
     )
 
@@ -153,7 +149,5 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
 
     # depending on type of heating device, hard to define default connections
     my_building.connect_input(
-        my_building.ThermalPowerDelivered,
-        my_heat_pump.component_name,
-        my_heat_pump.ThermalPowerDelivered,
+        my_building.ThermalPowerDelivered, my_heat_pump.component_name, my_heat_pump.ThermalPowerDelivered,
     )

--- a/system_setups/default_connections.py
+++ b/system_setups/default_connections.py
@@ -121,7 +121,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         source_component_output=my_photovoltaic_system.ElectricityOutput,
         source_load_type=loadtypes.LoadTypes.ELECTRICITY,
         source_unit=loadtypes.Units.WATT,
-        source_tags=[loadtypes.ComponentType.PV, loadtypes.InandOutputType.ELECTRICITY_PRODUCTION,],
+        source_tags=[loadtypes.ComponentType.PV, loadtypes.InandOutputType.ELECTRICITY_PRODUCTION],
         source_weight=999,
     )
 

--- a/system_setups/dynamic_components.py
+++ b/system_setups/dynamic_components.py
@@ -60,12 +60,10 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     my_advanced_battery_config_2.source_weight = 2
 
     my_advanced_battery_1 = advanced_battery_bslib.Battery(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_advanced_battery_config_1,
+        my_simulation_parameters=my_simulation_parameters, config=my_advanced_battery_config_1,
     )
     my_advanced_battery_2 = advanced_battery_bslib.Battery(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_advanced_battery_config_2,
+        my_simulation_parameters=my_simulation_parameters, config=my_advanced_battery_config_2,
     )
 
     my_advanced_fuel_cell_config_1 = advanced_fuel_cell.CHPConfig.get_default_config()
@@ -74,12 +72,10 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     my_advanced_fuel_cell_config_2.name = "CHP2"
 
     my_advanced_fuel_cell_1 = advanced_fuel_cell.CHP(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_advanced_fuel_cell_config_1,
+        my_simulation_parameters=my_simulation_parameters, config=my_advanced_fuel_cell_config_1,
     )
     my_advanced_fuel_cell_2 = advanced_fuel_cell.CHP(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_advanced_fuel_cell_config_2,
+        my_simulation_parameters=my_simulation_parameters, config=my_advanced_fuel_cell_config_2,
     )
     my_cl2_config = cl2.EMSConfig.get_default_config_ems()
     my_cl2 = cl2.L2GenericEnergyManagementSystem(
@@ -97,8 +93,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
 
     my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_photovoltaic_system_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_photovoltaic_system_config,
     )
     my_photovoltaic_system.connect_only_predefined_connections(my_weather)
 
@@ -196,12 +191,10 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     )
 
     my_advanced_fuel_cell_1.connect_dynamic_input(
-        input_fieldname=advanced_fuel_cell.CHP.ElectricityFromCHPTarget,
-        src_object=electricity_from_fuel_cell_target_1,
+        input_fieldname=advanced_fuel_cell.CHP.ElectricityFromCHPTarget, src_object=electricity_from_fuel_cell_target_1,
     )
     my_advanced_fuel_cell_2.connect_dynamic_input(
-        input_fieldname=advanced_fuel_cell.CHP.ElectricityFromCHPTarget,
-        src_object=electricity_from_fuel_cell_target_2,
+        input_fieldname=advanced_fuel_cell.CHP.ElectricityFromCHPTarget, src_object=electricity_from_fuel_cell_target_2,
     )
 
     my_sim.add_component(my_advanced_battery_1)

--- a/system_setups/electrolyzer_with_renewables.py
+++ b/system_setups/electrolyzer_with_renewables.py
@@ -103,11 +103,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
 
     # Setup the transformer and rectifier unit
     my_transformer = Transformer(
-        my_simulation_parameters=my_simulation_parameters,
-        config=TransformerConfig(
-            name=name,
-            efficiency=efficiency,
-        ),
+        my_simulation_parameters=my_simulation_parameters, config=TransformerConfig(name=name, efficiency=efficiency,),
     )
 
     # Setup the controller
@@ -129,21 +125,15 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     my_transformer.connect_input(my_transformer.TransformerInput, csv_loader.component_name, csv_loader.Output1)
 
     my_controller.connect_input(
-        my_controller.ProvidedLoad,
-        my_transformer.component_name,
-        my_transformer.TransformerOutput,
+        my_controller.ProvidedLoad, my_transformer.component_name, my_transformer.TransformerOutput,
     )
 
     my_electrolyzer.connect_input(
-        my_electrolyzer.InputState,
-        my_controller.component_name,
-        my_controller.CurrentMode,
+        my_electrolyzer.InputState, my_controller.component_name, my_controller.CurrentMode,
     )
 
     my_electrolyzer.connect_input(
-        my_electrolyzer.LoadInput,
-        my_controller.component_name,
-        my_controller.DistributedLoad,
+        my_electrolyzer.LoadInput, my_controller.component_name, my_controller.DistributedLoad,
     )
 
     # =================================================================================================================================

--- a/system_setups/household_1_advanced_hp_diesel_car.py
+++ b/system_setups/household_1_advanced_hp_diesel_car.py
@@ -145,6 +145,7 @@ class HouseholdAdvancedHPDieselCarConfig(SystemSetupConfigBase):
             hp_config=advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                 heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                 heating_reference_temperature_in_celsius=my_building_information.heating_reference_temperature_in_celsius,
+                annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
             ),
             simple_hot_water_storage_config=simple_hot_water_storage.SimpleHotWaterStorageConfig.get_scaled_hot_water_storage(
                 max_thermal_power_in_watt_of_heating_system=my_building_information.max_thermal_building_demand_in_watt,

--- a/system_setups/household_1_advanced_hp_diesel_car.py
+++ b/system_setups/household_1_advanced_hp_diesel_car.py
@@ -145,7 +145,7 @@ class HouseholdAdvancedHPDieselCarConfig(SystemSetupConfigBase):
             hp_config=advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                 heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                 heating_reference_temperature_in_celsius=my_building_information.heating_reference_temperature_in_celsius,
-                annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
+                building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
             ),
             simple_hot_water_storage_config=simple_hot_water_storage.SimpleHotWaterStorageConfig.get_scaled_hot_water_storage(
                 max_thermal_power_in_watt_of_heating_system=my_building_information.max_thermal_building_demand_in_watt,

--- a/system_setups/household_1_advanced_hp_diesel_car.py
+++ b/system_setups/household_1_advanced_hp_diesel_car.py
@@ -190,8 +190,7 @@ class HouseholdAdvancedHPDieselCarConfig(SystemSetupConfigBase):
 
 
 def setup_function(
-    my_sim: Any,
-    my_simulation_parameters: Optional[SimulationParameters] = None,
+    my_sim: Any, my_simulation_parameters: Optional[SimulationParameters] = None,
 ) -> None:  # noqa: too-many-statements
     """System setup with advanced hp and diesel car.
 
@@ -250,8 +249,7 @@ def setup_function(
 
     # Build heat Distribution System Controller
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        config=my_config.hds_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.hds_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -268,8 +266,7 @@ def setup_function(
 
     # Build Building
     my_building = building.Building(
-        config=my_config.building_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.building_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -282,8 +279,7 @@ def setup_function(
     my_heat_pump_controller_config.name = "HeatPumpHplibController"
 
     my_heat_pump_controller = advanced_heat_pump_hplib.HeatPumpHplibController(
-        config=my_heat_pump_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Pump
@@ -291,14 +287,12 @@ def setup_function(
     my_heat_pump_config.name = "HeatPumpHPLib"
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Water Storage
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_config.simple_hot_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.simple_hot_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build DHW
@@ -325,8 +319,7 @@ def setup_function(
     )
 
     my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -356,8 +349,7 @@ def setup_function(
 
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_meter_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_meter_config,
     )
 
     # =================================================================================================================================

--- a/system_setups/household_2_advanced_hp_diesel_car_pv.py
+++ b/system_setups/household_2_advanced_hp_diesel_car_pv.py
@@ -251,8 +251,7 @@ def setup_function(
 
     # Build heat Distribution System Controller
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        config=my_config.hds_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.hds_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -269,14 +268,12 @@ def setup_function(
 
     # Build PV
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_config.pv_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.pv_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Building
     my_building = building.Building(
-        config=my_config.building_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.building_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -289,8 +286,7 @@ def setup_function(
     my_heat_pump_controller_config.name = "HeatPumpHplibController"
 
     my_heat_pump_controller = advanced_heat_pump_hplib.HeatPumpHplibController(
-        config=my_heat_pump_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Pump
@@ -298,14 +294,12 @@ def setup_function(
     my_heat_pump_config.name = "HeatPumpHPLib"
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Water Storage
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_config.simple_hot_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.simple_hot_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build DHW
@@ -324,8 +318,7 @@ def setup_function(
     )
 
     my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -355,14 +348,12 @@ def setup_function(
 
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_meter_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_meter_config,
     )
 
     # Build EMS
     my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_controller_config,
     )
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -389,20 +380,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -433,19 +418,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
             source_weight=3,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,

--- a/system_setups/household_2_advanced_hp_diesel_car_pv.py
+++ b/system_setups/household_2_advanced_hp_diesel_car_pv.py
@@ -133,6 +133,7 @@ class HouseholdAdvancedHPDieselCarPVConfig(SystemSetupConfigBase):
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                     heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
+                    annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
                 )
             ),
             simple_hot_water_storage_config=(

--- a/system_setups/household_2_advanced_hp_diesel_car_pv.py
+++ b/system_setups/household_2_advanced_hp_diesel_car_pv.py
@@ -380,14 +380,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -418,13 +418,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL],
             source_weight=3,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,

--- a/system_setups/household_2_advanced_hp_diesel_car_pv.py
+++ b/system_setups/household_2_advanced_hp_diesel_car_pv.py
@@ -133,7 +133,7 @@ class HouseholdAdvancedHPDieselCarPVConfig(SystemSetupConfigBase):
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                     heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
-                    annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
+                    building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
                 )
             ),
             simple_hot_water_storage_config=(

--- a/system_setups/household_3_advanced_hp_diesel_car_pv_battery.py
+++ b/system_setups/household_3_advanced_hp_diesel_car_pv_battery.py
@@ -257,8 +257,7 @@ def setup_function(
 
     # Build heat Distribution System Controller
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        config=my_config.hds_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.hds_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -275,14 +274,12 @@ def setup_function(
 
     # Build PV
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_config.pv_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.pv_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Building
     my_building = building.Building(
-        config=my_config.building_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.building_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -295,8 +292,7 @@ def setup_function(
     my_heat_pump_controller_config.name = "HeatPumpHplibController"
 
     my_heat_pump_controller = advanced_heat_pump_hplib.HeatPumpHplibController(
-        config=my_heat_pump_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Pump
@@ -304,14 +300,12 @@ def setup_function(
     my_heat_pump_config.name = "HeatPumpHPLib"
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Water Storage
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_config.simple_hot_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.simple_hot_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build DHW
@@ -330,8 +324,7 @@ def setup_function(
     )
 
     my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -361,20 +354,17 @@ def setup_function(
 
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_meter_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_meter_config,
     )
 
     # Build EMS
     my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_controller_config,
     )
 
     # Build Battery
     my_advanced_battery = advanced_battery_bslib.Battery(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.advanced_battery_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.advanced_battery_config,
     )
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -401,20 +391,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -445,19 +429,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
             source_weight=3,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -509,10 +487,7 @@ def setup_function(
 
     electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[
-            lt.ComponentType.BATTERY,
-            lt.InandOutputType.ELECTRICITY_TARGET,
-        ],
+        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
         source_weight=4,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,

--- a/system_setups/household_3_advanced_hp_diesel_car_pv_battery.py
+++ b/system_setups/household_3_advanced_hp_diesel_car_pv_battery.py
@@ -136,7 +136,7 @@ class HouseholdAdvancedHPDieselCarPVBatteryConfig(SystemSetupConfigBase):
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                     heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
-                    annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
+                    building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
                 )
             ),
             simple_hot_water_storage_config=(

--- a/system_setups/household_3_advanced_hp_diesel_car_pv_battery.py
+++ b/system_setups/household_3_advanced_hp_diesel_car_pv_battery.py
@@ -136,6 +136,7 @@ class HouseholdAdvancedHPDieselCarPVBatteryConfig(SystemSetupConfigBase):
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                     heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
+                    annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
                 )
             ),
             simple_hot_water_storage_config=(

--- a/system_setups/household_3_advanced_hp_diesel_car_pv_battery.py
+++ b/system_setups/household_3_advanced_hp_diesel_car_pv_battery.py
@@ -391,14 +391,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -429,13 +429,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL],
             source_weight=3,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -487,7 +487,7 @@ def setup_function(
 
     electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
+        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET],
         source_weight=4,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,

--- a/system_setups/household_4a_with_car_priority_advanced_hp_ev_pv.py
+++ b/system_setups/household_4a_with_car_priority_advanced_hp_ev_pv.py
@@ -140,6 +140,7 @@ class HouseholdAdvancedHPEvPvConfig(SystemSetupConfigBase):
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                     heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
+                    annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
                 )
             ),
             simple_hot_water_storage_config=(

--- a/system_setups/household_4a_with_car_priority_advanced_hp_ev_pv.py
+++ b/system_setups/household_4a_with_car_priority_advanced_hp_ev_pv.py
@@ -140,7 +140,7 @@ class HouseholdAdvancedHPEvPvConfig(SystemSetupConfigBase):
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                     heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
-                    annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
+                    building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
                 )
             ),
             simple_hot_water_storage_config=(

--- a/system_setups/household_4a_with_car_priority_advanced_hp_ev_pv.py
+++ b/system_setups/household_4a_with_car_priority_advanced_hp_ev_pv.py
@@ -275,8 +275,7 @@ def setup_function(
 
     # Build heat Distribution System Controller
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        config=my_config.hds_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.hds_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -293,14 +292,12 @@ def setup_function(
 
     # Build PV
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_config.pv_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.pv_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Building
     my_building = building.Building(
-        config=my_config.building_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.building_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -313,8 +310,7 @@ def setup_function(
     my_heat_pump_controller_config.name = "HeatPumpHplibController"
 
     my_heat_pump_controller = advanced_heat_pump_hplib.HeatPumpHplibController(
-        config=my_heat_pump_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Pump
@@ -322,14 +318,12 @@ def setup_function(
     my_heat_pump_config.name = "HeatPumpHPLib"
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Water Storage
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_config.simple_hot_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.simple_hot_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build DHW
@@ -348,8 +342,7 @@ def setup_function(
     )
 
     my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -387,8 +380,7 @@ def setup_function(
         my_car_battery_config.source_weight = car.config.source_weight
         my_car_battery_config.name = f"CarBattery_{car_number}"
         my_car_battery = advanced_ev_battery_bslib.CarBattery(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_car_battery_config,
+            my_simulation_parameters=my_simulation_parameters, config=my_car_battery_config,
         )
         my_car_batteries.append(my_car_battery)
 
@@ -401,8 +393,7 @@ def setup_function(
             my_car_battery_controller_config.battery_set = 0.4
 
         my_car_battery_controller = controller_l1_generic_ev_charge.L1Controller(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_car_battery_controller_config,
+            my_simulation_parameters=my_simulation_parameters, config=my_car_battery_controller_config,
         )
         my_car_battery_controllers.append(my_car_battery_controller)
 
@@ -410,14 +401,12 @@ def setup_function(
 
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_meter_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_meter_config,
     )
 
     # Build EMS
     my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_controller_config,
     )
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -434,20 +423,14 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[
-                    lt.ComponentType.CAR_BATTERY,
-                    lt.InandOutputType.ELECTRICITY_REAL,
-                ],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL,],
                 # source_weight=car_battery.source_weight,
                 source_weight=1,
             )
 
             electricity_target = my_electricity_controller.add_component_output(
                 source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-                source_tags=[
-                    lt.ComponentType.CAR_BATTERY,
-                    lt.InandOutputType.ELECTRICITY_TARGET,
-                ],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
                 # source_weight=car_battery_controller.source_weight,
                 source_weight=1,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -465,9 +448,7 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[
-                    lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,
-                ],
+                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
                 source_weight=999,
             )
 
@@ -495,20 +476,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -539,19 +514,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
             source_weight=3,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,

--- a/system_setups/household_4a_with_car_priority_advanced_hp_ev_pv.py
+++ b/system_setups/household_4a_with_car_priority_advanced_hp_ev_pv.py
@@ -423,14 +423,14 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL,],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL],
                 # source_weight=car_battery.source_weight,
                 source_weight=1,
             )
 
             electricity_target = my_electricity_controller.add_component_output(
                 source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET],
                 # source_weight=car_battery_controller.source_weight,
                 source_weight=1,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -448,7 +448,7 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
+                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
                 source_weight=999,
             )
 
@@ -476,14 +476,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -514,13 +514,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL],
             source_weight=3,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,

--- a/system_setups/household_4b_with_heatpump_priority_advanced_hp_ev_pv.py
+++ b/system_setups/household_4b_with_heatpump_priority_advanced_hp_ev_pv.py
@@ -25,9 +25,7 @@ from hisim.components import controller_l2_energy_management_system
 from hisim import utils
 from hisim import loadtypes as lt
 from system_setups.modular_example import cleanup_old_lpg_requests
-from system_setups.household_4a_with_car_priority_advanced_hp_ev_pv import (
-    HouseholdAdvancedHPEvPvConfig,
-)
+from system_setups.household_4a_with_car_priority_advanced_hp_ev_pv import HouseholdAdvancedHPEvPvConfig
 
 __authors__ = "Markus Blasberg"
 __copyright__ = "Copyright 2023, FZJ-IEK-3"
@@ -101,8 +99,7 @@ def setup_function(
 
     # Build heat Distribution System Controller
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        config=my_config.hds_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.hds_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -119,14 +116,12 @@ def setup_function(
 
     # Build PV
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_config.pv_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.pv_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Building
     my_building = building.Building(
-        config=my_config.building_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.building_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -139,8 +134,7 @@ def setup_function(
     my_heat_pump_controller_config.name = "HeatPumpHplibController"
 
     my_heat_pump_controller = advanced_heat_pump_hplib.HeatPumpHplibController(
-        config=my_heat_pump_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Pump
@@ -148,14 +142,12 @@ def setup_function(
     my_heat_pump_config.name = "HeatPumpHPLib"
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Water Storage
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_config.simple_hot_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.simple_hot_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build DHW
@@ -174,8 +166,7 @@ def setup_function(
     )
 
     my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -213,8 +204,7 @@ def setup_function(
         my_car_battery_config.source_weight = car.config.source_weight
         my_car_battery_config.name = f"CarBattery_{car_number}"
         my_car_battery = advanced_ev_battery_bslib.CarBattery(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_car_battery_config,
+            my_simulation_parameters=my_simulation_parameters, config=my_car_battery_config,
         )
         my_car_batteries.append(my_car_battery)
 
@@ -227,8 +217,7 @@ def setup_function(
             my_car_battery_controller_config.battery_set = 0.4
 
         my_car_battery_controller = controller_l1_generic_ev_charge.L1Controller(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_car_battery_controller_config,
+            my_simulation_parameters=my_simulation_parameters, config=my_car_battery_controller_config,
         )
         my_car_battery_controllers.append(my_car_battery_controller)
 
@@ -236,14 +225,12 @@ def setup_function(
 
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_meter_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_meter_config,
     )
 
     # Build EMS
     my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_controller_config,
     )
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -260,20 +247,14 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[
-                    lt.ComponentType.CAR_BATTERY,
-                    lt.InandOutputType.ELECTRICITY_REAL,
-                ],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL,],
                 # source_weight=car_battery.source_weight,
                 source_weight=3,
             )
 
             electricity_target = my_electricity_controller.add_component_output(
                 source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-                source_tags=[
-                    lt.ComponentType.CAR_BATTERY,
-                    lt.InandOutputType.ELECTRICITY_TARGET,
-                ],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
                 # source_weight=car_battery_controller.source_weight,
                 source_weight=3,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -291,9 +272,7 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[
-                    lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,
-                ],
+                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
                 source_weight=999,
             )
 
@@ -321,20 +300,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -365,19 +338,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
             source_weight=1,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
             source_weight=1,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,

--- a/system_setups/household_4b_with_heatpump_priority_advanced_hp_ev_pv.py
+++ b/system_setups/household_4b_with_heatpump_priority_advanced_hp_ev_pv.py
@@ -247,14 +247,14 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL,],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL],
                 # source_weight=car_battery.source_weight,
                 source_weight=3,
             )
 
             electricity_target = my_electricity_controller.add_component_output(
                 source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET],
                 # source_weight=car_battery_controller.source_weight,
                 source_weight=3,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -272,7 +272,7 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
+                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
                 source_weight=999,
             )
 
@@ -300,14 +300,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -338,13 +338,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL],
             source_weight=1,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET],
             source_weight=1,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,

--- a/system_setups/household_5a_with_car_priority_advanced_hp_ev_pv_battery.py
+++ b/system_setups/household_5a_with_car_priority_advanced_hp_ev_pv_battery.py
@@ -145,7 +145,7 @@ class HouseholdAdvancedHpEvPvBatteryConfig(SystemSetupConfigBase):
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                     heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
-                    annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
+                    building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
                 )
             ),
             simple_hot_water_storage_config=(

--- a/system_setups/household_5a_with_car_priority_advanced_hp_ev_pv_battery.py
+++ b/system_setups/household_5a_with_car_priority_advanced_hp_ev_pv_battery.py
@@ -145,6 +145,7 @@ class HouseholdAdvancedHpEvPvBatteryConfig(SystemSetupConfigBase):
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                     heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
+                    annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
                 )
             ),
             simple_hot_water_storage_config=(

--- a/system_setups/household_5a_with_car_priority_advanced_hp_ev_pv_battery.py
+++ b/system_setups/household_5a_with_car_priority_advanced_hp_ev_pv_battery.py
@@ -284,8 +284,7 @@ def setup_function(
 
     # Build heat Distribution System Controller
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        config=my_config.hds_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.hds_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -302,14 +301,12 @@ def setup_function(
 
     # Build PV
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_config.pv_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.pv_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Building
     my_building = building.Building(
-        config=my_config.building_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.building_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -322,8 +319,7 @@ def setup_function(
     my_heat_pump_controller_config.name = "HeatPumpHplibController"
 
     my_heat_pump_controller = advanced_heat_pump_hplib.HeatPumpHplibController(
-        config=my_heat_pump_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Pump
@@ -331,14 +327,12 @@ def setup_function(
     my_heat_pump_config.name = "HeatPumpHPLib"
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Water Storage
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_config.simple_hot_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.simple_hot_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build DHW
@@ -357,8 +351,7 @@ def setup_function(
     )
 
     my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -396,8 +389,7 @@ def setup_function(
         my_car_battery_config.source_weight = car.config.source_weight
         my_car_battery_config.name = f"CarBattery_{car_number}"
         my_car_battery = advanced_ev_battery_bslib.CarBattery(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_car_battery_config,
+            my_simulation_parameters=my_simulation_parameters, config=my_car_battery_config,
         )
         my_car_batteries.append(my_car_battery)
 
@@ -410,8 +402,7 @@ def setup_function(
             my_car_battery_controller_config.battery_set = 0.4
 
         my_car_battery_controller = controller_l1_generic_ev_charge.L1Controller(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_car_battery_controller_config,
+            my_simulation_parameters=my_simulation_parameters, config=my_car_battery_controller_config,
         )
         my_car_battery_controllers.append(my_car_battery_controller)
 
@@ -419,20 +410,17 @@ def setup_function(
 
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_meter_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_meter_config,
     )
 
     # Build EMS
     my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_controller_config,
     )
 
     # Build Battery
     my_advanced_battery = advanced_battery_bslib.Battery(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.advanced_battery_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.advanced_battery_config,
     )
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -449,20 +437,14 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[
-                    lt.ComponentType.CAR_BATTERY,
-                    lt.InandOutputType.ELECTRICITY_REAL,
-                ],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL,],
                 # source_weight=car_battery.source_weight,
                 source_weight=1,
             )
 
             electricity_target = my_electricity_controller.add_component_output(
                 source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-                source_tags=[
-                    lt.ComponentType.CAR_BATTERY,
-                    lt.InandOutputType.ELECTRICITY_TARGET,
-                ],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
                 # source_weight=car_battery_controller.source_weight,
                 source_weight=1,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -480,9 +462,7 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[
-                    lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,
-                ],
+                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
                 source_weight=999,
             )
 
@@ -510,20 +490,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -554,19 +528,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
             source_weight=3,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -618,10 +586,7 @@ def setup_function(
 
     electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[
-            lt.ComponentType.BATTERY,
-            lt.InandOutputType.ELECTRICITY_TARGET,
-        ],
+        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
         source_weight=4,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,

--- a/system_setups/household_5a_with_car_priority_advanced_hp_ev_pv_battery.py
+++ b/system_setups/household_5a_with_car_priority_advanced_hp_ev_pv_battery.py
@@ -437,14 +437,14 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL,],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL],
                 # source_weight=car_battery.source_weight,
                 source_weight=1,
             )
 
             electricity_target = my_electricity_controller.add_component_output(
                 source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET],
                 # source_weight=car_battery_controller.source_weight,
                 source_weight=1,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -462,7 +462,7 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
+                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
                 source_weight=999,
             )
 
@@ -490,14 +490,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -528,13 +528,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL],
             source_weight=3,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -586,7 +586,7 @@ def setup_function(
 
     electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
+        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET],
         source_weight=4,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,

--- a/system_setups/household_5b_with_battery_priority_advanced_hp_ev_pv_battery.py
+++ b/system_setups/household_5b_with_battery_priority_advanced_hp_ev_pv_battery.py
@@ -26,9 +26,7 @@ from hisim.components import controller_l2_energy_management_system
 from hisim import utils
 from hisim import loadtypes as lt
 from system_setups.modular_example import cleanup_old_lpg_requests
-from system_setups.household_5a_with_car_priority_advanced_hp_ev_pv_battery import (
-    HouseholdAdvancedHpEvPvBatteryConfig,
-)
+from system_setups.household_5a_with_car_priority_advanced_hp_ev_pv_battery import HouseholdAdvancedHpEvPvBatteryConfig
 
 __authors__ = "Markus Blasberg"
 __copyright__ = "Copyright 2023, FZJ-IEK-3"
@@ -103,8 +101,7 @@ def setup_function(
 
     # Build heat Distribution System Controller
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        config=my_config.hds_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.hds_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -121,14 +118,12 @@ def setup_function(
 
     # Build PV
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_config.pv_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.pv_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Building
     my_building = building.Building(
-        config=my_config.building_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.building_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -141,8 +136,7 @@ def setup_function(
     my_heat_pump_controller_config.name = "HeatPumpHplibController"
 
     my_heat_pump_controller = advanced_heat_pump_hplib.HeatPumpHplibController(
-        config=my_heat_pump_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Pump
@@ -150,14 +144,12 @@ def setup_function(
     my_heat_pump_config.name = "HeatPumpHPLib"
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Water Storage
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_config.simple_hot_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.simple_hot_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build DHW
@@ -176,8 +168,7 @@ def setup_function(
     )
 
     my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -215,8 +206,7 @@ def setup_function(
         my_car_battery_config.source_weight = car.config.source_weight
         my_car_battery_config.name = f"CarBattery_{car_number}"
         my_car_battery = advanced_ev_battery_bslib.CarBattery(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_car_battery_config,
+            my_simulation_parameters=my_simulation_parameters, config=my_car_battery_config,
         )
         my_car_batteries.append(my_car_battery)
 
@@ -229,8 +219,7 @@ def setup_function(
             my_car_battery_controller_config.battery_set = 0.4
 
         my_car_battery_controller = controller_l1_generic_ev_charge.L1Controller(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_car_battery_controller_config,
+            my_simulation_parameters=my_simulation_parameters, config=my_car_battery_controller_config,
         )
         my_car_battery_controllers.append(my_car_battery_controller)
 
@@ -238,20 +227,17 @@ def setup_function(
 
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_meter_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_meter_config,
     )
 
     # Build EMS
     my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_controller_config,
     )
 
     # Build Battery
     my_advanced_battery = advanced_battery_bslib.Battery(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.advanced_battery_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.advanced_battery_config,
     )
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -268,20 +254,14 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[
-                    lt.ComponentType.CAR_BATTERY,
-                    lt.InandOutputType.ELECTRICITY_REAL,
-                ],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL,],
                 # source_weight=car_battery.source_weight,
                 source_weight=4,
             )
 
             electricity_target = my_electricity_controller.add_component_output(
                 source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-                source_tags=[
-                    lt.ComponentType.CAR_BATTERY,
-                    lt.InandOutputType.ELECTRICITY_TARGET,
-                ],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
                 # source_weight=car_battery_controller.source_weight,
                 source_weight=4,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -299,9 +279,7 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[
-                    lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,
-                ],
+                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
                 source_weight=999,
             )
 
@@ -329,20 +307,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=3,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -373,19 +345,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -437,10 +403,7 @@ def setup_function(
 
     electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[
-            lt.ComponentType.BATTERY,
-            lt.InandOutputType.ELECTRICITY_TARGET,
-        ],
+        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
         source_weight=1,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,

--- a/system_setups/household_5b_with_battery_priority_advanced_hp_ev_pv_battery.py
+++ b/system_setups/household_5b_with_battery_priority_advanced_hp_ev_pv_battery.py
@@ -254,14 +254,14 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL,],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_REAL],
                 # source_weight=car_battery.source_weight,
                 source_weight=4,
             )
 
             electricity_target = my_electricity_controller.add_component_output(
                 source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
+                source_tags=[lt.ComponentType.CAR_BATTERY, lt.InandOutputType.ELECTRICITY_TARGET],
                 # source_weight=car_battery_controller.source_weight,
                 source_weight=4,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -279,7 +279,7 @@ def setup_function(
                 source_component_output=car_battery_controller.BatteryChargingPowerToEMS,
                 source_load_type=lt.LoadTypes.ELECTRICITY,
                 source_unit=lt.Units.WATT,
-                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED,],
+                source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
                 source_weight=999,
             )
 
@@ -307,14 +307,14 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL],
             # source_weight=my_dhw_heatpump_config.source_weight,
             source_weight=3,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -345,13 +345,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL],
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET],
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -403,7 +403,7 @@ def setup_function(
 
     electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
+        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET],
         source_weight=1,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,

--- a/system_setups/household_cluster_advanced_hp_pv_battery_ems.py
+++ b/system_setups/household_cluster_advanced_hp_pv_battery_ems.py
@@ -329,13 +329,13 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL],
             source_weight=1,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET],
             source_weight=1,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -354,13 +354,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL],
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET],
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -379,7 +379,7 @@ def setup_function(
 
         electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -405,7 +405,7 @@ def setup_function(
         # use only default connections of ems and add outputs
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=1,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -415,7 +415,7 @@ def setup_function(
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET],
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -424,7 +424,7 @@ def setup_function(
 
         electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
+            source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,

--- a/system_setups/household_cluster_advanced_hp_pv_battery_ems.py
+++ b/system_setups/household_cluster_advanced_hp_pv_battery_ems.py
@@ -221,6 +221,7 @@ def setup_function(
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
         heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
+        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year
     )
     my_heat_pump_config.group_id = group_id
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius
@@ -240,9 +241,9 @@ def setup_function(
         my_simulation_parameters=my_simulation_parameters,
     )
 
-    # Build Heat Water Storage
+    # Build Heat Water Storage (should scale first normally with max thermal building demand in watt, not with hp power)
     my_simple_heat_water_storage_config = simple_hot_water_storage.SimpleHotWaterStorageConfig.get_scaled_hot_water_storage(
-        max_thermal_power_in_watt_of_heating_system=my_heat_pump_config.set_thermal_output_power_in_watt,
+        max_thermal_power_in_watt_of_heating_system=my_building_information.max_thermal_building_demand_in_watt,  #my_heat_pump_config.set_thermal_output_power_in_watt,
         temperature_difference_between_flow_and_return_in_celsius=my_hds_controller_information.temperature_difference_between_flow_and_return_in_celsius,
         heating_system_name=my_heat_pump.component_name,
         water_mass_flow_rate_from_hds_in_kg_per_second=my_hds_controller_information.water_mass_flow_rate_in_kp_per_second,

--- a/system_setups/household_cluster_advanced_hp_pv_battery_ems.py
+++ b/system_setups/household_cluster_advanced_hp_pv_battery_ems.py
@@ -28,9 +28,7 @@ from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDict
 from hisim.postprocessingoptions import PostProcessingOptions
 from hisim import loadtypes as lt
 from hisim import log
-from system_setups.household_cluster_reference_advanced_hp import (
-    BuildingPVWeatherConfig,
-)
+from system_setups.household_cluster_reference_advanced_hp import BuildingPVWeatherConfig
 
 __authors__ = "Katharina Rieck"
 __copyright__ = "Copyright 2022, FZJ-IEK-3"
@@ -185,8 +183,7 @@ def setup_function(
     my_photovoltaic_system_config.tilt = tilt
 
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_photovoltaic_system_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_photovoltaic_system_config, my_simulation_parameters=my_simulation_parameters,
     )
     # Build Heat Distribution Controller
     my_heat_distribution_controller_config = heat_distribution_system.HeatDistributionControllerConfig.get_default_heat_distribution_controller_config(
@@ -197,8 +194,7 @@ def setup_function(
     )
 
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_heat_distribution_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_heat_distribution_controller_config,
     )
     my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
         config=my_heat_distribution_controller_config
@@ -221,14 +217,13 @@ def setup_function(
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
         heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
-        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year
+        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
     )
     my_heat_pump_config.group_id = group_id
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -237,27 +232,24 @@ def setup_function(
         water_mass_flow_rate_in_kg_per_second=my_hds_controller_information.water_mass_flow_rate_in_kp_per_second,
     )
     my_heat_distribution_system = heat_distribution_system.HeatDistribution(
-        config=my_heat_distribution_system_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_distribution_system_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Water Storage (should scale first normally with max thermal building demand in watt, not with hp power)
     my_simple_heat_water_storage_config = simple_hot_water_storage.SimpleHotWaterStorageConfig.get_scaled_hot_water_storage(
-        max_thermal_power_in_watt_of_heating_system=my_building_information.max_thermal_building_demand_in_watt,  #my_heat_pump_config.set_thermal_output_power_in_watt,
+        max_thermal_power_in_watt_of_heating_system=my_building_information.max_thermal_building_demand_in_watt,  # my_heat_pump_config.set_thermal_output_power_in_watt,
         temperature_difference_between_flow_and_return_in_celsius=my_hds_controller_information.temperature_difference_between_flow_and_return_in_celsius,
         heating_system_name=my_heat_pump.component_name,
         water_mass_flow_rate_from_hds_in_kg_per_second=my_hds_controller_information.water_mass_flow_rate_in_kp_per_second,
     )
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_simple_heat_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_simple_heat_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build EMS
     my_electricity_controller_config = controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
     my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_electricity_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_electricity_controller_config,
     )
 
     # Build Battery
@@ -265,27 +257,20 @@ def setup_function(
         total_pv_power_in_watt_peak=my_photovoltaic_system_config.power_in_watt
     )
     my_advanced_battery = advanced_battery_bslib.Battery(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_advanced_battery_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_advanced_battery_config,
     )
 
     # Build DHW (this is taken from household_3_advanced_hp_diesel-car_pv_battery.py)
     my_dhw_heatpump_config = generic_heat_pump_modular.HeatPumpConfig.get_scaled_waterheating_to_number_of_apartments(
-        number_of_apartments=my_building_information.number_of_apartments,
-        default_power_in_watt=6000,
+        number_of_apartments=my_building_information.number_of_apartments, default_power_in_watt=6000,
     )
 
-    my_dhw_heatpump_controller_config = (
-        controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
-            name="DHWHeatpumpController"
-        )
+    my_dhw_heatpump_controller_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
+        name="DHWHeatpumpController"
     )
 
-    my_dhw_storage_config = (
-        generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
-            number_of_apartments=my_building_information.number_of_apartments,
-            default_volume_in_liter=450,
-        )
+    my_dhw_storage_config = generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
+        number_of_apartments=my_building_information.number_of_apartments, default_volume_in_liter=450,
     )
     my_dhw_storage_config.compute_default_cycle(
         temperature_difference_in_kelvin=my_dhw_heatpump_controller_config.t_max_heating_in_celsius
@@ -297,8 +282,7 @@ def setup_function(
     )
 
     my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -345,19 +329,13 @@ def setup_function(
             source_component_output=my_domnestic_hot_water_heatpump.ElectricityOutput,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_REAL,],
             source_weight=1,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
             source_weight=1,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -376,19 +354,13 @@ def setup_function(
             source_component_output=my_heat_pump.ElectricalInputPower,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_REAL,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_REAL,],
             source_weight=2,
         )
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -407,10 +379,7 @@ def setup_function(
 
         electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.BATTERY,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -436,10 +405,7 @@ def setup_function(
         # use only default connections of ems and add outputs
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_DHW,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
             # source_weight=my_domnestic_hot_water_heatpump.config.source_weight,
             source_weight=1,
             source_load_type=lt.LoadTypes.ELECTRICITY,
@@ -449,10 +415,7 @@ def setup_function(
 
         my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.HEAT_PUMP_BUILDING,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
             source_weight=2,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -461,10 +424,7 @@ def setup_function(
 
         electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
             source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-            source_tags=[
-                lt.ComponentType.BATTERY,
-                lt.InandOutputType.ELECTRICITY_TARGET,
-            ],
+            source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
             source_weight=3,
             source_load_type=lt.LoadTypes.ELECTRICITY,
             source_unit=lt.Units.WATT,
@@ -518,8 +478,7 @@ def setup_function(
         sorting_option = SortingOptionEnum.MASS_SIMULATION_WITH_HASH_ENUMERATION
 
         SingletonSimRepository().set_entry(
-            key=SingletonDictKeyEnum.RESULT_SCENARIO_NAME,
-            entry=f"surplus_modifier_{hash_number}",
+            key=SingletonDictKeyEnum.RESULT_SCENARIO_NAME, entry=f"surplus_modifier_{hash_number}",
         )
 
     # if config_filename is not given, make result path with index enumeration

--- a/system_setups/household_cluster_advanced_hp_pv_battery_ems.py
+++ b/system_setups/household_cluster_advanced_hp_pv_battery_ems.py
@@ -217,7 +217,7 @@ def setup_function(
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
         heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
-        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
+        building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
     )
     my_heat_pump_config.group_id = group_id
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius

--- a/system_setups/household_cluster_reference_advanced_hp.py
+++ b/system_setups/household_cluster_reference_advanced_hp.py
@@ -229,7 +229,7 @@ def setup_function(
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
         heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
-        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
+        building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
     )
     my_heat_pump_config.group_id = group_id
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius

--- a/system_setups/household_cluster_reference_advanced_hp.py
+++ b/system_setups/household_cluster_reference_advanced_hp.py
@@ -207,8 +207,7 @@ def setup_function(
     )
 
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_heat_distribution_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_heat_distribution_controller_config,
     )
     my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
         config=my_heat_distribution_controller_config
@@ -236,8 +235,7 @@ def setup_function(
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -246,8 +244,7 @@ def setup_function(
         water_mass_flow_rate_in_kg_per_second=my_hds_controller_information.water_mass_flow_rate_in_kp_per_second,
     )
     my_heat_distribution_system = heat_distribution_system.HeatDistribution(
-        config=my_heat_distribution_system_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_distribution_system_config, my_simulation_parameters=my_simulation_parameters,
     )
     # Build Heat Water Storage
     my_simple_heat_water_storage_config = simple_hot_water_storage.SimpleHotWaterStorageConfig.get_scaled_hot_water_storage(
@@ -257,27 +254,20 @@ def setup_function(
         water_mass_flow_rate_from_hds_in_kg_per_second=my_hds_controller_information.water_mass_flow_rate_in_kp_per_second,
     )
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_simple_heat_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_simple_heat_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build DHW (this is taken from household_3_advanced_hp_diesel-car_pv_battery.py)
     my_dhw_heatpump_config = generic_heat_pump_modular.HeatPumpConfig.get_scaled_waterheating_to_number_of_apartments(
-        number_of_apartments=my_building_information.number_of_apartments,
-        default_power_in_watt=6000,
+        number_of_apartments=my_building_information.number_of_apartments, default_power_in_watt=6000,
     )
 
-    my_dhw_heatpump_controller_config = (
-        controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
-            name="DHWHeatpumpController"
-        )
+    my_dhw_heatpump_controller_config = controller_l1_heatpump.L1HeatPumpConfig.get_default_config_heat_source_controller_dhw(
+        name="DHWHeatpumpController"
     )
 
-    my_dhw_storage_config = (
-        generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
-            number_of_apartments=my_building_information.number_of_apartments,
-            default_volume_in_liter=450,
-        )
+    my_dhw_storage_config = generic_hot_water_storage_modular.StorageConfig.get_scaled_config_for_boiler_to_number_of_apartments(
+        number_of_apartments=my_building_information.number_of_apartments, default_volume_in_liter=450,
     )
     my_dhw_storage_config.compute_default_cycle(
         temperature_difference_in_kelvin=my_dhw_heatpump_controller_config.t_max_heating_in_celsius
@@ -289,8 +279,7 @@ def setup_function(
     )
 
     my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -328,8 +317,7 @@ def setup_function(
         sorting_option = SortingOptionEnum.MASS_SIMULATION_WITH_HASH_ENUMERATION
 
         SingletonSimRepository().set_entry(
-            key=SingletonDictKeyEnum.RESULT_SCENARIO_NAME,
-            entry=f"ref_{hash_number}",
+            key=SingletonDictKeyEnum.RESULT_SCENARIO_NAME, entry=f"ref_{hash_number}",
         )
 
     # if config_filename is not given, make result path with index enumeration

--- a/system_setups/household_cluster_reference_advanced_hp.py
+++ b/system_setups/household_cluster_reference_advanced_hp.py
@@ -230,6 +230,7 @@ def setup_function(
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
         heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
+        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
     )
     my_heat_pump_config.group_id = group_id
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius

--- a/system_setups/household_gas_heater.py
+++ b/system_setups/household_gas_heater.py
@@ -219,8 +219,7 @@ def setup_function(
     """
     # Heat Distribution System Controller
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        config=my_config.hds_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.hds_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Occupancy
@@ -252,8 +251,7 @@ def setup_function(
 
     # Gas Heater Controller
     my_gas_heater_controller = controller_l1_generic_gas_heater.GenericGasHeaterControllerL1(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.gas_heater_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.gas_heater_controller_config,
     )
 
     # Gas heater
@@ -290,8 +288,7 @@ def setup_function(
         my_display_config=DisplayConfig.show("Warmwasserspeicher"),
     )
     my_domestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
     my_domestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
         config=my_dhw_heatpump_config,

--- a/system_setups/household_heat_pump.py
+++ b/system_setups/household_heat_pump.py
@@ -156,6 +156,7 @@ class HouseholdHeatPumpConfig(SystemSetupConfigBase):
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                     heating_reference_temperature_in_celsius=my_building_information.heating_reference_temperature_in_celsius,
+                    annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
                 )
             ),
             simple_hot_water_storage_config=(

--- a/system_setups/household_heat_pump.py
+++ b/system_setups/household_heat_pump.py
@@ -86,9 +86,7 @@ class HouseholdHeatPumpConfig(SystemSetupConfigBase):
 
     @classmethod
     def get_scaled_default(
-        cls,
-        building_config: building.BuildingConfig,
-        options: HouseholdHeatPumpOptions = HouseholdHeatPumpOptions(),
+        cls, building_config: building.BuildingConfig, options: HouseholdHeatPumpOptions = HouseholdHeatPumpOptions(),
     ) -> "HouseholdHeatPumpConfig":
         """Get scaled HouseholdHeatPumpConfig.
 
@@ -156,7 +154,7 @@ class HouseholdHeatPumpConfig(SystemSetupConfigBase):
                 advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
                     heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
                     heating_reference_temperature_in_celsius=my_building_information.heating_reference_temperature_in_celsius,
-                    annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
+                    building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
                 )
             ),
             simple_hot_water_storage_config=(
@@ -223,8 +221,7 @@ def setup_function(
     """
     # Heat Distribution System Controller
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        config=my_config.hds_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.hds_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Occupancy
@@ -256,8 +253,7 @@ def setup_function(
 
     # Advanced Heat Pump Controller
     my_heat_pump_controller = advanced_heat_pump_hplib.HeatPumpHplibController(
-        config=my_config.hp_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.hp_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Advanced Heat Pump
@@ -294,8 +290,7 @@ def setup_function(
         my_display_config=DisplayConfig.show("Warmwasserspeicher"),
     )
     my_domestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
     my_domestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
         config=my_dhw_heatpump_config,

--- a/system_setups/household_reference_gas_heater_diesel_car.py
+++ b/system_setups/household_reference_gas_heater_diesel_car.py
@@ -213,8 +213,7 @@ def setup_function(
 
     # Build heat Distribution System Controller
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        config=my_config.hds_controller_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.hds_controller_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Occupancy
@@ -231,20 +230,17 @@ def setup_function(
 
     # Build Building
     my_building = building.Building(
-        config=my_config.building_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.building_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Gas Heater Controller
     my_gasheater_controller = controller_l1_generic_gas_heater.GenericGasHeaterControllerL1(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.gasheater_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.gasheater_controller_config,
     )
 
     # Build Gasheater
     my_gasheater = generic_gas_heater.GasHeater(
-        config=my_config.gasheater_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.gasheater_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -254,8 +250,7 @@ def setup_function(
 
     # Build Heat Water Storage
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_config.simple_hot_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_config.simple_hot_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build DHW
@@ -274,8 +269,7 @@ def setup_function(
     )
 
     my_domnestic_hot_water_heatpump_controller = controller_l1_heatpump.L1HeatPumpController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_dhw_heatpump_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_dhw_heatpump_controller_config,
     )
 
     my_domnestic_hot_water_heatpump = generic_heat_pump_modular.ModularHeatPump(
@@ -305,8 +299,7 @@ def setup_function(
 
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_config.electricity_meter_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_config.electricity_meter_config,
     )
 
     # =================================================================================================================================

--- a/system_setups/household_with_advanced_hp_hws_hds_pv_battery_ems.py
+++ b/system_setups/household_with_advanced_hp_hws_hds_pv_battery_ems.py
@@ -100,8 +100,7 @@ def setup_function(
     )
 
     my_photovoltaic_system = generic_pv_system.PVSystem(
-        config=my_photovoltaic_system_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_photovoltaic_system_config, my_simulation_parameters=my_simulation_parameters,
     )
     # Build Heat Distribution Controller
     my_heat_distribution_controller_config = heat_distribution_system.HeatDistributionControllerConfig.get_default_heat_distribution_controller_config(
@@ -112,8 +111,7 @@ def setup_function(
     )
 
     my_heat_distribution_controller = heat_distribution_system.HeatDistributionController(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_heat_distribution_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_heat_distribution_controller_config,
     )
     my_hds_controller_information = heat_distribution_system.HeatDistributionControllerInformation(
         config=my_heat_distribution_controller_config
@@ -142,8 +140,7 @@ def setup_function(
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius
 
     my_heat_pump = advanced_heat_pump_hplib.HeatPumpHplib(
-        config=my_heat_pump_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_pump_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Distribution System
@@ -152,8 +149,7 @@ def setup_function(
         water_mass_flow_rate_in_kg_per_second=my_hds_controller_information.water_mass_flow_rate_in_kp_per_second,
     )
     my_heat_distribution_system = heat_distribution_system.HeatDistribution(
-        config=my_heat_distribution_system_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_heat_distribution_system_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build Heat Water Storage
@@ -164,15 +160,13 @@ def setup_function(
         water_mass_flow_rate_from_hds_in_kg_per_second=my_hds_controller_information.water_mass_flow_rate_in_kp_per_second,
     )
     my_simple_hot_water_storage = simple_hot_water_storage.SimpleHotWaterStorage(
-        config=my_simple_heat_water_storage_config,
-        my_simulation_parameters=my_simulation_parameters,
+        config=my_simple_heat_water_storage_config, my_simulation_parameters=my_simulation_parameters,
     )
 
     # Build EMS
     my_electricity_controller_config = controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
     my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_electricity_controller_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_electricity_controller_config,
     )
 
     # Build Battery
@@ -180,8 +174,7 @@ def setup_function(
         total_pv_power_in_watt_peak=my_photovoltaic_system_config.power_in_watt
     )
     my_advanced_battery = advanced_battery_bslib.Battery(
-        my_simulation_parameters=my_simulation_parameters,
-        config=my_advanced_battery_config,
+        my_simulation_parameters=my_simulation_parameters, config=my_advanced_battery_config,
     )
 
     # -----------------------------------------------------------------------------------------------------------------
@@ -189,10 +182,7 @@ def setup_function(
 
     my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[
-            lt.ComponentType.HEAT_PUMP_DHW,
-            lt.InandOutputType.ELECTRICITY_TARGET,
-        ],
+        source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
         source_weight=1,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
@@ -201,10 +191,7 @@ def setup_function(
 
     my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[
-            lt.ComponentType.HEAT_PUMP_BUILDING,
-            lt.InandOutputType.ELECTRICITY_TARGET,
-        ],
+        source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
         source_weight=2,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
@@ -213,10 +200,7 @@ def setup_function(
 
     electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[
-            lt.ComponentType.BATTERY,
-            lt.InandOutputType.ELECTRICITY_TARGET,
-        ],
+        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
         source_weight=3,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,

--- a/system_setups/household_with_advanced_hp_hws_hds_pv_battery_ems.py
+++ b/system_setups/household_with_advanced_hp_hws_hds_pv_battery_ems.py
@@ -134,7 +134,7 @@ def setup_function(
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
         heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
-        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
+        building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
     )
     my_heat_pump_config.group_id = group_id
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius

--- a/system_setups/household_with_advanced_hp_hws_hds_pv_battery_ems.py
+++ b/system_setups/household_with_advanced_hp_hws_hds_pv_battery_ems.py
@@ -182,7 +182,7 @@ def setup_function(
 
     my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET,],
+        source_tags=[lt.ComponentType.HEAT_PUMP_DHW, lt.InandOutputType.ELECTRICITY_TARGET],
         source_weight=1,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
@@ -191,7 +191,7 @@ def setup_function(
 
     my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET,],
+        source_tags=[lt.ComponentType.HEAT_PUMP_BUILDING, lt.InandOutputType.ELECTRICITY_TARGET],
         source_weight=2,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,
@@ -200,7 +200,7 @@ def setup_function(
 
     electricity_to_or_from_battery_target = my_electricity_controller.add_component_output(
         source_output_name=lt.InandOutputType.ELECTRICITY_TARGET,
-        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET,],
+        source_tags=[lt.ComponentType.BATTERY, lt.InandOutputType.ELECTRICITY_TARGET],
         source_weight=3,
         source_load_type=lt.LoadTypes.ELECTRICITY,
         source_unit=lt.Units.WATT,

--- a/system_setups/household_with_advanced_hp_hws_hds_pv_battery_ems.py
+++ b/system_setups/household_with_advanced_hp_hws_hds_pv_battery_ems.py
@@ -136,6 +136,7 @@ def setup_function(
     my_heat_pump_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_building_information.max_thermal_building_demand_in_watt,
         heating_reference_temperature_in_celsius=heating_reference_temperature_in_celsius,
+        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_building_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
     )
     my_heat_pump_config.group_id = group_id
     my_heat_pump_config.flow_temperature_in_celsius = flow_temperature_in_celsius

--- a/system_setups/modular_example.py
+++ b/system_setups/modular_example.py
@@ -530,6 +530,6 @@ def needs_ems(  # pylint: disable=R0911
     if heating_system_installed in [
         lt.HeatingSystems.HEAT_PUMP,
         lt.HeatingSystems.ELECTRIC_HEATING,
-    ] or water_heating_system_installed in [lt.HeatingSystems.HEAT_PUMP, lt.HeatingSystems.ELECTRIC_HEATING,]:
+    ] or water_heating_system_installed in [lt.HeatingSystems.HEAT_PUMP, lt.HeatingSystems.ELECTRIC_HEATING]:
         return True
     return False

--- a/system_setups/modular_example.py
+++ b/system_setups/modular_example.py
@@ -23,9 +23,7 @@ from hisim.components import (
     weather,
 )
 from hisim.modular_household import component_connections
-from hisim.modular_household.interface_configs.modular_household_config import (
-    read_in_configs,
-)
+from hisim.modular_household.interface_configs.modular_household_config import read_in_configs
 from hisim.postprocessingoptions import PostProcessingOptions
 from hisim.simulator import SimulationParameters
 from obsolete import loadprofilegenerator_connector
@@ -54,9 +52,7 @@ def cleanup_old_lpg_requests():
             os.remove(full_file_path)
 
 
-def get_heating_reference_temperature_and_season_from_location(
-    location: str,
-) -> Tuple[float, List[int]]:
+def get_heating_reference_temperature_and_season_from_location(location: str,) -> Tuple[float, List[int]]:
     """Reads in temperature of coldest day for sizing of heating system and heating season for control of the heating system.
 
     Both relies on the location.
@@ -183,10 +179,9 @@ def setup_function(
     my_sim.add_component(my_weather)
 
     # Build building
-    (
-        reference_temperature,
-        heating_season,
-    ) = get_heating_reference_temperature_and_season_from_location(location=location)
+    (reference_temperature, heating_season,) = get_heating_reference_temperature_and_season_from_location(
+        location=location
+    )
 
     my_building_config = building.BuildingConfig(
         name="Building_1",
@@ -235,8 +230,7 @@ def setup_function(
         )
 
         my_occupancy = loadprofilegenerator_utsp_connector.UtspLpgConnector(
-            config=my_occupancy_config,
-            my_simulation_parameters=my_simulation_parameters,
+            config=my_occupancy_config, my_simulation_parameters=my_simulation_parameters,
         )
 
     else:
@@ -251,8 +245,7 @@ def setup_function(
             predictive_control=False,
         )
         my_occupancy = loadprofilegenerator_connector.Occupancy(
-            config=my_occupancy_config,
-            my_simulation_parameters=my_simulation_parameters,
+            config=my_occupancy_config, my_simulation_parameters=my_simulation_parameters,
         )
 
     my_building.connect_only_predefined_connections(my_weather, my_occupancy)
@@ -314,8 +307,7 @@ def setup_function(
     ):
         my_electricity_controller_config = controller_l2_energy_management_system.EMSConfig.get_default_config_ems()
         my_electricity_controller = controller_l2_energy_management_system.L2GenericEnergyManagementSystem(
-            my_simulation_parameters=my_simulation_parameters,
-            config=my_electricity_controller_config,
+            my_simulation_parameters=my_simulation_parameters, config=my_electricity_controller_config,
         )
 
         my_electricity_controller.add_component_inputs_and_connect(
@@ -353,8 +345,7 @@ def setup_function(
     # use clever controller if smart devices are included and do not use it if it is false
     if smart_devices_included and controllable and utsp_connected:
         component_connections.configure_smart_controller_for_smart_devices(
-            my_electricity_controller=my_electricity_controller,
-            my_smart_devices=my_smart_devices,
+            my_electricity_controller=my_electricity_controller, my_smart_devices=my_smart_devices,
         )
 
     # """WATERHEATING"""
@@ -390,11 +381,7 @@ def setup_function(
             lt.HeatingSystems.HEAT_PUMP,
             lt.HeatingSystems.ELECTRIC_HEATING,
         ]:
-            (
-                _,
-                my_buffer,
-                count,
-            ) = component_connections.configure_heating_with_buffer_electric(
+            (_, my_buffer, count,) = component_connections.configure_heating_with_buffer_electric(
                 my_sim=my_sim,
                 my_simulation_parameters=my_simulation_parameters,
                 my_building=my_building,
@@ -408,11 +395,7 @@ def setup_function(
                 count=count,
             )
         else:
-            (
-                _,
-                my_buffer,
-                count,
-            ) = component_connections.configure_heating_with_buffer(
+            (_, my_buffer, count,) = component_connections.configure_heating_with_buffer(
                 my_sim=my_sim,
                 my_simulation_parameters=my_simulation_parameters,
                 my_building=my_building,
@@ -547,9 +530,6 @@ def needs_ems(  # pylint: disable=R0911
     if heating_system_installed in [
         lt.HeatingSystems.HEAT_PUMP,
         lt.HeatingSystems.ELECTRIC_HEATING,
-    ] or water_heating_system_installed in [
-        lt.HeatingSystems.HEAT_PUMP,
-        lt.HeatingSystems.ELECTRIC_HEATING,
-    ]:
+    ] or water_heating_system_installed in [lt.HeatingSystems.HEAT_PUMP, lt.HeatingSystems.ELECTRIC_HEATING,]:
         return True
     return False

--- a/system_setups/power_to_x_transformation_battery_electrolyzer_grid.py
+++ b/system_setups/power_to_x_transformation_battery_electrolyzer_grid.py
@@ -118,8 +118,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     csv_loader = CSVLoader(my_csv_loader, my_simulation_parameters=my_simulation_parameters)
 
     my_transformer = Transformer(
-        my_simulation_parameters=my_simulation_parameters,
-        config=TransformerConfig.get_default_transformer(),
+        my_simulation_parameters=my_simulation_parameters, config=TransformerConfig.get_default_transformer(),
     )
     # Setup the battery
     """
@@ -163,9 +162,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     my_transformer.connect_input(my_transformer.TransformerInput, csv_loader.component_name, csv_loader.Output1)
 
     my_ptx_controller.connect_input(
-        my_ptx_controller.RESLoad,
-        my_transformer.component_name,
-        my_transformer.TransformerOutput,
+        my_ptx_controller.RESLoad, my_transformer.component_name, my_transformer.TransformerOutput,
     )
     """
     my_ptx_controller.connect_input(
@@ -181,9 +178,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     )
     """
     my_electrolyzer_controller.connect_input(
-        my_electrolyzer_controller.ProvidedLoad,
-        my_ptx_controller.component_name,
-        my_ptx_controller.PowerToSystem,
+        my_electrolyzer_controller.ProvidedLoad, my_ptx_controller.component_name, my_ptx_controller.PowerToSystem,
     )
 
     my_electrolyzer.connect_input(
@@ -193,9 +188,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     )
 
     my_electrolyzer.connect_input(
-        my_electrolyzer.InputState,
-        my_electrolyzer_controller.component_name,
-        my_electrolyzer_controller.CurrentMode,
+        my_electrolyzer.InputState, my_electrolyzer_controller.component_name, my_electrolyzer_controller.CurrentMode,
     )
 
     # =================================================================================================================================

--- a/system_setups/power_to_x_transformation_battery_electrolyzer_no_grid.py
+++ b/system_setups/power_to_x_transformation_battery_electrolyzer_no_grid.py
@@ -117,8 +117,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     csv_loader = CSVLoader(my_csv_loader, my_simulation_parameters=my_simulation_parameters)
 
     my_transformer = Transformer(
-        my_simulation_parameters=my_simulation_parameters,
-        config=TransformerConfig.get_default_transformer(),
+        my_simulation_parameters=my_simulation_parameters, config=TransformerConfig.get_default_transformer(),
     )
     # Setup the battery
     """
@@ -162,9 +161,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     my_transformer.connect_input(my_transformer.TransformerInput, csv_loader.component_name, csv_loader.Output1)
 
     my_ptx_controller.connect_input(
-        my_ptx_controller.RESLoad,
-        my_transformer.component_name,
-        my_transformer.TransformerOutput,
+        my_ptx_controller.RESLoad, my_transformer.component_name, my_transformer.TransformerOutput,
     )
     """
     my_ptx_controller.connect_input(
@@ -180,9 +177,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     )
     """
     my_electrolyzer_controller.connect_input(
-        my_electrolyzer_controller.ProvidedLoad,
-        my_ptx_controller.component_name,
-        my_ptx_controller.PowerToSystem,
+        my_electrolyzer_controller.ProvidedLoad, my_ptx_controller.component_name, my_ptx_controller.PowerToSystem,
     )
 
     my_electrolyzer.connect_input(
@@ -192,9 +187,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     )
 
     my_electrolyzer.connect_input(
-        my_electrolyzer.InputState,
-        my_electrolyzer_controller.component_name,
-        my_electrolyzer_controller.CurrentMode,
+        my_electrolyzer.InputState, my_electrolyzer_controller.component_name, my_electrolyzer_controller.CurrentMode,
     )
 
     # =================================================================================================================================

--- a/system_setups/simple_system_setup_one.py
+++ b/system_setups/simple_system_setup_one.py
@@ -34,10 +34,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     # Create first RandomNumbers object and adds to simulator
     my_rn1 = RandomNumbers(
         config=RandomNumbersConfig(
-            name="Random numbers 100-200",
-            timesteps=my_simulation_parameters.timesteps,
-            minimum=100,
-            maximum=200,
+            name="Random numbers 100-200", timesteps=my_simulation_parameters.timesteps, minimum=100, maximum=200,
         ),
         my_simulation_parameters=my_simulation_parameters,
     )
@@ -46,10 +43,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     # Create second RandomNumbers object and adds to simulator
     my_rn2 = RandomNumbers(
         config=RandomNumbersConfig(
-            name="Random numbers 10-20",
-            timesteps=my_simulation_parameters.timesteps,
-            minimum=10,
-            maximum=20,
+            name="Random numbers 10-20", timesteps=my_simulation_parameters.timesteps, minimum=10, maximum=20,
         ),
         my_simulation_parameters=my_simulation_parameters,
     )
@@ -57,18 +51,13 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
 
     # Create sum builder object
     my_sum = SumBuilderForTwoInputs(
-        config=SumBuilderConfig.get_sumbuilder_default_config(),
-        my_simulation_parameters=my_simulation_parameters,
+        config=SumBuilderConfig.get_sumbuilder_default_config(), my_simulation_parameters=my_simulation_parameters,
     )
     # Connect inputs from sum object to both previous outputs
     my_sum.connect_input(
-        input_fieldname=my_sum.SumInput1,
-        src_object_name=my_rn1.component_name,
-        src_field_name=my_rn1.RandomOutput,
+        input_fieldname=my_sum.SumInput1, src_object_name=my_rn1.component_name, src_field_name=my_rn1.RandomOutput,
     )
     my_sum.connect_input(
-        input_fieldname=my_sum.SumInput2,
-        src_object_name=my_rn2.component_name,
-        src_field_name=my_rn2.RandomOutput,
+        input_fieldname=my_sum.SumInput2, src_object_name=my_rn2.component_name, src_field_name=my_rn2.RandomOutput,
     )
     my_sim.add_component(my_sum)

--- a/system_setups/simple_system_setup_two.py
+++ b/system_setups/simple_system_setup_two.py
@@ -40,10 +40,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     # Create first RandomNumbers object and adds to simulator
     my_rn1 = RandomNumbers(
         config=RandomNumbersConfig(
-            name="Random numbers 100-200",
-            timesteps=my_simulation_parameters.timesteps,
-            minimum=100,
-            maximum=200,
+            name="Random numbers 100-200", timesteps=my_simulation_parameters.timesteps, minimum=100, maximum=200,
         ),
         my_simulation_parameters=my_simulation_parameters,
     )
@@ -52,10 +49,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     # Create second RandomNumbers object and adds to simulator
     my_rn2 = RandomNumbers(
         config=RandomNumbersConfig(
-            name="Random numbers 10-20",
-            timesteps=my_simulation_parameters.timesteps,
-            minimum=10,
-            maximum=20,
+            name="Random numbers 10-20", timesteps=my_simulation_parameters.timesteps, minimum=10, maximum=20,
         ),
         my_simulation_parameters=my_simulation_parameters,
     )
@@ -64,8 +58,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     # Create new Transformer object
     # my_transformer = Transformer(name="MyTransformer", my_simulation_parameters=my_simulation_parameters)
     my_transformer = ExampleTransformer(
-        config=ExampleTransformerConfig.get_default_transformer(),
-        my_simulation_parameters=my_simulation_parameters,
+        config=ExampleTransformerConfig.get_default_transformer(), my_simulation_parameters=my_simulation_parameters,
     )
     my_transformer.connect_input(
         input_fieldname=my_transformer.TransformerInput,  # Connect input from my transformer
@@ -76,14 +69,11 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
 
     # Create sum builder object
     my_sum = SumBuilderForTwoInputs(
-        config=SumBuilderConfig.get_sumbuilder_default_config(),
-        my_simulation_parameters=my_simulation_parameters,
+        config=SumBuilderConfig.get_sumbuilder_default_config(), my_simulation_parameters=my_simulation_parameters,
     )
     # Connect inputs from sum object to both previous outputs
     my_sum.connect_input(
-        input_fieldname=my_sum.SumInput1,
-        src_object_name=my_rn1.component_name,
-        src_field_name=my_rn1.RandomOutput,
+        input_fieldname=my_sum.SumInput1, src_object_name=my_rn1.component_name, src_field_name=my_rn1.RandomOutput,
     )
     my_sum.connect_input(
         input_fieldname=my_sum.SumInput2,

--- a/tests/test_electricity_meter.py
+++ b/tests/test_electricity_meter.py
@@ -177,9 +177,9 @@ def test_house(
     with open(os.path.join(my_sim._simulation_parameters.result_directory, "all_kpis.json"), "r", encoding="utf-8") as file:  # pylint: disable=W0212
         jsondata = json.load(file)
 
-    cumulative_consumption_kpi_in_kilowatt_hour = jsondata["Consumption"].get("value")
+    cumulative_consumption_kpi_in_kilowatt_hour = jsondata["Total electricity consumption"].get("value")
 
-    cumulative_production_kpi_in_kilowatt_hour = jsondata["Production"].get("value")
+    cumulative_production_kpi_in_kilowatt_hour = jsondata["Total electricity production"].get("value")
 
     # simualtion results from grid energy balancer (last entry)
     simulation_results_electricity_meter_cumulative_production_in_watt_hour = (

--- a/tests/test_sizing_energy_systems.py
+++ b/tests/test_sizing_energy_systems.py
@@ -191,7 +191,7 @@ def simulation_for_one_timestep(
     # Set hplib
     my_hplib_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
         heating_load_of_building_in_watt=my_residence_information.max_thermal_building_demand_in_watt,
-        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_residence_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
+        building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_residence_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
     )
 
     # Set Hot Water Storage

--- a/tests/test_sizing_energy_systems.py
+++ b/tests/test_sizing_energy_systems.py
@@ -190,7 +190,8 @@ def simulation_for_one_timestep(
 
     # Set hplib
     my_hplib_config = advanced_heat_pump_hplib.HeatPumpHplibConfig.get_scaled_advanced_hp_lib(
-        heating_load_of_building_in_watt=my_residence_information.max_thermal_building_demand_in_watt
+        heating_load_of_building_in_watt=my_residence_information.max_thermal_building_demand_in_watt,
+        annual_building_heating_demand_in_kilowatt_hour_per_m2_per_year=my_residence_information.energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
     )
 
     # Set Hot Water Storage


### PR DESCRIPTION
- problem was: 12% of all buildings in mass simulations (all building types and sizes) were too cold (Tmin < 14°C)
- the buildings that were too cold were the ones with high heating demands (elder, no refurbished houses)

- problem solution: scale heat pump power up for building heating demand over 130 kWh/m2a and even more for heating demands higher than 200 kWh/m2a (see advanced heat pump hplib)

- result: after the changes, no house was too cold anymore!

- sample tested for this purpose: 1000 randomly generated houses of all types and sizes