### PR TITLE
Added missing data files for installation from PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+include AUTHORS.rst
+include CONTRIBUTING.rst
+include HISTORY.rst
+include LICENSE
+include README.rst
+
+recursive-include hisim/inputs *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+
+recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     license="MIT license",
     long_description=readme,
     long_description_content_type="text/markdown",
+    package_data={"hisim": ["inputs/*"]},
     include_package_data=True,
     keywords="hisim",
     name="hisim",
@@ -52,6 +53,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/FZJ-IEK3-VSA/HiSim",
-    version="1.2.1",
+    version="1.2.2",
     zip_safe=False,
 )


### PR DESCRIPTION
When installing from PyPI, the inputs folder containing relevant data files was missing.
A MANIFEST.in file was added to include this folder, and it was added as package data in setup.py.