### PR TITLE
Adds the ability to pass real building-envelope parameters

### DIFF
--- a/hisim/building_sizer_utils/interface_configs/archetype_config.py
+++ b/hisim/building_sizer_utils/interface_configs/archetype_config.py
@@ -55,3 +55,18 @@ class ArcheTypeConfig:
     construction_year: int = 1964
     coordinates_latitude: float = 50.77664
     coordinates_longitude: float = 6.0834
+
+    # Optional building-envelope override. If any of these are set, the value is passed through to
+    # the Building component and used instead of the TABULA archetype default. If left None (default),
+    # the envelope is derived from the TABULA building_code exactly as before (opt-in, backward compatible).
+    building_heat_capacity_class: Optional[str] = None
+    floor_u_value_in_watt_per_m2_per_kelvin: Optional[float] = None
+    floor_area_in_m2: Optional[float] = None
+    facade_u_value_in_watt_per_m2_per_kelvin: Optional[float] = None
+    facade_area_in_m2: Optional[float] = None
+    roof_u_value_in_watt_per_m2_per_kelvin: Optional[float] = None
+    roof_area_in_m2: Optional[float] = None
+    window_u_value_in_watt_per_m2_per_kelvin: Optional[float] = None
+    window_area_in_m2: Optional[float] = None
+    door_u_value_in_watt_per_m2_per_kelvin: Optional[float] = None
+    door_area_in_m2: Optional[float] = None

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -238,6 +238,23 @@ def setup_function(
     my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+
+    # Optional building-envelope override from the archetype config. Each field defaults to None,
+    # in which case the Building component derives the value from the TABULA building_code as before.
+    # Only when a real U-value/area is provided in the config is it used instead (opt-in).
+    my_building_config.floor_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.floor_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.floor_area_in_m2 = arche_type_config_.floor_area_in_m2
+    my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.facade_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.facade_area_in_m2 = arche_type_config_.facade_area_in_m2
+    my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.roof_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.roof_area_in_m2 = arche_type_config_.roof_area_in_m2
+    my_building_config.window_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.window_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.window_area_in_m2 = arche_type_config_.window_area_in_m2
+    my_building_config.door_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.door_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.door_area_in_m2 = arche_type_config_.door_area_in_m2
+    if arche_type_config_.building_heat_capacity_class is not None:
+        my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
+
     my_building_information = building.BuildingInformation(config=my_building_config)
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -197,6 +197,23 @@ def setup_function(
     my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+
+    # Optional building-envelope override from the archetype config. Each field defaults to None,
+    # in which case the Building component derives the value from the TABULA building_code as before.
+    # Only when a real U-value/area is provided in the config is it used instead (opt-in).
+    my_building_config.floor_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.floor_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.floor_area_in_m2 = arche_type_config_.floor_area_in_m2
+    my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.facade_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.facade_area_in_m2 = arche_type_config_.facade_area_in_m2
+    my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.roof_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.roof_area_in_m2 = arche_type_config_.roof_area_in_m2
+    my_building_config.window_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.window_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.window_area_in_m2 = arche_type_config_.window_area_in_m2
+    my_building_config.door_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.door_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.door_area_in_m2 = arche_type_config_.door_area_in_m2
+    if arche_type_config_.building_heat_capacity_class is not None:
+        my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
+
     my_building_information = building.BuildingInformation(config=my_building_config)
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -205,6 +205,23 @@ def setup_function(
     my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+
+    # Optional building-envelope override from the archetype config. Each field defaults to None,
+    # in which case the Building component derives the value from the TABULA building_code as before.
+    # Only when a real U-value/area is provided in the config is it used instead (opt-in).
+    my_building_config.floor_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.floor_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.floor_area_in_m2 = arche_type_config_.floor_area_in_m2
+    my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.facade_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.facade_area_in_m2 = arche_type_config_.facade_area_in_m2
+    my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.roof_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.roof_area_in_m2 = arche_type_config_.roof_area_in_m2
+    my_building_config.window_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.window_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.window_area_in_m2 = arche_type_config_.window_area_in_m2
+    my_building_config.door_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.door_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.door_area_in_m2 = arche_type_config_.door_area_in_m2
+    if arche_type_config_.building_heat_capacity_class is not None:
+        my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
+
     my_building_information = building.BuildingInformation(config=my_building_config)
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_gas_solar_thermal_building_sizer.py
+++ b/system_setups/household_gas_solar_thermal_building_sizer.py
@@ -196,6 +196,23 @@ def setup_function(
     my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+
+    # Optional building-envelope override from the archetype config. Each field defaults to None,
+    # in which case the Building component derives the value from the TABULA building_code as before.
+    # Only when a real U-value/area is provided in the config is it used instead (opt-in).
+    my_building_config.floor_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.floor_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.floor_area_in_m2 = arche_type_config_.floor_area_in_m2
+    my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.facade_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.facade_area_in_m2 = arche_type_config_.facade_area_in_m2
+    my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.roof_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.roof_area_in_m2 = arche_type_config_.roof_area_in_m2
+    my_building_config.window_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.window_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.window_area_in_m2 = arche_type_config_.window_area_in_m2
+    my_building_config.door_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.door_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.door_area_in_m2 = arche_type_config_.door_area_in_m2
+    if arche_type_config_.building_heat_capacity_class is not None:
+        my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
+
     my_building_information = building.BuildingInformation(config=my_building_config)
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -200,6 +200,23 @@ def setup_function(
     my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+
+    # Optional building-envelope override from the archetype config. Each field defaults to None,
+    # in which case the Building component derives the value from the TABULA building_code as before.
+    # Only when a real U-value/area is provided in the config is it used instead (opt-in).
+    my_building_config.floor_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.floor_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.floor_area_in_m2 = arche_type_config_.floor_area_in_m2
+    my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.facade_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.facade_area_in_m2 = arche_type_config_.facade_area_in_m2
+    my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.roof_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.roof_area_in_m2 = arche_type_config_.roof_area_in_m2
+    my_building_config.window_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.window_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.window_area_in_m2 = arche_type_config_.window_area_in_m2
+    my_building_config.door_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.door_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.door_area_in_m2 = arche_type_config_.door_area_in_m2
+    if arche_type_config_.building_heat_capacity_class is not None:
+        my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
+
     my_building_information = building.BuildingInformation(config=my_building_config)
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_heatpump_car_building_sizer.py
+++ b/system_setups/household_heatpump_car_building_sizer.py
@@ -206,6 +206,23 @@ def setup_function(
     my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+
+    # Optional building-envelope override from the archetype config. Each field defaults to None,
+    # in which case the Building component derives the value from the TABULA building_code as before.
+    # Only when a real U-value/area is provided in the config is it used instead (opt-in).
+    my_building_config.floor_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.floor_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.floor_area_in_m2 = arche_type_config_.floor_area_in_m2
+    my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.facade_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.facade_area_in_m2 = arche_type_config_.facade_area_in_m2
+    my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.roof_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.roof_area_in_m2 = arche_type_config_.roof_area_in_m2
+    my_building_config.window_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.window_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.window_area_in_m2 = arche_type_config_.window_area_in_m2
+    my_building_config.door_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.door_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.door_area_in_m2 = arche_type_config_.door_area_in_m2
+    if arche_type_config_.building_heat_capacity_class is not None:
+        my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
+
     my_building_information = building.BuildingInformation(config=my_building_config)
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.py
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.py
@@ -194,6 +194,23 @@ def setup_function(
     my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+
+    # Optional building-envelope override from the archetype config. Each field defaults to None,
+    # in which case the Building component derives the value from the TABULA building_code as before.
+    # Only when a real U-value/area is provided in the config is it used instead (opt-in).
+    my_building_config.floor_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.floor_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.floor_area_in_m2 = arche_type_config_.floor_area_in_m2
+    my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.facade_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.facade_area_in_m2 = arche_type_config_.facade_area_in_m2
+    my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.roof_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.roof_area_in_m2 = arche_type_config_.roof_area_in_m2
+    my_building_config.window_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.window_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.window_area_in_m2 = arche_type_config_.window_area_in_m2
+    my_building_config.door_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.door_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.door_area_in_m2 = arche_type_config_.door_area_in_m2
+    if arche_type_config_.building_heat_capacity_class is not None:
+        my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
+
     my_building_information = building.BuildingInformation(config=my_building_config)
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_hydrogen_boiler_building_sizer.py
+++ b/system_setups/household_hydrogen_boiler_building_sizer.py
@@ -195,6 +195,23 @@ def setup_function(
     my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+
+    # Optional building-envelope override from the archetype config. Each field defaults to None,
+    # in which case the Building component derives the value from the TABULA building_code as before.
+    # Only when a real U-value/area is provided in the config is it used instead (opt-in).
+    my_building_config.floor_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.floor_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.floor_area_in_m2 = arche_type_config_.floor_area_in_m2
+    my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.facade_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.facade_area_in_m2 = arche_type_config_.facade_area_in_m2
+    my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.roof_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.roof_area_in_m2 = arche_type_config_.roof_area_in_m2
+    my_building_config.window_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.window_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.window_area_in_m2 = arche_type_config_.window_area_in_m2
+    my_building_config.door_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.door_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.door_area_in_m2 = arche_type_config_.door_area_in_m2
+    if arche_type_config_.building_heat_capacity_class is not None:
+        my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
+
     my_building_information = building.BuildingInformation(config=my_building_config)
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -230,6 +230,23 @@ def setup_function(
     my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+
+    # Optional building-envelope override from the archetype config. Each field defaults to None,
+    # in which case the Building component derives the value from the TABULA building_code as before.
+    # Only when a real U-value/area is provided in the config is it used instead (opt-in).
+    my_building_config.floor_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.floor_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.floor_area_in_m2 = arche_type_config_.floor_area_in_m2
+    my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.facade_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.facade_area_in_m2 = arche_type_config_.facade_area_in_m2
+    my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.roof_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.roof_area_in_m2 = arche_type_config_.roof_area_in_m2
+    my_building_config.window_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.window_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.window_area_in_m2 = arche_type_config_.window_area_in_m2
+    my_building_config.door_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.door_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.door_area_in_m2 = arche_type_config_.door_area_in_m2
+    if arche_type_config_.building_heat_capacity_class is not None:
+        my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
+
     my_building_information = building.BuildingInformation(config=my_building_config)
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -200,6 +200,23 @@ def setup_function(
     my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+
+    # Optional building-envelope override from the archetype config. Each field defaults to None,
+    # in which case the Building component derives the value from the TABULA building_code as before.
+    # Only when a real U-value/area is provided in the config is it used instead (opt-in).
+    my_building_config.floor_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.floor_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.floor_area_in_m2 = arche_type_config_.floor_area_in_m2
+    my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.facade_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.facade_area_in_m2 = arche_type_config_.facade_area_in_m2
+    my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.roof_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.roof_area_in_m2 = arche_type_config_.roof_area_in_m2
+    my_building_config.window_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.window_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.window_area_in_m2 = arche_type_config_.window_area_in_m2
+    my_building_config.door_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.door_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.door_area_in_m2 = arche_type_config_.door_area_in_m2
+    if arche_type_config_.building_heat_capacity_class is not None:
+        my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
+
     my_building_information = building.BuildingInformation(config=my_building_config)
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -201,6 +201,23 @@ def setup_function(
     my_building_config.absolute_conditioned_floor_area_in_m2 = absolute_conditioned_floor_area_in_m2
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+
+    # Optional building-envelope override from the archetype config. Each field defaults to None,
+    # in which case the Building component derives the value from the TABULA building_code as before.
+    # Only when a real U-value/area is provided in the config is it used instead (opt-in).
+    my_building_config.floor_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.floor_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.floor_area_in_m2 = arche_type_config_.floor_area_in_m2
+    my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.facade_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.facade_area_in_m2 = arche_type_config_.facade_area_in_m2
+    my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.roof_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.roof_area_in_m2 = arche_type_config_.roof_area_in_m2
+    my_building_config.window_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.window_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.window_area_in_m2 = arche_type_config_.window_area_in_m2
+    my_building_config.door_u_value_in_watt_per_m2_per_kelvin = arche_type_config_.door_u_value_in_watt_per_m2_per_kelvin
+    my_building_config.door_area_in_m2 = arche_type_config_.door_area_in_m2
+    if arche_type_config_.building_heat_capacity_class is not None:
+        my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
+
     my_building_information = building.BuildingInformation(config=my_building_config)
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator


### PR DESCRIPTION
### Summary
Adds the ability to pass real, measured building-envelope parameters (per-element U-values and areas plus the heat-capacity class) into HiSim instead of relying solely on the TABULA archetype derived from `building_code`.

`BuildingConfig` already supported this per-element override — it was just not wired through from `ArcheTypeConfig` and the system setups. This PR closes that gap.

### Changes
- **`hisim/building_sizer_utils/interface_configs/archetype_config.py`**
  Added 11 optional fields (default `None`): `floor/facade/roof/window/door_u_value_in_watt_per_m2_per_kelvin`, the matching `_area_in_m2` fields, and `building_heat_capacity_class`.
- **`system_setups/household_*_building_sizer.py` (all 11 building-sizer setups)**
  Pass the archetype fields through to `BuildingConfig` after construction. Because the archetype fields default to `None` and `BuildingInformation` treats `None` as "use TABULA", behavior is unchanged when no U-values are provided.

### Design principle
Purely **opt-in** and **backward compatible**:
- U-values provided in the config → used.
- Nothing provided → unchanged TABULA behavior.
- No changes to HiSim core simulation logic.

### Known limitations (accepted for now)
- **Floor factor 0.5:** HiSim still applies a fixed factor of 0.5 to an overridden floor U-value. To reproduce the real conductance without touching core logic, the floor U-value is pre-divided by 0.5 in the config (documented via `_envelope_note`).
- **Ventilation, thermal bridges, and solar orientation/g-value** remain archetype-based.

### Verification
- `py_compile` passes for all 11 setups and `archetype_config.py`.