### PR TITLE
Remove unused pyam-iamc dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ pydot
 graphviz
 dataclass_wizard==0.34.0
 utspclient==0.1.6
-pyam-iamc
 html2image
 control
 casadi


### PR DESCRIPTION
pyam-iamc is not imported anywhere in the codebase. The only remaining references are comments and commented-out code in postprocessing_main.py and scenario_evaluation/result_data_plotting.py; the one test that used it (test_house_with_pyam_postprocessingoption.py) moved to obsolete/ in #517.

It is also what currently caps pandas. pyam-iamc 3.2.0 required "pandas>=2.1.2", but 3.5.0 requires "pandas<3.0.0,>=2.1.2". When the weekly docker-test-image rebuild missed its layer cache on 2026-08-10 and re-resolved from scratch, pyam-iamc moved 3.2.0 -> 3.5.0 and pandas was downgraded 3.0.5 -> 2.3.3. That changed simulation output (PV production 83.3 -> 82.5 kWh for the one-week building_sizer setups) and broke every golden reference, on a commit whose CI had been green three days earlier.

Dropping it also removes the ixmp4 / litestar / polars / minio / msgspec tree it pulled in.

pandas is deliberately left unpinned here to observe what the resolver picks on its own.