### PR TITLE
Pin pandas==3.0.5 to stop the golden references drifting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-pandas>=2.2
+pandas==3.0.5
 matplotlib
 seaborn
 reportlab


### PR DESCRIPTION
## What happened

The golden references were blessed in a test image that resolved **pandas 3.0.5**. On 2026-08-10 the weekly `docker-test-image` rebuild missed its GHA layer cache, re-resolved from scratch, and picked up `pyam-iamc` 3.5.0:

| | pandas constraint |
|---|---|
| `pyam-iamc==3.2.0` | `pandas>=2.1.2` — no upper bound |
| `pyam-iamc==3.5.0` | `pandas>=2.1.2,<3.0.0` — caps it |

pandas was downgraded **3.0.5 → 2.3.3** and every golden reference broke.

Nothing in the repo changed. The same commit `e2033174` **passed on attempt 1** (08-07) and **failed on attempt 2** (08-10), and every golden-check since has failed across unrelated branches.

## Why it matters

pandas 2 vs 3 changes simulation output. PV production for the one-week `building_sizer` setups moves **83.3 → 82.5 kWh**, cascading into 42–64 KPI divergences per setup, on all 8 setups. Against the gate's `rel_tol=1e-9` / `abs_tol=0` that is a hard failure.

The same 82.5 reproduces on an unrelated Windows box running pandas 2.3.3 — with a different numpy — which is how the cause was isolated to pandas rather than platform, numpy, pvlib or scipy (identical across both images).

## What this changes

One line: `pandas>=2.2` → `pandas==3.0.5`.

Pinning makes the resolver move *other* packages instead. Verified by clean-slate resolution:

- `pandas==3.0.5` with `pyam-iamc` unpinned → uv backtracks to `pyam-iamc==3.2.0` / `ixmp4==0.14.0`, exit 0.
- A genuinely unsatisfiable pin fails loudly at resolution, before any simulation runs.

## Expected effect

**golden-check should go green on this PR with no re-blessing.** The pin applies at test time — the image's pandas 2.3.3 no longer satisfies the requirement, so uv installs 3.0.5 — which means no image rebuild is needed to observe it.

If it does *not* go green, something beyond pandas moved, and this PR is the place to find that out.

## Follow-ups (not in this PR)

- Remove the unused `pyam-iamc` dependency (no imports anywhere; the one test using it moved to `obsolete/` in #517). It drags in ixmp4/litestar/polars/minio — 53 packages.
- Publish the test image to an immutable tag and pin workflows to the digest, so a rebuild cannot replace the reference environment under a green history.
- Record `pip freeze` in `golden_references/manifest.json` at bless time. It stores platform and Python but not package versions, which is the only reason this took a forensic investigation instead of a one-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
