### PR TITLE
Add bounds in installation requirements to fix installation issues

### DIFF
--- a/.github/workflows/basic-execution.yml
+++ b/.github/workflows/basic-execution.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: "3.12"
+        python-version: "3.11"
     - name: Setup Graphviz
       uses: ts-graphviz/setup-graphviz@v1
     - name: Install dependencies

--- a/.github/workflows/basic-execution.yml
+++ b/.github/workflows/basic-execution.yml
@@ -26,7 +26,6 @@ jobs:
         pip install uv
         if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
         uv pip install --system -e .
-        - name: Run hisim_main.py directly from the command line
     - name: Run hisim_main.py directly from the command line
       working-directory: ./system_setups/
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy
-pandas
-matplotlib
+numpy<2 # upper bound only required because wetterdienst is pinned to ==0.63.0
+pandas<2.2 # see wetterdienst note above
+matplotlib<3.9 # see wetterdienst note above
 seaborn
 reportlab
 pvlib # ==0.10.2


### PR DESCRIPTION
Add bounds in installation requirements.
For proper fix work on issue #450 with detailed instructions on how to upgrade to newer version of wetterdienst package