### PR TITLE
Fix issue # 448

### DIFF
--- a/hisim/hisim_main.py
+++ b/hisim/hisim_main.py
@@ -121,22 +121,19 @@ def initialize_from_python(
             sim_params_data = load_json_file(my_simulation_parameters)
             sim_params_data["start_date"] = datetime.fromisoformat(sim_params_data["start_date"])
             sim_params_data["end_date"] = datetime.fromisoformat(sim_params_data["end_date"])
-            sim_params_data["post_processing_options"] = [
-                PostProcessingOptions[option] for option in sim_params_data.get("post_processing_options", [])
-            ]
+            sim_params_data["post_processing_options"] = [PostProcessingOptions[option] for option in sim_params_data.get("post_processing_options", [])]
             sim_params = SimulationParameters(**sim_params_data)
         elif isinstance(my_simulation_parameters, SimulationParameters):
             sim_params = my_simulation_parameters
         else:
-            raise TypeError(f"Type for simulation parameter argument {type(my_simulation_parameters)} either not recognized or not implemented yet. "
-                            "Should be string or SimulationParamters object.")
+            raise TypeError(
+                f"Type for simulation parameter argument {type(my_simulation_parameters)} either not recognized or not implemented yet. "
+                "Should be string or SimulationParamters object."
+            )
     else:
         sim_params = None
 
-    SingletonSimRepository().set_entry(
-        key=SingletonDictKeyEnum.DESCRIPTION,
-        entry=f"{get_description_from_py(path_obj)}",
-    )
+    SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.DESCRIPTION, entry=f"{get_description_from_py(path_obj)}")
 
     # Make setup function executable
     targetmodule = importlib.import_module(module_filename)
@@ -220,10 +217,7 @@ def initialize_from_json(
 
     # Load JSON files
     scenario_data = load_json_file(scenario)
-    SingletonSimRepository().set_entry(
-        key=SingletonDictKeyEnum.DESCRIPTION,
-        entry=f"{scenario_data.get('description', '')}",
-    )
+    SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.DESCRIPTION, entry=f"{scenario_data.get('description', '')}")
     # Missing in the following data: result_directory, surplus_control, cache_dir_path, multiple_buildings
     # -> Result Directory is set in prepare_simulation_directory function, called by run_all_timesteps
     # -> Cache Dir Path is filled by default in SimulationParameters
