### PR TITLE
Read weather data from direct filepath

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -21,14 +21,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install prospector[with_everything]
-        pip install prospector[with-everything]
-        pip install prospector[with_bandit]
-        pip install prospector[with_mypy]
-        pip install prospector[with_pyroma]
-        pip install prospector[with_vulture]
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install -e .
+        pip install uv
+        uv pip install prospector[with_everything]
+        uv pip install prospector[with-everything]
+        uv pip install prospector[with_bandit]
+        uv pip install prospector[with_mypy]
+        uv pip install prospector[with_pyroma]
+        uv pip install prospector[with_vulture]
+        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
+        uv pip install -e .
     - name: Lint with prospector
       working-directory: ./
       run: |

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -22,14 +22,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-        uv pip install prospector[with_everything]
-        uv pip install prospector[with-everything]
-        uv pip install prospector[with_bandit]
-        uv pip install prospector[with_mypy]
-        uv pip install prospector[with_pyroma]
-        uv pip install prospector[with_vulture]
-        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
-        uv pip install -e .
+        uv pip install --system prospector[with_everything]
+        uv pip install --system prospector[with-everything]
+        uv pip install --system prospector[with_bandit]
+        uv pip install --system prospector[with_mypy]
+        uv pip install --system prospector[with_pyroma]
+        uv pip install --system prospector[with_vulture]
+        if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
+        uv pip install --system -e .
     - name: Lint with prospector
       working-directory: ./
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,10 +25,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install uv
         python3 -m pip install --upgrade setuptools wheel
