### PR TITLE
Correction in input date for specific simulation period

### DIFF
--- a/hisim/components/generic_pv_system.py
+++ b/hisim/components/generic_pv_system.py
@@ -3,7 +3,6 @@
 # clean
 
 # Generic/Built-in
-import datetime
 import enum
 import math
 import os
@@ -707,17 +706,6 @@ class PVSystem(cp.Component):
                 for t in range(self.my_simulation_parameters.timesteps)
             ]
             SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.PVFORECASTYEARLY, entry=pv_forecast_yearly)
-
-    def interpolate(self, pd_database: Any, year: Any) -> Any:
-        """Interpolates."""
-        lastday = pd.Series(
-            pd_database[-1],
-            index=[pd.to_datetime(datetime.datetime(year, 12, 31, 22, 59), utc=True).tz_convert("Europe/Berlin")],
-        )
-
-        pd_database = pd_database.append(lastday)
-        pd_database = pd_database.sort_index()
-        return pd_database.resample("1T").asfreq().interpolate(method="linear").tolist()
 
     def get_modules_from_database(self, module_database: Any, load_module_data: bool, module_name: str) -> Any:
         """Get modules from pvlib module database."""

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -656,6 +656,14 @@ class Weather(Component):
                 weatherconfig=self.weather_config,
                 year=self.my_simulation_parameters.year,
             )
+
+            start_date = self.my_simulation_parameters.start_date,
+            end_date = self.my_simulation_parameters.end_date,
+            print(start_date)
+            print(end_date)
+            print(tmy_data)
+
+
             if self.weather_config.data_source == WeatherDataSourceEnum.NSRDB_15MIN:
                 dni = tmy_data["DNI"].resample("1T").asfreq().interpolate(method="linear")
                 temperature = tmy_data["T"].resample("1T").asfreq().interpolate(method="linear")

--- a/hisim/simulationparameters.py
+++ b/hisim/simulationparameters.py
@@ -40,6 +40,8 @@ class SimulationParameters(JSONWizard):
         """Initializes the class."""
         self.start_date: datetime.datetime = start_date
         self.end_date: datetime.datetime = end_date
+        if self.start_date > self.end_date:
+            raise KeyError("Simulation start date is after end date!")
         self.seconds_per_timestep = seconds_per_timestep
         self.duration = end_date - start_date
         total_seconds = self.duration.total_seconds()