@@ -232,9 +226,7 @@ def initialize_from_json(
     sim_params_data["multiple_buildings"] = scenario_data.get("multiple_buildings", False)
     sim_params_data["start_date"] = datetime.fromisoformat(sim_params_data["start_date"])
     sim_params_data["end_date"] = datetime.fromisoformat(sim_params_data["end_date"])
-    sim_params_data["post_processing_options"] = [
-        PostProcessingOptions[option] for option in sim_params_data.get("post_processing_options", [])
-    ]
+    sim_params_data["post_processing_options"] = [PostProcessingOptions[option] for option in sim_params_data.get("post_processing_options", [])]
     sim_params = SimulationParameters(**sim_params_data)
 
     my_sim = _build_simulator_from_scenario(scenario_data, path_to_module, sim_params)
@@ -307,10 +299,7 @@ def initialize_from_json_with_parameters(
         The initialized ``Simulator`` with its component graph wired.
     """
     scenario_data = load_json_file(scenario)
-    SingletonSimRepository().set_entry(
-        key=SingletonDictKeyEnum.DESCRIPTION,
-        entry=f"{scenario_data.get('description', '')}",
-    )
+    SingletonSimRepository().set_entry(key=SingletonDictKeyEnum.DESCRIPTION, entry=f"{scenario_data.get('description', '')}")
     my_simulation_parameters.multiple_buildings = scenario_data.get("multiple_buildings", False)
     my_simulation_parameters.log_connections = True  # For easy post-processing (and debugging)
     return _build_simulator_from_scenario(scenario_data, scenario, my_simulation_parameters)
@@ -377,12 +366,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "inputs",
         nargs="+",
-        help=(
-            "JSON mode:\n"
-            "  <scenario_params.json> <simulation_params.json> [scenario_delta.json]\n\n"
-            "Legacy Python mode:\n"
-            "  <module.py> [module_config]"
-        ),
+        help=("JSON mode:\n" "  <scenario_params.json> <simulation_params.json> [scenario_delta.json]\n\n" "Legacy Python mode:\n" "  <module.py> [module_config]"),
     )
 
     return parser.parse_args()
@@ -421,10 +405,7 @@ def validate_args(args: argparse.Namespace) -> dict[str, Optional[str]]:
 
     if inputs[0].endswith(".py"):
         if len(inputs) > 3:
-            raise ValueError(
-                "The legancy Python mode accepts at most 3 arguments:\n"
-                "  <module.py> <module_config.json> <simulation_params.json>"
-            )
+            raise ValueError("The legancy Python mode accepts at most 3 arguments:\n" "  <module.py> <module_config.json> <simulation_params.json>")
 
         module_file = inputs[0]
         module_config = inputs[1] if len(inputs) >= 2 else None
@@ -442,15 +423,9 @@ def validate_args(args: argparse.Namespace) -> dict[str, Optional[str]]:
 
     if inputs[0].endswith(".json"):
         if len(inputs) < 2:
-            raise ValueError(
-                "The JSON mode requires at least 2 files:\n"
-                "  <scenario.json> <simulation_params.json> [delta.json]"
-            )
+            raise ValueError("The JSON mode requires at least 2 files:\n" "  <scenario.json> <simulation_params.json> [delta.json]")
         if len(inputs) > 3:
-            raise ValueError(
-                "The JSON mode accepts at most 3 files:\n"
-                "  <scenario.json> <simulation_params.json> [delta.json]"
-            )
+            raise ValueError("The JSON mode accepts at most 3 files:\n" "  <scenario.json> <simulation_params.json> [delta.json]")
 
         for f in inputs:
             if not f.endswith(".json"):
@@ -465,11 +440,7 @@ def validate_args(args: argparse.Namespace) -> dict[str, Optional[str]]:
             "delta": inputs[2] if len(inputs) == 3 else None,
         }
 
-    raise ValueError(
-        "First argument must be either:\n"
-        "  - a Python file (*.py) for legacy Python mode, or\n"
-        "  - a JSON file (*.json) for JSON mode"
-    )
+    raise ValueError("First argument must be either:\n" "  - a Python file (*.py) for legacy Python mode, or\n" "  - a JSON file (*.json) for JSON mode")
 
 
 def get_required_config_value(config: dict[str, Optional[str]], key: str) -> str:
@@ -516,10 +487,7 @@ def main_cli() -> None:
     elif config["mode"] == "json":
         scenario = get_required_config_value(config, "scenario")
         simulation = get_required_config_value(config, "simulation")
-        print(
-            f"Running simulation of scenario {scenario} with simulation parameters {simulation}"
-            + (f" and delta {config['delta']}" if config["delta"] else "")
-        )
+        print(f"Running simulation of scenario {scenario} with simulation parameters {simulation}" + (f" and delta {config['delta']}" if config["delta"] else ""))
         my_sim = initialize_from_json(
             scenario=scenario,
             simulation_parameters=simulation,

--- a/hisim/hisim_main.py
+++ b/hisim/hisim_main.py
@@ -388,12 +388,25 @@ def validate_args(args: argparse.Namespace) -> dict[str, Optional[str]]:
         args: Parsed arguments from ``parse_args``.
 
     Returns:
-        A dict with key ``"mode"`` (``"python"`` or ``"json"``) plus
-        mode-specific keys: ``module_file``/``module_config`` for Python
-        mode, ``scenario``/``simulation``/``delta`` for JSON mode.
+        A dictionary containing the execution ``mode`` and the corresponding
+        mode-specific input files.
+
+        For ``"python"`` mode, the dictionary contains:
+            - ``module_file``: Path to the Python module.
+            - ``module_config``: Path to the module configuration JSON file,
+              or ``None``.
+            - ``my_simulation_parameters``: Path to the simulation parameters
+              JSON file, or ``None``.
+
+        For ``"json"`` mode, the dictionary contains:
+            - ``scenario``: Path to the scenario JSON file.
+            - ``simulation``: Path to the simulation parameters JSON file.
+            - ``delta``: Path to the optional delta JSON file, or ``None``.
 
     Raises:
-        ValueError: If the arguments match neither expected mode.
+        ValueError: If the arguments do not match a supported execution mode,
+            if the required number of arguments is not provided, if too many
+            arguments are provided, or if a file has an invalid extension.
         FileNotFoundError: If a required input file does not exist.
     """
 
@@ -403,11 +416,11 @@ def validate_args(args: argparse.Namespace) -> dict[str, Optional[str]]:
         if len(inputs) > 3:
             raise ValueError(
                 "The legancy Python mode accepts at most 3 arguments:\n"
-                "  <module_config.json> <simulation_params.json> [delta.json]"
+                "  <module.py> <module_config.json> <simulation_params.json>"
             )
 
         module_file = inputs[0]
-        module_config = inputs[1] if (len(inputs) == 2 or len(inputs) == 3) else None
+        module_config = inputs[1] if len(inputs) >= 2 else None
         my_simulation_parameters = inputs[2] if len(inputs) == 3 else None
 
         if not os.path.isfile(module_file):

--- a/hisim/hisim_main.py
+++ b/hisim/hisim_main.py
@@ -405,7 +405,8 @@ def validate_args(args: argparse.Namespace) -> dict[str, Optional[str]]:
 
     if inputs[0].endswith(".py"):
         if len(inputs) > 3:
-            raise ValueError("The legancy Python mode accepts at most 3 arguments:\n" "  <module.py> <module_config.json> <simulation_params.json>")
+            raise ValueError("The legancy Python mode accepts at most 3 arguments:\n"
+                            "  <module.py> <module_config.json> <simulation_params.json>")
 
         module_file = inputs[0]
         module_config = inputs[1] if len(inputs) >= 2 else None
@@ -423,9 +424,11 @@ def validate_args(args: argparse.Namespace) -> dict[str, Optional[str]]:
 
     if inputs[0].endswith(".json"):
         if len(inputs) < 2:
-            raise ValueError("The JSON mode requires at least 2 files:\n" "  <scenario.json> <simulation_params.json> [delta.json]")
+            raise ValueError("The JSON mode requires at least 2 files:\n"
+                             "  <scenario.json> <simulation_params.json> [delta.json]")
         if len(inputs) > 3:
-            raise ValueError("The JSON mode accepts at most 3 files:\n" "  <scenario.json> <simulation_params.json> [delta.json]")
+            raise ValueError("The JSON mode accepts at most 3 files:\n"
+                             "  <scenario.json> <simulation_params.json> [delta.json]")
 
         for f in inputs:
             if not f.endswith(".json"):
@@ -440,7 +443,8 @@ def validate_args(args: argparse.Namespace) -> dict[str, Optional[str]]:
             "delta": inputs[2] if len(inputs) == 3 else None,
         }
 
-    raise ValueError("First argument must be either:\n" "  - a Python file (*.py) for legacy Python mode, or\n" "  - a JSON file (*.json) for JSON mode")
+    raise ValueError("First argument must be either:\n"
+                     "  - a Python file (*.py) for legacy Python mode, or\n" "  - a JSON file (*.json) for JSON mode")
 
 
 def get_required_config_value(config: dict[str, Optional[str]], key: str) -> str:

--- a/hisim/hisim_main.py
+++ b/hisim/hisim_main.py
@@ -67,7 +67,7 @@ def get_description_from_py(path_obj: Path) -> str:
 
 def initialize_from_python(
     path_to_module: str,
-    my_simulation_parameters: Optional[SimulationParameters] = None,
+    my_simulation_parameters: Optional[str] = None,
     my_module_config: Optional[str] = None,
 ) -> sim.Simulator:
     """Initialize the simulator from a Python household configuration file.
@@ -436,11 +436,13 @@ def validate_args(args: argparse.Namespace) -> dict[str, Optional[str]]:
     if inputs[0].endswith(".json"):
         if len(inputs) < 2:
             raise ValueError(
-                "The JSON mode requires at least 2 files:\n" "  <scenario.json> <simulation_params.json> [delta.json]"
+                "The JSON mode requires at least 2 files:\n"
+                "  <scenario.json> <simulation_params.json> [delta.json]"
             )
         if len(inputs) > 3:
             raise ValueError(
-                "The JSON mode accepts at most 3 files:\n" "  <scenario.json> <simulation_params.json> [delta.json]"
+                "The JSON mode accepts at most 3 files:\n"
+                "  <scenario.json> <simulation_params.json> [delta.json]"
             )
 
         for f in inputs:

--- a/hisim/hisim_main.py
+++ b/hisim/hisim_main.py
@@ -114,9 +114,21 @@ def initialize_from_python(
     # Final check and import
     if not path_obj.is_file():
         raise ValueError(f"Python script {module_filename}.py could not be found at {path_obj}")
+    # Make SimulationParameters object
+    if my_simulation_parameters is not None:
+        sim_params_data = load_json_file(my_simulation_parameters)
+        sim_params_data["start_date"] = datetime.fromisoformat(sim_params_data["start_date"])
+        sim_params_data["end_date"] = datetime.fromisoformat(sim_params_data["end_date"])
+        sim_params_data["post_processing_options"] = [
+            PostProcessingOptions[option] for option in sim_params_data.get("post_processing_options", [])
+        ]
+        sim_params = SimulationParameters(**sim_params_data)
+    else:
+        sim_params = None
 
     SingletonSimRepository().set_entry(
-        key=SingletonDictKeyEnum.DESCRIPTION, entry=f"{get_description_from_py(path_obj)}",
+        key=SingletonDictKeyEnum.DESCRIPTION,
+        entry=f"{get_description_from_py(path_obj)}",
     )
 
     # Make setup function executable
@@ -127,7 +139,7 @@ def initialize_from_python(
         module_directory=str(module_dir),
         module_filename=module_filename,
         setup_function=function_in_module,
-        my_simulation_parameters=my_simulation_parameters,
+        my_simulation_parameters=sim_params,
         my_module_config=my_module_config,
         # Always log component connections in Python mode (mirrors the JSON path, hisim_main.py:215)
         # so component_connections.json is written for easy post-processing and debugging.
@@ -138,7 +150,7 @@ def initialize_from_python(
     model_init_method = getattr(targetmodule, function_in_module)
 
     # Pass setup function to simulator
-    model_init_method(my_sim, my_simulation_parameters)
+    model_init_method(my_sim, sim_params)
 
     return my_sim
 
@@ -202,17 +214,20 @@ def initialize_from_json(
     # Load JSON files
     scenario_data = load_json_file(scenario)
     SingletonSimRepository().set_entry(
-        key=SingletonDictKeyEnum.DESCRIPTION, entry=f"{scenario_data.get('description', '')}",
+        key=SingletonDictKeyEnum.DESCRIPTION,
+        entry=f"{scenario_data.get('description', '')}",
     )
     # Missing in the following data: result_directory, surplus_control, cache_dir_path, multiple_buildings
     # -> Result Directory is set in prepare_simulation_directory function, called by run_all_timesteps
     # -> Cache Dir Path is filled by default in SimulationParameters
     # -> Surplus Control: see comment in hisim_convert_to_json.py
     sim_params_data = load_json_file(simulation_parameters)
-    sim_params_data['multiple_buildings'] = scenario_data.get('multiple_buildings', False)
-    sim_params_data['start_date'] = datetime.fromisoformat(sim_params_data['start_date'])
-    sim_params_data['end_date'] = datetime.fromisoformat(sim_params_data['end_date'])
-    sim_params_data['post_processing_options'] = [PostProcessingOptions[option] for option in sim_params_data.get('post_processing_options', [])]
+    sim_params_data["multiple_buildings"] = scenario_data.get("multiple_buildings", False)
+    sim_params_data["start_date"] = datetime.fromisoformat(sim_params_data["start_date"])
+    sim_params_data["end_date"] = datetime.fromisoformat(sim_params_data["end_date"])
+    sim_params_data["post_processing_options"] = [
+        PostProcessingOptions[option] for option in sim_params_data.get("post_processing_options", [])
+    ]
     sim_params = SimulationParameters(**sim_params_data)
 
     my_sim = _build_simulator_from_scenario(scenario_data, path_to_module, sim_params)
@@ -286,7 +301,8 @@ def initialize_from_json_with_parameters(
     """
     scenario_data = load_json_file(scenario)
     SingletonSimRepository().set_entry(
-        key=SingletonDictKeyEnum.DESCRIPTION, entry=f"{scenario_data.get('description', '')}",
+        key=SingletonDictKeyEnum.DESCRIPTION,
+        entry=f"{scenario_data.get('description', '')}",
     )
     my_simulation_parameters.multiple_buildings = scenario_data.get("multiple_buildings", False)
     my_simulation_parameters.log_connections = True  # For easy post-processing (and debugging)
@@ -304,9 +320,11 @@ def run_simulation(my_sim: sim.Simulator, path_to_module: Optional[str]) -> None
 
     # If debugging is needed, this may be used to print components and their inputs/outputs
     for comp in my_sim.wrapped_components:
-        log.debug(f"Component {comp.my_component.component_name} has inputs "
-                  f"{[input.fullname for input in comp.component_inputs]} and"
-                  f" outputs {[output.full_name for output in comp.component_outputs]}")
+        log.debug(
+            f"Component {comp.my_component.component_name} has inputs "
+            f"{[input.fullname for input in comp.component_inputs]} and"
+            f" outputs {[output.full_name for output in comp.component_outputs]}"
+        )
 
     log.information("#################################")
     log.information(f"Starting simulation of {path_to_module}")
@@ -382,14 +400,15 @@ def validate_args(args: argparse.Namespace) -> dict[str, Optional[str]]:
     inputs = args.inputs
 
     if inputs[0].endswith(".py"):
-        if len(inputs) > 2:
+        if len(inputs) > 3:
             raise ValueError(
-                "The legancy Python mode accepts at most 2 arguments:\n"
-                "  <module.py> [module_config]"
+                "The legancy Python mode accepts at most 3 arguments:\n"
+                "  <module_config.json> <simulation_params.json> [delta.json]"
             )
 
         module_file = inputs[0]
-        module_config = inputs[1] if len(inputs) == 2 else None
+        module_config = inputs[1] if (len(inputs) == 2 or len(inputs) == 3) else None
+        my_simulation_parameters = inputs[2] if len(inputs) == 3 else None
 
         if not os.path.isfile(module_file):
             raise FileNotFoundError(f"Python module not found: {module_file}")
@@ -398,18 +417,17 @@ def validate_args(args: argparse.Namespace) -> dict[str, Optional[str]]:
             "mode": "python",
             "module_file": module_file,
             "module_config": module_config,
+            "my_simulation_parameters": my_simulation_parameters,
         }
 
     if inputs[0].endswith(".json"):
         if len(inputs) < 2:
             raise ValueError(
-                "The JSON mode requires at least 2 files:\n"
-                "  <scenario.json> <simulation_params.json> [delta.json]"
+                "The JSON mode requires at least 2 files:\n" "  <scenario.json> <simulation_params.json> [delta.json]"
             )
         if len(inputs) > 3:
             raise ValueError(
-                "The JSON mode accepts at most 3 files:\n"
-                "  <scenario.json> <simulation_params.json> [delta.json]"
+                "The JSON mode accepts at most 3 files:\n" "  <scenario.json> <simulation_params.json> [delta.json]"
             )
 
         for f in inputs:
