### PR TITLE
429 system setups fail due to car

### DIFF
--- a/hisim/components/generic_car.py
+++ b/hisim/components/generic_car.py
@@ -64,7 +64,11 @@ class GenericCarInformation:
         ):
             raise ValueError(
                 "The car data from occupancy contains only empty dictionaries in its value lists. "
-                "If you are using the predefined occupancy profile, no car data is currently available. "
+                "This is likely caused by one of the following reasons: "
+                "(1) You are using the predefined occupancy profile, no car data is currently available. "
+                "(2) The UTSP request failed (e.g., due to missing or incorrect UTSP configuration). "
+                "(3) USE_LOCAL_LPG is currently not supported on macOS (darwin). "
+                "Please switch to USE_UTSP with a reachable UTSP endpoint with correct UTSP configuration."
             )
 
         # get car names and household names

--- a/hisim/hisim_main.py
+++ b/hisim/hisim_main.py
@@ -37,9 +37,11 @@ __credits__ = ["Noah Pflugradt", "Katharina Rieck"]
 __maintainer__ = "Valentin Janser"
 __email__ = "v.janser@fz-juelich.de"
 
+
 def is_hisim_root(path: Path) -> bool:
     """Check if given path is HiSim root directory."""
     return (path / "setup.py").exists() and (path / "hisim").is_dir()
+
 
 def initialize_from_python(
     path_to_module: str,

--- a/hisim/hisim_main.py
+++ b/hisim/hisim_main.py
@@ -24,7 +24,10 @@ except ModuleNotFoundError:
         "Could not import HiSim modules. "
         "It may not be installed in the current Python environment.\n\n"
         "If you already installed HiSim locally with 'pip install -e .', "
-        "make sure you are using the same virtual environment/interpreter."
+        "make sure you are using the same virtual environment/interpreter.\n\n"
+        "If you recently updated the repository via 'git pull', new dependencies "
+        "may have been added. Try re-running 'pip install -e .' from the HiSim "
+        "root directory to install any missing packages."
     ) from None
 
 load_dotenv()

--- a/hisim/hisim_main.py
+++ b/hisim/hisim_main.py
@@ -39,7 +39,7 @@ __email__ = "v.janser@fz-juelich.de"
 
 def is_hisim_root(path: Path) -> bool:
     """Check if given path is HiSim root directory."""
-    return (path / "setup.py").exists() and (path / "hisim").isdir()
+    return (path / "setup.py").exists() and (path / "hisim").is_dir()
 
 def initialize_from_python(
     path_to_module: str,

--- a/hisim/hisim_main.py
+++ b/hisim/hisim_main.py
@@ -37,6 +37,9 @@ __credits__ = ["Noah Pflugradt", "Katharina Rieck"]
 __maintainer__ = "Valentin Janser"
 __email__ = "v.janser@fz-juelich.de"
 
+def is_hisim_root(path: Path) -> bool:
+    """Check if given path is HiSim root directory."""
+    return (path / "setup.py").exists() and (path / "hisim").isdir()
 
 def initialize_from_python(
     path_to_module: str,
@@ -58,6 +61,8 @@ def initialize_from_python(
     for parent in path_obj.parents:
         if parent.exists():
             sys.path.append(str(parent))
+            if is_hisim_root(parent):
+                break
         else:
             raise ValueError(f"Directory of module does not exist: {module_dir}")
 


### PR DESCRIPTION
Changes:
1. Improved error message: Added detailed comment to raised Error Message explaining why car data may not be available and what steps to take
2. Bug fix: Fixed "infinite" parent directory traversal in initialize_from_python - path, resolution now stops at the HiSim root directory
3. Documentation: Added hint to error message that "pip install -e ." may need to be re-run after git pull if new dependencies were added.