### PR TITLE
two small fixes: boiler efficiency and water storage temperature loss

### DIFF
--- a/hisim/components/generic_boiler.py
+++ b/hisim/components/generic_boiler.py
@@ -662,7 +662,7 @@ class GenericBoiler(Component):
             delta_power = self.maximal_thermal_power_in_watt - self.minimal_thermal_power_in_watt
             slope = delta_efficiency / delta_power
             # real efficiency formula
-            real_combustion_efficiency = (self.min_combustion_efficiency 
+            real_combustion_efficiency = (self.min_combustion_efficiency
                 + (maximum_power_used_in_watt - self.minimal_thermal_power_in_watt) * slope)
 
         # energy consumption

--- a/hisim/components/simple_water_storage.py
+++ b/hisim/components/simple_water_storage.py
@@ -396,10 +396,12 @@ class SimpleWaterStorage(cp.Component):
         ambient_temperature_in_celsius: float,
         mass_in_storage_in_kg: float,
     ) -> Tuple[float, float]:
-        """Calculate the heat energy loss in W and the temperature loss in K/s of the water storage
-        based on surface area, heat transfer coefficient, inner and outer temperature and water
-        mass in storage."""
+        """Calculate heat energy loss in W and temperature loss in K/s.
 
+        Calculate the heat energy loss in W and the temperature loss in K/s of the water storage
+        based on surface area, heat transfer coefficient, inner and outer temperature and water
+        mass in storage.
+        """
         heat_loss_in_watt = self.calculate_heat_loss_in_watt(
             mean_temperature_in_storage_in_celsius=mean_water_temperature_in_water_storage_in_celsius,
             storage_surface_in_m2=storage_surface_in_m2,


### PR DESCRIPTION
As the title says, I am asking to merge two small fixes:
1) In the generic boiler, the efficiency wasn't calculated as it was supposed to be.
2) In the simple water storage, the temperature loss was actually calculated in Kelvin per second,
therefore it had to be multiplied by the seconds per timestep to get the absolute temperature
loss per timestep. I added this and specified the relevant documentation.