@@ -468,6 +486,7 @@ def main_cli() -> None:
         print(f"Calling setup_function from {module_file}")
         my_sim = initialize_from_python(
             path_to_module=module_file,
+            my_simulation_parameters=config["my_simulation_parameters"],
             my_module_config=config["module_config"],
         )
         ptm = module_file
@@ -490,7 +509,11 @@ def main_cli() -> None:
     run_simulation(my_sim, path_to_module=ptm)
 
 
-def main(path_to_module: str, my_simulation_parameters: Optional[SimulationParameters] = None, my_module_config: Optional[str] = None) -> str:
+def main(
+    path_to_module: str,
+    my_simulation_parameters: Optional[SimulationParameters] = None,
+    my_module_config: Optional[str] = None,
+) -> str:
     """Run a Python-based system setup and return the directory it wrote results to.
 
     This is the legacy entry point used by the system-setup tests. It initializes

--- a/hisim/hisim_main.py
+++ b/hisim/hisim_main.py
@@ -6,7 +6,7 @@ import importlib
 from pathlib import Path
 import sys
 from datetime import datetime
-from typing import Optional, Any, cast
+from typing import Optional, Any, cast, Union
 import argparse
 from pydantic import TypeAdapter
 from dotenv import load_dotenv
@@ -67,7 +67,7 @@ def get_description_from_py(path_obj: Path) -> str:
 
 def initialize_from_python(
     path_to_module: str,
-    my_simulation_parameters: Optional[str] = None,
+    my_simulation_parameters: Optional[Union[SimulationParameters, str]] = None,
     my_module_config: Optional[str] = None,
 ) -> sim.Simulator:
     """Initialize the simulator from a Python household configuration file.