-        uv pip install h5py --upgrade
-        uv pip install coverage
-        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
-        uv pip install -e .
+        uv pip install --system h5py --upgrade
+        uv pip install --system coverage
+        if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
+        uv pip install --system -e .
     - name: Coverage test
       env:
         UTSP_URL: ${{ secrets.UTSP_URL }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,11 +23,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install uv
         python3 -m pip install --upgrade setuptools wheel
-        pip install h5py --upgrade
-        pip install coverage
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install -e .
+        uv pip install h5py --upgrade
+        uv pip install coverage
+        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
+        uv pip install -e .
     - name: Coverage test
       env:
         UTSP_URL: ${{ secrets.UTSP_URL }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -18,8 +18,9 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install mypy
-        pip install pytest
+        pip install uv
+        uv pip install --system mypy
+        uv pip install --system pytest
     - name: mypy
       run: |
         mypy -p hisim --config-file mypy.ini

--- a/.github/workflows/pytest-base.yml
+++ b/.github/workflows/pytest-base.yml
@@ -24,7 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-#         pip install pytest  # pytest already included in requirements.txt
         if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
         uv pip install --system -e .
     - name: Test with pytest

--- a/.github/workflows/pytest-base.yml
+++ b/.github/workflows/pytest-base.yml
@@ -24,9 +24,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-        uv pip install pytest
-        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
-        uv pip install -e .
+        uv pip install --system pytest
+        if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
+        uv pip install --system -e .
     - name: Test with pytest
       working-directory: ./tests/
       run: |

--- a/.github/workflows/pytest-base.yml
+++ b/.github/workflows/pytest-base.yml
@@ -23,9 +23,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install -e .
+        pip install uv
+        uv pip install pytest
+        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
+        uv pip install -e .
     - name: Test with pytest
       working-directory: ./tests/
       run: |

--- a/.github/workflows/pytest-base.yml
+++ b/.github/workflows/pytest-base.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-        uv pip install --system pytest
+#         pip install pytest  # pytest already included in requirements.txt
         if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
         uv pip install --system -e .
     - name: Test with pytest

--- a/.github/workflows/pytest-buildingtest.yml
+++ b/.github/workflows/pytest-buildingtest.yml
@@ -24,7 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-#         pip install pytest  # pytest already included in requirements.txt
         if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
         uv pip install --system -e .
     - name: Test with pytest

--- a/.github/workflows/pytest-buildingtest.yml
+++ b/.github/workflows/pytest-buildingtest.yml
@@ -23,9 +23,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install uv
         pip install pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install -e .
+        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
+        uv pip install -e .
     - name: Test with pytest
       working-directory: ./tests/
       run: |

--- a/.github/workflows/pytest-buildingtest.yml
+++ b/.github/workflows/pytest-buildingtest.yml
@@ -25,8 +25,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install uv
         pip install pytest
-        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
-        uv pip install -e .
+        if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
+        uv pip install --system -e .
     - name: Test with pytest
       working-directory: ./tests/
       run: |

--- a/.github/workflows/pytest-buildingtest.yml
+++ b/.github/workflows/pytest-buildingtest.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-        pip install pytest
+#         pip install pytest  # pytest already included in requirements.txt
         if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
         uv pip install --system -e .
     - name: Test with pytest

--- a/.github/workflows/pytest-others.yml
+++ b/.github/workflows/pytest-others.yml
@@ -24,7 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-#         pip install pytest  # pytest already included in requirements.txt
         if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
         uv pip install --system -e .
     - name: Test with pytest

--- a/.github/workflows/pytest-others.yml
+++ b/.github/workflows/pytest-others.yml
@@ -23,9 +23,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install uv
         pip install pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install -e .
+        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
+        uv pip install -e .
     - name: Test with pytest
       working-directory: ./tests/
       run: |

--- a/.github/workflows/pytest-others.yml
+++ b/.github/workflows/pytest-others.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Test with pytest
       working-directory: ./tests/
       run: |
-        sh -c 'pytest -m "not base and not buildingtest and not system_setups and not utsp"; ret=$?; [ $ret = 5 ] && exit 0 || exit 1'
+        sh -c 'pytest -m "not base and not buildingtest and not system_setups and not utsp"; ret=$?; [ $ret = 5 ] && exit 0 || [ $ret = 0 ] && exit 0 || exit 1'
         #        
 
     #    # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/pytest-others.yml
+++ b/.github/workflows/pytest-others.yml
@@ -25,8 +25,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install uv
         pip install pytest
-        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
-        uv pip install -e .
+        if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
+        uv pip install --system -e .
     - name: Test with pytest
       working-directory: ./tests/
       run: |

--- a/.github/workflows/pytest-others.yml
+++ b/.github/workflows/pytest-others.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-        pip install pytest
+#         pip install pytest  # pytest already included in requirements.txt
         if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
         uv pip install --system -e .
     - name: Test with pytest

--- a/.github/workflows/pytest-system-setups.yml
+++ b/.github/workflows/pytest-system-setups.yml
@@ -24,7 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-#         pip install pytest  # pytest already included in requirements.txt
         if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
         uv pip install --system -e .
     - name: Test with pytest

--- a/.github/workflows/pytest-system-setups.yml
+++ b/.github/workflows/pytest-system-setups.yml
@@ -23,9 +23,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install uv
         pip install pytest
-        if [ -f requirements.txt ]; then pip install --no-deps -r requirements.txt; fi
-        pip install -e .
+        if [ -f requirements.txt ]; then uv pip install --no-deps -r requirements.txt; fi
+        uv pip install -e .
     - name: Test with pytest
       env:
         UTSP_URL: ${{ secrets.UTSP_URL }}

--- a/.github/workflows/pytest-system-setups.yml
+++ b/.github/workflows/pytest-system-setups.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-        pip install pytest
+#         pip install pytest  # pytest already included in requirements.txt
         if [ -f requirements.txt ]; then uv pip install --system --no-deps -r requirements.txt; fi
         uv pip install --system -e .
     - name: Test with pytest

--- a/.github/workflows/pytest-system-setups.yml
+++ b/.github/workflows/pytest-system-setups.yml
@@ -25,8 +25,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install uv
         pip install pytest
-        if [ -f requirements.txt ]; then uv pip install --no-deps -r requirements.txt; fi
-        uv pip install -e .
+        if [ -f requirements.txt ]; then uv pip install --system --no-deps -r requirements.txt; fi
+        uv pip install --system -e .
     - name: Test with pytest
       env:
         UTSP_URL: ${{ secrets.UTSP_URL }}

--- a/.github/workflows/pytest-system-setups.yml
+++ b/.github/workflows/pytest-system-setups.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install uv
 #         pip install pytest  # pytest already included in requirements.txt
-        if [ -f requirements.txt ]; then uv pip install --system --no-deps -r requirements.txt; fi
+        if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
         uv pip install --system -e .
     - name: Test with pytest
       env:

--- a/.github/workflows/pytest-utsp.yml
+++ b/.github/workflows/pytest-utsp.yml
@@ -22,9 +22,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install uv
         pip install pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install -e .
+        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
+        uv pip install -e .
     - name: Test with pytest
       env:
         UTSP_URL: ${{ secrets.UTSP_URL }}

--- a/.github/workflows/pytest-utsp.yml
+++ b/.github/workflows/pytest-utsp.yml
@@ -23,7 +23,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-#         pip install pytest  # pytest already included in requirements.txt
         if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
         uv pip install --system -e .
     - name: Test with pytest

--- a/.github/workflows/pytest-utsp.yml
+++ b/.github/workflows/pytest-utsp.yml
@@ -24,8 +24,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install uv
         pip install pytest
-        if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
-        uv pip install -e .
+        if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
+        uv pip install --system -e .
     - name: Test with pytest
       env:
         UTSP_URL: ${{ secrets.UTSP_URL }}

--- a/.github/workflows/pytest-utsp.yml
+++ b/.github/workflows/pytest-utsp.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install uv
-        pip install pytest
+#         pip install pytest  # pytest already included in requirements.txt
         if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
         uv pip install --system -e .
     - name: Test with pytest

--- a/.pylintrc
+++ b/.pylintrc
@@ -91,7 +91,7 @@ recursive=no
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
+# suggestion-mode removed in pylint 4.0
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.

--- a/hisim/building_sizer_utils/interface_configs/archetype_config.py
+++ b/hisim/building_sizer_utils/interface_configs/archetype_config.py
@@ -25,12 +25,12 @@ class ArcheTypeConfig:
     conditioned_floor_area_in_m2: float = 121.2
     number_of_dwellings_per_building: int = 1
     norm_heating_load_in_kilowatt: Optional[float] = None
-    #weather_location: str = "AACHEN"
-    weather_location: str = None
+    # weather_location: str = "AACHEN"
+    weather_location: Optional[str] = None
     weather_try_region: int = 6
 
-    weather_filepath: str = None
-    weather_datasource: str = None
+    weather_filepath: Optional[str] = None
+    weather_datasource: Optional[str] = None
 
     building_postal_code: str = "52062"
     building_location: str = "Aachen"

--- a/hisim/building_sizer_utils/interface_configs/archetype_config.py
+++ b/hisim/building_sizer_utils/interface_configs/archetype_config.py
@@ -28,10 +28,10 @@ class ArcheTypeConfig:
     #weather_location: str = "AACHEN"
     weather_location: str = None
     weather_try_region: int = 6
-    #
-    weather_filepath: str = None,
-    weather_datasource: str = None,
-    #
+
+    weather_filepath: str = None
+    weather_datasource: str = None
+
     building_postal_code: str = "52062"
     building_location: str = "Aachen"
     lpg_households: List[str] = field(default_factory=lambda: ["CHR01_Couple_both_at_Work"])

--- a/hisim/building_sizer_utils/interface_configs/archetype_config.py
+++ b/hisim/building_sizer_utils/interface_configs/archetype_config.py
@@ -25,8 +25,13 @@ class ArcheTypeConfig:
     conditioned_floor_area_in_m2: float = 121.2
     number_of_dwellings_per_building: int = 1
     norm_heating_load_in_kilowatt: Optional[float] = None
-    weather_location: str = "AACHEN"
+    #weather_location: str = "AACHEN"
+    weather_location: str = None
     weather_try_region: int = 6
+    #
+    weather_filepath: str = None,
+    weather_datasource: str = None,
+    #
     building_postal_code: str = "52062"
     building_location: str = "Aachen"
     lpg_households: List[str] = field(default_factory=lambda: ["CHR01_Couple_both_at_Work"])

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -420,8 +420,6 @@ class WeatherConfig(ConfigBase):
         # Use direct filepath
         else:
             if weather_direct_filepath is None:
-                print(f"DEBUG checking file: '{weather_direct_filepath}'")
-                print(f"DEBUG file exists: {os.path.isfile(weather_direct_filepath)}")
                 raise ValueError(
                     f"Location '{location_entry}' not found in Weather LocationEnum and no weather_direct_filepath was provided."
                 )
@@ -1019,10 +1017,6 @@ def read_test_reference_year_data(weatherconfig: WeatherConfig, simulation_param
     # get the correct file path
     filepath = os.path.join(weatherconfig.source_path)
 
-    print(f"DEBUG data_source: '{weatherconfig.data_source}'")
-    print(f"DEBUG data_source type: {type(weatherconfig.data_source)}")
-    print(f"DEBUG source_path: '{weatherconfig.source_path}'")
-
     if weatherconfig.data_source == WeatherDataSourceEnum.NSRDB:
         data = read_nsrdb_data(filepath, simulation_parameters.year)
     elif weatherconfig.data_source == WeatherDataSourceEnum.DWD_TRY:
@@ -1042,12 +1036,7 @@ def read_test_reference_year_data(weatherconfig: WeatherConfig, simulation_param
 
 
 def read_dwd_try_data(filepath: str, year: int) -> pd.DataFrame:
-    """Reads the DWD Test Reference Year (TRY) data."""
-
-    print(f"DEBUG filepath: '{filepath}'")
-    print(f"DEBUG .csv exists: {os.path.isfile(filepath + '.csv')}")
-    print(f"DEBUG .dat exists: {os.path.isfile(filepath + '.dat')}")
-
+    """Reads the DWD Test Reference Year (TRY) data.""
 
     # get the geoposition
     with open(filepath + ".dat", encoding="utf-8") as file_stream:

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -402,10 +402,10 @@ class WeatherConfig(ConfigBase):
         if isinstance(location_entry, LocationEnum):
             enum_entry = location_entry
 
-        # Read location_entry from enum        
+        # Read location_entry from enum
         elif isinstance(location_entry, str):
             enum_entry = getattr(LocationEnum, location_entry.strip(), None)
-        
+
         if enum_entry is not None:
             location = enum_entry.value[0]
             path = os.path.join(
@@ -436,7 +436,7 @@ class WeatherConfig(ConfigBase):
             location = str(location_entry)
             path = weather_direct_filepath
             data_source = weather_direct_data_source
-        
+
         config = WeatherConfig(
             building_name=building_name,
             name=name,
@@ -648,8 +648,7 @@ class Weather(Component):
         if self.weather_config.predictive_control:
             timesteps_24h = 24 * 3600 / self.my_simulation_parameters.seconds_per_timestep
             last_forecast_timestep = int(timestep + timesteps_24h)
-            if last_forecast_timestep > len(self.temperature_list):
-                last_forecast_timestep = len(self.temperature_list)
+            last_forecast_timestep = min(last_forecast_timestep, len(self.temperature_list))
             # log.information( type(self.temperature))
             temperatureforecast = self.temperature_list[timestep:last_forecast_timestep]
             self.simulation_repository.set_entry(self.Weather_Temperature_Forecast_24h, temperatureforecast)
@@ -1027,6 +1026,8 @@ def read_test_reference_year_data(weatherconfig: WeatherConfig, simulation_param
         data = read_dwd_15min_data(filepath, simulation_parameters)
     elif weatherconfig.data_source == WeatherDataSourceEnum.ERA5:
         data = read_era5_data(filepath, simulation_parameters.year)
+    else:
+        raise ValueError(f"Unsupported weather data source: {weatherconfig.data_source}")
 
     return data
 

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -392,8 +392,8 @@ class WeatherConfig(ConfigBase):
         location_entry: Any,
         name: str = "Weather",
         building_name: str = "BUI1",
-        direct_filepath: str = None,
-        direct_data_source: WeatherDataSourceEnum = None,
+        weather_direct_filepath: str = None,
+        weather_direct_data_source: WeatherDataSourceEnum = None,
     ) -> Any:
         """Gets the default configuration for a given location."""
 
@@ -419,23 +419,23 @@ class WeatherConfig(ConfigBase):
 
         # Use direct filepath
         else:
-            if direct_filepath is None:
+            if weather_direct_filepath is None:
                 raise ValueError(
-                    f"Location '{location_entry}' not found in Weather LocationEnum and no direct_filepath was provided."
+                    f"Location '{location_entry}' not found in Weather LocationEnum and no weather_direct_filepath was provided."
                 )
-            if not os.path.isfile(direct_filepath):
+            if not os.path.isfile(weather_direct_filepath):
                 raise ValueError(
-                    f"Weather data file not found: {direct_filepath}")
-            if direct_data_source is None:
+                    f"Weather data file not found: {weather_direct_filepath}")
+            if weather_direct_data_source is None:
                 raise ValueError(
-                    f"No data source (data type) provided for direct_filepath {direct_filepath}."
+                    f"No data source (data type) provided for weather_direct_filepath {weather_direct_filepath}."
                 )
-            if direct_filepath.lower().endswith(".dat"):
-                direct_filepath = direct_filepath[:-4]
+            if weather_direct_filepath.lower().endswith(".dat"):
+                weather_direct_filepath = weather_direct_filepath[:-4]
 
             location = str(location_entry)
-            path = direct_filepath
-            data_source = direct_data_source
+            path = weather_direct_filepath
+            data_source = weather_direct_data_source
         
         config = WeatherConfig(
             building_name=building_name,

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -432,6 +432,8 @@ class WeatherConfig(ConfigBase):
                 )
             if weather_direct_filepath.lower().endswith(".dat"):
                 weather_direct_filepath = weather_direct_filepath[:-4]
+            elif weather_direct_filepath.lower().endswith(".csv"):
+                weather_direct_filepath = weather_direct_filepath[:-4]
 
             location = str(location_entry)
             path = weather_direct_filepath

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -7,7 +7,7 @@ import math
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, List
+from typing import Any, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -392,8 +392,8 @@ class WeatherConfig(ConfigBase):
         location_entry: Any,
         name: str = "Weather",
         building_name: str = "BUI1",
-        weather_direct_filepath: str = None,
-        weather_direct_data_source: WeatherDataSourceEnum = None,
+        weather_direct_filepath: Optional[str] = None,
+        weather_direct_data_source: Optional[WeatherDataSourceEnum] = None,
     ) -> Any:
         """Gets the default configuration for a given location."""
 

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -1036,7 +1036,7 @@ def read_test_reference_year_data(weatherconfig: WeatherConfig, simulation_param
 
 
 def read_dwd_try_data(filepath: str, year: int) -> pd.DataFrame:
-    """Reads the DWD Test Reference Year (TRY) data.""
+    """Reads the DWD Test Reference Year (TRY) data."""
 
     # get the geoposition
     with open(filepath + ".dat", encoding="utf-8") as file_stream:

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -432,7 +432,7 @@ class WeatherConfig(ConfigBase):
                 )
             if weather_direct_filepath.lower().endswith(".dat"):
                 weather_direct_filepath = weather_direct_filepath[:-4]
-            elif weather_direct_filepath.lower().endswith(".csv"): 
+            elif weather_direct_filepath.lower().endswith(".csv"):
                 weather_direct_filepath = weather_direct_filepath[:-4]
 
             location = str(location_entry)

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -392,32 +392,57 @@ class WeatherConfig(ConfigBase):
         location_entry: Any,
         name: str = "Weather",
         building_name: str = "BUI1",
+        direct_filepath: str = None,
+        direct_data_source: WeatherDataSourceEnum = None,
     ) -> Any:
-        """Gets the default configuration for Aachen."""
-        if not isinstance(location_entry, LocationEnum):
-            if location_entry in LocationEnum._member_names_:  # pylint: disable=W0212
-                location_entry = getattr(LocationEnum, location_entry)
-            else:
-                try:
-                    location_entry = getattr(LocationEnum, location_entry.strip())
-                except Exception as exc:
-                    raise ValueError(
-                        f"The location_entry {location_entry} could not be found in the Weather Location Enum class."
-                    ) from exc
+        """Gets the default configuration for a given location."""
 
-        path = os.path.join(
+        enum_entry = None
+        # If location_entry is enum entry, use it directly
+        if isinstance(location_entry, LocationEnum):
+            enum_entry = location_entry
+
+        # Read location_entry from enum        
+        elif isinstance(location_entry, str):
+            enum_entry = getattr(LocationEnum, location_entry.strip(), None)
+        
+        if enum_entry is not None:
+            location = enum_entry.value[0]
+            path = os.path.join(
             utils.get_input_directory(),
             "weather",
-            location_entry.value[1],
-            location_entry.value[2],
-            location_entry.value[3],
-        )
+            enum_entry.value[1],
+            enum_entry.value[2],
+            enum_entry.value[3],
+            )
+            data_source = enum_entry.value[4]
+
+        # Use direct filepath
+        else:
+            if direct_filepath is None:
+                raise ValueError(
+                    f"Location '{location_entry}' not found in Weather LocationEnum and no direct_filepath was provided."
+                )
+            if not os.path.isfile(direct_filepath):
+                raise ValueError(
+                    f"Weather data file not found: {direct_filepath}")
+            if direct_data_source is None:
+                raise ValueError(
+                    f"No data source (data type) provided for direct_filepath {direct_filepath}."
+                )
+            if direct_filepath.lower().endswith(".dat"):
+                direct_filepath = direct_filepath[:-4]
+
+            location = str(location_entry)
+            path = direct_filepath
+            data_source = direct_data_source
+        
         config = WeatherConfig(
             building_name=building_name,
             name=name,
-            location=location_entry.value[0],
+            location=location,
             source_path=path,
-            data_source=location_entry.value[4],
+            data_source=data_source,
             predictive_control=False,
         )
         return config

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -419,6 +419,8 @@ class WeatherConfig(ConfigBase):
 
         # Use direct filepath
         else:
+            print(f"DEBUG checking file: '{direct_filepath}'")
+            print(f"DEBUG file exists: {os.path.isfile(direct_filepath)}")
             if direct_filepath is None:
                 raise ValueError(
                     f"Location '{location_entry}' not found in Weather LocationEnum and no direct_filepath was provided."
@@ -431,6 +433,8 @@ class WeatherConfig(ConfigBase):
                     f"No data source (data type) provided for direct_filepath {direct_filepath}."
                 )
             if direct_filepath.lower().endswith(".dat"):
+                direct_filepath = direct_filepath[:-4]
+            elif direct_filepath.lower().endswith(".csv"): 
                 direct_filepath = direct_filepath[:-4]
 
             location = str(location_entry)
@@ -1015,6 +1019,11 @@ def read_test_reference_year_data(weatherconfig: WeatherConfig, simulation_param
     """
     # get the correct file path
     filepath = os.path.join(weatherconfig.source_path)
+
+    print(f"DEBUG data_source: '{weatherconfig.data_source}'")
+    print(f"DEBUG data_source type: {type(weatherconfig.data_source)}")
+    print(f"DEBUG source_path: '{weatherconfig.source_path}'")
+
     if weatherconfig.data_source == WeatherDataSourceEnum.NSRDB:
         data = read_nsrdb_data(filepath, simulation_parameters.year)
     elif weatherconfig.data_source == WeatherDataSourceEnum.DWD_TRY:
@@ -1033,6 +1042,12 @@ def read_test_reference_year_data(weatherconfig: WeatherConfig, simulation_param
 
 def read_dwd_try_data(filepath: str, year: int) -> pd.DataFrame:
     """Reads the DWD Test Reference Year (TRY) data."""
+
+    print(f"DEBUG filepath: '{filepath}'")
+    print(f"DEBUG .csv exists: {os.path.isfile(filepath + '.csv')}")
+    print(f"DEBUG .dat exists: {os.path.isfile(filepath + '.dat')}")
+
+
     # get the geoposition
     with open(filepath + ".dat", encoding="utf-8") as file_stream:
         lines = file_stream.readlines()
@@ -1046,6 +1061,7 @@ def read_dwd_try_data(filepath: str, year: int) -> pd.DataFrame:
     else:
         # get data
         data = pd.read_csv(filepath + ".dat", sep=r"\s+", skiprows=list(range(0, 31)))
+
         data.index = pd.date_range(f"{year}-01-01 00:30:00", periods=8760, freq="H", tz="Europe/Berlin")
         data["GHI"] = data["D"] + data["B"]
         data = data.rename(

--- a/hisim/project_code_overview_generator.py
+++ b/hisim/project_code_overview_generator.py
@@ -22,7 +22,7 @@ __maintainer__ = "Noah Pflugradt"
 __email__ = "n.pflugradt@fz-juelich.de"
 __status__ = "development"
 
-BuiltInAttributes = [
+BUILT_IN_ATTRIBUTES = [
     "__builtins__",
     "__cached__",
     "__doc__",
@@ -274,7 +274,7 @@ class OverviewGenerator:
                 # this is an import from another module, therefore skip
                 if str(python_module_name) != str(module_member[1].__module__):
                     continue
-            if str(module_member[0]) in BuiltInAttributes:
+            if str(module_member[0]) in BUILT_IN_ATTRIBUTES:
                 continue
             mytype = type(module_member[1])
             strname = str(module_member[0])

--- a/pylintrc-critical-only
+++ b/pylintrc-critical-only
@@ -91,7 +91,7 @@ recursive=yes
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
+# suggestion-mode removed in pylint 4.0
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.24,<2.0 # pinned to satisfy wetterdienst==0.63.0 constraints
-pandas>=2.0,<2.2
+numpy
+pandas
 matplotlib
 seaborn
 reportlab

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy
-pandas
+numpy>=1.24,<2.0 # pinned to satisfy wetterdienst==0.63.0 constraints
+pandas>=2.0,<2.2
 matplotlib
 seaborn
 reportlab
@@ -27,7 +27,7 @@ typing_extensions
 python-dotenv
 windpowerlib  # ==0.2.1
 timezonefinder<6.0
-wetterdienst==0.63.0
+wetterdienst==0.63.0 # TODO: migrate weather_data_import.py to new API before upgrading
 cdsapi
 xarray
 pygfunction

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -138,7 +138,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        weather_location = "AACHEN" # default weather location
+        weather_location = "AACHEN"  # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
@@ -240,7 +240,7 @@ def setup_function(
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource
+        weather_direct_data_source=weather_datasource,
     )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -143,6 +143,8 @@ def setup_function(
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
+    if isinstance(weather_datasource, str):
+        weather_datasource = weather.WeatherDataSourceEnum[weather_datasource]
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -138,7 +138,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        raise ValueError("weather_location must not be None.")
+        weather_location = "AACHEN" # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -137,6 +137,9 @@ def setup_function(
 
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    if weather_location is None:
+        raise ValueError("weather_location must not be None.")
+
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
@@ -232,7 +235,7 @@ def setup_function(
 
     # Build Weather
     #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -140,7 +140,7 @@ def setup_function(
     if weather_location is None:
         raise ValueError("weather_location must not be None.")
 
-    # testing AU weather data 
+    # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
     if isinstance(weather_datasource, str):
@@ -237,7 +237,11 @@ def setup_function(
 
     # Build Weather
     #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource
+    )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -236,7 +236,7 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -137,6 +137,9 @@ def setup_function(
 
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    # testing AU weather data 
+    weather_filepath = arche_type_config_.weather_filepath
+    weather_datasource = arche_type_config_.weather_datasource
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth
@@ -228,7 +231,8 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -130,6 +130,8 @@ def setup_function(
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
+    if isinstance(weather_datasource, str):
+        weather_datasource = weather.WeatherDataSourceEnum[weather_datasource]
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -124,6 +124,9 @@ def setup_function(
 
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    if weather_location is None:
+        raise ValueError("weather_location must not be None.")
+
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
@@ -219,7 +222,7 @@ def setup_function(
 
     # Build Weather
     #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -127,7 +127,7 @@ def setup_function(
     if weather_location is None:
         raise ValueError("weather_location must not be None.")
 
-    # testing AU weather data 
+    # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
     if isinstance(weather_datasource, str):
@@ -223,8 +223,12 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
+    # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource
+    )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -125,7 +125,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        weather_location = "AACHEN" # default weather location
+        weather_location = "AACHEN"  # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
@@ -227,7 +227,7 @@ def setup_function(
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource
+        weather_direct_data_source=weather_datasource,
     )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -124,6 +124,9 @@ def setup_function(
 
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    # testing AU weather data 
+    weather_filepath = arche_type_config_.weather_filepath
+    weather_datasource = arche_type_config_.weather_datasource
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth
@@ -215,7 +218,8 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -125,7 +125,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        raise ValueError("weather_location must not be None.")
+        weather_location = "AACHEN" # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -141,7 +141,7 @@ def setup_function(
     if weather_location is None:
         raise ValueError("weather_location must not be None.")
 
-    # testing AU weather data 
+    # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
     if isinstance(weather_datasource, str):
@@ -236,8 +236,12 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
+    # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource
+    )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -138,6 +138,9 @@ def setup_function(
 
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    # testing AU weather data 
+    weather_filepath = arche_type_config_.weather_filepath
+    weather_datasource = arche_type_config_.weather_datasource
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth
@@ -228,7 +231,8 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -138,6 +138,9 @@ def setup_function(
 
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    if weather_location is None:
+        raise ValueError("weather_location must not be None.")
+
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
@@ -232,7 +235,7 @@ def setup_function(
 
     # Build Weather
     #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -113,7 +113,7 @@ def setup_function(
 
     simu_params_year = my_simulation_parameters.year
 
-    my_simulation_parameters.country = 'DE'
+    my_simulation_parameters.country = "DE"
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # =================================================================================================================================
@@ -139,7 +139,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        weather_location = "AACHEN" # default weather location
+        weather_location = "AACHEN"  # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
@@ -240,7 +240,7 @@ def setup_function(
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource
+        weather_direct_data_source=weather_datasource,
     )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -139,7 +139,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        raise ValueError("weather_location must not be None.")
+        weather_location = "AACHEN" # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -144,6 +144,8 @@ def setup_function(
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
+    if isinstance(weather_datasource, str):
+        weather_datasource = weather.WeatherDataSourceEnum[weather_datasource]
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_gas_solar_thermal_building_sizer.py
+++ b/system_setups/household_gas_solar_thermal_building_sizer.py
@@ -134,6 +134,8 @@ def setup_function(
 
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    if weather_location is None:
+        raise ValueError("weather_location must not be None.")
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_gas_solar_thermal_building_sizer.py
+++ b/system_setups/household_gas_solar_thermal_building_sizer.py
@@ -135,7 +135,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        raise ValueError("weather_location must not be None.")
+        weather_location = "AACHEN" # default weather location
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_gas_solar_thermal_building_sizer.py
+++ b/system_setups/household_gas_solar_thermal_building_sizer.py
@@ -135,7 +135,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        weather_location = "AACHEN" # default weather location
+        weather_location = "AACHEN"  # default weather location
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -137,7 +137,7 @@ def setup_function(
     if weather_location is None:
         raise ValueError("weather_location must not be None.")
 
-    # testing AU weather data 
+    # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
     if isinstance(weather_datasource, str):
@@ -233,8 +233,12 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
+    # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource
+    )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -134,6 +134,9 @@ def setup_function(
         raise ValueError(f"Heat distrbution system not recognized: {energy_system_config_.heat_distribution_system}")
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    if weather_location is None:
+        raise ValueError("weather_location must not be None.")
+
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
@@ -229,7 +232,7 @@ def setup_function(
 
     # Build Weather
     #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -134,6 +134,9 @@ def setup_function(
         raise ValueError(f"Heat distrbution system not recognized: {energy_system_config_.heat_distribution_system}")
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    # testing AU weather data 
+    weather_filepath = arche_type_config_.weather_filepath
+    weather_datasource = arche_type_config_.weather_datasource
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth
@@ -225,7 +228,8 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -33,7 +33,6 @@ from hisim.building_sizer_utils.interface_configs.modular_household_config impor
 )
 from hisim import log
 
-
 __authors__ = "Katharina Rieck"
 __copyright__ = "Copyright 2022, FZJ-IEK-3"
 __credits__ = ["Noah Pflugradt"]
@@ -135,7 +134,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        weather_location = "AACHEN" # default weather location
+        weather_location = "AACHEN"  # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
@@ -237,7 +236,7 @@ def setup_function(
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource
+        weather_direct_data_source=weather_datasource,
     )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -140,6 +140,8 @@ def setup_function(
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
+    if isinstance(weather_datasource, str):
+        weather_datasource = weather.WeatherDataSourceEnum[weather_datasource]
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -135,7 +135,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        raise ValueError("weather_location must not be None.")
+        weather_location = "AACHEN" # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.py
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.py
@@ -134,6 +134,8 @@ def setup_function(
 
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    if weather_location is None:
+        raise ValueError("weather_location must not be None.")
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.py
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.py
@@ -135,7 +135,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        raise ValueError("weather_location must not be None.")
+        weather_location = "AACHEN" # default weather location
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.py
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.py
@@ -135,7 +135,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        weather_location = "AACHEN" # default weather location
+        weather_location = "AACHEN"  # default weather location
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_hydrogen_boiler_building_sizer.py
+++ b/system_setups/household_hydrogen_boiler_building_sizer.py
@@ -128,6 +128,8 @@ def setup_function(
 
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    if weather_location is None:
+        raise ValueError("weather_location must not be None.")
 
     # Set heat distribution system
     if energy_system_config_.heat_distribution_system == ComponentType.HEAT_DISTRIBUTION_SYSTEM_FLOORHEATING:

--- a/system_setups/household_hydrogen_boiler_building_sizer.py
+++ b/system_setups/household_hydrogen_boiler_building_sizer.py
@@ -129,7 +129,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        weather_location = "AACHEN" # default weather location
+        weather_location = "AACHEN"  # default weather location
 
     # Set heat distribution system
     if energy_system_config_.heat_distribution_system == ComponentType.HEAT_DISTRIBUTION_SYSTEM_FLOORHEATING:

--- a/system_setups/household_hydrogen_boiler_building_sizer.py
+++ b/system_setups/household_hydrogen_boiler_building_sizer.py
@@ -129,7 +129,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        raise ValueError("weather_location must not be None.")
+        weather_location = "AACHEN" # default weather location
 
     # Set heat distribution system
     if energy_system_config_.heat_distribution_system == ComponentType.HEAT_DISTRIBUTION_SYSTEM_FLOORHEATING:

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -136,6 +136,9 @@ def setup_function(
 
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    # testing AU weather data 
+    weather_filepath = arche_type_config_.weather_filepath
+    weather_datasource = arche_type_config_.weather_datasource
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth
@@ -227,7 +230,8 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -136,6 +136,9 @@ def setup_function(
 
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    if weather_location is None:
+        raise ValueError("weather_location must not be None.")
+
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
@@ -231,7 +234,7 @@ def setup_function(
 
     # Build Weather
     #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -137,7 +137,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        raise ValueError("weather_location must not be None.")
+        weather_location = "AACHEN" # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -137,7 +137,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        weather_location = "AACHEN" # default weather location
+        weather_location = "AACHEN"  # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
@@ -239,7 +239,7 @@ def setup_function(
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource
+        weather_direct_data_source=weather_datasource,
     )
 
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -142,6 +142,8 @@ def setup_function(
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
+    if isinstance(weather_datasource, str):
+        weather_datasource = weather.WeatherDataSourceEnum[weather_datasource]
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -139,7 +139,7 @@ def setup_function(
     if weather_location is None:
         raise ValueError("weather_location must not be None.")
 
-    # testing AU weather data 
+    # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
     if isinstance(weather_datasource, str):
@@ -235,8 +235,13 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
+    # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource
+    )
+
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -140,7 +140,7 @@ def setup_function(
     if weather_location is None:
         raise ValueError("weather_location must not be None.")
 
-    # testing AU weather data 
+    # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
 
@@ -237,8 +237,12 @@ def setup_function(
     # Build Weather
     if isinstance(weather_datasource, str):
         weather_datasource = weather.WeatherDataSourceEnum[weather_datasource]
-    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
+    # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource,
+    )
 
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -67,8 +67,6 @@ def setup_function(
         - Electricity Meter
     """
 
-    # ================================================================
-    # 
     # =================================================================
     # Set System Parameters from Config
 
@@ -143,7 +141,6 @@ def setup_function(
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
-
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -67,7 +67,9 @@ def setup_function(
         - Electricity Meter
     """
 
-    # =================================================================================================================================
+    # ================================================================
+    # 
+    # =================================================================
     # Set System Parameters from Config
 
     # household-pv-config
@@ -230,6 +232,8 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
+    if isinstance(weather_datasource, str):
+        weather_datasource = weather.WeatherDataSourceEnum[weather_datasource]
     #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
 

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -135,6 +135,10 @@ def setup_function(
         raise ValueError(f"Heat distrbution system not recognized: {energy_system_config_.heat_distribution_system}")
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    # testing AU weather data 
+    weather_filepath = arche_type_config_.weather_filepath
+    weather_datasource = arche_type_config_.weather_datasource
+
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth
@@ -226,7 +230,9 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
+
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -136,7 +136,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        raise ValueError("weather_location must not be None.")
+        weather_location = "AACHEN" # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -136,7 +136,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        weather_location = "AACHEN" # default weather location
+        weather_location = "AACHEN"  # default weather location
 
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -137,6 +137,9 @@ def setup_function(
         raise ValueError(f"Heat distrbution system not recognized: {energy_system_config_.heat_distribution_system}")
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    if weather_location is None:
+        raise ValueError("weather_location must not be None.")
+
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
@@ -235,7 +238,7 @@ def setup_function(
     if isinstance(weather_datasource, str):
         weather_datasource = weather.WeatherDataSourceEnum[weather_datasource]
     #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
 
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -136,7 +136,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        weather_location = "AACHEN" # default weather location
+        weather_location = "AACHEN"  # default weather location
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -135,6 +135,9 @@ def setup_function(
         raise ValueError(f"Heat distrbution system not recognized: {energy_system_config_.heat_distribution_system}")
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    # testing AU weather data 
+    weather_filepath = arche_type_config_.weather_filepath
+    weather_datasource = arche_type_config_.weather_datasource
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth
@@ -226,8 +229,10 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
+
     # Add to simulator
     my_sim.add_component(my_weather)
 

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -137,7 +137,7 @@ def setup_function(
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
         raise ValueError("Weather location must not be None.")
-    # testing AU weather data 
+    # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
     if isinstance(weather_datasource, str):
@@ -233,8 +233,12 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
+    # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource,
+    )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
     # Add to simulator

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -140,6 +140,8 @@ def setup_function(
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
+    if isinstance(weather_datasource, str):
+        weather_datasource = weather.WeatherDataSourceEnum[weather_datasource]
 
     # Set Photovoltaic System
     azimuth = arche_type_config_.pv_azimuth

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -136,7 +136,7 @@ def setup_function(
     # Set Weather
     weather_location = arche_type_config_.weather_location
     if weather_location is None:
-        raise ValueError("Weather location must not be None.")
+        weather_location = "AACHEN" # default weather location
     # testing AU weather data
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -135,6 +135,8 @@ def setup_function(
         raise ValueError(f"Heat distrbution system not recognized: {energy_system_config_.heat_distribution_system}")
     # Set Weather
     weather_location = arche_type_config_.weather_location
+    if weather_location is None:
+        raise ValueError("Weather location must not be None.")
     # testing AU weather data 
     weather_filepath = arche_type_config_.weather_filepath
     weather_datasource = arche_type_config_.weather_datasource
@@ -230,7 +232,7 @@ def setup_function(
 
     # Build Weather
     #my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, direct_filepath=weather_filepath, direct_data_source=weather_datasource)
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location, weather_direct_filepath=weather_filepath, weather_direct_data_source=weather_datasource)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
     # Add to simulator

--- a/system_setups/simple_weather_data_import.py
+++ b/system_setups/simple_weather_data_import.py
@@ -15,9 +15,9 @@ __email__ = ""
 __status__ = ""
 
 
-location: str = "Aachen"
-latitude: float = 50.775
-longitude: float = 6.083
+LOCATION: str = "Aachen"
+LATITUDE: float = 50.775
+LONGITUDE: float = 6.083
 
 start_date = datetime.datetime(year=2023, month=1, day=1, hour=0, minute=0, second=0)
 end_date = datetime.datetime(year=2024, month=1, day=1, hour=0, minute=0, second=0)
@@ -27,9 +27,9 @@ input_directory = utils.hisim_inputs
 weather_data = WeatherDataImport(
     start_date=start_date,
     end_date=end_date,
-    location=location,
-    latitude=latitude,
-    longitude=longitude,
+    location=LOCATION,
+    latitude=LATITUDE,
+    longitude=LONGITUDE,
     path_input_folder=input_directory,
     distance_weather_stations=30,
     weather_data_source=WeatherDataSourceEnum.DWD_10MIN,

--- a/tests/test_generic_electrolyzer_h2.py
+++ b/tests/test_generic_electrolyzer_h2.py
@@ -85,8 +85,7 @@ def test_electrolyzer():
 
     else:
         assert (
-            stsv.values[my_electrolyzer.hydrogen_flow_rate.global_index]
-            == 0.621840650119573
+            stsv.values[my_electrolyzer.hydrogen_flow_rate.global_index] == pytest.approx(0.621840650119573)
         )
 
     # python -m pytest ../tests/test_generic_electrolyzer_h2.py

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -38,6 +38,7 @@ def test_weather():
 
     assert sum(dni) > 950
 
+
 def test_weather_config_enum_vs_string_consistency():
     """Test consistency of enum vs. string configuration setup."""
     my_weather_config_enum = weather.WeatherConfig.get_default(
@@ -54,6 +55,7 @@ def test_weather_config_enum_vs_string_consistency():
     assert len(my_weather_config_enum.source_path) > 0
     assert my_weather_config_enum.source_path == my_weather_config_string.source_path
 
+
 def test_weather_config_with_direct_filepath(tmp_path):
     """Test weather config with direct filepath and direct data source."""
     weather_file = tmp_path / "weather.csv"
@@ -65,9 +67,10 @@ def test_weather_config_with_direct_filepath(tmp_path):
         weather_direct_data_source=weather.WeatherDataSourceEnum.DWD_10MIN
     )
 
-    assert my_weather_config.location=="CUSTOM_LOCATION"
-    assert my_weather_config.source_path==str(weather_file)[:-4]
-    assert my_weather_config.data_source==weather.WeatherDataSourceEnum.DWD_10MIN
+    assert my_weather_config.location == "CUSTOM_LOCATION"
+    assert my_weather_config.source_path == str(weather_file)[:-4]
+    assert my_weather_config.data_source == weather.WeatherDataSourceEnum.DWD_10MIN
+
 
 def test_weather_config_with_direct_filepath_without_data_source(tmp_path):
     """Test weather config fails for direct filepath without data source."""

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -37,3 +37,45 @@ def test_weather():
         dni.append(stsv.values[my_weather.dni_output.global_index])
 
     assert sum(dni) > 950
+
+def test_weather_config_enum_vs_string_consistency():
+    """Test consistency of enum vs. string configuration setup."""
+    my_weather_config_enum = weather.WeatherConfig.get_default(
+        location_entry=weather.LocationEnum.AACHEN
+    )
+
+    my_weather_config_string = weather.WeatherConfig.get_default(
+        location_entry="AACHEN"
+    )
+
+    assert my_weather_config_enum.location == my_weather_config_string.location
+    assert my_weather_config_enum.data_source == my_weather_config_string.data_source
+    assert isinstance(my_weather_config_enum.source_path, str)
+    assert len(my_weather_config_enum.source_path) > 0
+    assert my_weather_config_enum.source_path == my_weather_config_string.source_path
+
+def test_weather_config_with_direct_filepath(tmp_path):
+    """Test weather config with direct filepath and direct data source."""
+    weather_file = tmp_path / "weather.csv"
+    weather_file.write_text("dummy weather data", encoding="utf-8")
+
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry="CUSTOM_LOCATION",
+        weather_direct_filepath=str(weather_file),
+        weather_direct_data_source=weather.WeatherDataSourceEnum.DWD_10MIN
+    )
+
+    assert my_weather_config.location=="CUSTOM_LOCATION"
+    assert my_weather_config.source_path==str(weather_file)[:-4]
+    assert my_weather_config.data_source==weather.WeatherDataSourceEnum.DWD_10MIN
+
+def test_weather_config_with_direct_filepath_without_data_source(tmp_path):
+    """Test weather config fails for direct filepath without data source."""
+    weather_file = tmp_path / "weather.csv"
+    weather_file.write_text("dummy weather data", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        weather.WeatherConfig.get_default(
+            location_entry="CUSTOM_LOCATION",
+            weather_direct_filepath=str(weather_file)
+        )


### PR DESCRIPTION
This branch / PR extends the weather module to allow loading weather data directly from a given direct_filepath and by specifying the source format. This bypasses the previous requirement to use a LocationEnum, enabling more flexible use of custom datasets.

The changes are implemented within the weather module and keep the existing LocationEnum workflow fully intact, ensuring backward compatibility.

Additionally, a minor adjustment was made to the absolute comparison in the test_generic_electrolyzer_h2.py test to avoid numerical errors.