--- a/system_setups/dynamic_components.py
+++ b/system_setups/dynamic_components.py
@@ -35,7 +35,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     Here two fuel_cell/chp_systems and two batteries
     are added.
     """
-    year = 2018
+    year = 2021
     seconds_per_timestep = 60 * 15
 
     if my_simulation_parameters is None:

--- a/tests/test_system_setups/test_household_gas_heater.py
+++ b/tests/test_system_setups/test_household_gas_heater.py
@@ -56,7 +56,7 @@ def test_household_gas_heater_main():
     """Execute setup with default values with hisim main."""
 
     path = "../system_setups/household_gas_heater.py"
-    my_simpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    my_simpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     my_simpar.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     hisim_main.main(path, my_simpar)
     log.information(os.getcwd())

--- a/tests/test_system_setups/test_household_heat_pump.py
+++ b/tests/test_system_setups/test_household_heat_pump.py
@@ -58,7 +58,7 @@ def test_household_heat_pump_main():
     """Execute setup with default values with hisim main."""
 
     path = "../system_setups/household_heat_pump.py"
-    my_simpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    my_simpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     my_simpar.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     hisim_main.main(path, my_simpar)
     log.information(os.getcwd())

--- a/tests/test_system_setups_household_1_advanced_hp_diesel_car.py
+++ b/tests/test_system_setups_household_1_advanced_hp_diesel_car.py
@@ -22,7 +22,7 @@ def test_basic_household():
         os.remove(config_filename)
 
     path = "../system_setups/household_1_advanced_hp_diesel_car.py"
-    mysimpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     mysimpar.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     hisim_main.main(path, mysimpar)
     log.information(os.getcwd())

--- a/tests/test_system_setups_household_1b_more_advanced_hp_diesel_car.py
+++ b/tests/test_system_setups_household_1b_more_advanced_hp_diesel_car.py
@@ -22,7 +22,7 @@ def test_basic_household():
         os.remove(config_filename)
 
     path = "../system_setups/household_1b_more_advanced_hp_diesel_car.py"
-    mysimpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     mysimpar.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     hisim_main.main(path, mysimpar)
     log.information(os.getcwd())

--- a/tests/test_system_setups_household_1d_more_advanced_hp_dhw_hp_no_hot_water_storage.py
+++ b/tests/test_system_setups_household_1d_more_advanced_hp_dhw_hp_no_hot_water_storage.py
@@ -22,7 +22,7 @@ def test_basic_household():
         os.remove(config_filename)
 
     path = "../system_setups/household_1d_more_advanced_hp_dhw_hp_no_hot_water_storage.py"
-    mysimpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     mysimpar.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     hisim_main.main(path, mysimpar)
     log.information(os.getcwd())

--- a/tests/test_system_setups_household_2_advanced_hp_diesel_car_pv.py
+++ b/tests/test_system_setups_household_2_advanced_hp_diesel_car_pv.py
@@ -22,7 +22,7 @@ def test_basic_household():
         os.remove(config_filename)
 
     path = "../system_setups/household_2_advanced_hp_diesel_car_pv.py"
-    mysimpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     mysimpar.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     hisim_main.main(path, mysimpar)
     log.information(os.getcwd())

--- a/tests/test_system_setups_household_3_advanced_hp_diesel_car_pv_battery.py
+++ b/tests/test_system_setups_household_3_advanced_hp_diesel_car_pv_battery.py
@@ -22,7 +22,7 @@ def test_basic_household():
         os.remove(config_filename)
 
     path = "../system_setups/household_3_advanced_hp_diesel_car_pv_battery.py"
-    mysimpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     mysimpar.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     hisim_main.main(path, mysimpar)
     log.information(os.getcwd())

--- a/tests/test_system_setups_household_4a_with_car_priority.py
+++ b/tests/test_system_setups_household_4a_with_car_priority.py
@@ -23,7 +23,7 @@ def test_basic_household():
 
     path = "../system_setups/household_4a_with_car_priority_advanced_hp_ev_pv.py"
 
-    mysimpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     mysimpar.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     hisim_main.main(path, mysimpar)
     log.information(os.getcwd())

--- a/tests/test_system_setups_household_4b_with_heatpump_priority.py
+++ b/tests/test_system_setups_household_4b_with_heatpump_priority.py
@@ -23,7 +23,7 @@ def test_basic_household():
 
     path = "../system_setups/household_4b_with_heatpump_priority_advanced_hp_ev_pv.py"
 
-    mysimpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     mysimpar.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     hisim_main.main(path, mysimpar)
     log.information(os.getcwd())

--- a/tests/test_system_setups_household_5a_with_car_priority.py
+++ b/tests/test_system_setups_household_5a_with_car_priority.py
@@ -25,7 +25,7 @@ def test_basic_household():
         "../system_setups/household_5a_with_car_priority_advanced_hp_ev_pv_battery.py"
     )
 
-    mysimpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     mysimpar.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     hisim_main.main(path, mysimpar)
     log.information(os.getcwd())

--- a/tests/test_system_setups_household_5b_with_battery_priority.py
+++ b/tests/test_system_setups_household_5b_with_battery_priority.py
@@ -23,7 +23,7 @@ def test_basic_household():
 
     path = "../system_setups/household_5b_with_battery_priority_advanced_hp_ev_pv_battery.py"
 
-    mysimpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     mysimpar.post_processing_options.append(PostProcessingOptions.MAKE_NETWORK_CHARTS)
     hisim_main.main(path, mysimpar)
     log.information(os.getcwd())

--- a/tests/test_system_setups_household_reference_gas_heater_diesel_car.py
+++ b/tests/test_system_setups_household_reference_gas_heater_diesel_car.py
@@ -16,6 +16,6 @@ def test_basic_household():
     """Single day."""
     path = "../system_setups/household_reference_gas_heater_diesel_car.py"
 
-    mysimpar = SimulationParameters.one_day_only(year=2019, seconds_per_timestep=60)
+    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     hisim_main.main(path, mysimpar)
     log.information(os.getcwd())


### PR DESCRIPTION
changes in simulation time span --> use utc for lpg and weather input data, so every time period can simulated
----
Problem bevor was, that simulation starts every single time from 01. January even the simulation parameter where changed --> only in post processing the timestamps were correct from simulationsparameters, but now every time span can simulate and the specific period is loaded from lpg and weather data
( see issue #347)