@@ -114,15 +114,22 @@ def initialize_from_python(
     # Final check and import
     if not path_obj.is_file():
         raise ValueError(f"Python script {module_filename}.py could not be found at {path_obj}")
+
     # Make SimulationParameters object
     if my_simulation_parameters is not None:
-        sim_params_data = load_json_file(my_simulation_parameters)
-        sim_params_data["start_date"] = datetime.fromisoformat(sim_params_data["start_date"])
-        sim_params_data["end_date"] = datetime.fromisoformat(sim_params_data["end_date"])
-        sim_params_data["post_processing_options"] = [
-            PostProcessingOptions[option] for option in sim_params_data.get("post_processing_options", [])
-        ]
-        sim_params = SimulationParameters(**sim_params_data)
+        if isinstance(my_simulation_parameters, str):
+            sim_params_data = load_json_file(my_simulation_parameters)
+            sim_params_data["start_date"] = datetime.fromisoformat(sim_params_data["start_date"])
+            sim_params_data["end_date"] = datetime.fromisoformat(sim_params_data["end_date"])
+            sim_params_data["post_processing_options"] = [
+                PostProcessingOptions[option] for option in sim_params_data.get("post_processing_options", [])
+            ]
+            sim_params = SimulationParameters(**sim_params_data)
+        elif isinstance(my_simulation_parameters, SimulationParameters):
+            sim_params = my_simulation_parameters
+        else:
+            raise TypeError(f"Type for simulation parameter argument {type(my_simulation_parameters)} either not recognized or not implemented yet. "
+                            "Should be string or SimulationParamters object.")
     else:
         sim_params = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.black]
-line-length = 120
+line-length = 170

--- a/tests/test_hisim_main_json.py
+++ b/tests/test_hisim_main_json.py
@@ -1,0 +1,120 @@
+"""Test for running main json execution in all possible ways.
+
+JSON
+├── 2 inputs: scenario.json + simulation.json
+└── 3 inputs: scenario.json + simulation.json + delta.json
+"""
+
+from pathlib import Path
+import argparse
+
+import pytest
+
+from hisim import hisim_main
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SCENARIO_JSON = str(
+    REPO_ROOT
+    / "system_setups"
+    / "household_gas_building_sizer.scenario.json"
+)
+SIMULATION_PARAMS_JSON = str(
+    REPO_ROOT
+    / "system_setups"
+    / "2021_15minutely_noplots_buildingsizer.simulation.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# initialize_from_json
+# ---------------------------------------------------------------------------
+@pytest.mark.base
+def test_initialize_from_json_without_delta():
+    """Initialize from json without delta.json file."""
+    simulator = hisim_main.initialize_from_json(
+        scenario=SCENARIO_JSON,
+        simulation_parameters=SIMULATION_PARAMS_JSON,
+        path_to_module=SCENARIO_JSON,
+        delta=None,
+    )
+
+    assert simulator is not None
+
+
+# ---------------------------------------------------------------------------
+# validate_args - JSON mode
+# ---------------------------------------------------------------------------
+@pytest.mark.base
+def test_validate_json_arguments_without_delta():
+    """Validate json arguments without delta."""
+    args = argparse.Namespace(
+        inputs=[
+            SCENARIO_JSON,
+            SIMULATION_PARAMS_JSON,
+        ]
+    )
+
+    config = hisim_main.validate_args(args)
+
+    assert config == {
+        "mode": "json",
+        "scenario": SCENARIO_JSON,
+        "simulation": SIMULATION_PARAMS_JSON,
+        "delta": None,
+    }
+
+
+@pytest.mark.base
+def test_validate_json_arguments_with_delta():
+    """Validate json arguments with delta.json file."""
+    # Use a real delta JSON here once one is available.
+    delta_json = REPO_ROOT / "path" / "to" / "delta.json"
+
+    if not delta_json.is_file():
+        pytest.skip("No delta JSON fixture available")
+
+    args = argparse.Namespace(
+        inputs=[
+            SCENARIO_JSON,
+            SIMULATION_PARAMS_JSON,
+            delta_json,
+        ]
+    )
+
+    config = hisim_main.validate_args(args)
+
+    assert config == {
+        "mode": "json",
+        "scenario": SCENARIO_JSON,
+        "simulation": SIMULATION_PARAMS_JSON,
+        "delta": delta_json,
+    }
+
+
+@pytest.mark.base
+def test_validate_json_arguments_requires_simulation_file():
+    """Validate json arguments with only one argument."""
+    args = argparse.Namespace(
+        inputs=[SCENARIO_JSON]
+    )
+
+    with pytest.raises(ValueError, match="requires at least 2 files"):
+        hisim_main.validate_args(args)
+
+
+@pytest.mark.base
+def test_validate_json_arguments_rejects_four_files():
+    """Validate json arguments with four arguments."""
+    args = argparse.Namespace(
+        inputs=[
+            SCENARIO_JSON,
+            SIMULATION_PARAMS_JSON,
+            "delta.json",
+            "another.json",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="at most 3 files"):
+        hisim_main.validate_args(args)

--- a/tests/test_hisim_main_python.py
+++ b/tests/test_hisim_main_python.py
@@ -101,7 +101,7 @@ def test_initialize_from_python_rejects_invalid_simulation_parameters():
     with pytest.raises(TypeError, match="not recognized"):
         hisim_main.initialize_from_python(
             PYTHON_SETUP,
-            my_simulation_parameters=123,
+            my_simulation_parameters=123,  # type: ignore[arg-type]
         )
 
 

--- a/tests/test_hisim_main_python.py
+++ b/tests/test_hisim_main_python.py
@@ -1,0 +1,163 @@
+"""Test for running main python execution in all possible ways.
+
+Python
+├── 1 input: module.py
+├── 2 inputs: module.py + module_config
+├── 2 inputs: module.py + simulation_params.json
+└── 3 inputs: module.py + module_config + simulation_params.json
+"""
+
+from pathlib import Path
+import argparse
+
+import pytest
+
+from hisim import hisim_main
+from hisim.simulationparameters import SimulationParameters
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PYTHON_SETUP = str(
+    REPO_ROOT / "system_setups" / "household_gas_building_sizer.py"
+)
+MODULE_CONFIG = str(
+    REPO_ROOT
+    / "hisim"
+    / "building_sizer_utils"
+    / "interface_configs"
+    / "example_modular_household_config.json"
+)
+SIMULATION_PARAMS_JSON = str(
+    REPO_ROOT
+    / "system_setups"
+    / "2021_15minutely_noplots_buildingsizer.simulation.json"
+)
+SIMULATION_PARAMS_OBJECT = SimulationParameters.one_day_only(2021, 60)
+
+
+# ---------------------------------------------------------------------------
+# initialize_from_python
+# ---------------------------------------------------------------------------
+@pytest.mark.base
+def test_initialize_from_python_without_optional_arguments():
+    """Initialize from python with only python module."""
+    simulator = hisim_main.initialize_from_python(PYTHON_SETUP)
+
+    assert simulator is not None
+
+
+@pytest.mark.base
+def test_initialize_from_python_with_module_config():
+    """Initialize from python with python module and module config."""
+    simulator = hisim_main.initialize_from_python(
+        PYTHON_SETUP,
+        my_module_config=MODULE_CONFIG,
+    )
+
+    assert simulator is not None
+
+
+@pytest.mark.base
+def test_initialize_from_python_with_simulation_parameters():
+    """Initialize from python with python module and simulation parameters object."""
+    simulator = hisim_main.initialize_from_python(
+        PYTHON_SETUP,
+        my_simulation_parameters=SIMULATION_PARAMS_OBJECT,
+    )
+
+    assert simulator.get_simulation_parameters() is SIMULATION_PARAMS_OBJECT
+
+
+@pytest.mark.base
+def test_initialize_from_python_with_simulation_parameters_json():
+    """Initialize from python with python module and simulation parameters json."""
+    simulator = hisim_main.initialize_from_python(
+        PYTHON_SETUP,
+        my_simulation_parameters=SIMULATION_PARAMS_JSON,
+    )
+
+    simulation_parameters = simulator.get_simulation_parameters()
+
+    assert simulation_parameters.start_date is not None
+    assert simulation_parameters.end_date is not None
+
+
+@pytest.mark.base
+def test_initialize_from_python_with_all_inputs():
+    """Initialize from python with all input arguments."""
+    simulator = hisim_main.initialize_from_python(
+        path_to_module=PYTHON_SETUP,
+        my_simulation_parameters=SIMULATION_PARAMS_JSON,
+        my_module_config=MODULE_CONFIG,
+    )
+
+    assert simulator is not None
+
+
+@pytest.mark.base
+def test_initialize_from_python_rejects_invalid_simulation_parameters():
+    """Initialize from python with invalid argument."""
+    with pytest.raises(TypeError, match="not recognized"):
+        hisim_main.initialize_from_python(
+            PYTHON_SETUP,
+            my_simulation_parameters=123,
+        )
+
+
+# ---------------------------------------------------------------------------
+# validate_args - Python mode
+# ---------------------------------------------------------------------------
+@pytest.mark.base
+@pytest.mark.parametrize(
+    "inputs, expected_config",
+    [
+        (
+            [PYTHON_SETUP],
+            {
+                "mode": "python",
+                "module_file": PYTHON_SETUP,
+                "module_config": None,
+                "my_simulation_parameters": None,
+            },
+        ),
+        (
+            [PYTHON_SETUP, MODULE_CONFIG],
+            {
+                "mode": "python",
+                "module_file": PYTHON_SETUP,
+                "module_config": MODULE_CONFIG,
+                "my_simulation_parameters": None,
+            },
+        ),
+        (
+            [PYTHON_SETUP, MODULE_CONFIG, SIMULATION_PARAMS_JSON],
+            {
+                "mode": "python",
+                "module_file": PYTHON_SETUP,
+                "module_config": MODULE_CONFIG,
+                "my_simulation_parameters": SIMULATION_PARAMS_JSON,
+            },
+        ),
+    ],
+)
+def test_validate_python_arguments(inputs, expected_config):
+    """Validate python arguments."""
+    args = argparse.Namespace(inputs=inputs)
+
+    assert hisim_main.validate_args(args) == expected_config
+
+
+def test_validate_python_arguments_rejects_four_files():
+    """Validate four arguments rejection."""
+    args = argparse.Namespace(
+        inputs=[
+            PYTHON_SETUP,
+            MODULE_CONFIG,
+            SIMULATION_PARAMS_JSON,
+            "another.json",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="at most 3 arguments"):
+        hisim_main.validate_args(args)


### PR DESCRIPTION
- in hisim_main.py function "validate_args" only took 2 arguments for python execution although "initialize-from_python" takes 3 arguments. this means "my_simulation_parameters" was never passed
- change made: enable to pass 3 argments for python execution (like before): module.py, module_config.json (optional), my_simulation_paramters.json (optional)