### PR TITLE
Cost module stack 1/8: shared kernel (uncertainty, timeline, provenance, facts, parameters)

### DIFF
--- a/cost_module_issues.md
+++ b/cost_module_issues.md
@@ -1,0 +1,277 @@
+# Cost module implementation — open issues and decisions to clarify
+
+Running log of ambiguities found while implementing `cost_spec.md`. Items marked **DECIDED (provisional)**
+were resolved with a documented default to keep the implementation moving; they should be reviewed.
+
+## Spec open questions (§11) — provisional defaults taken in code
+
+- **Q1 (nominal vs real rates)**: implemented nominal as documented default (interest 3 %, general escalation 2 %).
+- **Q2 (default escalation rates / CO2 paths)**: `escalation_defaults_DE.json` ships with a small,
+  clearly-labeled EXPERT_ESTIMATE table (electricity 2 %, gas 3 %, oil 3 %, others 2 %); the
+  per-asset-class investment escalation table ships **empty** per the spec proposal. CO2 price paths
+  for DE encode nEHS 2024–2026 fixed prices and an ETS2 corridor estimate from 2027 — values are
+  EXPERT_ESTIMATE and need team review against sources [33]–[35].
+- **Q4 (replacement timing)**: end-of-year convention everywhere, as proposed.
+- **Q5 (gross vs net storage)**: device entries migrated from `configuration.py` carry
+  `vat_rate: 0.19` (DE) / `0.20` (AT) and are stored **as-is** from the legacy dicts. The legacy
+  numbers' VAT status is *undocumented* — parity requires using them unchanged, so the migrated
+  entries are flagged `"price_basis": "AS_LEGACY"` and the gross-up for FINANCIAL accounting is a
+  no-op for them. Needs a data-review PR to reclassify each entry as net and set true VAT handling.
+- **Q6 (anyway-cost threshold)**: default 2 years, credit on by default, gross figures always reported.
+- **Q10 (EEG feed-in)**: fixed nominal for 20 years from install (escalation 0.0 default).
+- **Q14 (strictness rollout)**: `strict_cost_completeness` defaults to warning; tests/CI use strict=True.
+- **Q15 (capacity-field convention)**: dataclass field metadata `field(metadata={"capacity": True})`.
+- **Q16 (spot series)**: no licensed EPEX data shipped; a synthetic reference profile generator is
+  provided for tests plus a documented CSV loader for user-supplied series.
+- **Q17 (spread escalation)**: defaults to the carrier escalation rate.
+- **Q18 (default counterfactual)**: tariff counterfactual is always computed when a DYNAMIC contract is
+  active; behavioral counterfactual is a second run (not automated).
+- **Q19 (§14a depth)**: grid-fee discount as tariff data only; no dimming simulation requirement.
+- **Q21 (cube explosion)**: warn > 1 000 scenarios, error > 100 000.
+- **Q25 (bands beyond money)**: service lives and emission factors stay exact in v1.
+- **Q27 (source granularity)**: per-entry `source_ids` mandatory, per-field `field_sources` optional.
+- **Q28 (registry scope)**: one `sources.json` per directory (cost_database and subsidy_catalog).
+- **Q30 (subsidy overlays)**: data overlays on subsidy catalog entries are accepted by the schema and
+  re-run scheme selection per scenario.
+
+## New issues found during implementation
+
+1. **Legacy capex dict has meter "maintenance rates" > 1** (`ELECTRICITY_METER: 2.4`,
+   `GAS_METER: 1.8` in DE/2024, i.e. 240 %/180 % of investment per year — these encode absolute
+   yearly fees, not rates). Migrated 1:1 into `devices_DE.json` for parity, but they violate the
+   sanity range a maintenance *rate* should have. The new schema has
+   `fixed_operation_cost_in_euro_per_year` for exactly this; a data PR should move
+   240 €/a resp. 360 €/a there and zero the rate — that would be a deliberate, visible KPI delta.
+   The AT entries (0.2 / 0.15) look like the same confusion with different magnitudes (20 €/month
+   comment vs 0.2 rate).
+2. **Legacy `ENERGY_MANAGEMENT_SYSTEM` investment comment says "EUR/kW" but the key is absolute EUR**
+   (`investment_costs_in_euro: 3500`). Migrated as absolute (per_unit = null); needs review.
+3. **`opex_techno_economic_parameters` mixes carriers and units** (oil in €/l, pellets in €/t,
+   diesel absurdly `128.90` €/l for DE/2018 — an obvious typo for 1.2890). Migrated 1:1 (parity),
+   but the DE/2018 diesel price should be corrected in a data PR.
+4. **VAT status of legacy prices unknown** (see Q5 above): all migrated energy prices and device
+   costs are treated as household-final prices; `tax_and_levy_share` is only filled where a source
+   exists, otherwise 0 with an EXPERT_ESTIMATE source — macroeconomic results for migrated data are
+   therefore approximate until the data review.
+5. **`EconomicParameters` on `SimulationParameters`**: `SimulationParameters` has a custom
+   `__init__` and its JSONWizard field list does not include e.g. `country`. To stay strictly
+   additive (identical `*.simulation.json` round-trips), `economic_parameters` is a plain attribute
+   (default None) set via keyword arg or `set_economic_parameters()`, **not** a dataclass field. A
+   follow-up decision is needed on how `*.simulation.json` should carry it (spec Q3 proposes
+   serializing it there — that changes the JSON schema of simulation files).
+6. **New namespaced lifecycle KPIs are written to `lifecycle_kpis.json`**, not merged into
+   `all_kpis.json`, so the legacy KPI JSON stays byte-identical during the parallel phase. The spec
+   (§7.3) is ambiguous on whether new names should already appear in the existing KPI collection;
+   merging them in is a one-line change at cutover.
+7. **`KpiEntry` gains optional `value_min`/`value_max` fields (spec §7.3)**. dataclass-wizard emits
+   `null` for unset optional fields, so `all_kpis.json` gains two null keys per entry. This is the
+   one visible (backward-compatible) change to a legacy artifact; if the JSON golden parity check
+   diffs byte-wise it must be re-baselined once.
+8. **Meter identification during the parallel phase**: the compatibility adapter maps the known
+   meter classes (`ElectricityMeter`, `GasMeter`, `FuelMeter`, `HeatingMeter`) to carriers by class
+   name to avoid importing component modules (import cycles). District/EMS-as-meter setups are not
+   yet covered by the adapter and fall back to a postprocessing warning listing unbilled carriers.
+9. **Peak billing intervals**: `BillingDeterminants` peaks are computed from the meter's power
+   series in postprocessing; if `seconds_per_timestep` does not divide the billing interval the
+   pre-check fails per spec §8.4. For setups with 3600 s timesteps and 15-min intervals this means
+   capacity tariffs simply cannot be billed — acceptable? (Spec says fail; implemented as fail.)
+10. **CO2KostAufG tier table and modernization levy parameters** are shipped as data
+    (`allocation_DE_2024.json`) with values per §559/§559e BGB and CO2KostAufG as of 2024 — the spec
+    itself requires a legal review pass before release (§10 Phase 5).
+11. **BEG EM catalog values** (`subsidy_catalog/DE.json`): base 30 %, speed bonus 20 %, income bonus
+    30 % (income ≤ 40 000 €), efficiency bonus 5 %, combined cap 70 %, eligible-cost cap
+    30 000 € first unit / 15 000 € units 2–6 / 8 000 € further; §35c EStG 20 % over 3 years
+    (7/7/6 %) mutually exclusive with BEG. Encoded from the Richtlinie as of 2024 — needs legal
+    verification, as the spec demands.
+12. **Building envelope measures (Q7) — IMPLEMENTED** (2026-07-07, user-approved design;
+    taxonomy refined 2026-08-18 per review round 3): thirteen `ComponentType`s — ten insulation/
+    window measures following the renovation measure database element by element
+    (WALL_EXTERNAL_INSULATION, WALL_INTERNAL_INSULATION, ROOF_INSULATION_BETWEEN_JOISTS,
+    ROOF_INSULATION_OVER_JOISTS, WARM_ROOF_INSULATION, TOP_CEILING_UPPER_INSULATION,
+    BASEMENT_CEILING_BOTTOM_INSULATION, BASEMENT_WALLS_INTERNAL_INSULATION,
+    GROUND_EXTERNAL_INSULATION, WINDOWS_TRIPLE_GLAZED) plus EXTERIOR_DOOR, AIR_SEALING and
+    VENTILATION_SYSTEM — with AI-estimate entries for DE/IE 2026/2035, BEG EM envelope schemes
+    (15 % + 5 % iSFP, U-value conditions) plus the `building.has_isfp` question, and three
+    engine mechanics (see README §3.2b).
+    Decisions taken:
+    - **(a)** `energy_related_cost_share` implemented as the coupled-cost (Ohnehin-Kosten)
+      mechanism but **shipped as 1.0 everywhere** — user-acknowledged as "a bit of a hack, but
+      good enough to start"; the credit logic is tested via scenario overlays and activates the
+      moment reviewed shares land in the data.
+    - **(b)** Granularity: the thirteen fine classes are authoritative; RenoVisor's three envelope
+      MVP types (roof/wall/floor + windows) are temporary and need to be mapped onto the finer
+      classes when the translator adopts the cost engine (extends issue #13).
+    - **(c)** Envelope anyway-cost threshold ~5 a, implemented as the per-entry
+      `anyway_threshold_years_override` (devices keep the 2 a default).
+    Additional evaluator change worth knowing: the replaced-asset check now runs *before* the
+    same-class "kept" match, so like-for-like measures (new windows replacing old windows) are
+    charged as investments when the register declares `replaced_by_asset_classes` — previously
+    they would have been silently treated as kept.
+    Still open: BEG's 60 kEUR-with-iSFP eligible-cost cap cannot be expressed (caps are not
+    conditional on context fields yet; shipped cap is the 30 kEUR base), and envelope embodied
+    CO2 values are rough per-m2 AI estimates.
+13. **RenoVisor integration**: engine-side APIs (perspectives, existing assets, question list,
+    economic parameters) are implemented and additive optional request fields are documented, but
+    wiring them through `hisim/renovisor/mapping.py` was deferred to keep the translator stable —
+    the translator has its own spec/test suite and should adopt the cost engine in its own PR.
+    (See §10 Phase 3: "RenoVisor request schema gains ... additive, optional fields".)
+14. **Attribution view (Q7b)** is implemented per-component as each consumer's kWh share of the
+    carrier total, sourced from `get_component_kpi_entries()` consumption KPIs where available.
+    Components without consumption KPIs simply don't appear in the attribution view.
+15. **Simulated-period fraction**: simulations shorter than a year are annualized by linear
+    extrapolation with a warning (spec §3.6 rule 5). Simulations *longer* than a year are not
+    supported by the lifecycle engine (first simulated year is used, warning emitted) — spec is
+    silent on multi-year simulations.
+16. **Dynamic-tariff in-simulation cost integration** (§8.4) is implemented in postprocessing from
+    the meter power series and the contract's spot series (native resolution). The optional
+    `simulated_cost_in_euro` hand-off from a meter that already integrated cost during simulation
+    is honored when present, but no meter currently computes it.
+17. **`TariffProvider` component** publishes price signals per timestep; the price *forecast*
+    publication to `SingletonSimRepository` mirrors what `generic_price_signal.py` does today
+    (24 h horizon). Whether MPC should consume the new provider already in the parallel phase is a
+    control-side decision (spec keeps EMS work out of scope).
+18. **Heating meter / district heating carrier mapping**: `HeatingMeter` maps to DISTRICT_HEATING.
+    Setups that use `HeatingMeter` for contracting-style heat delivery may need a different carrier;
+    flagged in the adapter with a warning.
+19. **Hydrogen price key**: legacy opex dict prices "green hydrogen gas" per kWh; the EnergyCarrier
+    enum has HYDROGEN. Migrated as HYDROGEN with the legacy value; the name difference is recorded
+    in the entry notes.
+20a. **Latent legacy bug — battery capex size**: `advanced_battery_bslib.get_cost_capex` computes
+    `size_of_energy_system = config.custom_battery_capacity_generic_in_kilowatt_hour * 1e-3`,
+    i.e. it prices a 10 kWh battery as 0.01 kWh. The adapter declares the physically correct
+    kWh size, so the parity report will show a deliberate, explained discrepancy for batteries
+    (spec §9.7: legacy bugs are documented, not silently reproduced). Decision needed at
+    cutover whether the legacy KPI keeps the bug until Phase 7. (Referenced in code as issue #21.)
+
+21. **Energy-price field names vs native units**: the spec's `working_price_in_euro_per_kwh` /
+    `emission_factor_in_kg_per_kwh` field names are kept, but for HEATING_OIL/DIESEL (liter) and
+    PELLETS/WOOD_CHIPS (ton) the migrated entries carry `quantity_unit` and the "per kWh" reads
+    "per quantity_unit". A data PR converting everything to true €/kWh (with documented heating
+    values) would be cleaner but changes legacy-parity numbers.
+
+22. **`scenario_cube.csv` and `scenario_evaluation`**: the export is written in the long format
+    the spec prescribes so the existing `scenario_evaluation` aggregation can consume it, but no
+    ingestion code was added on the `scenario_evaluation` side (that module aggregates across
+    runs and should adopt the cube in its own PR — spec §4.6 "which this layer feeds, not
+    replaces").
+
+24. **Emission-factor units in migrated pellet/wood-chip price entries**: the legacy dicts price
+    pellets/wood chips per ton but state their emission factors per kWh; the migration kept both
+    as-is, so for these two carriers the engine multiplies tons by a per-kWh factor —
+    understating CO2 by a factor of a few thousand. The new AI-estimate entries (2026/2035)
+    carry per-ton factors (pellets ~175 kg/t, wood chips ~80 kg/t); the migrated pre-2026
+    entries should be corrected in the same data-review PR as issue #21.
+
+25. **AI-estimate data for DE and IE, 2026 and 2035** (added 2026-07-07 for testing): all device
+    classes and carriers have entries under source id `src_ai_estimates` ("AI Estimates",
+    kind EXPERT_ESTIMATE) with real min/best_estimate/max bands. Deliberate modeling differences vs the
+    migrated legacy entries, all of which exercise engine features the legacy data cannot:
+    - fossil carriers carry `co2_price_exposure = 1.0` with working prices **excluding** the
+      explicit CO2 price (legacy entries embed it, exposure 0) — so 2026+ basis years price
+      carbon via `co2_price_paths.json`, including the new IE carbon-tax/ETS2 path;
+    - electricity/gas/district/hydrogen entries have non-zero **standing charges** and gas a
+      grid exit fee;
+    - meter entries put the metering fee into `fixed_operation_cost_in_euro_per_year` instead
+      of the bogus legacy >1 "maintenance rates" (fixes issue #1 for the new years);
+    - `tax_and_levy_share` is filled with rough estimates so the macroeconomic view does
+      something meaningful.
+    All values are placeholders to be replaced by reviewed sources; the bands are honest
+    guesses of market spreads, not survey data. Ireland has **no subsidy catalog yet** (SEAI
+    grants would be the natural content) — the legacy flat shim fields carry rough SEAI-like
+    shares (HP 25 %, solar 30 %, PV 20 %) so `*_net` perspectives differ from `*_gross`.
+
+26. **Report layer (LIFECYCLE_COST_REPORT, added 2026-07-07)**: `reporting.py` +
+    `report_plots.py` write `cost_summary.md`, `lifecycle_report.html` and five PNGs; the flag
+    implies COMPUTE_LIFECYCLE_COSTS. Plausibility thresholds live in
+    `cost_database/plausibility_checks.json` (deliberately generous — they catch unit mix-ups,
+    not modelling disagreements; tighten as experience accumulates). Two notes:
+    - **`UncertainValue.__sub__` semantics changed** while building the comparison view:
+      slot-wise deltas can legitimately invert ordering when the subtrahend's band is wider
+      (dropping a very uncertain gas bill), so the delta band is now the *envelope* of the
+      three slot deltas — "minimum" reads "best-case delta", not "LOW-world delta". The
+      warm-rent-neutrality flags keep their meaning ("neutral even in the worst case").
+    - The HTML uses native SVG `<title>` tooltips instead of a JS hover layer — a deliberate
+      trade for a dependency-free file that renders from any archived result directory.
+
+27. **Config-mutation contamination found in a real run and fixed by ordering** (2026-07-07,
+    full-year `household_heatpump_building_sizer` end-to-end): with the lifecycle engine
+    running *after* COMPUTE_CAPEX, the legacy `get_cost_capex` had already written its computed
+    values into the component configs (`overwrite_config_values_with_new_capex_values`), so
+    adopted components' `get_cost_facts()` picked them up as "overrides" — the new engine
+    inherited the legacy battery unit bug and the parity report showed vacuous zero deltas.
+    Exactly the §10.0-rule-4 hazard the spec warns about. Fix: the engine now runs **before**
+    the legacy opex/capex blocks (pristine configs), and the parity report is written in a
+    second postprocessing step after them (`write_parity_from_stored_inputs`, reading the
+    pre-captured `economic_inputs.json`). The parity report immediately became meaningful:
+    Battery legacy 12.16 EUR vs new 12,159.42 EUR — the documented #20a discrepancy, now
+    visible in every shadow run. Note for RenoVisor/building_sizer flows: config cost fields
+    set *before* the simulation remain legitimate overrides; only post-hoc mutation is
+    excluded by this ordering.
+
+28. **EconomicContext + the economic clock** (2026-07-07): system setups can now attach an
+    `EconomicContext` (existing assets, subsidy context, envelope measures, technical
+    attributes per subject, tenancy data, scenario set) via
+    `SimulationParameters.set_economic_context()`; the bridge merges it and the full
+    perspective bundle/subsidy engine/scenario cube activate. Worked example:
+    `system_setups/economic_example/`. **Semantic change**: subsidy scheme validity, the
+    CO2-price-path anchor and existing-asset ages now follow the **price basis year** (the
+    economic "today") instead of the possibly historical weather year — a 2021 weather year
+    with 2026 economics previously found no valid 2024+ schemes. Reports gained: uncertainty
+    band on the cumulative-NPV chart, actor-split section (6b), scenario tornado (9).
+    Open question: should `WEATHER_YEAR != PRICE_BASIS_YEAR` emit an advisory note in the
+    report header (currently only visible in the parameters line)?
+
+29. **Report coverage pass + Ireland example** (2026-07-07): after a spec-coverage review,
+    the report gained CO2 section 4b (§3.8 was previously unvisualized), the sources-used
+    table (§3.10), category/subject/perspective/payer/investment/delta result tables, the
+    loan amortization chart (§4.4), the subsidy composition bars + awards table (with a
+    flat-shim note for countries without a catalog), the robustness summary (§4.6) and the
+    KPI table section (§7.3); the `report` CLI accepts `--scenarios`. Second worked example:
+    `economic_example_ireland_gas_to_heatpump.py` (two simulations, gas-kept reference vs.
+    heat-pump variant, IE economics — result: −26.5 kEUR NPV, payback 5/6/7 a).
+    Remaining known non-covered spec outputs (deliberate): the §8.5 dynamic-tariff
+    decomposition (volume/flexibility/capacity) has no report section because no shipped
+    example runs a dynamic contract yet (the synthetic contract exists; a meter-side
+    cost-integration example is control-side work, issues #16/#17), and the parity report
+    stays a CSV-only artifact (it is transition tooling, not a result).
+
+30. **Actor-scoped timeline charts fixed** (2026-07-07, user-reported): `LifecycleCostResult.
+    timeline` holds the FULL allocated timeline (all payers — needed for the zero-sum
+    invariant and payer pivots), but the report's timeline charts (annual flows, cumulative
+    NPV, loan chart, year-1 bill, PNG) plotted it unfiltered, so the tenant view showed the
+    landlord's investment and the cumulative-NPV endpoint contradicted its own label. Fix:
+    `scope_payer` on the result + `scoped_timeline()`; all presentation-of-"this
+    perspective's flows" consumers filter by it (the actor-split payer table deliberately
+    keeps the full timeline). The tables/KPIs were always correct — only the charts lied.
+    Regression test: tenant chart must not contain investment flows.
+
+31. **Per-component chart redesigned as diverging stacks** (2026-07-07, user-reported): the
+    §7.4 chart previously stacked the *absolute values* of all display groups, so credits
+    (residual value, subsidies, feed-in, anyway credit) were drawn as if they were costs —
+    the bar showed gross activity Σ|group| and the net-NPV whisker therefore always ended
+    "inside" it. Redesign (HTML SVG + PNG): costs stack right of a zero line, credits left,
+    whisker + dot mark the net NPV band on the same signed axis (`net = costs - credits` is
+    now visible geometry). Immediately made the envelope economics readable: wall insulation
+    nets -6.5 kEUR [-26.9 | +14.5] in the German example because residual value + anyway
+    credit outweigh the investment in the optimistic world. Regression test pins that
+    residual-value segments render on the credit side with negative tooltips.
+
+32. **Year-2 "residual value" drop in the German example explained + detail table added**
+    (2026-07-07, user-reported): the spike is 58 kEUR of ANYWAY_COST_CREDIT — the example's
+    old wall/windows/top-ceiling (1988/1993/1988) have exactly 2 years of life left at the
+    2026 price basis, so §4.1 books the avoided like-for-like renovation at year 2. Correct
+    behavior, but presented misleadingly: the display group was labeled just "Residual
+    value" (now "Residual value & anyway credit"), and there was no way to attribute a
+    timeline spike without opening the CSV. Section 3 now carries a **cash-flow detail
+    table** (year x subject x category with bands, discounted values and year subtotals) per
+    perspective. Two modelling notes this surfaced: (a) with the interim
+    `energy_related_cost_share = 1.0`, a like-for-like envelope credit equals nearly the
+    full measure cost — the "vs doing nothing" frame is only as honest as that share (user
+    decision (a), issue #12); (b) the anyway credit is currently booked in *gross* views
+    too, while spec §4.1 ties it to the *differential comparison* — worth a review whether
+    `*_gross` perspectives should exclude it (the credit is separately reported either way).
+
+33. **Wood chips / pellets per-ton prices**: energy prices for pellets/wood chips are stored per
+    ton in the legacy dicts; converted to €/kWh at migration using the heating values from
+    `PhysicsConfig` (pellets 4.9 kWh/kg — LHV 11.7 GJ/m3 at 650 kg/m3; wood chips 17.3 GJ/m3 at
+    250 kg/m3). The conversion factors are recorded in the entry notes and the provenance ledger.

--- a/cost_spec.md
+++ b/cost_spec.md
@@ -1,0 +1,1919 @@
+# Specification: Lifecycle Cost Calculation for HiSim (v2)
+
+Status: DRAFT — proposal for review
+Author: generated 2026-07-05, based on a review of the current CAPEX/OPEX implementation; extended with
+multi-perspective costing (greenfield/brownfield, actor split, EU subsidy engine)
+Revision 2026-07-05: added per-component cost breakdowns for frontend visualization (§3.7, §7.4) and
+restructured the migration plan around a strictly parallel implementation with a single final cutover (§10)
+Revision 2026-07-07: every cost input now carries a minimum/best_estimate/maximum uncertainty band that is
+propagated slot-wise through all calculations, results and exports (§3.9); all cost data files gain
+mandatory structured source metadata, and a provenance ledger traces every result value back to the
+datapoints and sources that produced it, on demand (§3.10)
+Revision 2026-07-07 (c): scenario sets can now overlay individual cost-database datapoints (§4.6);
+CO2 price paths and escalation defaults are country-keyed data, tariff contracts declare a
+jurisdiction, and investment escalation is settable per asset class (learning curves)
+Revision 2026-07-07 (d): subsidy context extended by heritage-protection status and
+residential/commercial usage split (with eligible-cost proration); new user-facing eligibility
+questionnaire derived from the scheme conditions, with tri-state eligibility for unanswered
+questions (§5.7)
+Replaces: per-component `get_cost_capex()` / `get_cost_opex()` + CSV-based postprocessing aggregation
+(after a fully parallel transition period, §10)
+
+Contents:
+1. Review of the current implementation
+2. Goals and non-goals
+3. Core engine (facts → cash flows → results)
+4. Cost perspectives (greenfield, brownfield, operating, liquidity, socio-economic)
+5. Subsidy engine (EU scheme modeling)
+6. Actor model (owner-occupier, landlord, tenant)
+7. Standard perspective bundle, outputs and KPIs
+8. Dynamic electricity prices and capacity tariffs
+9. Maintainability: keeping per-component verification easy and safe
+10. Migration plan
+11. Open questions
+
+---
+
+## 1. Review of the current implementation
+
+### 1.1 How it works today
+
+1. **Per-component methods.** Every `Component` subclass (~46 files) implements two methods
+   (`hisim/component.py:425-438`):
+   - `get_cost_capex(config, simulation_parameters) -> CapexCostDataClass` (static): investment cost,
+     device CO2 footprint, lifetime, maintenance cost, subsidy percentage — either taken from the
+     component config (all-or-nothing: all five fields set) or looked up from the hard-coded dict
+     `capex_techno_economic_parameters[country][year][ComponentType]` in
+     `hisim/components/configuration.py` and scaled by system size (per kW / kWh / liter / m² / unitless).
+   - `get_cost_opex(all_outputs, postprocessing_results) -> OpexCostDataClass`: sums the component's own
+     electricity/fuel output column, multiplies by a single-year price and emission factor from
+     `opex_techno_economic_parameters[country][year]`, and adds a maintenance cost that is *derived from
+     the capex data* via `calc_maintenance_cost()`.
+
+2. **Proration to the simulated period.** `CapexComputationHelperFunctions.compute_capex_costs_and_emissions`
+   (`postprocessing/cost_and_emission_computation/capex_computation.py`) converts investment into a
+   "per simulated period" figure by straight-line depreciation:
+   `investment / lifetime * (simulated_seconds / seconds_per_year)`.
+
+3. **Postprocessing aggregation.** `opex_and_capex_cost_calculation.py` loops over all components, builds
+   two CSV tables (`investment_cost_co2_footprint.csv`, `operational_costs_co2_footprint.csv`) with
+   hard-coded subtotal rows ("Total", "Total_without_heatpump", "Total_only_heatpump"), special-casing
+   heat pump classes and meter classes by `isinstance` checks.
+
+4. **KPI computation re-reads the CSVs.** `kpi_computation/kpi_preparation.py` parses those CSV files back
+   in by string-matching row and column names, and computes e.g.
+   `Total costs for simulated period = maintenance + rest-investment(prorated) + energy costs`.
+
+### 1.2 Problems
+
+**Methodological gaps**
+
+- **No time value of money.** There is no interest/discount rate anywhere in the codebase — no NPV, no
+  annuity, no discounted payback.
+- **No projection horizon.** Everything is expressed "per simulated period" (usually one year). There is
+  no concept of an observation period (e.g. 20 years) over which investments, replacements and operating
+  costs are projected.
+- **No replacement costs.** A battery with a 10-year lifetime inside a 20-year horizon needs one
+  replacement; straight-line proration silently assumes fractional replacement at original prices.
+- **No residual value** at the end of the horizon, no disposal/demolition costs.
+- **No price escalation.** Energy prices are a snapshot of one year.
+- **No uncertainty.** Every price and cost rate is a point estimate; results pretend four-digit
+  precision on inputs that are honestly ±30 %. There is no way to express, propagate or report
+  cost-data uncertainty, so studies cannot publish defensible ranges.
+- **One implicit perspective.** The current model computes exactly one number set — effectively a
+  greenfield system-total view. Brownfield (partial replacement of an existing system), operating-only,
+  owner-liquidity, and landlord/tenant views cannot be expressed.
+- **Simplistic subsidies.** A single flat percentage of investment. Real EU programs have caps,
+  eligibility conditions, stacking bonuses, lump sums, tax-credit schedules, reduced VAT, and
+  subsidized loans.
+- **Investment = device price only.** No separation of device cost, installation cost, planning cost,
+  removal/disposal of replaced equipment.
+
+**Architectural problems**
+
+- **Massive duplication.** ~46 components each contain nearly identical `get_cost_opex` boilerplate
+  (find own output column → sum → multiply by price), bugs included (matching outputs by
+  `component_name` strings is flagged with `# Todo` in several files).
+- **Double-counting handled ad hoc.** Component-level energy costs overlap with meter-level costs; the
+  aggregation excludes meters from subtotals via `isinstance` checks, and KPI code later picks the meter
+  values again.
+- **Config mutation as a side effect.** `get_cost_capex` calls
+  `overwrite_config_values_with_new_capex_values(config, ...)`, mutating the component config during
+  postprocessing.
+- **CSV round-trip as an API.** KPIs are computed by re-parsing CSV files with string-matched row/column
+  names.
+- **Hard-coded domain special cases.** "without_heatpump" / "only_heatpump" groupings are baked into the
+  generic aggregation code via `isinstance` against four specific classes.
+- **Cost data hard-coded in Python.** Prices, lifetimes and emission factors live in nested dicts in
+  `configuration.py`; adding a country or year means editing source code.
+- **Sources are prose, not data.** The price references live in `configuration.py` docstrings; they
+  are neither machine-checkable (nothing fails when a value has no source) nor connected to results —
+  given a published KPI value, there is no way to tell which prices, lifetimes and factors produced
+  it, which is untenable for scientific use.
+- **Costs and CO2 entangled** in the same dataclasses despite different logic.
+- **Precision loss.** Intermediate values are rounded to 2 decimals before aggregation.
+
+### 1.3 What is worth keeping
+
+- The split between *device-dependent facts* (size, type) and *centrally maintained price data*.
+- The config-override mechanism (a scenario can pin exact investment costs) — RenoVisor and
+  building_sizer both use it.
+- The KPI entry structure (`KpiEntry`, tags, webtool JSON) as the delivery channel.
+- Emission factor tables per country/year as a data model — they just don't belong in `.py` files.
+
+---
+
+## 2. Goals and non-goals
+
+### Goals
+
+1. **Lifecycle cost analysis over a configurable horizon** (default 20 years) following the annuity
+   method of **VDI 2067-1** / **DIN EN 15459-1**, and compatible with the EU cost-optimal methodology
+   (**Commission Delegated Regulation (EU) 244/2012**), which distinguishes a *financial* perspective
+   (with taxes and subsidies) from a *macroeconomic* perspective (without transfers, with GHG damage
+   cost) — both must be producible.
+2. **Multiple named cost perspectives** computed from one canonical cash-flow model:
+   greenfield installation, brownfield partial replacement, operating-only, monthly owner liquidity,
+   landlord view, tenant view, each with and without subsidies (§4, §6, §7).
+3. **Replacements, residual values, disposal, and per-carrier price escalation** correctly modeled,
+   including CO2-price trajectories (national ETS / EU ETS2).
+4. **A data-driven subsidy engine** capable of representing the currently active EU residential
+   energy-retrofit schemes (percentage grants with caps and stacking bonuses, lump sums, per-unit
+   grants, multi-year tax credits, reduced VAT, subsidized loans, operational per-kWh support) with
+   eligibility conditions and cumulation rules (§5) — including a user-facing eligibility
+   questionnaire derived from the same condition data, so frontends can ask users exactly the
+   friendly questions needed to determine eligibility (§5.7).
+5. **An actor model** that allocates every cash flow to a payer (owner-occupier / landlord / tenant)
+   via country-specific, data-driven allocation rulesets (§6).
+6. **A basic financing model** (annuity loan, optionally subsidized) — required for the monthly owner
+   cost and for loan-type subsidies. *(Moved here from the non-goals of the first draft.)*
+7. **One central calculation engine**; components only *declare facts*, they do not compute costs.
+8. **Cost and subsidy data as versioned data files**, not Python literals.
+9. **Typed, in-memory result objects**; CSV/JSON are export formats, never an internal API.
+10. **Differential analysis support**: comparing two variants (RenoVisor base vs. measures) is a
+    first-class operation, including differential discounted payback and warm-rent neutrality.
+11. Full **backward compatibility of published KPIs** during a transition phase.
+12. **Per-component cost breakdowns in every perspective and every variant**, as typed results and
+    exports, so the frontend can visualize what each component contributes to the total (stacked
+    bars per variant, component-level diffs between variants) — §3.7, §7.4.
+13. **Strictly parallel implementation.** The new engine is built, activated and validated *alongside*
+    the existing cost calculation without modifying it; the legacy path remains the sole source of all
+    published numbers until a single, explicit cutover at the very end (§10). Until then, every change
+    to existing files is purely additive.
+14. **Cost uncertainty as a first-class citizen.** Every cost input is a (minimum, best_estimate, maximum)
+    triplet; the engine propagates all three values through every cash flow, perspective, KPI and
+    export, so every published cost figure carries a defensible band (§3.9).
+15. **Transparency and traceability for science.** Every datapoint in the cost data files carries
+    mandatory, structured source metadata, and the engine can answer on demand which datapoints —
+    and therefore which sources — went into any given result value (§3.10).
+
+### Non-goals (v1 of the new engine)
+
+- Income-tax modeling beyond what subsidy tax credits require (no depreciation-for-tax, no
+  landlord income tax on rent).
+- Intra-year discounting (all cash flows end-of-year; monthly figures are annual figures / 12).
+- Re-dispatch or re-simulation of projection years under future price profiles: dynamic tariffs are
+  fully modeled in the simulated year and projected via the decomposition of §8.5, not by simulating
+  20 years of spot markets.
+- Rent-market feedback (whether the market bears a modernization levy is out of scope; the levy is
+  computed per the legal cap).
+- Portfolio optimization across subsidy schemes over multiple years (the cumulation solver optimizes
+  one investment event).
+- Built-in Monte-Carlo UI (but the engine is a pure function, so parameter sweeps are cheap; §4.5
+  provides the scenario hook). Deterministic min/best_estimate/max bands per §3.9 *are* in scope; sampled
+  distributions are not.
+
+---
+
+## 3. Core engine
+
+### 3.1 Overview
+
+```
+┌─────────────┐  declares   ┌───────────────────┐
+│  Component   │───────────▶│ ComponentCostFacts │  (what am I, how big, overrides)
+└─────────────┘             └────────┬──────────┘
+                                     │
+┌─────────────┐  measures   ┌────────▼──────────┐
+│  Meters      │───────────▶│  EnergyFlowFacts   │  (kWh bought/sold per carrier, simulated year)
+└─────────────┘             └────────┬──────────┘
+                                     │
+   cost_database/*.json   ──────────▶│◀───────── subsidy_catalog/*.json
+   EconomicParameters     ──────────▶│◀───────── ApplicantProfile / BuildingContext
+   PerspectiveDefinitions ──────────▶│◀───────── ExistingAssetRegister (brownfield)
+                            ┌────────▼──────────┐
+                            │ EconomicEvaluator  │  (postprocessing, pure function)
+                            └────────┬──────────┘
+                                     │
+              ┌──────────────────────┼────────────────────────┐
+              ▼                      ▼                        ▼
+      CashFlowTimeline        EvaluationMatrix          KpiEntries / CSV / webtool JSON
+      (year × category ×      {perspective →
+       payer × component)      LifecycleCostResult}
+```
+
+Principles:
+
+1. **Components declare, the engine computes.** A component provides a `ComponentCostFacts` object
+   (asset class, size, unit, optional overrides). It never touches prices, discounting, or output
+   dataframes.
+2. **Energy costs are computed only at carrier boundaries.** The meters (electricity, gas, fuel,
+   heating) already integrate what crosses the system boundary. Only these flows are priced. Component
+   consumption figures are kept for *attribution* but never summed into the bill — this removes the
+   double-counting problem structurally.
+3. **One canonical timeline, many views.** The engine builds a single set of dated, categorized,
+   payer-tagged cash flows per variant; every perspective (§4), actor view (§6) and KPI is a filter,
+   allocation or discounting of that same timeline. No perspective recomputes physics or prices.
+4. **The evaluator is a pure function** `(facts, flows, cost_db, subsidy_catalog, econ_params,
+   perspective) -> results`. No config mutation, no file I/O inside the calculation, unit-testable
+   against hand-computed VDI 2067 / EN 15459 examples.
+5. **Every monetary figure is a triplet.** Cost inputs are (minimum, best_estimate, maximum) values (§3.9);
+   the engine evaluates every timeline in three coherent slots, so an uncertainty band exists on
+   every result by construction — never bolted on as a separate error analysis.
+6. **No unsourced numbers.** Every datapoint entering a calculation is either simulation output, an
+   enumerated engine default, or carries structured source metadata; the provenance ledger (§3.10)
+   connects every result value back to these origins on demand.
+
+### 3.2 Economic parameters
+
+New dataclass, JSON-serializable, attached to `SimulationParameters` (settable from
+`*.simulation.json` and the RenoVisor request):
+
+```python
+@dataclass
+class EconomicParameters(JSONWizard):
+    """Parameters of the lifecycle cost evaluation (annuity method, VDI 2067 / DIN EN 15459)."""
+
+    observation_period_in_years: int = 20
+    # Nominal calculation interest rate (discount rate).
+    interest_rate: float = 0.03
+    # General price change for maintenance/operation-related costs.
+    general_price_escalation_rate: float = 0.02
+    # Per-carrier nominal energy price escalation rates. Unset carriers fall back to the country's
+    # `escalation_defaults_<COUNTRY>.json` (§3.5), then to `general_price_escalation_rate`.
+    energy_price_escalation_rates: dict[EnergyCarrier, float] = field(default_factory=dict)
+    # Escalation applied to feed-in remuneration (EEG-style tariffs are nominally fixed → 0.0).
+    feed_in_escalation_rate: float = 0.0
+    # Investment price change rate for replacements.
+    investment_price_escalation_rate: float = 0.02
+    # Per-asset-class overrides for diverging technology trajectories (PV/battery learning curves
+    # falling while labor-heavy installation rises). Unset classes fall back to the country defaults
+    # file (§3.5), then to `investment_price_escalation_rate`.
+    investment_price_escalation_rates: dict[ComponentType, float] = field(default_factory=dict)
+    # Named CO2-price trajectory (see §3.5); "none" disables explicit carbon pricing.
+    co2_price_scenario: str = "central"
+    # CO2 damage cost for the macroeconomic perspective (UBA recommendation ~250 EUR/t, configurable).
+    co2_damage_cost_in_euro_per_ton: float = 250.0
+    # Price basis year for database lookups; defaults to simulation year.
+    price_basis_year: Optional[int] = None
+    country: str = "DE"
+    apply_subsidies: bool = True            # default for perspectives that don't override it
+    cost_database_path: Optional[str] = None
+    subsidy_catalog_path: Optional[str] = None
+```
+
+All rates are nominal; results are in nominal euros discounted to year 0. (Real-term calculation is
+possible by supplying real rates consistently; the engine does not care, but the docs must state the
+convention.)
+
+`EnergyCarrier` is a new enum (ELECTRICITY, ELECTRICITY_FEED_IN, NATURAL_GAS, HEATING_OIL, PELLETS,
+WOOD_CHIPS, DISTRICT_HEATING, HYDROGEN, DIESEL) replacing the ad-hoc use of `LoadTypes` for pricing.
+
+### 3.3 What components provide: `ComponentCostFacts`
+
+Replaces `get_cost_capex` / `get_cost_opex` on `Component`:
+
+```python
+@dataclass
+class ComponentCostFacts:
+    """Facts a component declares about itself for cost/emission evaluation. No prices."""
+
+    asset_class: ComponentType            # key into the cost database
+    size: float                           # capacity in `size_unit`
+    size_unit: Units                      # KILOWATT / KWH / LITER / SQUARE_METER / ANY
+    kpi_tag: Optional[KpiTagEnumClass]
+    count: int = 1
+    # Per-field overrides (no more all-or-nothing). Monetary overrides are UncertainValue triplets
+    # (§3.9); a plain number is accepted and means exact (min = best_estimate = max):
+    investment_cost_override_in_euro: Optional[UncertainValue] = None
+    installation_cost_override_in_euro: Optional[UncertainValue] = None
+    lifetime_override_in_years: Optional[float] = None
+    maintenance_rate_override: Optional[UncertainValue] = None
+    fixed_operation_cost_override_in_euro_per_year: Optional[UncertainValue] = None
+    embodied_co2_override_in_kg: Optional[float] = None
+    # Provenance of the overrides (§3.10): who set them, based on what — e.g. "installer quote
+    # 2026-03-14", "RenoVisor request field investmentCosts". Mandatory whenever any override is
+    # set (enforced in strict mode, §9.3); recorded in the provenance ledger.
+    override_source: Optional[str] = None
+    # Technical attributes consumed by subsidy eligibility conditions (§5.4), e.g.
+    # {"scop": 4.1, "refrigerant": "R290", "heat_source": "air"}:
+    technical_attributes: dict[str, Any] = field(default_factory=dict)
+
+class Component:
+    def get_cost_facts(self) -> Optional[ComponentCostFacts]:
+        """Return cost-relevant facts, or None if the component has no cost representation."""
+        return None
+```
+
+Differences from today: default is **None = not part of the cost model** (controllers, weather,
+occupancy simply don't override the hook); overrides are per-field; no dataframe access — the typical
+implementation shrinks from ~40 lines to ~6. Energy-consumption *attribution* for KPI display stays in
+`get_component_kpi_entries()` and is no longer entangled with billing.
+
+### 3.4 What meters provide: `EnergyFlowFacts`
+
+The meter components (`ElectricityMeter`, `GasMeter`, `FuelMeter`, `HeatingMeter`, EMS as district
+meter) implement:
+
+```python
+@dataclass
+class EnergyFlowFacts:
+    carrier: EnergyCarrier
+    energy_bought_in_kwh: float          # simulated-period total, integrated by the meter
+    energy_sold_in_kwh: float = 0.0
+    # Optional: cost already computed against a dynamic tariff during simulation; if set, used as the
+    # year-1 cost instead of energy * static price.
+    simulated_cost_in_euro: Optional[float] = None
+    simulated_revenue_in_euro: Optional[float] = None
+```
+
+If a simulation has no meter for a carrier that some component consumes, postprocessing emits a
+warning listing the unbilled outputs — the previously implicit double-counting rules become explicit
+and checkable. For time-of-use, dynamic, and capacity tariffs, `EnergyFlowFacts` is superseded by the
+richer `BillingDeterminants` (§8.4).
+
+### 3.5 Cost database
+
+Move `capex_techno_economic_parameters` and `opex_techno_economic_parameters` out of
+`configuration.py` into data files under `hisim/cost_database/`:
+
+```
+hisim/cost_database/
+    devices_DE.json         # per ComponentType, per valid-from year
+    devices_AT.json
+    energy_prices_DE.json   # per EnergyCarrier, per year: working price, standing charge, taxes/levies
+    co2_price_paths.json    # named trajectories, keyed by country (see below)
+    escalation_defaults_DE.json  # default per-carrier and per-asset-class escalation rates (§3.2)
+    sources.json            # structured source registry (§3.10) — replaces the reference list
+                            # currently living in configuration.py docstrings
+```
+
+Prices are maintained at **country level** deliberately: regional variation within a country (labor
+costs, installer density) is expressed through the uncertainty band (§3.9) or per-request overrides,
+while regionally differing *subsidies* are handled by the catalog's `jurisdiction` field (§5.2).
+
+Every data file entry **must** reference at least one entry of the source registry (`source_ids`);
+an entry without a resolvable source fails schema validation (§9.6). Registry entry schema:
+
+```jsonc
+{
+  "id": "src_hp_market_survey_2024",
+  "citation": "Fraunhofer ISE: Wärmepumpen-Marktanalyse 2024, Tab. 12",   // mandatory
+  "url": "https://...",                       // mandatory where one exists, else null + notes
+  "publication_year": 2024,                   // mandatory
+  "retrieved": "2026-05-12",                  // mandatory — feeds the staleness checks (§9.6)
+  "kind": "MARKET_SURVEY",                    // MARKET_SURVEY | STANDARD | STATUTE | MANUFACTURER |
+                                              // LITERATURE | PROJECT_DATA | EXPERT_ESTIMATE
+  "notes": "min/max span the regional installer quote spread"
+}
+```
+
+`EXPERT_ESTIMATE` is an admissible kind — an honestly labeled guess is scientifically fine, a number
+without provenance is not. Entries reference sources per entry (`source_ids`, mandatory) and may
+refine per field (`field_sources`) when one field comes from a different source than the rest.
+
+Device entry schema (one entry per `(component_type, valid_from_year)`):
+
+```jsonc
+{
+  "component_type": "HEAT_PUMP",
+  "valid_from_year": 2024,
+  // Every monetary value is an uncertainty triplet (§3.9); a bare number means min = best_estimate = max.
+  "specific_investment": {"value": {"min": 1250, "best_estimate": 1600, "max": 2100}, "per_unit": "kW"},
+  // Optional economies of scale: cost = c0 * size^exponent; linear if omitted.
+  "scaling_exponent": null,
+  "fixed_installation_cost_in_euro": 0,
+  "planning_cost_in_euro": 0,              // energy consultant, permits — subsidy-eligible in DE
+  "removal_cost_in_euro": 0,               // disposal of THIS device type when replaced
+  "maintenance_rate_per_year": {"min": 0.01, "best_estimate": 0.015, "max": 0.025},
+  "fixed_operation_cost_in_euro_per_year": 0,  // e.g. chimney sweep, metering service, insurance delta
+  "service_life_in_years": 18,
+  "embodied_co2": {"value": 165.84, "per_unit": "kW"},
+  "vat_rate": 0.19,                        // prices stored NET; VAT applied per country/scheme (§5)
+  "source_ids": ["src_hp_market_survey_2024"],          // mandatory, resolved against sources.json
+  "field_sources": {                                     // optional per-field refinement (§3.10)
+    "maintenance_rate_per_year": ["src_vdi2067_blatt1"],
+    "service_life_in_years": ["src_vdi2067_blatt1"]
+  }
+}
+```
+
+Energy price entries become **two-part tariffs with an explicit CO2 component**:
+
+```jsonc
+{
+  "carrier": "NATURAL_GAS",
+  "year": 2024,
+  // incl. taxes/levies, excl. explicit CO2 price; triplet spans the supplier/contract spread:
+  "working_price_in_euro_per_kwh": {"min": 0.09, "best_estimate": 0.11, "max": 0.14},
+  "standing_charge_in_euro_per_year": {"min": 120, "best_estimate": 160, "max": 220},  // Grundpreis
+  "grid_exit_fee_in_euro": 250,               // one-off disconnection fee when the carrier is dropped
+  "emission_factor_in_kg_per_kwh": 0.20,
+  "co2_price_exposure": 1.0,                  // share of emissions subject to the CO2 price path
+  "source_ids": ["src_bdew_gas_2024", "src_uba_emission_factors_2024"]   // mandatory (§3.10)
+}
+```
+
+The CO2 price is **not** buried in escalation rates: `co2_price_paths.json` holds named year-by-year
+trajectories **keyed by country** — carbon pricing differs per member state before EU ETS2 takes
+over (e.g. `DE`: `low`/`central`/`high` covering nEHS 2024-2026 and ETS2 from 2027; `AT`: the NEHG
+path into the same ETS2 segments). Shared EU-wide segments are defined once and referenced by the
+national paths rather than duplicated. The engine computes
+`fuel_cost_t = E * (working_price * (1+e)^t + emission_factor * co2_price(country, t))`.
+This makes carbon-price sensitivity a first-class research knob and feeds the tenant/landlord CO2 cost
+split (§6.3).
+
+Lookup rules: `get_device_entry(component_type, year)` picks the entry with the greatest
+`valid_from_year <= year` (today's code falls back to an arbitrary first year with only a log warning).
+`EconomicParameters.cost_database_path` lets research projects swap in their own price sets.
+
+### 3.6 Cash flow construction
+
+For each component with cost facts, over horizon `T` (all monetary parameters enter as uncertainty
+triplets; every step below is evaluated in the three slots of §3.9):
+
+1. **Initial investment** at year 0 (whether it is actually charged depends on the installation
+   context, §4.1): `I_gross = device_cost(size) + fixed_installation_cost + planning_cost`, plus
+   `removal_cost` of any replaced existing asset. Subsidies enter as separate cash flows (§5.6), never
+   by silently shrinking `I_gross`.
+2. **Replacements** at years `n·L` while `n·L < T` (L = service life; for brownfield assets the first
+   replacement is at `L − current_age`): replacement cost `I_gross · (1 + r_inv)^t`, discounted.
+3. **Residual value** at year `T`: straight-line share of the last-installed unit's escalated purchase
+   price, entered as negative cost (VDI 2067).
+4. **Maintenance & fixed operation**: `(maintenance_rate · I_gross + fixed_operation_cost) · (1+r_gen)^t`.
+5. **Energy costs** per carrier: year-1 cost from `EnergyFlowFacts` (or the meter's simulated dynamic-
+   tariff cost), split into working price (escalated), standing charge (escalated with the general
+   rate), and CO2-price component (from the trajectory). Feed-in revenue as negative cost with its own
+   escalation. If the simulated period is shorter than one year, flows are annualized by linear
+   extrapolation, explicitly and with a warning.
+6. **Financing** (only if the perspective's financing plan says so, §4.4): loan disbursement, interest
+   and principal flows replace the year-0 outflow.
+
+Every entry in the timeline is:
+
+```python
+@dataclass
+class CashFlowEntry:
+    year: int
+    amount_in_euro: UncertainValue       # nominal, LOW/BEST_ESTIMATE/HIGH slots (§3.9);
+                                         # sign: cost positive, revenue/subsidy negative
+    category: CostCategory               # INVESTMENT | PLANNING | REMOVAL | REPLACEMENT |
+                                         # RESIDUAL_VALUE | MAINTENANCE | FIXED_OPERATION |
+                                         # ENERGY_WORKING | ENERGY_STANDING | ENERGY_CO2_PRICE |
+                                         # FEED_IN_REVENUE | SUBSIDY | LOAN_INTEREST | LOAN_PRINCIPAL |
+                                         # CO2_DAMAGE (macroeconomic only)
+    subject: str                         # component name or carrier
+    payer: Actor                         # assigned by the allocation ruleset, §6; SYSTEM before allocation
+    subsidy_scheme_id: Optional[str]     # provenance for SUBSIDY entries
+    provenance_ids: tuple[int, ...]      # interned ParameterProvenance records (§3.10) of every
+                                         # datapoint that entered this amount
+```
+
+### 3.7 Result objects
+
+```python
+@dataclass
+class LifecycleCostResult:
+    perspective: PerspectiveId
+    parameters: EconomicParameters
+    # Every monetary field is an UncertainValue triplet (§3.9); .best_estimate is the headline figure.
+    total_npv_in_euro: UncertainValue              # net present cost over the horizon
+    equivalent_annual_cost_in_euro: UncertainValue # NPV * annuity factor — the headline KPI
+    npv_by_category: dict[CostCategory, UncertainValue]
+    npv_by_component: dict[str, UncertainValue]
+    npv_by_payer: dict[Actor, UncertainValue]
+    # Full per-subject breakdown for frontend visualization (§7.4); keys are timeline subjects
+    # (component names and carriers), values sum to the perspective totals by construction.
+    component_breakdowns: dict[str, ComponentCostBreakdown]
+    annual_cost_series_nominal_in_euro: list[UncertainValue]  # liquidity view, year 1..T
+    monthly_cost_year1_in_euro: Optional[UncertainValue]      # for liquidity perspectives (§4.4)
+    levelized_cost_of_heat_in_euro_per_kwh: Optional[UncertainValue]
+    timeline: CashFlowTimeline
+    lifecycle_co2_result: LifecycleCo2Result             # parallel, undiscounted (§3.8)
+```
+
+Because every timeline entry carries a `subject` (§3.6), the per-component breakdown is a pure pivot
+of the canonical timeline — no separate computation, no chance of diverging from the headline totals:
+
+```python
+@dataclass
+class ComponentCostBreakdown:
+    subject: str                                  # component name, or carrier for energy subjects
+    subject_kind: SubjectKind                     # COMPONENT | CARRIER
+    asset_class: Optional[ComponentType]          # None for carriers
+    kpi_tag: Optional[KpiTagEnumClass]
+    npv_by_category: dict[CostCategory, UncertainValue]  # discounted, signed (subsidies/residuals neg.)
+    total_npv_in_euro: UncertainValue
+    equivalent_annual_cost_in_euro: UncertainValue
+    # Undiscounted display figures for "what does X cost to buy" views:
+    investment_gross_in_euro: UncertainValue      # device + installation + planning, year 0
+    subsidies_nominal_in_euro: UncertainValue     # support received, nominal euros, positive band
+    subsidies_npv_in_euro: UncertainValue         # the same support discounted (= -npv_by_category[SUBSIDY])
+    annual_cost_series_nominal_in_euro: list[UncertainValue]
+    lifecycle_co2_in_kg: float                    # embodied + attributed operational (§3.8)
+```
+
+Variant comparison (the RenoVisor case):
+
+```python
+def compare(reference: LifecycleCostResult, variant: LifecycleCostResult) -> VariantComparison:
+    """Differential NPV, differential annuity, discounted payback, warm-rent-neutrality (§6.4)."""
+```
+
+`VariantComparison` also carries `npv_delta_by_subject: dict[str, UncertainValue]`, with subjects
+aligned across the two variants by `(asset_class, subject)` and explicit zero entries for subjects
+present in only one variant — this feeds the "which component drives the difference" visualization
+(§7.4) without name-matching heuristics in the frontend.
+
+All deltas are computed **slot-wise** (§3.9): reference and variant are compared within the same
+LOW/BEST_ESTIMATE/HIGH world, so shared cost uncertainty (the same heat-pump price band appearing in both
+variants) cancels instead of inflating the delta band.
+
+The **discounted payback time** is the first year where cumulative discounted savings exceed the
+differential investment (`None` if never within the horizon). It is computed per slot, yielding a
+payback band (best case / expected / worst case, each independently `None`-able).
+
+### 3.8 CO2 accounting
+
+Separate, parallel `LifecycleCo2Result`: embodied emissions at install and each replacement (no
+discounting), plus annual operational emissions per carrier with an optional per-carrier emission-factor
+trend (grid electricity decarbonizes; a constant 20-year factor overstates heat pump emissions). The
+CO2 *damage cost* (macroeconomic perspective) and the CO2 *price* (a real cash flow) are distinct and
+must never be added together.
+
+### 3.9 Cost uncertainty (minimum / best_estimate / maximum)
+
+No cost input in this domain is actually known to the euro: device prices vary by installer and
+region, maintenance rates are rules of thumb, energy prices vary by supplier and contract. The engine
+therefore treats **every monetary input as a (minimum, best_estimate, maximum) triplet** and propagates all
+three values through every calculation — uncertainty is carried from input to KPI, never estimated
+after the fact.
+
+```python
+@dataclass(frozen=True)
+class UncertainValue:
+    """A monetary figure with an uncertainty band. Invariant: minimum <= best_estimate <= maximum."""
+
+    best_estimate: float
+    minimum: float
+    maximum: float
+
+    @staticmethod
+    def exact(value: float) -> "UncertainValue":
+        """Degenerate band for values that are actually certain (statutory amounts, contracts)."""
+        return UncertainValue(value, value, value)
+```
+
+In every JSON schema (cost database, tariff contracts, subsidy catalog, config overrides) a **bare
+number means exact** (`min = best_estimate = max`) and `{"min": .., "best_estimate": .., "max": ..}` declares a band;
+loaders validate `min <= best_estimate <= max` and finiteness on load. Legally fixed values (lump-sum grants,
+statutory levy caps, tax rates, contracted EEG feed-in tariffs) thus stay naturally exact without a
+second schema.
+
+**What carries a band:** every monetary parameter — specific and fixed investment, installation,
+planning and removal costs, maintenance rates, fixed operation costs, energy working prices and
+standing charges, tariff components (markup, grid fee, taxes/levies, capacity price), feed-in
+remuneration, grid exit fees, and the per-field config overrides of §3.3.
+
+**What stays exact (v1):** physical quantities from the simulation (kWh, peaks — measured, not
+estimated); the economic *rates* of §3.2 (interest, escalations — their uncertainty is explored via
+scenario axes, §4.6); CO2 price paths (uncertainty already expressed as named low/central/high
+trajectories); service lives and emission factors (§11 Q25).
+
+**Propagation: three coherent worlds, not per-entry interval arithmetic.** The engine evaluates every
+timeline in three parallel *slots*:
+
+- **LOW** — the optimistic world: every cost-type parameter at its minimum, every revenue-type
+  parameter (feed-in remuneration, operational support) at its *maximum*.
+- **BEST_ESTIMATE** — all parameters at their best-estimate value; the headline figure everywhere.
+- **HIGH** — the pessimistic world: cost-type parameters at maximum, revenue-type at minimum.
+
+Whether a parameter is cost- or revenue-type is fixed by its role (its cost category), never guessed
+per entry. Within a slot everything is internally consistent: the subsidy is the scheme rate times
+*that slot's* eligible cost, checked against caps at that slot's basis; maintenance is the rate band
+times the slot's investment; replacements and residual values escalate the slot's purchase price.
+Because every parameter's effect on total cost is monotone (caps and subsidy shares dampen but never
+reverse a price increase), the slot totals are true optimistic/pessimistic envelopes of the total —
+while nonlinear rules (subsidy caps, levy caps, payback crossings) still see a consistent world. A
+cap may bind in HIGH but not in LOW; that is intended and is reported per slot.
+
+Mechanically, `CashFlowEntry.amount_in_euro` carries the triplet; discounting and aggregation are
+linear and act slot-wise, so all three valuations come out of a single pass at negligible extra cost.
+Every monetary field of every result object (§3.7), KPI (§7.3) and export (§7.2, §7.4) is an
+`UncertainValue`, and the reconciliation invariants (§6.5, §7.4) hold per slot.
+
+**Semantics — envelope, not confidence interval.** The bounds mean "if everything comes in at the
+favorable / unfavorable end": full correlation toward cheap respectively expensive. They are *not*
+statistical quantiles — treating the inputs as independent random variables would produce narrower
+bands. The envelope is the honest deterministic statement the input data supports; distribution-based
+sampling remains a non-goal (§2) and can later be layered onto the scenario hook (§4.6) without
+engine changes.
+
+**Differences and decisions.**
+
+- Variant deltas, payback and warm-rent neutrality are computed slot-wise (§3.7, §6.5): both variants
+  are evaluated in the same world, so shared uncertainty cancels correctly. Caveat: slot-wise deltas
+  are coherent scenarios, not outer envelopes of the difference — an extremal delta could occur in a
+  mixed world (gas price at max *while* the heat pump comes in cheap). Cross-parameter questions of
+  that kind are exactly what the scenario axes and break-even search (§4.6) are for.
+- Anything the engine *chooses* — the subsidy cumulation combination (§5.4), the default tariff
+  counterfactual (§8.5) — is decided once on the BEST_ESTIMATE slot and then valued in all three slots, so
+  LOW/BEST_ESTIMATE/HIGH always describe the same physical and contractual plan. Where a different choice
+  would win in another slot, the audit trail says so.
+
+### 3.10 Provenance: from any result value back to its sources
+
+Scientific use demands that every published number be traceable: a reviewer asking "where does this
+equivalent annual cost come from" must get an answer down to the individual datapoints and their
+citations, without reverse-engineering the engine. Two mechanisms provide this — mandatory source
+metadata on the data side (the `sources.json` registry and `source_ids` fields of §3.5, mirrored in
+the subsidy catalog and tariff contracts), and a provenance ledger on the engine side.
+
+**The provenance ledger.** During parameter resolution (the same pass as the pre-run resolution
+check, §9.3 — the lookups happen anyway), every resolved input is recorded once as an interned,
+immutable record:
+
+```python
+@dataclass(frozen=True)
+class ParameterProvenance:
+    parameter: str                  # dotted path, e.g. "devices_DE.HEAT_PUMP@2024.specific_investment"
+    value: UncertainValue | float | str
+    origin: ParameterOrigin         # DATABASE_ENTRY | CONFIG_OVERRIDE | REQUEST | SCENARIO_OVERLAY |
+                                    # ENGINE_DEFAULT | SIMULATION_OUTPUT
+    data_file: Optional[str]        # file, entry key and valid_from_year for DATABASE_ENTRY origins
+    source_ids: tuple[str, ...]     # resolved against the source registry; may be empty only for
+                                    # SIMULATION_OUTPUT and ENGINE_DEFAULT origins
+    detail: Optional[str]           # override_source text, request field name, scenario id, ...
+```
+
+`ORIGIN` covers everything that can feed a number: cost database and subsidy catalog entries,
+per-field config overrides (with their mandatory `override_source`, §3.3), RenoVisor request fields,
+scenario overlays (§4.6), engine defaults (all of which are enumerated in one documented table — a
+default is a source too), and simulation outputs (kWh, peaks — their provenance is the simulation
+itself). Every `CashFlowEntry` carries the ids of the records that entered its amount (§3.6);
+`EconomicParameters` fields get ledger records of their own (default / `*.simulation.json` /
+request / overlay).
+
+**Lineage of any result value is then a set union, not a new mechanism.** Every result figure —
+total NPV, a category NPV, a per-component breakdown cell, a KPI — is by construction a
+filter/pivot/discounting of timeline entries (§3.1 principle 3), so the datapoints behind it are
+exactly the union of the contributing entries' provenance records plus the discounting parameters.
+The engine exposes this on demand:
+
+```python
+result.explain("npv_by_category[MAINTENANCE]") -> ProvenanceReport
+result.explain("equivalent_annual_cost_in_euro") -> ProvenanceReport
+```
+
+```bash
+python -m hisim.economics explain <results_dir> --value "brownfield_net/equivalent_annual_cost"
+```
+
+A `ProvenanceReport` is a tree: the value at the root, the contributing timeline entries (year,
+category, subject, amount) below it, each entry's parameters below that, and at the leaves the
+resolved sources with full citation, url and retrieval date. It renders as human-readable text and
+as JSON. Addressing uses the result field paths (perspective / field / key), the same names as the
+exports — no separate query language.
+
+**Storage and reproducibility.** The ledger is serialized as `cost_provenance.json` next to
+`economic_inputs.json` (§4.6), and every row of every export carries the ids of its timeline entries
+— so any number in any CSV produced years ago can still be explained offline from the archived
+result directory, with no re-run. KPI payloads for the webtool do *not* embed provenance (size);
+they are addressable by (perspective, field), which `explain` resolves against the stored ledger.
+
+**Guarantees, enforced not hoped for** (§9.6): every non-`SIMULATION_OUTPUT`,
+non-`ENGINE_DEFAULT` record has at least one resolvable source id — a datapoint without a source
+cannot enter a calculation without failing CI or strict-mode runs; unknown source ids and orphaned
+registry entries fail schema validation; `retrieved` dates feed staleness warnings for all data
+files, not just subsidy catalogs. Cost: the ledger is built once per variant in the structure pass;
+scenario overlays add only records for the fields they override — negligible against the evaluation
+itself.
+
+---
+
+## 4. Cost perspectives
+
+A **perspective** is a named configuration of five orthogonal dimensions. The engine evaluates a set of
+perspectives against the same simulation results and returns an `EvaluationMatrix`.
+
+```python
+@dataclass
+class Perspective:
+    id: str
+    installation_context: InstallationContext    # §4.1
+    actor_scope: ActorScope                      # SYSTEM | OWNER_OCCUPIER | LANDLORD | TENANT (§6)
+    subsidy_mode: SubsidyMode                    # NONE | FULL | ONLY(scheme_ids) | EXCLUDE(scheme_ids)
+    financing: Optional[FinancingPlan]           # §4.4; None = cash purchase
+    accounting: Accounting                       # FINANCIAL | MACROECONOMIC (§4.5)
+```
+
+### 4.1 Installation contexts
+
+**GREENFIELD** — everything is bought new at year 0. All components with cost facts contribute full
+investment (device + installation + planning). This is the right frame for new construction and for
+"what does this system cost in absolute terms" research comparisons.
+
+**BROWNFIELD(register)** — the building has an existing system; only the *measures* cost money. Needs
+an explicit register of what is already there:
+
+```python
+@dataclass
+class ExistingAsset:
+    asset_class: ComponentType
+    size: float
+    size_unit: Units
+    installation_year: int                  # → age, remaining life, replacement schedule
+    replacement_cost_override_in_euro: Optional[UncertainValue] = None   # scalar accepted = exact (§3.9)
+    is_functional: bool = True              # feeds subsidy conditions (e.g. "functioning oil boiler")
+```
+
+Brownfield rules:
+- Components matched to an existing asset that is *kept* cost no investment; they contribute
+  maintenance, energy, and a replacement at `service_life − current_age` (like-for-like, at
+  then-escalated prices).
+- Components that *replace* an existing asset contribute full investment plus the old asset's
+  `removal_cost`. The written-off residual book value of the replaced asset is reported separately
+  (`sunk_cost_written_off_in_euro`) but excluded from decision KPIs — sunk costs must not distort the
+  comparison, yet researchers want to see them.
+- **Anyway-cost (Sowieso-Kosten) credit**: if the replaced asset had ≤ `anyway_threshold_years`
+  (default 2) of remaining life, the differential comparison credits the avoided like-for-like
+  replacement against the measure. This is the "anyway renovation" baseline of the EU cost-optimal
+  methodology and the fair frame for RenoVisor's base-vs-measures question: replacing a dead boiler
+  with a heat pump should be charged the *extra* cost over a new boiler, not the full heat pump price.
+  The credit is reported as its own category so both gross and anyway-adjusted figures are available.
+
+**STATUS_QUO(register)** — no measures; the existing system is kept and replaced like-for-like at end
+of life. This is the natural *reference variant* for brownfield comparisons: "do nothing" still costs
+money, and pretending otherwise flatters doing nothing. RenoVisor's `base` variant maps here (or to
+BROWNFIELD with an empty measure list, which is equivalent).
+
+The register comes from the scenario/RenoVisor request; for TABULA-typology buildings, defaults
+(existing boiler type, age = building renovation state) can be derived by the RenoVisor mapping layer.
+
+### 4.2 Operating-cost view
+
+`installation_context = OPERATING_ONLY`: investment and financing categories are excluded; the view
+contains energy (working + standing + CO2), maintenance, fixed operation, and a **replacement reserve**
+— the sinking-fund rate that pre-funds all replacements within the horizon
+(`annuity of discounted replacement costs`). This answers "what does running this system cost per
+year/month, honestly including wear" — the figure a homeowner or WEG should put aside, and the German
+Instandhaltungsrücklage logic.
+
+### 4.3 Economic vs. liquidity view
+
+Both are always derivable from the same timeline; `LifecycleCostResult` carries both:
+- **Economic**: discounted NPV and equivalent annual cost — for comparing alternatives.
+- **Liquidity**: nominal euros out of pocket per year (`annual_cost_series_nominal_in_euro`), divided
+  by 12 for the monthly figure — for "can I afford this". Financing changes the liquidity profile
+  dramatically and the NPV only via the spread between loan rate and discount rate.
+
+### 4.4 Financing plan (needed for "monthly cost for the owners")
+
+```python
+@dataclass
+class FinancingPlan:
+    financed_share: float = 1.0               # of net investment after upfront subsidies
+    nominal_interest_rate: float = 0.04
+    term_in_years: int = 20
+    type: LoanType = LoanType.ANNUITY          # ANNUITY | INTEREST_ONLY_WITH_BULLET
+    # A subsidized-loan scheme (§5.3 SoftLoan) can override rate/term and add a repayment grant.
+    subsidized_by_scheme_id: Optional[str] = None
+```
+
+Generates LOAN_INTEREST / LOAN_PRINCIPAL flows replacing the year-0 outflow. Replacements within the
+horizon are always paid cash / from the reserve; refinancing them is a possible future feature
+(cost-spec-v2 §8 D23).
+
+### 4.5 Financial vs. macroeconomic accounting (EU 244/2012)
+
+- **FINANCIAL**: household prices (gross of VAT and energy taxes), subsidies included per
+  `subsidy_mode`. The default for owner/landlord/tenant perspectives.
+- **MACROECONOMIC**: transfers removed — no subsidies, prices net of VAT and energy taxes/levies —
+  and a CO2_DAMAGE flow added (`co2_damage_cost_in_euro_per_ton`). This is the standard
+  socio-economic research view and mandatory for EPBD cost-optimal studies.
+
+This requires the energy-price database to record the tax/levy share per carrier (already implied by
+the two-part schema in §3.5; add `tax_and_levy_share`).
+
+Price and rate scenarios (low/central/high escalations, interest rates, CO2 paths) are *not* a
+perspective dimension; they are separate `EconomicParameters` sets, evaluated by the scenario
+analysis layer (§4.6).
+
+### 4.6 Scenario analysis
+
+Research questions like "does the heat pump still win at 5 % interest and low gas prices?" need the
+same simulation evaluated under many economic assumptions. The design splits scenario dimensions by
+what they touch:
+
+- **Economic-only dimensions** — interest rate, escalation rates, CO2-price path, subsidy mode,
+  observation period, financing terms, damage cost. These do **not** change the simulated load
+  profiles, so a scenario is just another call of the pure evaluator on the same facts and billing
+  determinants: milliseconds each, full factorial sweeps are cheap.
+- **Physics-affecting dimensions** — component sizing, retrofit measures, weather year, and any
+  tariff whose price signal a controller consumed during the run. These require a new simulation and
+  are *variants*, handled by the existing infrastructure (system setups, hpc_harness, and the
+  `scenario_evaluation` cross-run aggregation module — which this layer feeds, not replaces).
+
+**Cost-data uncertainty (§3.9) is a third, orthogonal mechanism**: scenario axes vary *economic
+assumptions* (rates, paths) across scenarios, while the min/best_estimate/max slots vary *cost data* within
+every single evaluation. Every cell of the cube therefore already carries an uncertainty band. The
+robustness summary reports extremes across scenarios × slots (worst worst-case, best best-case), and
+the dominance flag is strongest in its slot-aware form: variant A beats B in every scenario *even
+comparing A's HIGH slot against B's LOW slot*. Break-even search runs on the BEST_ESTIMATE slot by default
+and reports the LOW/HIGH crossings as a bracket around the break-even point.
+
+The boundary is enforced, not documented-only: the run records which inputs the simulation consumed
+(notably the active `TariffContract` id, §8.3). An economic scenario that overrides a consumed field
+is rejected by default — rebilling a load profile that was optimized against a different tariff has
+tariff-counterfactual semantics (§8.5), and the user must opt in to exactly that interpretation
+(`allow_counterfactual_billing: true`) rather than get it silently.
+
+**Scenario set definition** (data file or RenoVisor request block):
+
+```jsonc
+{
+  "base": "central",                       // the EconomicParameters everything else deviates from
+  "mode": "FACTORIAL",                     // FACTORIAL | ONE_AT_A_TIME
+  "axes": [
+    {"name": "interest", "field": "interest_rate",
+     "levels": {"low": 0.01, "central": 0.03, "high": 0.05}},
+    {"name": "electricity_price", "field": "energy_price_escalation_rates.ELECTRICITY",
+     "levels": {"low": 0.00, "central": 0.02, "high": 0.05}},
+    {"name": "co2", "field": "co2_price_scenario", "levels": {"low": "low", "high": "high"}},
+    // Axes may also target individual cost-database datapoints (data overlays, see below):
+    {"name": "hp_price", "field": "devices_DE.HEAT_PUMP.specific_investment",
+     "levels": {"central": null,                                  // null = as shipped
+                "cheap": {"min": 900, "best_estimate": 1100, "max": 1400}}}
+  ],
+  // Alternatively/additionally: explicit named overlays for hand-picked storylines; overrides may
+  // mix EconomicParameters fields and cost-database datapoints:
+  "named_scenarios": [
+    {"id": "stagnation", "overrides": {"interest_rate": 0.05,
+                                        "energy_price_escalation_rates": {"ELECTRICITY": 0.0}}}
+  ]
+}
+```
+
+`FACTORIAL` expands the cartesian product (scenario ids like `interest=high|electricity_price=low`);
+`ONE_AT_A_TIME` varies each axis from the base individually — the standard input for tornado
+diagrams and much easier to interpret. Axes address `EconomicParameters` fields by dotted path,
+validated against the dataclass schema at load time (unknown field = hard error, in the spirit of §9).
+
+**Data overlays: scenario-specific cost data.** Axes and named-scenario overrides may equally
+address individual **cost-database datapoints**, using a dotted path rooted at the data file stem
+(`devices_DE.HEAT_PUMP.specific_investment`,
+`energy_prices_DE.NATURAL_GAS.working_price_in_euro_per_kwh`; an `@year` suffix pins a specific
+`valid_from_year` entry where a type has several). Overlay values are validated against the database
+entry schema at load time (unknown entry or field = hard error) and may be uncertainty triplets
+(§3.9). This answers "does the retrofit still win if heat pumps get 30 % cheaper?" without forking
+database files: the shipped database stays the single maintained source, the overlay is a diffable
+few-line change, and every overlaid value enters the provenance ledger as `SCENARIO_OVERLAY` with
+its scenario id (§3.10) — an explained result names exactly which numbers were counterfactual.
+Overlays touching `service_life_in_years` move replacement years and therefore invalidate the
+structure-once optimization below: such scenarios rebuild their timeline structure (correct, merely
+slower; the loader warns when an axis forces per-scenario rebuilds).
+
+Two fields are **not sweepable** and rejected as axis/override targets with an explanatory error:
+`cost_database_path` / `subsidy_catalog_path` (a whole-dataset swap is a run-level choice — sweep
+individual datapoints via overlays instead), and `country` (a country change invalidates the
+simulated physics context — building stock, weather, codes — and is a *variant*, not an economic
+scenario).
+
+**Evaluation cube.** The result is `results[variant][perspective][scenario]`, each cell a full
+`LifecycleCostResult`. Implementation guidance: the event *structure* of the timeline (what is bought
+when, replacement years, billing determinants) does not depend on rates — build it once per
+variant/perspective, apply each scenario's escalation and discounting as a second pass. Sweeps of
+10³–10⁴ scenarios must stay interactive.
+
+**Post-hoc re-pricing without re-simulation.** All evaluator inputs — cost facts, billing
+determinants, existing-asset register — are serialized into the result directory
+(`economic_inputs.json`, accompanied by the provenance ledger `cost_provenance.json`, §3.10). A
+standalone entry point
+
+```bash
+python -m hisim.economics evaluate <results_dir> --scenarios scenarios.json
+```
+
+re-runs the full scenario cube on stored results: new interest-rate assumptions, updated subsidy
+catalogs, or a reviewer's "what if" never require re-running the building simulation. (This also
+means archived study results stay re-evaluable years later.)
+
+**Derived analyses** (all trivially built on the cube because the evaluator is pure and fast):
+
+- **Tornado data** (`ONE_AT_A_TIME`): per KPI and axis, the swing vs. the base scenario — exported as
+  a table; plotting hook in the report.
+- **Break-even search**: `find_break_even(axis, kpi, variant_a, variant_b)` — bisection on one axis
+  for the value where two variants' KPI difference crosses zero ("above which gas-price escalation
+  does the heat pump win?", "up to which interest rate is the retrofit NPV-positive?"). Reported with
+  the bracket, or "no crossing in range".
+- **Robustness summary** per variant pair: min / max / spread of the differential KPI across all
+  scenarios, and a dominance flag (variant A beats B in *every* scenario — the strongest statement a
+  study can make).
+
+**Exports.** `scenario_cube.csv` in long format — one row per (variant, perspective, scenario, KPI)
+with the scenario axes as separate columns — deliberately shaped so the existing
+`scenario_evaluation` aggregation and plotting can consume it alongside cross-run results, plus
+`scenario_cube.json` with the full typed cube for the webtool.
+
+---
+
+## 5. Subsidy engine
+
+### 5.1 Requirements derived from currently active EU schemes
+
+A survey of the scheme *mechanisms* the model must express (examples, parameters as of ~2024/25, all
+values live in data files and must be verifiable/updatable, not in code):
+
+| Mechanism | Examples |
+|---|---|
+| % of eligible cost with cap on eligible cost | DE BEG EM: 30 % base, eligible cost ≤ 30 k€ (1st dwelling unit, self-occupied), + further units tiered |
+| Stacking bonuses with a combined-rate cap | DE BEG: +20 % speed bonus (replacing functioning old fossil system, degressive over time), +30 % income bonus (taxable household income ≤ 40 k€, self-occupied), +5 % efficiency bonus (natural refrigerant / ground source); total ≤ 70 % |
+| Income-class lump sums per measure | FR MaPrimeRénov': fixed € amounts per measure by household income band and region |
+| Per-unit grants | Insulation subsidies in €/m²; some PV programs in €/kWp |
+| Multi-year tax credits | IT Ecobonus/Bonus Casa: 50–65 % of cost as income-tax deduction spread over 10 annual installments — payout *timing* materially changes NPV |
+| Reduced VAT | Zero/reduced VAT on heat pumps or renovation works (several member states); modeled as rate change on the eligible cost basis |
+| Subsidized loans ± repayment grant | DE KfW programs; modeled as a FinancingPlan override (§4.4) plus optional grant |
+| Operational per-kWh support | Feed-in remuneration (EEG, fixed nominal for 20 y from install), heat-generation premiums |
+| Regional stacking | National + Land/regional + municipal programs with cumulation caps (incl. EU state-aid ceilings) |
+| One-off lump sums | AT "Raus aus Öl und Gas" style fixed grants with regional top-ups |
+
+### 5.2 Scheme definition (data-driven)
+
+Schemes live in `hisim/subsidy_catalog/<COUNTRY>.json`, one file per country, versioned by validity
+dates; a `catalog_snapshot_date` documents when the file was last verified. `legal_basis` and `url`
+are **mandatory** fields — a scheme is a `STATUTE`-kind source in the sense of §3.10, and subsidy
+cash flows enter the provenance ledger via their `subsidy_scheme_id`, so an explained result value
+cites the funding directive it rests on.
+
+```jsonc
+{
+  "id": "DE_BEG_EM_HP_BASE_2024",
+  "jurisdiction": {"country": "DE", "region": null},        // region = NUTS code or null
+  "valid_from": "2024-01-01", "valid_to": null,
+  "legal_basis": "BEG EM Richtlinie 2023-12-21",
+  "url": "https://...",
+  "applies_to": {"asset_classes": ["HEAT_PUMP"], "measure_kinds": ["INSTALL", "REPLACE"]},
+  "eligibility": { "all": [
+      {"field": "applicant.actor", "op": "in", "value": ["OWNER_OCCUPIER", "LANDLORD", "WEG"]},
+      {"field": "building.construction_year", "op": "<=", "value": 2019},
+      // Residential program: building must be predominantly residential (mixed use prorated below)
+      {"field": "building.residential_share", "op": ">=", "value": 0.5},
+      // Heritage relaxation: the technical threshold drops for protected buildings
+      {"any": [
+          {"field": "measure.technical_attributes.scop", "op": ">=", "value": 3.0},
+          {"all": [{"field": "building.heritage_status", "op": "!=", "value": "NONE"},
+                    {"field": "measure.technical_attributes.scop", "op": ">=", "value": 2.7}]}
+      ]}
+  ]},
+  "benefit": {"kind": "SHARE_OF_ELIGIBLE_COST", "rate": 0.30},
+  "eligible_cost": {
+      "categories": ["INVESTMENT", "PLANNING", "REMOVAL"],
+      "cap_per_dwelling_unit_in_euro": [30000, 15000, 15000, 8000],  // 1st, 2nd, 3rd, further units
+      "basis": "GROSS",                                              // gross or net of VAT
+      "proration": "RESIDENTIAL_SHARE"   // mixed-use buildings: only the residential share of the
+                                         // cost basis is eligible (NONE if the scheme funds all use)
+  },
+  "cumulation": {"group": "DE_BEG_EM_RATES", "combined_rate_cap": 0.70,
+                  "excludes": ["DE_TAX_35C"]},                        // §35c EStG excludes BEG
+  "payout": {"kind": "UPFRONT_GRANT"}                                 // year 0
+}
+```
+
+Benefit kinds (tagged union):
+
+```
+SHARE_OF_ELIGIBLE_COST(rate)             BONUS_SHARE(rate)          LUMP_SUM(amount)
+PER_UNIT(amount, unit)                   TAX_CREDIT(rate, years)    REDUCED_VAT(vat_rate)
+SOFT_LOAN(interest_rate, term, repayment_grant_rate)                OPERATIONAL(rate_per_kwh, carrier,
+                                                                                 duration_years)
+```
+
+Payout kinds map benefits to timeline entries: `UPFRONT_GRANT` (year 0, negative SUBSIDY),
+`TAX_CREDIT_SCHEDULE` (negative flows years 1..N), `LOAN_TERMS` (modifies FinancingPlan),
+`OPERATIONAL` (annual negative flows for its duration), `VAT_REDUCTION` (reduces the gross-up applied
+to eligible cost categories).
+
+### 5.3 Eligibility conditions
+
+A small, data-only predicate language (`all` / `any` / `not` over `{field, op, value}` leaves;
+ops: `== != < <= > >= in contains exists`). Fields resolve against a typed `SubsidyContext`:
+
+```python
+@dataclass
+class ApplicantProfile:
+    actor: Actor                         # OWNER_OCCUPIER | LANDLORD | WEG | TENANT
+    taxable_household_income_in_euro: Optional[float]
+    household_size: Optional[int]
+    main_residence: bool = True
+    region: Optional[str] = None         # NUTS-3 or municipality key for regional schemes
+
+class HeritageStatus(Enum):
+    NONE = "none"
+    LISTED_MONUMENT = "listed_monument"          # Einzeldenkmal
+    ENSEMBLE_PROTECTED = "ensemble_protected"    # Ensembleschutz
+    PRESERVATION_WORTHY = "preservation_worthy"  # besonders erhaltenswerte Bausubstanz (BEG term)
+
+@dataclass
+class SubsidyBuildingContext:
+    construction_year: int
+    dwelling_units: int
+    heated_floor_area_in_m2: float
+    # Usage split — many schemes fund only (predominantly) residential buildings, run separate
+    # residential/non-residential programs, and prorate eligible costs in mixed-use buildings
+    # (§5.2 `proration`). `residential_share` is derived, never asked separately:
+    residential_floor_area_in_m2: float
+    commercial_floor_area_in_m2: float = 0.0
+    # Heritage protection — schemes relax technical thresholds for protected buildings (BEG:
+    # "Denkmal oder sonstige besonders erhaltenswerte Bausubstanz") or open dedicated variants:
+    heritage_status: HeritageStatus = HeritageStatus.NONE
+    energy_performance_class: Optional[str] = None  # for "worst-performing building" conditions (EPBD)
+    existing_heating: Optional[ExistingAsset] = None  # carrier, age, is_functional → speed bonus
+
+# measure.* resolves to the ComponentCostFacts of the subsidized measure, incl. technical_attributes.
+```
+
+No Python `eval`; the expression grammar is validated on catalog load with clear errors ("scheme
+DE_BEG_EM_HP_INCOME_2024 references unknown field applicant.incom").
+
+### 5.4 Cumulation solver
+
+Input: the set of schemes whose eligibility passed, per measure. Rules:
+- Schemes sharing a `cumulation.group` stack additively, capped by `combined_rate_cap`.
+- `excludes` lists define mutual exclusivity across groups.
+- An optional country-level `overall_cap` (EU state-aid ceiling) bounds total support per measure.
+
+The solver enumerates admissible combinations (the sets are small — typically < 10 schemes per
+measure) and picks the NPV-maximizing one *for the applicant*. The decision is made on the BEST_ESTIMATE
+uncertainty slot (§3.9); the chosen combination is then valued in all three slots, with caps checked
+per slot against that slot's eligible cost — so a cap can bind in HIGH but not in LOW, and the three
+results still describe one and the same funding application. Output is a `SubsidyDecision` that is
+fully reported: which schemes applied, each amount (as min/best_estimate/max), which caps were binding in which
+slot, which schemes were rejected and why (failed condition, excluded by, or undetermined for lack
+of an answer — §5.7), and whether a different combination would have been optimal in the LOW or
+HIGH slot. This audit trail is a research
+deliverable in itself and non-negotiable for trust in the results.
+
+### 5.5 With / without grants
+
+Because subsidies are separate timeline entries with provenance, "without grants" is a filter, not a
+recomputation: `subsidy_mode = NONE` drops SUBSIDY/TAX_CREDIT/OPERATIONAL-support flows and resets
+VAT/loan modifications. `ONLY([...])` / `EXCLUDE([...])` enable research questions like "what does the
+income bonus alone contribute to heat pump adoption economics".
+
+### 5.6 Sign convention and interaction with the levy (§6.4)
+
+Subsidies never reduce `I_gross` in place — German landlord law (and clean accounting) requires the
+gross investment and the subsidy to be visible separately, because the modernization levy must be
+computed on cost *net of subsidies* while maintenance rates reference gross investment.
+
+### 5.7 Eligibility questionnaire: asking users the right questions
+
+Most eligibility conditions reference facts only the user can know — income, ownership, heritage
+status, how the building is used. Because conditions are data over typed context fields (§5.3), the
+set of fields any scheme can ever reference is statically enumerable. That turns "fill in this form"
+into "answer exactly the questions that matter for *your* case":
+
+**Question catalog.** Every user-answerable context field has a question entry, localized, in
+`subsidy_catalog/questions_<COUNTRY>.json`:
+
+```jsonc
+{
+  "field": "building.heritage_status",
+  "answer_kind": "CHOICE",            // BOOLEAN | CHOICE | NUMBER(unit) | YEAR | INCOME_BAND
+  "options": ["NONE", "LISTED_MONUMENT", "ENSEMBLE_PROTECTED", "PRESERVATION_WORTHY"],
+  "question": {
+    "de": "Steht das Gebäude unter Denkmalschutz oder gilt es als besonders erhaltenswerte Bausubstanz?",
+    "en": "Is the building a listed monument or otherwise classified as worth preserving?"
+  },
+  "option_labels": {"de": {"NONE": "Nein", "LISTED_MONUMENT": "Ja, Einzeldenkmal", "...": "..."},
+                     "en": {"...": "..."}},
+  "help": {
+    "de": "Bei Denkmalschutz gelten in vielen Förderprogrammen erleichterte technische Anforderungen.",
+    "en": "Many subsidy schemes relax their technical requirements for heritage-protected buildings."
+  }
+}
+```
+
+The usage split is asked as two friendly numbers (residential and commercial floor area — or "is the
+building purely residential?" as a BOOLEAN shortcut that skips the NUMBER questions);
+`residential_share` is derived, never asked. Income is asked as a band (`INCOME_BAND`, aligning with
+the privacy proposal of Q9), not as an amount.
+
+**The minimal question set is computed, not curated.**
+
+```python
+def required_questions(catalog, schemes, planned_measures, known_answers) -> list[Question]
+```
+
+collects every context field referenced by the eligibility conditions, caps and proration rules of
+the *candidate* schemes (pre-filtered by jurisdiction and by the asset classes of the planned
+measures), drops fields that are already answered, known from the simulation/building model
+(construction year, floor areas where the request supplies them), or derivable, and orders the rest
+by pruning power (answers that can disqualify or qualify the most support first). Each question
+carries an automatically derived "asked because" list of the schemes that reference it — so the
+frontend can show *why* it asks, and the list can never go stale relative to the catalog.
+
+**Unanswered questions are first-class (tri-state eligibility).** Unknown fields make a scheme
+`UNDETERMINED(missing_fields=[...])` rather than silently ineligible. The cumulation solver applies
+only `ELIGIBLE` schemes by default, but the `SubsidyDecision` additionally reports the optimistic
+upper bound over the undetermined ones — "answering these 2 questions could unlock up to 9 100 €" —
+which is both the honest default and the friendly nudge for progressive disclosure: the frontend can
+start with zero questions and let the user decide whether the potential support is worth answering
+more.
+
+**Provenance and CI.** User answers enter the provenance ledger as `REQUEST`-origin records carrying
+the question field (§3.10) — an explained subsidy flow shows which answer enabled it. The data-file
+CI (§9.6) checks question coverage: every field referenced by any shipped scheme condition has a
+catalog entry in every supported language, and orphaned question entries are flagged. RenoVisor
+exposes the computed question list as an additive endpoint, so the frontend renders the dialogue
+without duplicating any scheme knowledge.
+
+---
+
+## 6. Actor model (owner-occupier / landlord / tenant)
+
+### 6.1 Actors and allocation
+
+```python
+class Actor(Enum):
+    SYSTEM = "system"            # before allocation / total view
+    OWNER_OCCUPIER = "owner_occupier"
+    LANDLORD = "landlord"
+    TENANT = "tenant"
+```
+
+After the timeline is built, an **allocation ruleset** stamps a payer on every entry (splitting entries
+where a law splits them). Rulesets are country-specific modules with data-file parameters — legal
+percentages and caps change, the *structure* rarely does:
+
+```python
+class AllocationRuleset(Protocol):
+    def allocate(self, timeline: CashFlowTimeline, ctx: AllocationContext) -> CashFlowTimeline: ...
+```
+
+For the owner-occupied case the allocation is trivial (everything → OWNER_OCCUPIER). The rented case
+ships first for Germany (`DE_2024` ruleset), as the structurally most complex EU regime:
+
+### 6.2 German ruleset `DE_2024` (parameters configurable, defaults to be legally verified)
+
+| Cost category | Payer | Mechanism |
+|---|---|---|
+| Investment, replacement, planning, removal | LANDLORD | may be partially passed on via modernization levy (§6.4) |
+| Structural maintenance | LANDLORD | not apportionable |
+| Heating system servicing (Wartung), chimney sweep, metering/billing service | TENANT | apportionable operating costs (BetrKV) |
+| Energy: working price + standing charge | TENANT | Heizkostenverordnung pass-through |
+| Energy: CO2-price component | SPLIT | CO2KostAufG tier table (§6.3) |
+| Feed-in revenue | LANDLORD | (tenant-electricity models out of scope v1) |
+| Subsidies | LANDLORD | reduce the levy basis |
+
+### 6.3 CO2 cost split (CO2KostAufG)
+
+The tenant/landlord split of the carbon-price component is a step function of the building's specific
+emissions (kg CO2 / m² / a), in 10 tiers from "tenant pays 100 %" (efficient building) to
+"landlord pays 95 %" (worst tier). The tier table is a data file. HiSim *simulates* the building's
+emission intensity, so the split is computed from simulation output rather than assumed — a genuine
+advantage over spreadsheet studies, and it responds correctly to retrofit variants (a renovation can
+shift the building several tiers and thus shift who pays the carbon price).
+
+### 6.4 Modernization levy (Modernisierungsumlage)
+
+Parameterized model (defaults per §559/§559e BGB as of 2024 — exact rates/caps to be verified in
+review):
+
+```python
+@dataclass
+class ModernizationLevyParameters:
+    levy_rate_per_year: float                 # e.g. 0.08 (general, §559)
+    cap_in_euro_per_m2_per_month: float       # e.g. 3.00, or 2.00 below a rent threshold
+    cap_low_rent_in_euro_per_m2_per_month: float
+    cap_low_rent_threshold_in_euro_per_m2: float
+    maintenance_deduction_share: float        # avoided-maintenance share deducted from the basis
+    duration_in_years: Optional[int]          # None = permanent rent increase
+    heating_levy_rate_per_year: float         # e.g. 0.10 (heating modernization, §559e)
+    heating_cap_in_euro_per_m2_per_month: float          # e.g. 0.50, on the §559e share alone
+    heating_measure_component_types: FrozenSet[str]      # ComponentType names levied under §559e
+```
+
+Basis = allocatable modernization cost − subsidies − avoided-maintenance share (which links directly
+to the anyway-cost logic of §4.1). Output flows: TENANT gets a positive rent-increase flow, LANDLORD
+the mirroring negative (revenue).
+
+**§559e: heating modernization** (D27). A measure that replaces or newly installs the heat supply is
+levied at the higher `heating_levy_rate_per_year` (10 %/a) instead of the general 8 %/a, and the rent
+increase attributable to those measures is separately capped at `heating_cap_in_euro_per_m2_per_month`
+(0.50 EUR/m²/month). Both paragraphs run the *same* basis rule — §559e Abs. 2 repeats the subsidy and
+maintenance deduction of §559 Abs. 2 verbatim — so only rate and cap differ.
+
+*Classification is data, not code.* `modernization_levy.heating_measure_component_types` in
+`allocation_DE_2024.json` lists the `ComponentType` names that earn the §559e rate: the §71 GEG
+65-%-renewable heat-supply options the device catalog knows (`HEAT_PUMP`, `DISTRICT_HEATING`,
+`SOLAR_THERMAL_SYSTEM`, `PELLET_HEATER`, `WOOD_CHIP_HEATER`) plus `THERMAL_ENERGY_STORAGE`. Fossil
+boilers, conditionally compliant generators, heat emitters and every envelope measure stay under
+§559. A name that is not a `ComponentType` is a located `CostDataError` at load time (§9.2).
+
+*The caps nest.* First the §559e leg is capped at 0.50 EUR/m²/month; then the **total** of both
+paragraphs must fit the general §559 Abs. 3a cap (3.00 EUR/m²/month, 2.00 below the low-rent
+threshold). When that total cap binds, the **non-heating leg is reduced first** — it is the larger
+rate base's residual claim, and reducing the heating leg first would give a landlord a lower total
+increase for doing the heating measure than for skipping it. The heating leg only yields where it
+alone exceeds the total cap. Both caps apply per slot (§3.9), as every cap in this engine does.
+
+*One booked pair.* The levy basis is attributed per measure (`ModernizationLevyBasis.by_subject`;
+support that belongs to no measure, such as a financing repayment grant, reduces the §559 pool), and
+the two legs are computed separately — but the timeline books their **sum** as a single
+tenant/landlord transfer pair, and `DE2024Ruleset.compute_modernization_levy` is the only place the
+split is visible. Reason: the total cap couples the legs, so with a banded basis a single leg can
+carry a slot-reordered band while their sum cannot; two separately booked entries would then not sum
+to the rent increase the tenant actually pays (the same representability limit as §6.5/B11). One
+consequence worth stating: the zero floor of the basis applies per paragraph pool, so an
+over-subsidized heating measure no longer nets its surplus against the envelope measures of the same
+package. Worked example: `tests/worked_examples/end_to_end/heating_levy_559e_mixed_package.xlsx`.
+
+### 6.5 Actor-level results and KPIs
+
+From `npv_by_payer` and the nominal series per payer (all figures as min/best_estimate/max bands, §3.9):
+- **Tenant**: Δ warm rent in €/month (rent levy + apportioned operating/energy costs vs. reference
+  variant), and the **warm-rent-neutrality flag** (Δ ≤ 0) — the standard German policy KPI for whether
+  a retrofit burdens tenants. The flag is evaluated per slot; neutrality in the HIGH slot ("neutral
+  even if everything comes in expensive") is the robust policy statement.
+- **Landlord**: net position (investment − subsidies − levy revenue − unrecoverable maintenance),
+  discounted payback of the landlord share (a payback band, per slot).
+- **Owner-occupier**: monthly cost year 1 (liquidity, §4.3/4.4) and equivalent annual cost.
+
+Landlord–tenant is a zero-sum reallocation of the SYSTEM view by construction; the engine asserts
+`sum(payer NPVs) == system NPV` as an invariant test — with **envelope semantics** for the
+uncertainty bands (decided 2026-08-12, see roadmap/cost-spec-v2.md §7 B11): for signed flows the
+band invariant min ≤ best_estimate ≤ max forces revenue entries to be *mirrored* (§3.9: "minimum" reads
+best-case, not LOW-world), so a slot-coherent transfer entry is unrepresentable. Consequently the
+invariant is: exact equality in the BEST_ESTIMATE slot always; exact per-slot equality for rulesets that
+only retag payers; for rulesets that *create* transfer pairs (modernization levy), the system band
+must lie within the envelope of the payer-band sums.
+
+---
+
+## 7. Standard perspective bundle, outputs and KPIs
+
+### 7.1 Default bundle
+
+Shipped as data (`perspectives_default.json`), evaluated when
+`PostProcessingOptions.COMPUTE_LIFECYCLE_COSTS` is set:
+
+| id | context | actor | subsidies | financing | accounting |
+|---|---|---|---|---|---|
+| `greenfield_gross` | GREENFIELD | SYSTEM | NONE | cash | FINANCIAL |
+| `greenfield_net` | GREENFIELD | SYSTEM | FULL | cash | FINANCIAL |
+| `brownfield_gross` | BROWNFIELD | SYSTEM | NONE | cash | FINANCIAL |
+| `brownfield_net` | BROWNFIELD | SYSTEM | FULL | cash | FINANCIAL |
+| `operating` | OPERATING_ONLY | SYSTEM | FULL | — | FINANCIAL |
+| `owner_monthly` | BROWNFIELD | OWNER_OCCUPIER | FULL | loan (default plan) | FINANCIAL |
+| `landlord` | BROWNFIELD | LANDLORD | FULL | cash | FINANCIAL |
+| `tenant` | BROWNFIELD | TENANT | FULL | — | FINANCIAL |
+| `macroeconomic` | BROWNFIELD | SYSTEM | (excluded by def.) | cash | MACROECONOMIC |
+
+Scenarios choose a subset; RenoVisor requests can define additional perspectives. Greenfield rows are
+skipped automatically when no `ExistingAssetRegister` is provided and vice versa.
+
+### 7.2 Exports
+
+All monetary figures are exported as min/best_estimate/max (triplet objects in JSON, `*_min`/`*_best_estimate`/`*_max`
+column groups in CSV, §3.9):
+
+- `lifecycle_costs.json` — full typed `EvaluationMatrix` incl. `SubsidyDecision` audit trails, for the
+  webtool and the RenoVisor uploader.
+- `component_costs.json` / `component_costs.csv` — the per-component breakdown for frontend
+  visualization (§7.4).
+- `cash_flow_timeline.csv` — long format: year, category, subject, payer, perspective, nominal,
+  discounted (each as min/best_estimate/max).
+- `cost_provenance.json` — the provenance ledger (§3.10); rows of the CSV exports carry their
+  timeline-entry ids, so every exported number stays explainable offline from the archived result
+  directory.
+- The legacy CSVs (`investment_cost_co2_footprint.csv`, `operational_costs_co2_footprint.csv`) keep
+  being written unchanged during the parallel phase, purely as exports; nothing reads them back.
+
+### 7.3 KPIs
+
+Existing KPI names keep being emitted (computed from the new engine, verified by golden tests). New
+KPIs are namespaced per perspective, e.g.:
+
+- `Equivalent annual cost [EUR/a] (brownfield_net)`
+- `Net present cost over 20 years [EUR] (greenfield_gross)`
+- `Monthly cost year 1 [EUR/month] (owner_monthly)`
+- `Warm rent change [EUR/month] (tenant)` + `Warm-rent neutral (tenant)` (bool)
+- `Discounted payback vs reference [a] (brownfield_net)`
+- `Total subsidies received [EUR]` + one KPI per applied scheme id
+- `Levelized cost of heat [EUR/kWh] (operating)`
+
+Every monetary KPI carries its uncertainty band: `KpiEntry` gains optional `value_min` / `value_max`
+fields (an additive change — the webtool JSON stays backward compatible), with `value` itself being
+the BEST_ESTIMATE slot. Legacy KPI names remain plain scalars during the parallel phase and switch to
+carrying bands at cutover (§10, Phase 7).
+
+### 7.4 Per-component costs for frontend visualization
+
+Requirement: the frontend must be able to show, for **every variant and every perspective**, what each
+component contributes to the total — e.g. a stacked bar per variant (investment / replacements /
+maintenance / subsidies per component), and a component-level diff between a base variant and a
+measure variant ("the heat pump adds X, the dropped gas contract saves Y").
+
+Design rules:
+
+1. **One source, no recomputation.** The breakdown is the `subject` pivot of the canonical timeline
+   (§3.6), materialized as `component_breakdowns` on every `LifecycleCostResult` (§3.7). Since every
+   perspective already has its own timeline, per-component figures exist automatically *in all
+   perspectives* — greenfield vs. brownfield per-component investment, per-payer allocations, with and
+   without subsidies — at zero additional engine complexity.
+2. **Subjects cover components *and* carriers.** Energy is billed at carrier boundaries (§3.1), so the
+   electricity bill appears as a carrier subject, not smeared over consuming components. The invariant
+   `sum(subject NPVs) == perspective total NPV` holds by construction — per uncertainty slot (§3.9) —
+   and is asserted in tests; stacked charts always reconcile with the headline KPI, and per-subject
+   min/best_estimate/max bands render as error bars/whiskers on the stacked bars.
+3. **Attribution is display-only and flagged.** An optional secondary view splits carrier costs over
+   consuming components using the attribution shares from `get_component_kpi_entries()` (e.g. "the
+   heat pump's share of the electricity bill"). These figures are marked `is_attribution: true` in the
+   export and are never summed together with the billed carrier subjects — the double-counting
+   protection of §3.1 extends into the visualization layer.
+4. **Cross-variant alignment happens server-side.** The RenoVisor comparison layer aligns subjects
+   across variants by `(asset_class, subject)` and emits explicit zero entries for one-sided subjects
+   (§3.7 `npv_delta_by_subject`), so the frontend renders diffs without name-matching heuristics.
+
+Exports (per run, next to `lifecycle_costs.json`):
+
+- `component_costs.json` — `{perspective: {subject: ComponentCostBreakdown}}`, typed, consumed by the
+  webtool and the RenoVisor uploader (which merges the variants' files into the cross-variant
+  comparison payload).
+- `component_costs.csv` — long format for ad-hoc analysis and plotting: one row per
+  (perspective, subject, subject_kind, asset_class, category) with NPV, equivalent annual cost and
+  year-1 nominal cost (each as min/best_estimate/max columns), and lifecycle CO2 columns.
+
+---
+
+## 8. Dynamic electricity prices and capacity tariffs
+
+### 8.1 The consistency problem
+
+Electricity prices currently live in three disconnected places: the postprocessing dicts in
+`configuration.py` (billing), the `PriceSignal` component in `generic_price_signal.py` (a dummy
+providing fixed/ToU per-timestep prices and 24 h forecasts to the `SingletonSimRepository` for the MPC
+controller), and nothing at all for the main rule-based EMS, which routes surplus without ever seeing
+a price. If an EMS optimizes against one price signal and the cost evaluation bills against another,
+the resulting "savings from smart control" are an artifact. The design rule therefore is:
+
+> **One `TariffContract` object per carrier is the single source of truth. The in-simulation price
+> provider and the postprocessing billing engine both read it; neither carries its own price data.**
+
+This also defines the split of responsibilities: *control strategy* (how an EMS reacts to prices,
+how a battery shaves peaks) is component/controller design and out of scope for this spec; this spec
+guarantees that (a) the signals controllers need exist during simulation, and (b) whatever load
+profile results is billed correctly and consistently.
+
+### 8.2 Tariff contract model
+
+Tariff contracts are data files (`hisim/cost_database/tariffs/*.json`), referenced by id from the
+scenario / RenoVisor request:
+
+```jsonc
+{
+  "id": "DE_DYNAMIC_SPOT_2024",
+  "carrier": "ELECTRICITY",
+  "jurisdiction": {"country": "DE", "region": null},   // explicit, like subsidy schemes (§5.2) —
+                                                       // not an id naming convention
+  "valid_from_year": 2024,
+  "supply": {
+    // FLAT | TIME_OF_USE | DYNAMIC
+    "kind": "DYNAMIC",
+    "spot_series": "epex_da_de_2024",        // reference to a price series in the database
+    "formula": {"spot_factor": 1.0, "markup_in_euro_per_kwh": 0.017},
+    // Non-energy components kept separate — needed for the macroeconomic view (strip taxes),
+    // §14a discounts (grid fee only), and time-variable grid fees (module 3):
+    "grid_fee_in_euro_per_kwh": 0.094,
+    "taxes_and_levies_in_euro_per_kwh": 0.051,
+    "vat_rate": 0.19
+  },
+  "standing_charge_in_euro_per_year": 140,
+  "capacity_charge": {
+    // NONE | ANNUAL_PEAK | MONTHLY_PEAK | PEAK_WINDOW (peaks counted only in high-load windows)
+    "kind": "MONTHLY_PEAK",
+    "price_in_euro_per_kw": 8.0,
+    "billing_interval_in_minutes": 15        // peaks measured as 15-min mean power, not instantaneous
+  },
+  "feed_in": {
+    // FIXED_TARIFF (EEG, nominally constant for its duration) | SPOT_REFERENCED (direct marketing)
+    "kind": "FIXED_TARIFF", "rate_in_euro_per_kwh": 0.081, "duration_in_years": 20
+  },
+  "controllability_discount": {
+    // §14a EnWG-style: reduced grid fee in exchange for dimmable devices; module 3 ToU grid fee
+    // is expressed as a TIME_OF_USE structure on grid_fee instead.
+    "kind": "NONE"
+  },
+  "source_ids": ["src_tariff_sheet_supplier_x_2024"]   // mandatory (§3.10); spot price series
+                                                       // referenced by `spot_series` carry their own
+}
+```
+
+`TIME_OF_USE` supply uses band definitions (weekday/hour masks); `DYNAMIC` references a spot price
+series (e.g. EPEX day-ahead for the simulated year) shipped as versioned CSV in the cost database.
+For fixed-price contracts, the tariff contract *replaces* the flat working price of §3.5's energy
+price entries; the §3.5 entries remain as the default contract (`DE_DEFAULT_<year>`), so scenarios
+without explicit tariffs behave as before.
+
+### 8.3 In-simulation: the `TariffProvider` component
+
+`generic_price_signal.py` evolves into a `TariffProvider` driven by a `TariffContract` (one instance
+per carrier contract). Per timestep it outputs:
+
+- `PricePurchase` / `PriceInjection` [EUR/kWh] — the *total* marginal price (all components summed),
+  what a cost-optimizing controller should react to;
+- `BillingPeriodPeakSoFar` [kW] and `CapacityChargeMarginal` [EUR/kW] — the state a peak-shaving
+  strategy needs: staying under the period's existing peak is free, setting a new one costs
+  `price_per_kw`. A rule-based EMS can implement meaningful peak shaving from these two signals alone,
+  without internal tariff bookkeeping; an MPC gets the same information via the existing forecast
+  mechanism (price forecast horizon published to `SingletonSimRepository`, as today).
+
+Controllers consume these via normal input wiring or the sim repository; the EMS gaining a
+price-reactive operating mode is a separate (worthwhile) work item outside this spec.
+
+### 8.4 Billing determinants: what the meter must measure
+
+Plain annual kWh is no longer a sufficient billing basis. `EnergyFlowFacts` (§3.4) is extended to:
+
+```python
+@dataclass
+class BillingDeterminants:
+    carrier: EnergyCarrier
+    energy_bought_in_kwh: float
+    energy_sold_in_kwh: float
+    energy_bought_per_band_in_kwh: dict[str, float]        # ToU tariffs
+    cost_integrated_in_euro: Optional[float]               # ∫ load·price dt for DYNAMIC supply,
+    revenue_integrated_in_euro: Optional[float]            #   integrated at native resolution
+    peak_per_billing_period_in_kw: list[float]             # mean power over the billing interval
+    annual_peak_in_kw: float
+```
+
+Rules:
+- **Peaks are billing-interval means** (typically 15 min), computed by resampling the meter's power
+  series — never instantaneous timestep values. Validation: `seconds_per_timestep` must divide the
+  billing interval, otherwise the run fails at pre-check (§9.3).
+- For `DYNAMIC` supply the meter integrates cost at native resolution during postprocessing
+  (load × price series), because annual kWh × average price is exactly the error dynamic tariffs
+  exist to exploit.
+- The billing engine is one pure function, `apply_tariff(determinants, contract) -> year-1 costs by
+  category`, with a new `CostCategory.ENERGY_CAPACITY_CHARGE`. It is property-tested (e.g. a flat
+  contract must reproduce `kWh × price` exactly; capacity charge is monotone in every peak).
+- Uncertain tariff components (§3.9 — markup, grid fee, taxes/levies, capacity price) do **not**
+  require re-integrating the load × price series per slot: the spot-indexed part is integrated once;
+  additive per-kWh components shift each slot's bill by `E × Δcomponent`, the capacity charge by
+  `Σ peaks × Δprice`. The spot series itself is simulation input and stays exact (§3.9).
+
+### 8.5 Projecting a dynamic-tariff year over the horizon
+
+Re-simulating 20 projection years under evolving spot profiles is out of scope (and spurious
+precision); naively escalating the year-1 bill is wrong in the other direction, because the *value of
+flexibility* has its own dynamics. Proposal — decompose the year-1 result, then escalate each part
+with its own rate:
+
+```
+bill_year1 = E_bought × p̄            (volume effect: energy at the year's average price)
+           − flexibility_value        (what load shifting saved vs. paying the average price)
+           + standing + capacity charges
+```
+
+- The volume effect escalates with the carrier's escalation rate (§3.2) plus the CO2-price path.
+- `flexibility_value` (= `E_bought × p̄ − cost_integrated`) escalates with its own
+  `spread_escalation_rate` — spot price *spreads* are expected to grow with renewable shares, and this
+  is precisely the research knob for "does an EMS pay off over 20 years". Default: equal to the
+  carrier escalation rate (i.e. flexibility value keeps pace with the price level).
+- Capacity charges escalate with a grid-fee escalation rate; feed-in per its contract kind
+  (EEG: nominally fixed for its duration, then market value).
+
+Two distinct counterfactuals answer "what does the dynamic tariff / the EMS earn", and both are
+supported without new machinery:
+1. **Tariff counterfactual** (free): bill the *same* simulated load profile under a flat contract —
+   isolates the tariff choice given unchanged behavior. This is just `apply_tariff` with a different
+   contract and becomes a standard output whenever a `DYNAMIC` contract is active.
+2. **Behavioral counterfactual** (a second simulation): run the variant with a flat tariff and a
+   price-blind EMS — isolates tariff + control together. This is an ordinary `VariantComparison`
+   (§3.7), the same mechanism as RenoVisor base-vs-measures.
+
+### 8.6 Interactions with the rest of the spec
+
+- **Actor model (§6):** all supply-side categories (working, standing, capacity, CO2 component) follow
+  the energy allocation rules; a capacity charge on a rented building's common heat pump is allocated
+  like heating energy. Tenant-electricity/Mieterstrom remains out of scope (§11 Q13).
+- **Macroeconomic view (§4.5):** strips `taxes_and_levies` and VAT from the tariff components — which
+  is why the contract stores them separately.
+- **§14a-style controllability discounts** reduce only the grid-fee component and presuppose that the
+  simulation actually models the dimming obligation; v1 supports the discount as data, while dimming
+  events in the simulation are a separate control-side work item (§11 Q19).
+- **Audit (§9.5):** the cost audit lists the active tariff contract id per carrier, and for dynamic
+  contracts the spot series id and the decomposition (volume effect, flexibility value, capacity
+  charges) — so reviewers see at a glance what the EMS was rewarded for.
+
+---
+
+## 9. Maintainability: keeping per-component verification easy and safe
+
+The current design's virtue is locality: opening `advanced_heat_pump_hplib.py` shows the cost
+calculation next to the config it reads, so a reviewer can check in one place that the component "has
+the proper calculations and uses the correct configuration". The new design must preserve that virtue —
+but it is worth being precise about what locality actually buys today. Verifying a component currently
+means reading ~40 lines of pricing math, dataframe indexing and manual unit conversion, per component,
+46 times; the copies have drifted (several still carry the same `# Todo: check component name`
+output-matching bug), and nothing *checks* them — verification is possible, not enforced.
+
+The resolution: **what is component-specific stays in the component file; what is generic moves out and
+becomes centrally tested.** The reviewable surface per component shrinks from ~40 lines of math to a
+~6-line declaration, and a set of automatic checks makes wrong or missing declarations fail loudly
+instead of relying on review discipline.
+
+### 9.1 The declaration lives in the component file
+
+`get_cost_facts()` is implemented in the component's own module, next to the lifecycle methods and the
+config it reads:
+
+```python
+# hisim/components/advanced_heat_pump_hplib.py
+def get_cost_facts(self) -> ComponentCostFacts:
+    return ComponentCostFacts(
+        asset_class=ComponentType.HEAT_PUMP,
+        size=self.config.set_thermal_output_power_in_watt.to(Units.KILOWATT).value,
+        size_unit=Units.KILOWATT,
+        kpi_tag=KpiTagEnumClass.HEATPUMP_SPACE_HEATING,
+        technical_attributes={"refrigerant": self.config.refrigerant},
+    )
+```
+
+Everything a reviewer must verify — right asset class, right config field, right unit — fits on one
+screen, in the same file as the config definition. What is no longer there is exactly the part that was
+identical (and identically buggy) across all components: price lookup, escalation, discounting,
+dataframe access. Sizes are converted via the typed `Quantity` helpers from `units.py` instead of
+ad-hoc factors (the current heat pump code does `* 1e-3` by hand — the classic W/kW slip).
+
+### 9.2 No silent omissions
+
+The naive default (`return None` = no costs) has a failure mode locality never had: a *forgotten*
+implementation silently drops a component from every cost result. Countermeasures:
+
+- **Mandatory class-level declaration.** Every `Component` subclass sets
+  `cost_relevance: ClassVar[CostRelevance]` with values `PRICED` (must return facts),
+  `FREE_OF_COST` (controllers, weather, idealized devices — must return `None`), or `METER`
+  (must provide `EnergyFlowFacts`). The base class default is `UNDECLARED`.
+- **Completeness check at simulation start, not end.** During component registration, any `UNDECLARED`
+  component, or a `PRICED` component whose facts don't build, aborts with a message naming the class
+  and file. Strictness is configurable (`strict_cost_completeness`): hard error in CI and tests,
+  downgradeable to a warning for legacy system setups during migration.
+
+Forgetting the cost model on a new component thus fails the very first test run — today, forgetting
+`get_cost_opex` merely produces a silent `NotImplementedError` swallowed by the None-filtering in
+`opex_calculation()`.
+
+### 9.3 Fail fast, before the simulation runs
+
+- `ComponentCostFacts.__post_init__` validates locally: size finite and > 0, unit in the supported
+  set, override bands valid (`0 <= min <= best_estimate <= max`, §3.9), technical attributes JSON-serializable,
+  and `override_source` present whenever any override field is set (strict mode; warning during
+  migration — §3.10).
+- **Pre-run resolution check**: before the timestep loop starts, the evaluator dry-resolves every
+  declared fact against the cost database and subsidy catalog — device entry exists for
+  country/year, the entry's `per_unit` matches the declared `size_unit`, every
+  `technical_attributes` field referenced by an applicable subsidy condition is present. A missing
+  database entry fails in seconds instead of after an hour of simulation. The same pass populates
+  the provenance ledger (§3.10) — resolution and provenance recording are one mechanism, so the
+  ledger cannot drift from what the evaluator actually used.
+
+### 9.4 Auto-discovered contract tests
+
+One parametrized pytest sweeps *all* `Component` subclasses with their `get_default_*` configs —
+new components are covered the moment the class exists, nobody has to remember to add a cost test:
+
+```
+tests/test_cost_facts_contract.py, for every Component subclass:
+  - cost_relevance is declared
+  - PRICED  → facts build from the default config, pass validation, and resolve against every
+              shipped cost database (DE, AT, …)
+  - PRICED  → facts respond to the config: rebuild with the capacity field scaled ×2 and assert
+              facts.size scales accordingly (catches hardcoded sizes and wrong config fields —
+              the "uses the correct configuration" property, now machine-checked)
+  - METER   → the declared EnergyCarrier has a price entry in every energy price file
+```
+
+The scaling assertion needs to know which config field is the capacity; proposal: mark it with
+dataclass field metadata (`field(metadata={"capacity": True})`) — a one-line convention that is also
+useful to building_sizer. The engine math itself is tested once, against hand-computed VDI 2067 /
+EN 15459 examples plus property tests (all rates zero ⇒ NPV equals the plain sum; payer NPVs sum to
+the system NPV; removing a subsidy never decreases cost; degenerate bands — min = best_estimate = max on every
+input — make all three slots identical; widening any input band never narrows a result band; every
+total satisfies LOW ≤ BEST_ESTIMATE ≤ HIGH, §3.9).
+
+### 9.5 The cost audit report: review one table instead of 46 files
+
+Every run emits `cost_audit.csv` (and a section in the PDF report): one row per component with asset
+class, size and unit, **the origin and sources of every parameter** (ledger origin plus resolved
+`source_ids`, §3.10 — config override with its `override_source` / database entry with its
+`valid_from_year` / engine default), unit price and its min/best_estimate/max band, lifetime, resulting gross
+investment (as a band), and the applied subsidy schemes with amounts per slot, including which caps
+bound in which slot (§3.9). The audit is the eager, tabular summary of the same ledger the `explain`
+API queries on demand. This changes the verification workflow qualitatively:
+
+- A researcher checking a study's cost inputs scans one table instead of reading 46 files.
+- A config-wiring mistake (wrong field → 5000 kW heat pump) is visible as an implausible number in
+  every run's audit, not buried in code.
+- PRs that change cost data produce a reviewable diff of the audit file on the golden scenario suite,
+  so price updates show up as explicit KPI/audit deltas rather than silent drift.
+
+### 9.6 Data-file CI
+
+Since prices and schemes become data, the data gets the CI treatment code used to get implicitly:
+
+- JSON-schema validation of cost databases, subsidy catalogs and scenario sets (including
+  data-overlay paths, §4.6), on load and in CI.
+- **Source completeness check (§3.10)**: every data entry (device, energy price, tariff, scheme,
+  CO2 path, escalation default, spot series) has at least one `source_ids` reference; every referenced id resolves
+  against the source registry; every registry entry has the mandatory citation / publication_year /
+  retrieved / kind fields; orphaned registry entries are flagged. An unsourced datapoint fails CI.
+- **Coverage matrix check**: every `asset_class` declared by any component × every supported country
+  has a device entry; every carrier used by a meter has a price entry — a new `ComponentType` without
+  cost data fails CI, the counterpart of today's "new component must implement get_cost_capex".
+- **Question coverage check (§5.7)**: every context field referenced by any shipped scheme's
+  conditions, caps or proration rules has a question-catalog entry in every supported language;
+  orphaned question entries (referencing no scheme) are flagged.
+- Staleness warning when a subsidy catalog's `catalog_snapshot_date` — or any source registry
+  entry's `retrieved` date backing a currently-valid data entry — is older than 12 months.
+- Golden KPI tests on the scenario suite pin end-to-end numbers.
+
+### 9.7 Per-component parity during the parallel phase
+
+Components adopt `get_cost_facts()` one (or a few) per PR, *next to* the untouched legacy methods
+(§10.0). A parity harness compares the legacy path's results against the new facts→engine path with
+degenerate parameters (the Phase 1 golden setting) and asserts equality per component. Parity is
+always checked against the BEST_ESTIMATE slot (§3.9); as long as the migrated database entries are
+degenerate (min = best_estimate = max), all three slots coincide anyway. It runs in two
+places:
+
+- **In CI**, as part of the auto-discovered contract test (§9.4), so a PR adopting a component fails
+  if its facts don't reproduce the legacy numbers.
+- **In shadow mode on every run** where both paths are active: postprocessing writes
+  `cost_parity_report.csv` (one row per component: legacy value, new value, delta) — so parity is
+  demonstrated across the whole zoo of real scenarios and RenoVisor requests, not just the test suite.
+  This report is the primary evidence for the cutover decision (§10, Phase 7).
+
+Any discrepancy is either a migration mistake or a latent bug in the old implementation — both worth
+surfacing explicitly (documented in the PR rather than silently "fixed"). The legacy methods remain
+the source of all published numbers until cutover; the parity harness is the only consumer that reads
+both.
+
+---
+
+## 10. Migration plan
+
+The phases build on each other; each is releasable on its own.
+
+### 10.0 Guiding constraint: strictly parallel implementation, one cutover at the end
+
+The new cost module is implemented **fully parallel to the existing calculation, which is not touched
+at all**; only after everything works (exit criteria below) is the old implementation removed, in one
+explicit final phase. Concretely, the following rules bind every phase except Phase 7:
+
+1. **New code lives in new modules** (`hisim/economics/`, `hisim/cost_database/`,
+   `hisim/subsidy_catalog/`). Existing cost code — the `get_cost_capex`/`get_cost_opex` methods,
+   `configuration.py` dicts, `capex_computation.py`, `opex_and_capex_cost_calculation.py`, the KPI
+   CSV re-parse — is neither edited nor refactored.
+2. **Changes to existing files are purely additive**: a new `PostProcessingOptions` flag
+   (`COMPUTE_LIFECYCLE_COSTS`), new optional methods on `Component` with a no-op default
+   (`get_cost_facts()` returning `None`), the `cost_relevance` class attribute (§9.2, metadata only,
+   warning-mode during the parallel phase). No existing line of calculation logic changes.
+3. **Activation is opt-in and side-effect-free.** With the flag off, behavior is bit-identical to
+   today. With the flag on, the new engine runs *in addition* and writes only new files
+   (`lifecycle_costs.json`, `component_costs.*`, `cash_flow_timeline.csv`, `cost_audit.csv`,
+   `cost_parity_report.csv`) and new namespaced KPIs — every legacy file, KPI name and KPI value stays
+   identical either way, pinned by golden tests in CI. The flag is on by default in CI (shadow mode,
+   to accumulate parity evidence) and opt-in for users during the parallel phase.
+4. **The new engine never calls the legacy methods** — `get_cost_capex` mutates the component config
+   as a side effect, so invoking it a second time from the new path would corrupt the very
+   calculation it must leave untouched. Facts come from `get_cost_facts()` where already adopted, and
+   otherwise from a compatibility adapter *inside the new package* that maps known component classes
+   and their configs to `ComponentCostFacts` directly. The parity harness (§9.7) compares against the
+   legacy path's already-computed results read-only.
+5. **The legacy path remains the sole source of published numbers** (existing KPI names, legacy CSVs,
+   webtool fields consumed by RenoVisor) until Phase 7.
+6. **Only Phase 7 touches or deletes legacy code**, and only after the exit criteria are met.
+
+**Exit criteria for cutover** (checked at the start of Phase 7): all priced components have adopted
+`get_cost_facts()` with green per-component parity (§9.7); `cost_parity_report.csv` shows zero
+unexplained deltas across the golden scenario suite and an agreed set of real RenoVisor runs;
+data-file CI (schema + coverage matrix) green; sign-off on the audited discrepancy list (legacy bugs
+found by parity are documented, and it is decided per case whether the new engine reproduces or fixes
+them — fixes become explicit, reviewed KPI deltas).
+
+### 10.1 Phases
+
+**Phase 1 — parallel core engine + data, no component changes.**
+`EconomicParameters`, the `UncertainValue` triplet type and slot-wise evaluation (§3.9 — built into
+the core from day one; retrofitting bands later would touch every type and export), `CostDatabase`
+(data files generated 1:1 from the existing dicts in `configuration.py`, sources preserved — the
+dicts themselves stay untouched; all entries start as degenerate bands, min = best_estimate = max, so every
+slot reproduces the legacy numbers), `EconomicEvaluator` with the canonical timeline, GREENFIELD
+context, SYSTEM actor, flat-percentage subsidy shim (reproducing today's behavior), and the
+compatibility adapter of §10.0 rule 4. The provenance ledger, `explain` API and `sources.json`
+registry (§3.10) also ship in this phase: the citation lists currently in `configuration.py`
+docstrings ([20], [22], …) are migrated 1:1 into registry entries during the data migration, so the
+mandatory-source CI check is green from the first commit. Real min/max ranges are then filled in per
+data source as data-only PRs, whose effect is visible in the audit diff (§9.5). **Golden test:** with
+`observation_period = simulated period`, all rates 0, the engine reproduces today's
+"per simulated period" numbers exactly — verified via the shadow-mode parity report, not by modifying
+the old path. Unit tests against hand-calculated VDI 2067 / EN 15459 examples. This phase also ships
+the maintenance infrastructure of §9: `cost_relevance` declarations (additive, warning-mode), the
+pre-run resolution check, the auto-discovered contract test, the cost audit report, and the data-file
+CI (schema + coverage matrix) — so the safety net exists *before* any component adopts the new API.
+
+**Phase 2 — parallel KPI set + per-component breakdowns.**
+The new lifecycle KPIs (§7.3) and the per-component visualization exports (§7.4) are emitted under
+their new, namespaced names/files when the flag is on. Legacy KPI computation (CSV re-parse included)
+keeps running unchanged and keeps owning the existing KPI names; the switch of those names to the new
+engine is deferred to Phase 7. The frontend can start building the per-component visualizations
+against `component_costs.json` in this phase, without waiting for the cutover.
+
+**Phase 3 — perspectives.**
+`ExistingAssetRegister`, BROWNFIELD/STATUS_QUO contexts with anyway-cost credit, OPERATING_ONLY,
+liquidity view + `FinancingPlan`, MACROECONOMIC accounting, two-part tariffs + CO2 price paths in the
+energy database, `VariantComparison` (incl. `npv_delta_by_subject`). RenoVisor request schema gains
+`existingAssets`, `economicParameters`, `perspectives` (additive, optional fields).
+
+**Phase 3b — tariff engine (§8).**
+`TariffContract` schema + default flat contracts generated from the §3.5 price entries (behavioral
+no-op, pinned by golden tests); `BillingDeterminants` on the electricity meter (band split, 15-min
+peak series, native-resolution cost integration — implemented as an additional output path, the
+meter's existing outputs unchanged); `apply_tariff` billing engine with property tests; a new
+`TariffProvider` component (`generic_price_signal.py` stays untouched and is only deprecated/removed
+in Phase 7); year-1 decomposition (volume / flexibility value / capacity) feeding the projection.
+Price-reactive EMS operating modes are tracked as separate control-side work, not part of this
+migration.
+
+**Phase 3c — scenario analysis (§4.6).**
+Scenario-set schema with dotted-path validation (`EconomicParameters` fields *and* cost-database
+data overlays, incl. the non-sweepable-field guards), FACTORIAL / ONE_AT_A_TIME expansion, the
+two-pass evaluator optimization (structure once, rates per scenario; per-scenario rebuild when an
+overlay touches service lives), `economic_inputs.json`
+serialization + the `python -m hisim.economics evaluate` re-pricing CLI, tornado / break-even /
+robustness helpers, and the `scenario_cube.csv` export wired into `scenario_evaluation`.
+
+**Phase 4 — subsidy engine (§5).**
+Scheme schema, condition language, cumulation solver with tri-state eligibility, payout profiles;
+`subsidy_catalog/DE.json` encoding BEG EM (incl. bonuses, heritage relaxations, residential-share
+proration), §35c tax credit exclusion, KfW loan variant; the question catalog and
+`required_questions` API with the RenoVisor questionnaire endpoint (§5.7); catalog + question
+coverage validation CI.
+Then AT, FR, IT catalogs as research needs dictate — the *engine* must not need changes for new
+countries; if it does, the schema failed.
+
+**Phase 5 — actor model.**
+`AllocationRuleset` protocol, `DE_2024` ruleset (BetrKV apportionment, HeizKV pass-through,
+CO2KostAufG tier table, modernization levy), actor KPIs, zero-sum invariant tests. Legal parameter
+review before release.
+
+**Phase 6 — additive component adoption.**
+Components gain `get_cost_facts()` (+ `get_energy_flow_facts()` / `BillingDeterminants` on meters)
+one (or a few) per PR, **next to the untouched legacy methods**, gated by the per-component parity
+harness (§9.7). The compatibility adapter shrinks as adoption grows; when the last component is
+adopted, the adapter is empty and every priced component is covered by shadow-mode parity.
+
+**Phase 7 — cutover & removal (the only phase that touches legacy code).**
+Entered only when the §10.0 exit criteria are met. In order: (1) existing KPI names switch to being
+computed from `LifecycleCostResult`, values pinned by golden tests (modulo the signed-off legacy-bug
+fixes); (2) the legacy CSVs remain as exports but are generated from the new engine; (3) delete
+`get_cost_capex`/`get_cost_opex` and their implementations, `CapexComputationHelperFunctions` (incl.
+the config-mutating overwrite), the hard-coded parameter dicts in `configuration.py`, the
+`isinstance`-based heat pump special-casing, the KPI CSV re-parse path, and `generic_price_signal.py`;
+(4) flip `strict_cost_completeness` to hard error everywhere; (5) update `example_component.py` and
+the "Adding a new component" section of CLAUDE.md/docs so the template shows `cost_relevance` +
+`get_cost_facts()` from day one. Until step (3) lands, the whole parallel period is trivially
+revertable by turning the flag off.
+
+---
+
+## 11. Open questions (decisions needed before the respective phase)
+
+**Phase 1**
+1. Nominal vs. real rates as the documented default. Proposal: nominal (interest 3 %, general
+   escalation 2 %, carrier escalations from a default table).
+2. Default per-carrier escalation rates and CO2 price paths — which sources, per country? (The
+   2025-2044 projection sources [33]-[35] already cited in `configuration.py` suggest existing team
+   opinions for DE.) Same question for the per-asset-class investment escalation defaults
+   (learning curves, §3.2) in `escalation_defaults_<COUNTRY>.json`; proposal: ship v1 with the
+   per-class table empty (uniform rate applies) until reviewed sources exist.
+3. `EconomicParameters` on `SimulationParameters` (serialized in `*.simulation.json`) — proposal: yes,
+   for reproducibility.
+4. Replacement timing convention: end-of-year everywhere (proposal), vs. EN 15459 mid-year variants.
+
+**Phase 1 (uncertainty, §3.9)**
+23. Sources and curation of the min/max bands: who defines the ranges per component type and energy
+    carrier, and are they maintained as explicit values (proposal — seeded from the spread of the
+    already-cited sources) or as symmetric ±x % rules? Entries without a reviewed band stay
+    degenerate (min = best_estimate = max) rather than getting an invented one.
+24. Is the envelope semantics (full correlation toward cheap/expensive, §3.9) sufficient for the
+    intended studies, or do some need statistical quantiles? Quantiles would require distributions
+    plus sampling via the scenario layer — currently a non-goal.
+25. Extending bands beyond money: service lives and emission factors carry at least as much
+    uncertainty as prices. Proposal: keep them exact in v1 (a lifetime band changes the replacement
+    *structure* of the timeline, not just amounts — a qualitatively bigger change) and revisit after
+    Phase 3.
+26. KPI surface for bands: are optional `value_min`/`value_max` fields on `KpiEntry` (§7.3) enough
+    for the webtool and RenoVisor frontend, or do bounds need to be separate KPI entries for the
+    existing plotting pipeline?
+
+**Phase 1 (provenance, §3.10)**
+27. Source granularity: per-entry `source_ids` mandatory with optional per-field `field_sources`
+    (proposal), or per-field sources mandatory everywhere? The latter is more precise but multiplies
+    curation effort across ~50 device types × countries × years.
+28. Registry scope: one `sources.json` per database file vs. one global registry shared by cost
+    database, subsidy catalogs and tariffs (proposal: one per directory — cost_database and
+    subsidy_catalog — since they are curated by different processes and change at different rates).
+29. Does the RenoVisor/webtool response need embedded provenance for end users, or is the stored
+    ledger + `explain` CLI sufficient (proposal: sufficient — provenance is a researcher/reviewer
+    tool; the frontend gets addressable values, not citation trees)?
+
+**Phase 3**
+5. Gross vs. net price storage in the cost database. Proposal: store net + `vat_rate` per entry;
+   household perspectives gross up, macroeconomic uses net directly, VAT-reduction subsidies override
+   the rate. Requires touching every price entry once during data migration.
+6. Anyway-cost threshold default (proposal: 2 years remaining life) and whether the credit is on by
+   default in RenoVisor comparisons (proposal: yes, with gross figures always reported alongside).
+7. Building-envelope measures (insulation, windows) as `ComponentCostFacts` of the `Building`
+   component with `size_unit = SQUARE_METER` and 40-50 a service life — needs cost-database entries
+   and interacts with the levy's maintenance deduction.
+7b. Per-component visualization (§7.4): how are the display-only attribution shares for carrier costs
+    defined — per component (each consumer's kWh share of the carrier total, proposal) or aggregated
+    per `KpiTag`? And does the frontend need the attribution view in v1 at all, or do billed
+    carrier subjects suffice for the first visualizations?
+
+**Phase 4**
+8. Catalog curation process: who verifies scheme files and how often? Schemes change quarterly.
+   Proposal: `catalog_snapshot_date` per file, a CI check that warns when > 12 months old, and scheme
+   files carry `legal_basis` + `url` for auditability. Scope v1 to DE + AT, add FR/IT on demand.
+9. Income data in RenoVisor requests (needed for income-dependent schemes): privacy handling — accept
+   an income *band* enum rather than an amount?
+10. EEG feed-in: fixed nominal remuneration for 20 years from install (proposal) vs. escalated price.
+31. Question catalog curation (§5.7): who writes and reviews the localized question texts (the
+    wording is user-facing *and* legally sensitive — "Denkmalschutz" vs. "erhaltenswerte
+    Bausubstanz" are different legal categories a layperson may conflate), and which languages ship
+    in v1 (proposal: de + en)?
+32. Questionnaire default posture (§5.7): start with zero questions and progressively disclose via
+    the optimistic upper bound (proposal), or ask the full computed question set upfront in the
+    RenoVisor flow? Affects the frontend UX contract, not the engine.
+33. Heritage scope: is `heritage_status` + condition-level relaxations enough (proposal), or do
+    v1 studies need dedicated heritage *programs* (e.g. §7i EStG monument depreciation) as their own
+    benefit kind? The tax-credit payout profile already exists, so this is likely catalog data, not
+    engine work.
+
+**Phase 5**
+11. Which allocation rulesets in v1 beyond `DE_2024`? (AT has no modernization-levy analogue → much
+    simpler ruleset; a generic `EU_SIMPLE` ruleset — landlord pays capex/maintenance, tenant pays
+    energy — as fallback for other countries?)
+12. Modernization levy parameters (§559 8 % vs. §559e 10 % heating variant, caps, duration) — needs a
+    legal review pass; the spec deliberately keeps them as data.
+13. Tenant-electricity models (Mieterstrom) for PV in rented buildings: v1 assigns feed-in revenue to
+    the landlord; is that acceptable for the intended studies?
+
+**Phase 3b (tariffs, §8)**
+16. Spot price data: which series ship in the cost database (EPEX day-ahead DE/AT per simulation
+    year)? Check redistribution licensing; fallback: a documented loader for user-supplied CSVs plus
+    one synthetic reference profile for tests.
+17. Default `spread_escalation_rate` for the flexibility value — equal to carrier escalation
+    (proposal), or an explicit scenario table from an energy-system study?
+18. Which counterfactual is reported by default when a dynamic contract is active: the free tariff
+    counterfactual (§8.5, proposal: always), the behavioral counterfactual (opt-in second run), or
+    both?
+19. §14a EnWG depth: v1 = grid-fee discount as tariff data only (proposal), or require the simulation
+    to model dimming events before the discount may be applied? The latter is more honest but blocks
+    on control-side work.
+
+**Phase 3c (scenario analysis, §4.6)**
+20. Default shipped scenario set: which axes and levels constitute the standard
+    low/central/high bundle (interest, per-carrier escalations, CO2 path), and from which sources?
+    This is the public face of every study — worth agreeing on early.
+21. Cube explosion control: FACTORIAL over many axes × perspectives × variants grows fast. Cap with a
+    warning at N scenarios (proposal: warn > 1 000, error > 100 000), or leave unbounded?
+22. Should the RenoVisor response include the full cube or only the robustness summary + tornado
+    data (proposal: summary by default, full cube behind a request flag — payload size)?
+30. Data-overlay scope (§4.6): overlaying device and energy-price datapoints is clearly needed;
+    should overlays also be allowed on subsidy catalog entries (e.g. "BEG base rate drops to
+    25 %")? Policy-change scenarios are a real research question, but the cumulation solver makes
+    the interaction harder to reason about. Proposal: yes, same mechanism, with the overlay
+    re-running scheme selection per scenario.
+
+**Cross-cutting (maintainability, §9)**
+14. Enforcement strictness rollout: when does `strict_cost_completeness` flip from warning to hard
+    error — per system setup, or globally at cutover (Phase 7)? Proposal: error in CI from Phase 1,
+    error everywhere at cutover.
+15. Capacity-field convention for the contract test's scaling check: dataclass field metadata
+    (`field(metadata={"capacity": True})`, proposal) vs. a `get_capacity_field_name()` classmethod on
+    `ConfigBase`.

--- a/hisim/economics/README.md
+++ b/hisim/economics/README.md
@@ -1,0 +1,498 @@
+# `hisim.economics` — the lifecycle cost engine
+
+This package is the parallel successor of HiSim's per-component capex/opex cost calculation.
+It computes **lifecycle costs over a configurable horizon** (default 20 years, annuity method
+per VDI 2067-1 / DIN EN 15459-1) from three kinds of inputs: *facts* declared by components
+(what am I, how big), *energy flows* measured by the meters (what crossed the system boundary),
+and *versioned data files* (prices, lifetimes, subsidy schemes). Everything else — discounting,
+replacements, subsidies, actor splits, uncertainty bands — happens in one central engine.
+
+The full specification lives in **`cost_spec.md`** at the repo root; every provisional decision
+and every legacy bug found during implementation is tracked in **`cost_module_issues.md`**.
+Section references like "§3.9" below point into the spec.
+
+---
+
+## 1. Overview
+
+### 1.1 What it computes
+
+For one simulated building variant the engine produces, per **perspective**:
+
+| Output | Meaning |
+|---|---|
+| Net present cost (NPV) | All cash flows over the horizon, discounted to year 0 |
+| Equivalent annual cost | NPV × annuity factor — the headline KPI |
+| NPV by category / component / payer | Pivots of the same timeline |
+| Per-component breakdowns | For stacked-bar frontends; sum exactly to the totals |
+| Nominal annual cost series | The liquidity view ("euros out of pocket per year") |
+| Monthly cost year 1 | Liquidity / affordability figure |
+| Lifecycle CO2 | Embodied + operational, undiscounted, parallel to money |
+| Subsidy decision audit trail | Which schemes applied, which caps bound, what was rejected and why |
+
+Every monetary figure is a **(minimum, best_estimate, maximum) triplet** (`UncertainValue`, §3.9):
+the engine evaluates three coherent worlds (LOW = everything comes in cheap, HIGH = everything
+expensive) in one pass, so every published number carries a defensible band. The bounds are
+*envelopes*, not statistical quantiles.
+
+### 1.2 The pipeline
+
+```
+Components ──get_cost_facts()──▶ ComponentCostFacts   (asset class, size, overrides — NO prices)
+Meters ──get_energy_flow_facts()─▶ BillingDeterminants (kWh bought/sold, peaks, ToU bands)
+                                        │
+   cost_database/*.json ───────────────▶│◀─────────── subsidy_catalog/*.json
+   EconomicParameters ─────────────────▶│◀─────────── ExistingAssetRegister (brownfield)
+                                        ▼
+                              EconomicEvaluator (pure function)
+                                        │
+                      one canonical CashFlowTimeline per perspective
+                     (year × category × subject × payer, all amounts banded)
+                                        │
+        ┌───────────────┬───────────────┼──────────────────┬────────────────┐
+        ▼               ▼               ▼                  ▼                ▼
+  LifecycleCostResult  exports    provenance ledger   cost audit     parity report
+  (typed, in memory)   (JSON/CSV) (explain any value) (one table)    (vs legacy path)
+```
+
+Principles (§3.1): components declare, the engine computes; energy is billed only at carrier
+boundaries (no double counting by construction); every perspective/KPI is a filter or pivot of
+one canonical timeline; the evaluator is a pure function; no unsourced numbers.
+
+### 1.3 Perspectives (§4, §7.1)
+
+A perspective is a named combination of five dimensions: installation context
+(GREENFIELD / BROWNFIELD / STATUS_QUO / OPERATING_ONLY), actor scope (SYSTEM /
+OWNER_OCCUPIER / LANDLORD / TENANT), subsidy mode (NONE / FULL / ONLY / EXCLUDE),
+financing (cash or an annuity loan), and accounting (FINANCIAL / MACROECONOMIC).
+The default bundle (`cost_database/perspectives_default.json`) evaluates nine of them;
+greenfield rows are skipped automatically when an existing-asset register is present and
+vice versa.
+
+### 1.4 Strictly parallel to the legacy path (§10)
+
+The legacy `get_cost_capex`/`get_cost_opex` path is **untouched** and remains the source of all
+published KPI names until the Phase-7 cutover. This engine is opt-in
+(`PostProcessingOptions.COMPUTE_LIFECYCLE_COSTS`) and writes only new files:
+
+`lifecycle_costs.json`, `component_costs.json/.csv`, `cash_flow_timeline.csv`,
+`lifecycle_kpis.json`, `cost_audit.csv`, `cost_parity_report.csv`, `economic_inputs.json`,
+`cost_provenance.json`.
+
+The parity report compares the legacy CSVs (read-only) against the new path per component and
+is the evidence base for the eventual cutover decision.
+
+### 1.5 How to run it
+
+```python
+# In a system setup / test:
+my_simulation_parameters.post_processing_options.append(PostProcessingOptions.COMPUTE_LIFECYCLE_COSTS)
+
+# Additionally write the human-readable reports (implies the computation):
+# cost_summary.md, lifecycle_report.html (plausibility panel + charts along the
+# calculation chain) and matplotlib PNGs:
+my_simulation_parameters.post_processing_options.append(PostProcessingOptions.LIFECYCLE_COST_REPORT)
+
+# Optionally attach parameters (otherwise defaults with the simulation's country apply):
+from hisim.economics import EconomicParameters
+my_simulation_parameters.set_economic_parameters(EconomicParameters(interest_rate=0.03))
+```
+
+```bash
+# Re-price stored results without re-simulating (§4.6):
+python -m hisim.economics evaluate <results_dir> [--scenarios scenarios.json]
+
+# Trace any result value back to its sources (§3.10):
+python -m hisim.economics explain <results_dir> --value "brownfield_net/equivalent_annual_cost_in_euro"
+
+# Data-file CI checks (§9.6):
+python -m hisim.economics validate
+
+# Human-readable report for stored results; --compare adds the variant comparison
+# (delta waterfall by subject, discounted payback curve, warm-rent change):
+python -m hisim.economics report <results_dir> [--compare <reference_results_dir>]
+```
+
+The report layer follows the money along the calculation chain — every spec feature has at
+least one visualization plus a result table: **0** automated plausibility panel (thresholds:
+`cost_database/plausibility_checks.json` — range checks WARN, structural invariants FAIL),
+**1** input audit + the §3.10 sources-used table, **2** year-0 investment waterfalls +
+investment table + sunk-cost note, **3** annual cash-flow timeline, cumulative discounted
+cost with its min/max uncertainty band, loan amortization chart when financed (§4.4), and
+the NPV-by-category table, **4** year-1 energy bill with implied effective prices (the
+fastest unit-mix-up detector) + decomposition table, **4b** lifecycle CO2 (§3.8: embodied
+vs. operational bars, cumulative curve, table), **5** subsidy composition bars + decision
+cards + awards table (flat-shim note when no catalog ships for the country), **6**
+perspective whiskers + result table (NPV/EAC/monthly/LCOH/sunk cost), **6b** actor split
+(payer whiskers + payer-by-cost-group table, zero-sum checked), **7** per-component stacks +
+subject table, **8** variant comparison (delta waterfall + delta table + payback band),
+**9** scenario tornado + all-scenarios table + robustness summary, **10** the lifecycle KPI
+table (§7.3). The HTML is fully self-contained (inline SVG, light/dark aware, native
+tooltips); the markdown summary is deliberately git-diffable so price-data PRs show up as
+clean textual deltas on golden scenarios (§9.5).
+
+To feed the engine what the simulation cannot know — the existing system, the applicant, the
+tenancy, envelope measures, scenario sets — attach a
+`hisim.economics.bridge.EconomicContext` via
+`simulation_parameters.set_economic_context(...)`. With a register present, the full
+brownfield/owner/landlord/tenant/macroeconomic bundle activates automatically. The complete
+worked example is **`system_setups/economic_example/`** (run it with
+`python system_setups/economic_example/economic_example_heatpump.py`).
+
+Tests: `pytest tests/test_economics_*.py` (engine math against hand-computed examples,
+property tests, subsidy/tariff/scenario behavior, data-file CI, and one real end-to-end
+simulation in shadow mode).
+
+---
+
+## 2. Code modules — which file does what
+
+| Module | Contents |
+|---|---|
+| `uncertainty.py` | `UncertainValue` (min/best_estimate/max triplet) and the slot arithmetic (§3.9). Revenue bands are mirrored via `as_revenue()` so slot ordering always holds. |
+| `carriers.py` | `EnergyCarrier` enum — the pricing vocabulary at the system boundary (distinct from `LoadTypes`). |
+| `parameters.py` | `EconomicParameters`: horizon, interest, escalation rates, CO2 scenario, country, data paths (§3.2). |
+| `facts.py` | What components/meters declare: `ComponentCostFacts`, `EnergyFlowFacts`, `BillingDeterminants`, `ExistingAsset(Register)`, `CostRelevance` (§3.3, §3.4, §9.2). Deliberately a leaf module so `hisim/component.py` can import it. |
+| `database.py` | Loads/validates `hisim/cost_database/` (device entries, energy prices, CO2 paths, escalation defaults, source registry) and applies scenario **data overlays** (§3.5, §4.6). |
+| `provenance.py` | The provenance ledger: interned `ParameterProvenance` records, `ProvenanceReport` rendering (§3.10). |
+| `timeline.py` | `CashFlowEntry`, `CashFlowTimeline`, `CostCategory`, `Actor` — the canonical timeline and its NPV/pivot helpers (§3.6). |
+| `financing.py` | `FinancingPlan` and annuity / interest-only loan schedules (§4.4). |
+| `perspectives.py` | `Perspective` and its five dimensions; loads the default bundle (§4, §7.1). |
+| `subsidies.py` | The data-driven subsidy engine: condition language (tri-state), benefit/payout kinds, eligible-cost caps and proration, cumulation solver, questionnaire (`required_questions`) (§5). |
+| `tariffs.py` | `TariffContract` (FLAT / TIME_OF_USE / DYNAMIC supply, capacity charges, feed-in, §14a discounts), the pure `apply_tariff` billing function, the §8.5 decomposition, tariff counterfactual, spot-series loader and the synthetic test profile (§8). |
+| `actors.py` | Allocation rulesets: trivial owner-occupier, `DE_2024` (BetrKV split, CO2KostAufG tier table, modernization levy), zero-sum invariant (§6). |
+| `evaluator.py` | **The core.** `EconomicEvaluator` builds the timeline (investment, replacements, residual value, maintenance, energy projection, subsidies, financing, CO2 damage) and evaluates perspectives. `EvaluationInputs` is the full input record. |
+| `results.py` | `LifecycleCostResult`, `ComponentCostBreakdown`, `LifecycleCo2Result`, `EvaluationMatrix`, `VariantComparison` + `compare()` (slot-wise deltas, payback bands, warm-rent neutrality) (§3.7). |
+| `scenarios.py` | Scenario sets (FACTORIAL / ONE_AT_A_TIME), parameter axes and data overlays, the evaluation cube, tornado / break-even / robustness helpers, cube exports (§4.6). |
+| `serialization.py` | `economic_inputs.json` round-trip — post-hoc re-pricing without re-simulation (§4.6). |
+| `adapter.py` | Compatibility adapter for components that have not yet adopted `get_cost_facts()`: maps known classes/configs to facts and meter specs. Shrinks as adoption grows; never calls legacy cost methods (§10.0 rule 4). |
+| `audit.py` | `cost_audit.csv` (one row per component: origin, sources, bands, subsidies) and the legacy parity report (§9.5, §9.7). |
+| `exports.py` | All JSON/CSV exports and the namespaced lifecycle KPIs with `value_min`/`value_max` bands (§7.2–§7.4). |
+| `bridge.py` | The postprocessing entry point behind `COMPUTE_LIFECYCLE_COSTS`: collects facts/flows from a finished run, picks a covered price basis year, evaluates the default bundle, writes everything. Guarded so it can never break a run. |
+| `validation.py` | Data-file CI: source completeness, coverage matrix, question coverage, staleness (§9.6). |
+| `reporting.py` | Human-readable reports (option `LIFECYCLE_COST_REPORT`): plausibility panel, `cost_summary.md`, self-contained `lifecycle_report.html` with inline-SVG charts, variant-comparison section. |
+| `report_plots.py` | Matplotlib PNG companions (annual cash flows, investment build-up, perspective whiskers, component stacks, payback curve) — same display groups and colors as the HTML. |
+| `__main__.py` | The `evaluate` / `explain` / `report` / `validate` CLI. |
+
+Related but outside this package: `hisim/components/tariff_provider.py` (the in-simulation
+price signal driven by the same `TariffContract`, §8.3), and the additive hooks on
+`hisim/component.py` (`get_cost_facts`, `get_energy_flow_facts`, `cost_relevance`).
+
+---
+
+## 3. Data files — where the numbers live and how to edit them
+
+All numbers live in JSON data files, never in Python. Two directories:
+
+```
+hisim/cost_database/          prices, lifetimes, emission factors, tariffs, allocation rules
+hisim/subsidy_catalog/        subsidy schemes and the user questionnaire
+```
+
+Each directory has its own `sources.json` registry. **Every data entry must reference at least
+one source id** — an unsourced datapoint fails loading (§3.10). After any edit, run
+`python -m hisim.economics validate` (the same checks run in `tests/test_economics_data_and_integration.py`).
+
+### 3.1 Uncertainty bands — the universal value syntax
+
+Every monetary field accepts either form:
+
+```jsonc
+"working_price_in_euro_per_kwh": 0.30                                  // exact (min = best_estimate = max)
+"working_price_in_euro_per_kwh": {"min": 0.28, "best_estimate": 0.32, "max": 0.38}  // band
+```
+
+Use exact values only for genuinely certain numbers (statutory amounts, contracted tariffs).
+Loaders enforce `min <= best_estimate <= max`.
+
+### 3.2 `devices_<COUNTRY>.json` — device costs
+
+One entry per `(component_type, valid_from_year)`. A lookup for year Y picks the entry with the
+**greatest `valid_from_year <= Y`** (a 2030 simulation uses the 2026 entries until 2035 entries
+exist). To change a price *from a given year on*, add a new entry with that `valid_from_year`
+rather than editing an old one — old basis years keep reproducing their published results.
+
+```jsonc
+{
+  "component_type": "HEAT_PUMP",             // ComponentType enum name
+  "valid_from_year": 2026,
+  "specific_investment": {"value": {"min": 1100, "best_estimate": 1500, "max": 2100}, "per_unit": "kW"},
+  "scaling_exponent": null,                  // economies of scale: cost = c0 * size^exp; linear if null
+  "fixed_installation_cost_in_euro": 0,
+  "planning_cost_in_euro": 0,                // energy consultant, permits — subsidy-eligible
+  "removal_cost_in_euro": 0,                 // disposal of THIS device type when it gets replaced
+  "maintenance_rate_per_year": {"min": 0.01, "best_estimate": 0.015, "max": 0.025},   // share of gross investment
+  "fixed_operation_cost_in_euro_per_year": 0,  // chimney sweep, metering fee — NOT a rate
+  "service_life_in_years": 18,
+  "embodied_co2": {"value": 165.0, "per_unit": "kW"},
+  "vat_rate": 0.19,
+  "price_basis": "AS_LEGACY",                // see assumptions below
+  "legacy_flat_subsidy_share": 0.30,         // LEGACY SHIM, not device data — see below
+  "energy_related_cost_share": 1.0,          // coupled-cost share for envelope measures, see §3.2b
+  "anyway_threshold_years_override": null,   // per-class anyway threshold; envelope ships 5.0
+  "source_ids": ["src_ai_estimates"],        // mandatory
+  "field_sources": {"service_life_in_years": ["src_vdi2067"]},   // optional per-field refinement
+  "notes": "..."
+}
+```
+
+#### 3.2a Legacy shim field: `legacy_flat_subsidy_share` (§10.1, W2.6)
+
+**This is the one field of the device schema that is not device data.** It carries the flat
+percentage subsidy the pre-catalog implementation applied to a device's investment, and exists
+only so countries without a subsidy catalog (Ireland today, issue #25) keep reproducing their
+previous numbers. Properties a reviewer should know:
+
+- read *only* by the legacy flat shim in `calculators/subsidy_application.py`, and ignored
+  entirely whenever a subsidy catalog is active — a catalog country's value is dead weight;
+- **not scenario-overlayable** (§3.10): sweeping a subsidy level is a subsidy axis, expressed
+  through the catalog and the perspective's subsidy mode, not through a device price;
+- provenance is recorded as `LEGACY_MIGRATION_SHIM`, citing no source unless the entry declares
+  `field_sources: {"legacy_flat_subsidy_share": [...]}` — the entry's own `source_ids` document
+  the device *price*, not any subsidy programme;
+- it disappears when §10.1 Phase 4 has a catalog for every shipped country. Do not add it to new
+  entries; add a scheme to `subsidy_catalog/<COUNTRY>.json` instead.
+
+#### 3.2b Building envelope measures (spec Q7)
+
+Insulation measures (external/internal wall, between/over the roof joists, warm roof, top-floor
+ceiling, basement ceiling, basement walls, ground-contacting perimeter), triple-glazed windows,
+exterior doors, air sealing and ventilation systems are ordinary cost subjects with their own
+`ComponentType`s — one per measure of the renovation measure database — sized in **m² of the
+respective envelope element** (`EXTERIOR_DOOR` and `VENTILATION_SYSTEM` per unit). They are
+*not* simulation components — the building physics only sees changed U-values — so their
+`SubjectCostFacts` are injected into `EvaluationInputs` by whoever defines the variant
+(RenoVisor mapping or a system setup), with areas taken from the building's TABULA data and
+the achieved `u_value` in `technical_attributes` (the BEG subsidy conditions test it).
+
+Three envelope-specific mechanics, all data-driven:
+
+- **`anyway_threshold_years_override`** (shipped 5.0 for envelope, devices keep the 2 a
+  default): if the replaced element had at most this much life left, the anyway-cost credit
+  applies.
+- **Like-for-like replacements are recognized**: register the old element in the
+  `ExistingAssetRegister` with `replaced_by_asset_classes` naming the measure's class (also
+  when both are e.g. `WINDOWS_TRIPLE_GLAZED`) — the measure is then charged as an investment and the dead
+  element's avoided like-for-like replacement is credited. Without the `replaced_by`
+  declaration, a same-class register entry still means "kept".
+- **`energy_related_cost_share`** (coupled costs / Ohnehin-Kosten): when < 1 and the element
+  was due anyway, the credit becomes `(1 − share) × gross` — the scaffolding/render share that
+  would have been spent regardless — *replacing* the like-for-like credit so the two never
+  double count. **Currently shipped as 1.0 everywhere** (deliberate interim decision: the
+  mechanism exists and is tested, the data does not use it yet); it is scenario-overlayable
+  for sensitivity studies. Acknowledged as a pragmatic simplification of the coupled-cost
+  problem.
+
+With 35–50 a service lives inside a 20 a horizon, envelope economics are dominated by the
+**residual value** (half the wall insulation cost is credited back at year 20 of a 40 a life)
+— that is the intended VDI 2067 treatment, not a bug. The DE catalog contains the BEG EM
+envelope schemes (15 % base with per-class U-value conditions + 5 % iSFP bonus, capped at
+20 %, mutually exclusive with §35c) and the `building.has_isfp` questionnaire entry.
+
+`per_unit` is one of `"kW"`, `"kWh"`, `"liter"`, `"m2"` or `null` (absolute price per device);
+it must match the `size_unit` the component declares — the pre-run resolution check enforces
+this. Adding a **new country** = creating `devices_XX.json` + `energy_prices_XX.json`
+(+ optionally `escalation_defaults_XX.json` and CO2 paths); no code changes.
+
+### 3.3 `energy_prices_<COUNTRY>.json` — energy prices
+
+One entry per `(carrier, year)`, same greatest-year-≤ lookup. Two-part tariff with an explicit
+CO2 component:
+
+```jsonc
+{
+  "carrier": "NATURAL_GAS",
+  "year": 2026,
+  "working_price_in_euro_per_kwh": {"min": 0.08, "best_estimate": 0.10, "max": 0.13},
+  "standing_charge_in_euro_per_year": {"min": 140, "best_estimate": 180, "max": 240},   // Grundpreis
+  "grid_exit_fee_in_euro": 250,              // one-off when the carrier is dropped
+  "emission_factor_in_kg_per_kwh": 0.20,     // per quantity_unit as stored; per kWh once resolved
+  "co2_price_exposure": 1.0,                 // share of emissions priced via co2_price_paths.json
+  "tax_and_levy_share": 0.25,                // stripped in the MACROECONOMIC view
+  "quantity_unit": "kWh",                    // "kWh" | "liter" (oil, diesel) | "ton" (pellets, wood chips)
+  "source_ids": ["src_ai_estimates"]
+}
+```
+
+**The CO2 double-counting rule:** if `co2_price_exposure > 0`, the working price must EXCLUDE
+the explicit CO2 price (the engine adds `emissions × co2_price(country, year)` from the paths
+file). If the working price already contains carbon costs (as the migrated pre-2026 entries
+do), exposure must be 0. Never both.
+
+`quantity_unit` says how the **file** quotes the row — `"liter"` for oil and diesel, `"ton"`
+for pellets and wood chips, as the cited sources publish them. Nothing is billed in those units:
+`CostDatabase.get_energy_price` divides the working price and the emission factor by the
+carrier's lower heating value (from `PhysicsConfig`) and hands out an entry in EUR/kWh and
+kg/kWh, recording the division in the provenance detail (decision D26). Quantities are kWh
+everywhere, so the `*_per_kwh` field names are literally true by the time anything reads them.
+The `ELECTRICITY_FEED_IN` carrier holds the feed-in remuneration as its working price.
+
+### 3.4 `co2_price_paths.json` — carbon price trajectories
+
+Named `low`/`central`/`high` paths per country, as year→€/t points with **step interpolation**
+(the last defined point ≤ the year applies). Shared EU segments live under `eu_shared` and are
+referenced via `include_eu_shared` instead of duplicated. Selected via
+`EconomicParameters.co2_price_scenario` (`"none"` disables carbon pricing).
+
+### 3.5 `escalation_defaults_<COUNTRY>.json` — price-change defaults
+
+Default nominal escalation rates per carrier and (optionally) per asset class (learning
+curves). Fallback chain (§3.2): explicit `EconomicParameters` value → this file → the general
+rate. The per-asset-class table ships empty on purpose (spec Q2) until reviewed sources exist.
+
+### 3.6 `sources.json` — the source registry
+
+```jsonc
+{"id": "src_hp_survey_2026", "citation": "…", "url": "https://…", "publication_year": 2026,
+ "retrieved": "2026-07-07", "kind": "MARKET_SURVEY", "notes": "…"}
+```
+
+`kind` ∈ MARKET_SURVEY | STANDARD | STATUTE | MANUFACTURER | LITERATURE | PROJECT_DATA |
+EXPERT_ESTIMATE. An honestly labeled guess is fine; a number without provenance is not.
+`retrieved` feeds the 12-month staleness warning; entries referenced by no datapoint are
+flagged as orphans. When you add a data entry, either reuse an existing source id or add a
+registry entry first.
+
+### 3.7 `perspectives_default.json`, `allocation_DE_2024.json`
+
+The default perspective bundle (§7.1) and the German rented-building allocation parameters:
+modernization-levy rate/caps (§559 BGB), the avoided-maintenance deduction, the apportionable
+maintenance share, and the CO2KostAufG tenant/landlord tier table. All legally sensitive —
+flagged for legal review (issues #10).
+
+### 3.8 `tariffs/*.json` and `spot_series/*.csv`
+
+Tariff contracts (§8.2), referenced by id (file name = id). Supply kinds FLAT, TIME_OF_USE
+(band definitions with weekday/hour masks) and DYNAMIC (references a spot series). One example
+ships: `DE_DYNAMIC_SYNTHETIC_2024` on the deterministic `synthetic_reference_hourly.csv`
+profile — real EPEX series are not shipped for licensing reasons (spec Q16); drop a
+user-supplied hourly CSV (one €/kWh price per line) into `spot_series/` instead. Non-energy
+components (markup, grid fee, taxes/levies) are stored separately so the macroeconomic view
+can strip them. Without an explicit contract, a default flat contract is generated from the
+§3.3 price entries — behaviorally identical to the plain price lookup.
+
+### 3.9 `subsidy_catalog/<COUNTRY>.json` + `questions_<COUNTRY>.json`
+
+Schemes (§5.2) with mandatory `legal_basis` and `url`, an eligibility condition tree
+(`all`/`any`/`not` over `{field, op, value}` leaves — no Python eval), a benefit
+(SHARE_OF_ELIGIBLE_COST, BONUS_SHARE, LUMP_SUM, PER_UNIT, TAX_CREDIT, REDUCED_VAT, SOFT_LOAN,
+OPERATIONAL), eligible-cost caps per dwelling unit, residential-share proration, and cumulation
+rules (group + combined rate cap + excludes). The shipped `DE.json` encodes BEG EM (base 30 % +
+speed/income/efficiency bonuses, 70 % cap), §35c EStG (mutually exclusive with BEG) and the
+KfW supplementary loan; `AT.json` a lump-sum boiler-replacement grant. **Ireland has no catalog
+yet** — the device entries carry rough SEAI-like flat shares in `legacy_flat_subsidy_share`
+instead (issue #25).
+
+Every context field a scheme's conditions reference must have a localized (de + en) entry in
+`questions_<COUNTRY>.json`, or validation fails — that's what keeps the user questionnaire
+(§5.7) complete by construction. The catalog itself is only used when
+`EconomicParameters.subsidy_catalog_path` is set; otherwise the flat shim applies.
+
+### 3.10 Scenario overlays — tweaking values without editing files
+
+For "what if" sweeps you usually should **not** edit the database at all. Scenario sets (§4.6)
+can overlay individual datapoints by dotted path:
+
+```jsonc
+{"axes": [{"name": "hp_price", "field": "devices_DE.HEAT_PUMP.specific_investment",
+           "levels": {"central": null, "cheap": {"min": 900, "best_estimate": 1100, "max": 1400}}}]}
+```
+
+Overlaid values enter the provenance ledger as `SCENARIO_OVERLAY`, so an explained result names
+exactly which numbers were counterfactual. `country` and the dataset paths are deliberately not
+sweepable, and neither is the `legacy_flat_subsidy_share` shim (§3.2a).
+
+---
+
+## 4. Assumptions
+
+### 4.1 Methodology (fixed in the engine, §2–§4)
+
+- **Nominal rates, nominal euros, discounted to year 0.** Defaults: 3 % interest, 2 % general
+  escalation. Real-term calculation works by supplying real rates consistently.
+- **End-of-year convention** for all flows; replacements at multiples of the service life;
+  intra-year discounting is out of scope (monthly figures = annual / 12).
+- **Residual value** = straight-line share of the last-installed unit's *escalated* purchase
+  price, credited at the horizon (VDI 2067).
+- **Kept brownfield assets** cost no investment; their first replacement comes at
+  `service_life − current_age`. Replaced assets add the old device's removal cost; their
+  written-off book value is reported as `sunk_cost_written_off_in_euro` but kept out of
+  decision KPIs; if ≤ 2 years of life remained (`anyway_threshold_years`), the avoided
+  like-for-like replacement is credited (Sowieso-Kosten, §4.1).
+- **Energy projection** (§8.5): year-1 bills are decomposed into volume effect (escalated with
+  the carrier rate), flexibility value (spread escalation rate, default = carrier rate),
+  standing charges (general rate), capacity charges (grid-fee rate) and the CO2-price component
+  (from the trajectory). EEG-style feed-in stays nominally fixed for its contract duration.
+  Simulations shorter than a year are annualized linearly with a warning.
+- **Uncertainty = envelope, not confidence interval** (§3.9): LOW/HIGH are fully correlated
+  cheap/expensive worlds. Physical quantities, economic *rates*, service lives and emission
+  factors stay exact in v1 (spec Q25); their uncertainty belongs to scenario axes.
+- **Choices are made on the BEST_ESTIMATE slot** (subsidy combination, counterfactual selection) and
+  then valued in all three slots, so the three results describe one plan.
+- **Macroeconomic view** (§4.5): subsidies dropped, tax/levy shares stripped, CO2 damage cost
+  (default 250 €/t, UBA) applied to operational emissions. It is a socio-economic research
+  view, not a household bill.
+- **Zero-sum actor split**: landlord + tenant (+ owner) NPVs sum exactly to the system NPV;
+  asserted per slot in tests.
+
+### 4.2 Data assumptions — three vintages of data
+
+**Migrated legacy entries (DE 2018–2024/2050, AT 2025/2040).** Copied 1:1 from the old
+`configuration.py` dicts as degenerate bands (min = best_estimate = max) so the parity harness can prove
+the engine reproduces today's numbers. Known warts are preserved on purpose and tracked in
+`cost_module_issues.md`: VAT status undocumented (`price_basis: "AS_LEGACY"` = "use as-is",
+issue Q5/#4), CO2 price embedded in the fuel prices (exposure 0), meter "maintenance rates"
+that are really absolute fees (#1), per-kWh emission factors on per-ton fuels (#24), a diesel
+price typo (#3). Fix these in explicit data-review PRs, not silently.
+
+**AI-estimate entries (DE + IE, 2026 and 2035; source id `src_ai_estimates`).** Placeholder
+values *for testing only*, created 2026-07-07 (issue #25). They are honest guesses with real
+min/best_estimate/max bands and deliberately use the engine's full modeling: CO2-exclusive fuel prices
+with `co2_price_exposure = 1.0`, standing charges and grid exit fees, metering fees as fixed
+operation costs, filled tax/levy shares, an Irish carbon-tax/ETS2 price path, and learning
+curves toward 2035 (PV/battery falling, labor-heavy trades rising; Irish heat-pump installs
+~25 % above German). Replace them with reviewed sources before any scientific use — the
+`explain` CLI will tell you exactly which results rest on them.
+
+**Statute-derived data** (subsidy catalogs, allocation rules, nEHS/ETS2 path segments). Encoded
+from the legal texts as of 2024 with `STATUTE` sources, but **not yet legally reviewed** — the
+spec requires a legal review pass before release (issues #10, #11). The ETS2 corridor from 2027
+onward is an expert estimate, not statute.
+
+### 4.3 Engine defaults you might want to change
+
+All on `EconomicParameters` (settable per run, per RenoVisor request, or per scenario axis):
+`observation_period_in_years` (20), `interest_rate` (0.03), `general_price_escalation_rate`
+(0.02), `investment_price_escalation_rate` (0.02), `co2_price_scenario` ("central"),
+`co2_damage_cost_in_euro_per_ton` (250), `anyway_threshold_years` (2),
+`price_basis_year` (defaults to the simulation year; when the database has no data for the
+simulated year the engine falls back to the earliest covered year with a warning — the same
+policy for every entry point, see `evaluator.effective_price_basis_year`, and the resolved year
+is recorded on the result's `parameters`),
+`apply_subsidies` (True), `allow_counterfactual_billing` (False — rebilling a load profile
+under a tariff it was not simulated with must be opted into, §4.6).
+
+---
+
+## 5. Adding things — quick recipes
+
+- **New component adopts the engine** (Phase 6 pattern, §9.1): set
+  `cost_relevance = CostRelevance.PRICED` on the class, implement `get_cost_facts()` (~6 lines:
+  asset class, size from the config, unit, KPI tag, optional per-field overrides with an
+  `override_source`), and mark the capacity config field with
+  `field(metadata={"capacity": True})` so the contract test can verify scaling. Leave the
+  legacy methods untouched until cutover. Meters additionally implement
+  `get_energy_flow_facts()`.
+- **New asset class**: add the `ComponentType`, then device entries for *every* shipped country
+  — the coverage-matrix check fails otherwise.
+- **New country**: `devices_XX.json` + `energy_prices_XX.json` (+ escalation defaults, CO2
+  paths, and — if needed — subsidy catalog with question file). The engine needs no code change;
+  if it did, the schema failed (§10.1 Phase 4).
+- **New envelope measure in a variant**: add a `SubjectCostFacts` entry (class, m², `u_value`
+  in `technical_attributes`) and register the replaced element with
+  `replaced_by_asset_classes` — see §3.2b.
+- **New subsidy scheme**: append to the country catalog; make sure every context field your
+  conditions reference has a question entry, and set `cumulation` correctly. `validate` catches
+  the rest.
+- **Price update**: new entry with a new `valid_from_year`/`year`; never rewrite history. The
+  effect shows up as a reviewable diff of `cost_audit.csv` on the golden scenarios (§9.5).

--- a/hisim/economics/__init__.py
+++ b/hisim/economics/__init__.py
@@ -1,0 +1,50 @@
+"""Lifecycle cost engine (cost_spec.md): parallel successor of the capex/opex calculation.
+
+Public API surface. The engine is strictly parallel to the legacy cost path until the
+Phase-7 cutover: it never calls ``get_cost_capex``/``get_cost_opex`` and only writes new
+files. See ``cost_spec.md`` and ``cost_module_issues.md`` at the repo root.
+
+The package computes lifecycle costs over a configurable horizon (default 20 years, annuity method
+per VDI 2067-1 / DIN EN 15459-1) from three kinds of input: *facts* declared by components (what am
+I, how big), *energy flows* measured by the meters (what crossed the system boundary), and
+*versioned data files* (prices, lifetimes, subsidy schemes). Everything else — discounting,
+replacements, subsidies, actor splits, uncertainty bands — happens centrally in
+`evaluator.EconomicEvaluator`, which is a pure function of its inputs.
+
+Re-exported here is only what a *caller from outside the package* needs: the declaration types a
+component or meter fills in (`ComponentCostFacts`, `EnergyFlowFacts`, `BillingDeterminants`,
+`CostRelevance`), the brownfield register (`ExistingAsset`, `ExistingAssetRegister`), the assumption
+record (`EconomicParameters`), and the value type every monetary figure uses (`UncertainValue`,
+`Slot`). The engine, timeline, database, subsidy and reporting layers are deliberately *not*
+re-exported — they are imported by module path, which keeps this file's import cost low enough that
+`hisim/component.py` can depend on `economics.facts` without pulling the engine into every
+simulation.
+
+For the package tour — pipeline diagram, perspective model, per-module table and the data-file
+layout — see ``hisim/economics/README.md``.
+"""
+
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.facts import (
+    BillingDeterminants,
+    ComponentCostFacts,
+    CostRelevance,
+    EnergyFlowFacts,
+    ExistingAsset,
+    ExistingAssetRegister,
+)
+from hisim.economics.parameters import EconomicParameters
+from hisim.economics.uncertainty import Slot, UncertainValue
+
+__all__ = [
+    "BillingDeterminants",
+    "ComponentCostFacts",
+    "CostRelevance",
+    "EconomicParameters",
+    "EnergyCarrier",
+    "EnergyFlowFacts",
+    "ExistingAsset",
+    "ExistingAssetRegister",
+    "Slot",
+    "UncertainValue",
+]

--- a/hisim/economics/carriers.py
+++ b/hisim/economics/carriers.py
@@ -1,0 +1,51 @@
+"""Energy carrier enum for pricing (cost_spec.md §3.2).
+
+Replaces the ad-hoc use of ``LoadTypes`` for pricing purposes. Simulation I/O keeps using
+``loadtypes.LoadTypes``; only the billing boundary speaks ``EnergyCarrier``.
+
+The separation is deliberate and is what makes "energy is billed only at carrier boundaries, so
+nothing can be double counted by construction" (§3.1) checkable: `LoadTypes` describes what flows
+along a wire or pipe anywhere inside the system, while an `EnergyCarrier` names something that is
+*bought or sold across the system boundary* and therefore has a price entry, an emission factor and
+a tariff contract. A member of this enum is simultaneously the key of an `energy_prices_<COUNTRY>`
+row, the carrier field of `facts.EnergyFlowFacts`/`facts.BillingDeterminants` that meters declare,
+and the subject of the resulting energy cash-flow entries.
+
+The module owns only the vocabulary — no prices, no emission factors, no conversion between carriers
+and `LoadTypes` (the adapter and the meter components make that mapping where they need it). Like
+`uncertainty.py` it is a leaf, imported by facts, catalog entries, tariffs and parameters alike.
+"""
+
+from __future__ import annotations
+
+import enum
+
+
+@enum.unique
+class EnergyCarrier(str, enum.Enum):
+    """Carriers priced at the system boundary.
+
+    One member per thing a building can buy or sell, and therefore per key of the country price
+    files: adding a carrier means adding price entries for every shipped country, not changing code.
+    Members are `str`-valued so they serialize to their own names in JSON exports and can be used
+    directly as data-file keys.
+
+    ``ELECTRICITY_FEED_IN`` is the one member that is not a purchased commodity: it carries the
+    feed-in remuneration as its "working price", which is what lets exported electricity be priced
+    by exactly the same lookup as imported electricity while keeping the two rates independent
+    (feed-in also has its own escalation rate, nominally fixed for EEG-style contracts). Every
+    member is *billed* per kWh; the price entry's ``quantity_unit`` says only how the data file
+    quotes it — per liter for oil and diesel, per ton for pellets and wood chips, as the cited
+    sources publish them — and the database divides such a quote by the carrier's heating value
+    when it resolves the entry (D26).
+    """
+
+    ELECTRICITY = "ELECTRICITY"
+    ELECTRICITY_FEED_IN = "ELECTRICITY_FEED_IN"
+    NATURAL_GAS = "NATURAL_GAS"
+    HEATING_OIL = "HEATING_OIL"
+    PELLETS = "PELLETS"
+    WOOD_CHIPS = "WOOD_CHIPS"
+    DISTRICT_HEATING = "DISTRICT_HEATING"
+    HYDROGEN = "HYDROGEN"
+    DIESEL = "DIESEL"

--- a/hisim/economics/facts.py
+++ b/hisim/economics/facts.py
@@ -1,0 +1,361 @@
+"""Facts that components and meters declare for the cost engine (cost_spec.md §3.3, §3.4, §9.2).
+
+This module is intentionally a leaf: it imports nothing from ``hisim.component`` so the
+component base class can import it without cycles.
+
+That leaf status is a hard architectural constraint, not an accident of the current import graph.
+`hisim/component.py` carries the additive hooks `get_cost_facts`, `get_energy_flow_facts` and the
+`cost_relevance` class attribute, whose type annotations name the classes defined here; if this
+module reached back into `hisim.component` — or into any evaluator, database or timeline module that
+transitively does — importing the simulator would drag in the whole cost engine and the cycle would
+break both. Hence: only `carriers`, `uncertainty`, `loadtypes` and the KPI tag enum are imported,
+and no pricing logic of any kind lives here.
+
+**The design question this module answers**: who knows what. Components know what they *are* — asset
+class, size, technical attributes — and meters know what actually *crossed the system boundary*;
+neither knows, or should know, what anything costs. So the declaration side is reduced to these
+value types (§3.1: "components declare, the engine computes"), and every price, lifetime and
+emission factor comes from the versioned data files instead. A typical component's cost declaration
+shrinks from the ~40 lines of the legacy `get_cost_capex`/`get_cost_opex` pair to about six.
+
+Its place in the pipeline: `bridge.py` collects these objects from a finished simulation (with
+`adapter.py` synthesizing them for components that have not adopted the hooks yet), packs them into
+`EvaluationInputs`, and the evaluator turns each one into cash-flow entries. `ExistingAssetRegister`
+is the one input the simulation cannot produce at all — it describes the building as it was before
+the measure — and is supplied through `bridge.EconomicContext`.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import math
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
+
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.uncertainty import UncertainValue
+from hisim.loadtypes import ComponentType, Units
+from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass
+
+
+class CostRelevance(str, enum.Enum):
+    """Mandatory class-level declaration of a component's cost role (§9.2).
+
+    Declared as a `ClassVar` on every `Component` subclass, this closes the one failure mode the
+    "return None means no costs" default introduces: a *forgotten* `get_cost_facts` implementation
+    would otherwise drop a component from every cost result without any complaint. Because the class
+    must state its role, the completeness check can compare intent against behavior at component
+    registration — an `UNDECLARED` component, or a `PRICED` one whose facts do not build, aborts the
+    run before the timestep loop starts rather than producing a quietly incomplete cost report.
+
+    `UNDECLARED` is the base-class default and exists only so that not-yet-migrated components stay
+    loadable during the parallel phase; strictness is configurable so CI can treat it as an error
+    while legacy system setups get a warning.
+    """
+
+    UNDECLARED = "UNDECLARED"
+    PRICED = "PRICED"  # must return ComponentCostFacts
+    FREE_OF_COST = "FREE_OF_COST"  # controllers, weather, idealized devices
+    METER = "METER"  # must provide EnergyFlowFacts / BillingDeterminants
+
+
+def _coerce_uncertain(
+    value: Optional[Union[float, int, UncertainValue]],
+) -> Optional[UncertainValue]:
+    """Accepts a plain number as an exact band (§3.9).
+
+    Applied to every monetary override field in `__post_init__`, so a component author can write
+    `investment_cost_override_in_euro=4200` and still have the engine see a proper triplet. `None`
+    passes through unchanged, because "no override" and "an override of zero" are different things.
+    """
+    if value is None or isinstance(value, UncertainValue):
+        return value
+    return UncertainValue.exact(float(value))
+
+
+@dataclass
+class ComponentCostFacts:
+    """Facts a component declares about itself for cost/emission evaluation. No prices.
+
+    The replacement for `get_cost_capex`/`get_cost_opex`: a component says which cost-database row
+    describes it (`asset_class`), how big it is (`size` in `size_unit`) and — only where it genuinely
+    knows better than the database — supplies per-field overrides. Everything monetary is then looked
+    up by the engine, which is what makes prices versioned, sourced, country-specific and
+    scenario-overlayable instead of hard-coded in component modules.
+
+    Three properties are worth a reviewer's attention. Overrides are **per field**, so quoting a real
+    installer price for the device no longer forces the caller to also invent a lifetime and a
+    maintenance rate. `override_source` is mandatory whenever any override is set (strict mode,
+    §9.3) and lands in the provenance ledger, so an overridden number stays as traceable as a
+    database one. And `technical_attributes` is the free-form channel subsidy eligibility conditions
+    read (§5.4) — an SCOP, a refrigerant, an achieved U-value — which is why it must be
+    JSON-serializable: it is exported and re-read on `evaluate`/`explain` runs.
+
+    Envelope measures (wall insulation, windows, doors, ventilation — §3.2b) use the same type even
+    though they are not simulation components at all: whoever defines the variant wraps their facts
+    in an `evaluator.SubjectCostFacts` and injects them into `EvaluationInputs` directly, sized in m²
+    of the respective element.
+    """
+
+    #: Size units the cost database can price against.
+    SUPPORTED_SIZE_UNITS: ClassVar[Tuple[Units, ...]] = (
+        Units.KILOWATT,
+        Units.KWH,
+        Units.LITER,
+        Units.SQUARE_METER,
+        Units.ANY,
+    )
+
+    asset_class: ComponentType  # key into the cost database
+    size: float  # capacity in `size_unit`
+    size_unit: Units  # KILOWATT / KWH / LITER / SQUARE_METER / ANY
+    kpi_tag: Optional[KpiTagEnumClass] = None
+    count: int = 1
+    # Per-field overrides (no more all-or-nothing). Monetary overrides are UncertainValue
+    # triplets (§3.9); a plain number is accepted and means exact (min = best_estimate = max):
+    investment_cost_override_in_euro: Optional[UncertainValue] = None
+    installation_cost_override_in_euro: Optional[UncertainValue] = None
+    lifetime_override_in_years: Optional[float] = None
+    maintenance_rate_override: Optional[UncertainValue] = None
+    fixed_operation_cost_override_in_euro_per_year: Optional[UncertainValue] = None
+    embodied_co2_override_in_kg: Optional[float] = None
+    # Provenance of the overrides (§3.10). Mandatory whenever any override is set
+    # (enforced in strict mode, §9.3); recorded in the provenance ledger.
+    override_source: Optional[str] = None
+    # Technical attributes consumed by subsidy eligibility conditions (§5.4).
+    technical_attributes: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Local fail-fast validation (§9.3).
+
+        Runs at declaration time — i.e. while the component is being registered, long before the
+        timestep loop — so a mis-declared fact fails in seconds rather than after an hour of
+        simulation followed by an unusable cost report. It also normalizes the monetary overrides,
+        accepting plain numbers as exact bands. Only *local* consistency is checked here; whether the
+        cost database actually has an entry for this asset class and whether its `per_unit` matches
+        `size_unit` is the pre-run resolution check's job, since that needs the database.
+
+        Raises:
+            ValueError: If the asset class is not a `ComponentType`, the size is not finite and
+                positive, the size unit is not priceable, `count` is below 1, the maintenance-rate
+                override is negative in any slot, a non-positive lifetime override was given, or the
+                technical attributes are not JSON-serializable.
+        """
+        self.investment_cost_override_in_euro = _coerce_uncertain(self.investment_cost_override_in_euro)
+        self.installation_cost_override_in_euro = _coerce_uncertain(self.installation_cost_override_in_euro)
+        self.maintenance_rate_override = _coerce_uncertain(self.maintenance_rate_override)
+        self.fixed_operation_cost_override_in_euro_per_year = _coerce_uncertain(
+            self.fixed_operation_cost_override_in_euro_per_year
+        )
+        if not isinstance(self.asset_class, ComponentType):
+            raise ValueError(f"asset_class must be a ComponentType, got {self.asset_class!r}.")
+        if not math.isfinite(self.size) or self.size <= 0:
+            raise ValueError(f"ComponentCostFacts.size must be finite and > 0, got {self.size!r}.")
+        if self.size_unit not in ComponentCostFacts.SUPPORTED_SIZE_UNITS:
+            raise ValueError(
+                f"size_unit {self.size_unit!r} is not supported for costing; "
+                f"expected one of {[u.value for u in ComponentCostFacts.SUPPORTED_SIZE_UNITS]}."
+            )
+        if self.count < 1:
+            raise ValueError("count must be >= 1.")
+        for band_name in ("maintenance_rate_override",):
+            band = getattr(self, band_name)
+            if band is not None and band.minimum < 0:
+                raise ValueError(f"{band_name} must be non-negative in every slot.")
+        if self.lifetime_override_in_years is not None and self.lifetime_override_in_years <= 0:
+            raise ValueError("lifetime_override_in_years must be > 0.")
+        try:
+            json.dumps(self.technical_attributes)
+        except (TypeError, ValueError) as err:
+            raise ValueError("technical_attributes must be JSON-serializable.") from err
+
+    def has_overrides(self) -> bool:
+        """True if any per-field override is set (then `override_source` is required in strict mode).
+
+        Used by the completeness/strictness checks and by the input audit, which flags a row whose
+        price came from an override that cites nothing. The tuple below is the authoritative list of
+        override fields; `override_source` and `technical_attributes` are deliberately not in it,
+        because neither replaces a database value.
+        """
+        return any(
+            getattr(self, name) is not None
+            for name in (
+                "investment_cost_override_in_euro",
+                "installation_cost_override_in_euro",
+                "lifetime_override_in_years",
+                "maintenance_rate_override",
+                "fixed_operation_cost_override_in_euro_per_year",
+                "embodied_co2_override_in_kg",
+            )
+        )
+
+
+@dataclass
+class EnergyFlowFacts:
+    """What a meter measured at a carrier boundary over the simulated period (§3.4).
+
+    The billing counterpart of `ComponentCostFacts`: implemented by the meter components
+    (`ElectricityMeter`, `GasMeter`, `FuelMeter`, `HeatingMeter`, the EMS acting as district meter),
+    it reports the integrated energy that actually crossed the system boundary for one carrier. That
+    the *only* quantities that get billed are the ones a meter declares is what makes double counting
+    structurally impossible — an internal flow between two components has no meter and therefore no
+    price — and lets postprocessing warn about a carrier some component consumes but nobody meters.
+
+    Quantities here are exact (`float`, not banded): they are measured by the simulation, not
+    estimated (§3.9). `simulated_cost_in_euro`/`simulated_revenue_in_euro` are the escape hatch for
+    dynamic tariffs, where the meter integrated load × price over the run and that integral is a
+    better year-1 bill than energy × a static average price; when set, the engine uses them instead.
+    Totals cover the *simulated* period, which the evaluator annualizes (with a warning) if it was
+    shorter than a year.
+    """
+
+    carrier: EnergyCarrier
+    energy_bought_in_kwh: float  # simulated-period total, integrated by the meter
+    energy_sold_in_kwh: float = 0.0
+    # Optional: cost already computed against a dynamic tariff during simulation; if set, used
+    # as the year-1 cost instead of energy * static price.
+    simulated_cost_in_euro: Optional[float] = None
+    simulated_revenue_in_euro: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        """Validation: rejects non-finite flows so a NaN cannot propagate into every KPI.
+
+        Raises:
+            ValueError: If either energy total is NaN or infinite.
+        """
+        if not math.isfinite(self.energy_bought_in_kwh) or not math.isfinite(self.energy_sold_in_kwh):
+            raise ValueError("Energy flows must be finite.")
+
+
+@dataclass
+class BillingDeterminants:
+    """Richer billing basis for time-of-use, dynamic and capacity tariffs (§8.4).
+
+    Supersedes :class:`EnergyFlowFacts` when a non-flat tariff contract is active.
+
+    A flat tariff needs only annual kWh; anything else needs the *shape* of consumption, which only
+    the simulation can supply and which cannot be reconstructed from an annual total afterwards.
+    Hence the extra determinants: per-band energy for time-of-use contracts, the integral of load ×
+    spot price for dynamic supply, per-billing-period and annual peaks for capacity charges, and the
+    unweighted mean spot price. That last one is what lets the §8.5 decomposition separate the pure
+    *volume* effect (how much was consumed) from the *flexibility value* (how well it was timed) —
+    the two escalate at different rates, so they must not be projected as one number.
+
+    `EvaluationInputs` carries only determinants, never raw `EnergyFlowFacts`, so there is exactly
+    one billing path (`tariffs.apply_tariff`); `from_energy_flow` is the lift for callers that hold
+    the simpler record.
+    """
+
+    carrier: EnergyCarrier
+    #: Always kilowatt-hours, for every carrier — including pellets, wood chips and oil, whose
+    #: prices are converted from EUR/t resp. EUR/l to EUR/kWh at resolution instead (D26).
+    energy_bought_in_kwh: float
+    energy_sold_in_kwh: float = 0.0
+    energy_bought_per_band_in_kwh: Dict[str, float] = field(default_factory=dict)  # ToU tariffs
+    cost_integrated_in_euro: Optional[float] = None  # integral of load*price for DYNAMIC supply
+    revenue_integrated_in_euro: Optional[float] = None
+    peak_per_billing_period_in_kw: List[float] = field(default_factory=list)  # billing-interval means
+    annual_peak_in_kw: float = 0.0
+    # Unweighted mean spot price of the simulated year (energy-only), so the billing engine can
+    # separate the volume effect from the flexibility value (§8.5):
+    mean_spot_price_in_euro_per_kwh: Optional[float] = None
+
+    @classmethod
+    def from_energy_flow(cls, flow: EnergyFlowFacts) -> "BillingDeterminants":
+        """Wraps plain annual flows for flat contracts.
+
+        The determinants a flat two-part tariff needs are exactly the fields `EnergyFlowFacts`
+        already has, so the conversion is a widening with the shape-dependent fields left empty; the
+        resulting bill is identical to a plain price lookup. Any meter that only knows annual totals
+        goes through here so the rest of the engine never has to branch on which record it holds.
+        """
+        return cls(
+            carrier=flow.carrier,
+            energy_bought_in_kwh=flow.energy_bought_in_kwh,
+            energy_sold_in_kwh=flow.energy_sold_in_kwh,
+            cost_integrated_in_euro=flow.simulated_cost_in_euro,
+            revenue_integrated_in_euro=flow.simulated_revenue_in_euro,
+        )
+
+
+@dataclass
+class ExistingAsset:
+    """An asset already installed in the building (brownfield register, §4.1).
+
+    Describes one device that is already there before any measure — the thing the simulation cannot
+    know, because it models the *result* of the retrofit, not its starting point. From
+    `installation_year` the engine derives age, remaining life and hence the replacement schedule; a
+    kept asset costs no investment but is replaced at `service_life − age`, while a replaced one adds
+    its removal cost, contributes its written-off book value to the reported (but decision-neutral)
+    sunk cost, and may trigger the anyway-cost credit.
+
+    Two fields exist purely to feed rules outside the pure cost arithmetic. `is_functional` and
+    `energy_carrier` are read by subsidy eligibility conditions such as BEG's speed bonus for
+    replacing a *functioning fossil* heating system. `replaced_by_asset_classes` is the explicit
+    declaration of which measure supersedes this asset: without it a same-class register entry means
+    "kept", and only with it does a like-for-like replacement (old windows → new windows) get
+    recognized as a replacement with its avoided future cost credited (§3.2b).
+    """
+
+    asset_class: ComponentType
+    size: float
+    size_unit: Units
+    installation_year: int  # -> age, remaining life, replacement schedule
+    replacement_cost_override_in_euro: Optional[UncertainValue] = None  # scalar accepted = exact
+    is_functional: bool = True  # feeds subsidy conditions (e.g. "functioning oil boiler")
+    # Carrier the asset burns, for subsidy speed-bonus conditions ("existing fossil heating"):
+    energy_carrier: Optional[EnergyCarrier] = None
+    # Which measure asset classes replace this asset (filled by the scenario/RenoVisor mapping;
+    # a component with one of these classes is charged full investment + this asset's removal
+    # cost, and triggers the sunk-cost / anyway-cost logic of §4.1):
+    replaced_by_asset_classes: List[ComponentType] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Validation: normalizes the replacement-cost override and rejects a non-positive size.
+
+        Raises:
+            ValueError: If the size is not finite and greater than zero.
+        """
+        self.replacement_cost_override_in_euro = _coerce_uncertain(self.replacement_cost_override_in_euro)
+        if self.size <= 0 or not math.isfinite(self.size):
+            raise ValueError("ExistingAsset.size must be finite and > 0.")
+
+    def age_in_years(self, reference_year: int) -> int:
+        """Age at the reference (simulation) year, floored at 0.
+
+        The input to both the remaining-life calculation that schedules the first replacement and the
+        anyway-cost test of §4.1. Flooring at 0 means an asset registered as installed *after* the
+        reference year is treated as brand new rather than producing a negative age that would push
+        its replacement beyond the horizon.
+        """
+        return max(0, reference_year - self.installation_year)
+
+
+@dataclass
+class ExistingAssetRegister:
+    """The building's existing system, for BROWNFIELD / STATUS_QUO contexts (§4.1).
+
+    A plain list of `ExistingAsset` entries that answers "what was already here". Its presence is
+    also a *switch*: `perspectives.select_applicable` evaluates the brownfield/status-quo/owner/
+    landlord/tenant perspectives when a register is attached and the greenfield ones when it is not,
+    so a caller declares the situation rather than picking perspectives by hand.
+
+    It is supplied from outside the simulation — a `bridge.EconomicContext`, a RenoVisor request, or
+    a system setup — because nothing in a HiSim run knows what the building looked like beforehand.
+    """
+
+    assets: List[ExistingAsset] = field(default_factory=list)
+
+    def find(self, asset_class: ComponentType) -> Optional[ExistingAsset]:
+        """First registered asset of the given class, if any.
+
+        The lookup the brownfield logic uses to decide whether a declared component is new, kept or
+        replacing something. First-match semantics means a register listing two assets of one class
+        (two boilers, several window batches) matches only the first — acceptable for the one-of-each
+        systems the register is designed for, but worth knowing before registering duplicates.
+        """
+        for asset in self.assets:
+            if asset.asset_class == asset_class:
+                return asset
+        return None

--- a/hisim/economics/parameters.py
+++ b/hisim/economics/parameters.py
@@ -1,0 +1,127 @@
+"""Economic parameters of the lifecycle cost evaluation (cost_spec.md §3.2).
+
+This module owns the *assumptions* half of the engine's inputs: horizon, interest, escalation
+rates, the CO2 scenario, the country and the data-directory paths. It deliberately owns no numbers
+that describe the world — every price, lifetime, emission factor and subsidy rule lives in the
+versioned data files under `hisim/cost_database/` and `hisim/subsidy_catalog/` — and no evaluation
+logic beyond the two textbook factors below.
+
+Its place in the pipeline: one `EconomicParameters` instance is attached to a run (via
+`SimulationParameters.set_economic_parameters`, a RenoVisor request or a scenario axis), reaches the
+evaluator inside `EvaluationInputs`, is stored on every `LifecycleCostResult`, and is written to
+`economic_inputs.json` so a stored result can be re-priced later without re-simulating (§4.6).
+Because scenario axes vary exactly these fields, keeping the type a plain serializable dataclass is
+what makes a full factorial sweep a matter of milliseconds per cell.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from dataclass_wizard import JSONWizard
+
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.timeline import discount_factor
+from hisim.loadtypes import ComponentType
+
+
+@dataclass
+class EconomicParameters(JSONWizard):
+    """Parameters of the lifecycle cost evaluation (annuity method, VDI 2067 / DIN EN 15459).
+
+    All rates are nominal; results are in nominal euros discounted to year 0. Real-term
+    calculation is possible by supplying real rates consistently.
+
+    Every field is a decision a reviewer may want to challenge, which is why they are gathered in
+    one serializable record rather than spread over call signatures: the record travels with the
+    results, is written to `economic_inputs.json`, and is the object a scenario axis overwrites
+    field by field. The defaults are the engine's documented baseline (20 a horizon, 3 % interest,
+    2 % general escalation, "central" CO2 path, 250 €/t damage cost); `EconomicParameters()` with no
+    arguments is therefore a complete, runnable assumption set.
+
+    Note the two fallback chains encoded in the field pairs: an unset per-carrier or per-asset-class
+    escalation rate falls back to the country's `escalation_defaults_<COUNTRY>.json` file and only
+    then to the corresponding general rate (§3.2/§3.5). `country`, `cost_database_path` and
+    `subsidy_catalog_path` are deliberately excluded from scenario overlays, so a sweep can never
+    silently change which dataset it is reading.
+    """
+
+    observation_period_in_years: int = 20
+    # Nominal calculation interest rate (discount rate).
+    interest_rate: float = 0.03
+    # General price change for maintenance/operation-related costs.
+    general_price_escalation_rate: float = 0.02
+    # Per-carrier nominal energy price escalation rates. Unset carriers fall back to the country's
+    # escalation defaults file (§3.5), then to `general_price_escalation_rate`.
+    energy_price_escalation_rates: Dict[EnergyCarrier, float] = field(default_factory=dict)
+    # Escalation applied to feed-in remuneration (EEG-style tariffs are nominally fixed -> 0.0).
+    feed_in_escalation_rate: float = 0.0
+    # Investment price change rate for replacements.
+    investment_price_escalation_rate: float = 0.02
+    # Per-asset-class overrides for diverging technology trajectories. Unset classes fall back to
+    # the country defaults file (§3.5), then to `investment_price_escalation_rate`.
+    investment_price_escalation_rates: Dict[ComponentType, float] = field(default_factory=dict)
+    # Named CO2-price trajectory (§3.5); "none" disables explicit carbon pricing.
+    co2_price_scenario: str = "central"
+    # CO2 damage cost for the macroeconomic perspective (UBA recommendation ~250 EUR/t).
+    co2_damage_cost_in_euro_per_ton: float = 250.0
+    # Price basis year for database lookups; defaults to the simulation year.
+    price_basis_year: Optional[int] = None
+    country: str = "DE"
+    apply_subsidies: bool = True  # default for perspectives that don't override it
+    cost_database_path: Optional[str] = None
+    subsidy_catalog_path: Optional[str] = None
+    # Escalation of spot-price spreads / flexibility value (§8.5); None = carrier escalation rate.
+    spread_escalation_rate: Optional[float] = None
+    # Escalation of grid fees / capacity charges (§8.5); None = general escalation rate.
+    grid_fee_escalation_rate: Optional[float] = None
+    # Anyway-cost (Sowieso-Kosten) threshold in remaining-life years (§4.1).
+    anyway_threshold_years: float = 2.0
+    # Opt-in for rebilling a load profile under a tariff it was not simulated with (§4.6).
+    allow_counterfactual_billing: bool = False
+
+    def __post_init__(self) -> None:
+        """Basic sanity validation.
+
+        Only the two conditions that would make the discounting and annuity formulas meaningless are
+        checked here (a horizon below one year, an interest rate at or below -100 %). Everything else
+        — a negative escalation rate, an unknown CO2 scenario name, a country without data files —
+        is legitimate input or is caught later by the data loaders with a far more informative
+        message.
+
+        Raises:
+            ValueError: If the observation period is below 1 year or the interest rate is <= -1.0.
+        """
+        if self.observation_period_in_years < 1:
+            raise ValueError("observation_period_in_years must be >= 1.")
+        if self.interest_rate <= -1.0:
+            raise ValueError("interest_rate must be > -100 %.")
+
+    def discount_factor(self, year: int) -> float:
+        """1 / (1 + i)^year at these parameters' interest rate.
+
+        Convenience wrapper around the canonical `timeline.discount_factor` (W4.3); the formula
+        itself exists exactly once, there.
+
+        Offered on the parameters because most callers already hold the parameter set and would
+        otherwise repeat `discount_factor(parameters.interest_rate, year)`. `year` counts from the
+        year-0 investment date under the end-of-year convention, so year 0 yields exactly 1.0.
+        """
+        return discount_factor(self.interest_rate, year)
+
+    def annuity_factor(self) -> float:
+        """Annuity factor over the observation period; 1/T for a zero interest rate.
+
+        Converts a net present cost into the equivalent annual cost — the headline KPI of the whole
+        engine (§1.1, §7.3) and the figure that makes systems with different investment/running-cost
+        profiles comparable at all. It is the capital recovery factor of VDI 2067-1 / DIN EN 15459-1,
+        `i(1+i)^T / ((1+i)^T - 1)`, evaluated at this parameter set's interest rate and horizon; the
+        zero-rate branch exists because that expression is 0/0 at i = 0, where the correct limit is
+        simply spreading the NPV evenly over the T years.
+        """
+        interest = self.interest_rate
+        years = self.observation_period_in_years
+        if interest == 0.0:
+            return 1.0 / years
+        return interest * (1.0 + interest) ** years / ((1.0 + interest) ** years - 1.0)

--- a/hisim/economics/provenance.py
+++ b/hisim/economics/provenance.py
@@ -1,0 +1,375 @@
+"""Provenance ledger: from any result value back to its sources (cost_spec.md §3.10).
+
+Scientific use of a cost result demands that a reviewer asking "where does this equivalent annual
+cost come from" gets an answer down to individual datapoints and their citations, without
+reverse-engineering the engine. Two mechanisms provide that: mandatory source metadata on the data
+side (`sources.py` and the `source_ids` of every data entry) and this ledger on the engine side.
+
+**How it works.** During parameter resolution — the same pass that dry-resolves every declared fact
+against the database, so the lookups happen anyway — each resolved input is recorded once as an
+immutable `ParameterProvenance`, and the ledger returns a small integer id for it. Every
+`CashFlowEntry` then carries the ids of the records that entered its amount. Because every published
+figure is by construction a filter, pivot or discounting of timeline entries (§3.1 principle 3),
+explaining a value is a *set union* over the contributing entries' ids — not a second mechanism that
+could disagree with the first.
+
+**Why interning.** The same device price feeds the year-0 investment, three replacements and the
+residual value; the same electricity price feeds twenty annual bills. Storing a full record on each
+entry would make the ledger far larger than the results themselves, and an entry-to-record
+comparison would depend on object identity. Interning gives value equality, deduplication and a
+compact `cost_provenance.json` in one step, and the integer ids survive serialization so a CSV
+archived years ago is still explainable offline.
+
+**What downstream needs from this module** to "explain any value": stable ids on entries, records
+that carry the origin *kind* as well as the value (a scenario overlay and a database entry must be
+distinguishable — that is the whole point of a counterfactual sweep), resolvable source ids on every
+record whose origin admits them, and a report type that renders as both text and JSON. The last is
+`ProvenanceReport`, assembled by `LifecycleCostResult.explain` and by the `explain` CLI command; the
+leaf citations it shows come from `sources.SourceEntry.to_resolved`.
+
+This module owns the records, the ledger and the report shapes. It does not decide *what* to record
+— the database, subsidy and scenario loaders do — and it holds no source registry of its own.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from hisim.economics.uncertainty import UncertainValue
+
+
+class ParameterOrigin(str, enum.Enum):
+    """Everything that can feed a number into the evaluation.
+
+    The closed list of ways a value can reach the engine: a versioned data-file entry, a per-field
+    config override, a RenoVisor request field, a scenario overlay, an engine default, a simulation
+    output, plus the two special cases documented below. Recording the origin alongside the value is
+    what lets an explained result distinguish "this is the published German 2026 price" from "this
+    was overridden by an installer quote" or "this cell of the sweep was counterfactual" — a
+    distinction no amount of citation text would convey.
+
+    Membership also carries an obligation: `requires_sources` derives from the origin whether a
+    record must cite the registry, so the "no unsourced numbers" rule is enforced by origin rather
+    than by remembering to pass ids at each call site.
+    """
+
+    DATABASE_ENTRY = "DATABASE_ENTRY"
+    CONFIG_OVERRIDE = "CONFIG_OVERRIDE"
+    REQUEST = "REQUEST"
+    SCENARIO_OVERLAY = "SCENARIO_OVERLAY"
+    ENGINE_DEFAULT = "ENGINE_DEFAULT"
+    SIMULATION_OUTPUT = "SIMULATION_OUTPUT"
+    #: Data defined in Python instead of loaded from a catalog file — tests, worked examples and
+    #: synthetic fixtures (W2.4). There is no source registry behind such data, so the record
+    #: carries none; `detail` names the in-memory definition (e.g. a scheme's legal basis). Never
+    #: legitimate for shipped catalog data: catalog loaders resolve real registry ids instead.
+    IN_MEMORY_DEFINITION = "IN_MEMORY_DEFINITION"
+    #: A value carried over from the pre-catalog implementation and kept alive by a migration
+    #: shim (§10.1) — today only `DeviceEntry.legacy_flat_subsidy_share`, subsidy data stranded
+    #: in the device catalog. It ships in a data file but its file's sources document the *device
+    #: price*, not the subsidy, so it carries none unless a `field_sources` entry supplies one:
+    #: the record is explicit that the number is a leftover awaiting the country's catalog (W2.6).
+    LEGACY_MIGRATION_SHIM = "LEGACY_MIGRATION_SHIM"
+
+    # Origins that legitimately carry no source ids:
+    @property
+    def requires_sources(self) -> bool:
+        """Every record except simulation outputs, engine defaults, in-memory and shim data needs sources.
+
+        The predicate `ProvenanceLedger.record` enforces, and therefore the mechanical form of the
+        §3.10 rule that an unsourced datapoint cannot enter a calculation. The four exemptions are
+        each principled rather than convenient: a simulated kWh is provenanced by the simulation
+        itself, an engine default is documented in the spec, in-memory test data has no registry
+        behind it, and the legacy shim's file cites the device price rather than the subsidy it
+        carries — all four say so in `detail` or in their own comments instead.
+        """
+        return self not in (
+            ParameterOrigin.SIMULATION_OUTPUT,
+            ParameterOrigin.ENGINE_DEFAULT,
+            ParameterOrigin.IN_MEMORY_DEFINITION,
+            ParameterOrigin.LEGACY_MIGRATION_SHIM,
+        )
+
+
+@dataclass(frozen=True)
+class ParameterProvenance:
+    """One interned, immutable record of a resolved input.
+
+    Answers, for one number that entered the evaluation: which parameter it is (a dotted path
+    mirroring the data-file structure, so a reviewer can go straight to the entry), what value it
+    took, where it came from, and which registry sources back it. Frozen — and therefore hashable —
+    because interning is implemented as a dictionary keyed on the record itself: two resolutions of
+    the same parameter to the same value from the same origin *are* the same record and must share
+    one id.
+
+    Note `value` is a union: monetary parameters arrive as `UncertainValue` bands, rates and
+    lifetimes as floats, and categorical resolutions (a chosen scheme, a price basis) as strings.
+    `data_file` locates a `DATABASE_ENTRY` down to the file, entry key and valid-from year, while
+    `detail` carries the free-form explanation the other origins need — an `override_source` text, a
+    request field name, a scenario id.
+    """
+
+    parameter: str  # dotted path, e.g. "devices_DE.HEAT_PUMP@2024.specific_investment"
+    value: Union[UncertainValue, float, str]
+    origin: ParameterOrigin
+    data_file: Optional[str] = None  # file / entry key / valid_from_year for DATABASE_ENTRY
+    source_ids: Tuple[str, ...] = ()
+    detail: Optional[str] = None  # override_source text, request field name, scenario id, ...
+
+    def to_json(self) -> dict:
+        """Serializes for cost_provenance.json.
+
+        Emits all six fields with no omissions, since the file is the only thing an offline
+        `explain` on an archived result directory has to work with. Bands are written through
+        `UncertainValue.to_json` (degenerate ones collapse to a bare number), while floats and
+        strings pass through unchanged; `from_json` on the ledger reverses this.
+        """
+        value: Any = self.value
+        if isinstance(value, UncertainValue):
+            value = value.to_json()
+        return {
+            "parameter": self.parameter,
+            "value": value,
+            "origin": self.origin.value,
+            "data_file": self.data_file,
+            "source_ids": list(self.source_ids),
+            "detail": self.detail,
+        }
+
+
+class ProvenanceLedger:
+    """Interns :class:`ParameterProvenance` records and assigns stable integer ids.
+
+    The append-only store built once per variant during the structure pass, and the thing every
+    `CashFlowEntry.provenance_ids` points into. An id is simply the record's index, so ids are
+    stable within a ledger, survive serialization, and let entries reference their inputs at the
+    cost of a few integers instead of embedding whole records — which is what keeps
+    `cost_provenance.json` and the CSV exports proportionate to the results.
+
+    It is also the enforcement point for §3.10: `record` refuses a source-requiring record with no
+    source ids, so an unsourced datapoint cannot silently enter a calculation. Scenario runs add
+    only the records for the fields they override, which is why a full sweep costs almost nothing
+    in provenance terms.
+    """
+
+    def __init__(self) -> None:
+        """Empty ledger, ready to be filled by the resolution pass."""
+        self._records: List[ParameterProvenance] = []
+        self._index: Dict[ParameterProvenance, int] = {}
+
+    def record(self, record: ParameterProvenance) -> int:
+        """Interns a record and returns its id; identical records share one id.
+
+        The single entry point for everything that resolves a value — the cost database, the subsidy
+        catalog, the scenario overlays. Deduplication is by value equality on the frozen record, so
+        the device price read for the investment and again for the third replacement yields the same
+        id, and the ledger stays proportional to the number of *distinct* datapoints rather than to
+        the number of cash flows.
+
+        Args:
+            record: The resolved input to intern.
+
+        Returns:
+            The record's stable id, to be stored in `CashFlowEntry.provenance_ids`.
+
+        Raises:
+            ValueError: If the record's origin requires sources and it carries none (§3.10).
+        """
+        if record.origin.requires_sources and not record.source_ids:
+            raise ValueError(
+                f"Provenance record for {record.parameter!r} with origin {record.origin.value} "
+                "has no source ids — a datapoint without a source cannot enter a calculation (§3.10)."
+            )
+        existing = self._index.get(record)
+        if existing is not None:
+            return existing
+        record_id = len(self._records)
+        self._records.append(record)
+        self._index[record] = record_id
+        return record_id
+
+    def get(self, record_id: int) -> ParameterProvenance:
+        """Record by id — the dereference `explain` performs on every contributing entry."""
+        return self._records[record_id]
+
+    def __len__(self) -> int:
+        """Number of interned records, i.e. of distinct datapoints this evaluation used."""
+        return len(self._records)
+
+    @property
+    def records(self) -> List[ParameterProvenance]:
+        """All records in id order; a copy, so a consumer cannot append to the ledger."""
+        return list(self._records)
+
+    def to_json(self) -> dict:
+        """Full ledger for cost_provenance.json.
+
+        Records are written in id order, which makes the id an implicit array index on the way back
+        in and keeps the file diffable between runs. This is the archival half of the §3.10
+        reproducibility promise: with this file plus the exported CSVs, any number can still be
+        explained years later with no re-run.
+        """
+        return {"records": [record.to_json() for record in self._records]}
+
+    @classmethod
+    def from_json(cls, data: dict) -> "ProvenanceLedger":
+        """Rehydrates a stored ledger (for offline `explain` on archived results).
+
+        Reads records back in file order so that stored ids keep pointing at the same records, and
+        restores values written as `{"min", "best_estimate", "max"}` objects to `UncertainValue`; anything
+        stored as a bare number comes back as a plain float, which is enough for rendering a report
+        but is not literally the type it was written from if it was a degenerate band. It appends
+        directly to the internal list rather than going through `record`, because the interning and
+        source checks already ran when the ledger was built and re-running them could renumber ids
+        that exported files still reference.
+
+        The interning index is rebuilt alongside the list, exactly as `record` would have built it:
+        first occurrence wins, later duplicates keep pointing at the earlier id. Without it a
+        rehydrated ledger would silently stop deduplicating — the next `record` call would append a
+        second copy of a datapoint already in the file under a new id — so a ledger read back for
+        an offline `explain` behaves like the one it was written from.
+        """
+        ledger = cls()
+        for raw in data.get("records", []):
+            value = raw.get("value")
+            if isinstance(value, dict) and {"min", "best_estimate", "max"} <= set(value.keys()):
+                value = UncertainValue.from_json(value)
+            record = ParameterProvenance(
+                parameter=raw["parameter"],
+                value=value,
+                origin=ParameterOrigin(raw["origin"]),
+                data_file=raw.get("data_file"),
+                source_ids=tuple(raw.get("source_ids", [])),
+                detail=raw.get("detail"),
+            )
+            ledger._index.setdefault(record, len(ledger._records))  # noqa: SLF001 — controlled rehydration
+            ledger._records.append(record)  # noqa: SLF001 — controlled rehydration
+        return ledger
+
+
+@dataclass
+class ResolvedSource:
+    """A fully resolved source registry entry, as it appears at a report leaf.
+
+    The presentation-side twin of `sources.SourceEntry`: the same citation data, but defined here so
+    that report and audit code can consume citations without importing the data layer (the seam the
+    import lint pins). Every field except the id and citation is optional, because a few sources are
+    synthesized rather than registry-backed — an `inline:` scheme definition, for instance, is
+    rendered with `kind="INLINE"` and no url or retrieval date.
+    """
+
+    source_id: str
+    citation: str
+    url: Optional[str]
+    publication_year: Optional[int]
+    retrieved: Optional[str]
+    kind: Optional[str]
+    notes: Optional[str] = None
+
+
+@dataclass
+class ProvenanceReportEntry:
+    """One contributing timeline entry inside a :class:`ProvenanceReport`.
+
+    The middle level of the explanation tree: a flattened `CashFlowEntry` (year, category, subject,
+    amount) together with the `ParameterProvenance` records its `provenance_ids` dereference to. It
+    is a copy of the facts a reader needs rather than a reference to the entry, so a report can be
+    serialized and read back without the timeline being present.
+    """
+
+    year: int
+    category: str
+    subject: str
+    amount: UncertainValue
+    parameters: List[ParameterProvenance] = field(default_factory=list)
+
+
+@dataclass
+class ProvenanceReport:
+    """Tree answering "where does this value come from" (§3.10).
+
+    Four levels: the addressed value at the root (`perspective/field`, the same names the exports
+    use — there is no separate query language), the timeline entries that make it up, each entry's
+    resolved parameters, and at the leaves the full citations. Assembled by
+    `LifecycleCostResult.explain` and by `python -m hisim.economics explain`, so a reviewer can
+    challenge a headline number and follow it to a url and a retrieval date in one step.
+
+    `discounting_parameters` is the slot for the rates and horizon that turn the nominal entries
+    into the reported present value — parameters that belong to the value as a whole rather than to
+    any single entry. Both renderings, `render_text` and `to_json`, are of the same object, because a
+    CLI reader and an archived machine-readable trace must not be able to disagree.
+    """
+
+    value_path: str
+    value: Optional[UncertainValue]
+    entries: List[ProvenanceReportEntry] = field(default_factory=list)
+    discounting_parameters: List[ParameterProvenance] = field(default_factory=list)
+    sources: List[ResolvedSource] = field(default_factory=list)
+
+    def render_text(self) -> str:
+        """Human-readable rendering.
+
+        The indented, column-aligned form the `explain` CLI prints: value, then one line per
+        contributing entry, then its parameters with the source ids they cite (falling back to the
+        origin name when an exempt origin cites none), then the discounting parameters and the full
+        citations. Read top-down it is the audit trail a reviewer asked for; the identical content
+        is available as JSON via `to_json`.
+        """
+        lines = [f"{self.value_path} = {self.value.to_json() if self.value else 'n/a'}"]
+        for entry in self.entries:
+            lines.append(
+                f"  year {entry.year:>3}  {entry.category:<22} {entry.subject:<30} "
+                f"{json.dumps(entry.amount.to_json())}"
+            )
+            for parameter in entry.parameters:
+                source_list = ", ".join(parameter.source_ids) or parameter.origin.value
+                lines.append(f"      <- {parameter.parameter} = {parameter.to_json()['value']} [{source_list}]")
+        if self.discounting_parameters:
+            lines.append("  discounting/aggregation parameters:")
+            for parameter in self.discounting_parameters:
+                lines.append(f"      {parameter.parameter} = {parameter.to_json()['value']}")
+        if self.sources:
+            lines.append("  sources:")
+            for source in self.sources:
+                retrieved = f", retrieved {source.retrieved}" if source.retrieved else ""
+                lines.append(f"      [{source.source_id}] {source.citation} ({source.url or 'no url'}{retrieved})")
+        return "\n".join(lines)
+
+    def to_json(self) -> dict:
+        """JSON rendering.
+
+        The machine-readable twin of `render_text`, with the same four levels expanded in full so a
+        frontend or a downstream script can present the lineage itself. Note the source objects use
+        the key `"id"` here while `input_audit` writes `"source_id"` for the same field; both are
+        read by their own consumers.
+        """
+        return {
+            "value_path": self.value_path,
+            "value": self.value.to_json() if self.value else None,
+            "entries": [
+                {
+                    "year": entry.year,
+                    "category": entry.category,
+                    "subject": entry.subject,
+                    "amount": entry.amount.to_json(),
+                    "parameters": [parameter.to_json() for parameter in entry.parameters],
+                }
+                for entry in self.entries
+            ],
+            "discounting_parameters": [parameter.to_json() for parameter in self.discounting_parameters],
+            "sources": [
+                {
+                    "id": source.source_id,
+                    "citation": source.citation,
+                    "url": source.url,
+                    "publication_year": source.publication_year,
+                    "retrieved": source.retrieved,
+                    "kind": source.kind,
+                    "notes": source.notes,
+                }
+                for source in self.sources
+            ],
+        }

--- a/hisim/economics/timeline.py
+++ b/hisim/economics/timeline.py
@@ -1,0 +1,554 @@
+"""The canonical cash-flow timeline (cost_spec.md §3.6).
+
+One set of dated, categorized, payer-tagged cash flows per variant; every perspective, actor
+view and KPI is a filter, allocation or discounting of this same timeline.
+
+That is the load-bearing design decision of the whole engine (§3.1 principle 3). Total NPV, the
+equivalent annual cost, NPV by category / component / payer, the nominal annual series, the monthly
+figure, the actor split, the per-component stacks in the frontend — none of them is computed
+separately. Each is a filter, a pivot or a discounting of the *same* list of `CashFlowEntry`
+objects, which is why `sum(component NPVs) == perspective NPV` and `landlord + tenant == system`
+hold by construction per uncertainty slot rather than by careful bookkeeping, and why `explain` can
+trace any published number back to the entries that produced it.
+
+**Sign convention, stated once for the whole package:** cost is positive, money arriving is
+negative. A subsidy, a feed-in revenue, a residual value at the horizon, an anyway-cost credit and a
+loan disbursement are all negative entries; investments, maintenance, energy bills and loan
+service are positive. An NPV is therefore a net present *cost* — a lower number is better, and a
+negative total means the variant nets money. Note the deliberate asymmetry documented on
+`CategoryRules` below: "is this entry negative" and "is this parameter's band mirrored" are two
+different questions with two different category sets (W3.7).
+
+This module owns the timeline kernel — the categories, the payer enum, the entry and container
+types, the sign contract and the one discount formula — and deliberately owns nothing that produces
+entries. Building them is the calculators' job (`hisim/economics/calculators/`), allocating payers
+is `actors.py`, and choosing which categories a given view drops is `perspectives.py` plus the
+engine-side category sets in `calculators/categories.py`. Keeping the kernel free of those keeps it
+importable from every layer, including presentation.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field, replace
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+from hisim.economics.uncertainty import UncertainValue
+
+
+class CostCategory(str, enum.Enum):
+    """Categories of timeline entries (§3.6).
+
+    The cost-type vocabulary of the engine: every cash flow is tagged with exactly one member, and
+    that tag is what every downstream rule keys off — which flows a perspective drops, which are
+    revenue-type for slot assembly, which sign they must carry, which subsidy scheme may count them
+    as eligible cost, and which display group they stack into in the reports. Categories are
+    finer-grained than a reader may expect (energy split into working / standing / CO2-price /
+    capacity charge, loans into interest / principal / disbursement) precisely because those parts
+    escalate at different rates and are treated differently by the macroeconomic and actor views.
+
+    Adding a member is therefore not a cosmetic act: the sets on `CategoryRules`, the engine sets in
+    `calculators/categories.py` and the display grouping in `presentation_style.py` all have to say
+    what the new category means, and an unclassified one silently defaults to positive-signed,
+    non-revenue and display group 0.
+    """
+
+    INVESTMENT = "INVESTMENT"
+    PLANNING = "PLANNING"
+    REMOVAL = "REMOVAL"
+    REPLACEMENT = "REPLACEMENT"
+    RESIDUAL_VALUE = "RESIDUAL_VALUE"
+    MAINTENANCE = "MAINTENANCE"
+    FIXED_OPERATION = "FIXED_OPERATION"
+    ENERGY_WORKING = "ENERGY_WORKING"
+    ENERGY_STANDING = "ENERGY_STANDING"
+    ENERGY_CO2_PRICE = "ENERGY_CO2_PRICE"
+    ENERGY_CAPACITY_CHARGE = "ENERGY_CAPACITY_CHARGE"
+    FEED_IN_REVENUE = "FEED_IN_REVENUE"
+    SUBSIDY = "SUBSIDY"
+    LOAN_INTEREST = "LOAN_INTEREST"
+    LOAN_PRINCIPAL = "LOAN_PRINCIPAL"
+    LOAN_DISBURSEMENT = "LOAN_DISBURSEMENT"
+    CO2_DAMAGE = "CO2_DAMAGE"  # macroeconomic only
+    ANYWAY_COST_CREDIT = "ANYWAY_COST_CREDIT"  # avoided like-for-like replacement (§4.1)
+    REPLACEMENT_RESERVE = "REPLACEMENT_RESERVE"  # sinking fund of the operating view (§4.2)
+    MODERNIZATION_LEVY = "MODERNIZATION_LEVY"  # tenant pays, landlord receives (§6.4)
+
+
+# The three sets below are read together with the engine-side category sets in
+# `hisim/economics/calculators/categories.py`, which documents where they disagree (W3.3).
+# They are defined here (and re-exported there) because `CostCategory` lives in this kernel
+# module: defining them in the engine would make the kernel import the engine.
+
+class CategoryRules:
+    """The semantic taxonomy over `CostCategory` — which categories mean what (§3.9, §4.2, §5.5).
+
+    Four questions a consumer of the timeline keeps asking — is this revenue-type for band
+    assembly, must it be negative, is it an investment flow, is it subsidy support — answered once,
+    as data, so that no calculator, exporter or report re-derives them with a slightly different
+    membership. Grouping them in a class rather than as loose module constants makes the taxonomy
+    greppable and gives the W3.7 distinction between mirroring and sign a single place to be
+    explained.
+
+    The sets are read together with the engine-side sets of `calculators/categories.py`, which
+    documents where the two disagree; they live here because `CostCategory` does, and defining them
+    on the engine side would invert the kernel's import direction.
+    """
+
+    #: Categories whose parameters are revenue-type **for slot assembly** (§3.9): the optimistic
+    #: world takes their band maximum, so the parameter band is mirrored with `as_revenue()`.
+    #:
+    #: W3.7: this is *not* the same question as "is the entry negative". Band mirroring and sign
+    #: are two properties, and they do not coincide — see `NEGATIVE_SIGN_CATEGORIES` and
+    #: `expected_sign` below. Conflating them is why sign validation could not be switched on.
+    REVENUE_CATEGORIES = frozenset(
+        {
+            CostCategory.FEED_IN_REVENUE,
+            CostCategory.SUBSIDY,
+            CostCategory.RESIDUAL_VALUE,
+            CostCategory.ANYWAY_COST_CREDIT,
+        }
+    )
+
+    #: Categories whose entries are **negative-signed** — money arriving rather than leaving (§3.9).
+    #:
+    #: `REVENUE_CATEGORIES` plus LOAN_DISBURSEMENT: a disbursement is money arriving, but its band is
+    #: *not* mirrored for slot assembly (it is a share of the year-0 investment band, so the world in
+    #: which the investment is expensive is the world in which the loan is large). MODERNIZATION_LEVY
+    #: is deliberately absent because its sign depends on the payer — see `expected_sign`.
+    NEGATIVE_SIGN_CATEGORIES = frozenset(REVENUE_CATEGORIES | {CostCategory.LOAN_DISBURSEMENT})
+
+    #: Categories dropped when a perspective excludes investment (OPERATING_ONLY, §4.2).
+    #: The broadest of the investment-related sets: everything investment-*caused*, including the
+    #: subsidies and loan flows that pay for it and the residual value and anyway credit netted
+    #: against it, so what remains is the honest running cost — to which §4.2 adds a replacement
+    #: reserve in place of the discarded replacement flows. Compare the two narrower engine sets in
+    #: `calculators/categories.py`, whose module docstring tabulates where the three differ and why.
+    INVESTMENT_CATEGORIES = frozenset(
+        {
+            CostCategory.INVESTMENT,
+            CostCategory.PLANNING,
+            CostCategory.REMOVAL,
+            CostCategory.REPLACEMENT,
+            CostCategory.RESIDUAL_VALUE,
+            CostCategory.SUBSIDY,
+            CostCategory.LOAN_INTEREST,
+            CostCategory.LOAN_PRINCIPAL,
+            CostCategory.LOAN_DISBURSEMENT,
+            CostCategory.ANYWAY_COST_CREDIT,
+        }
+    )
+
+    #: The support flows a perspective with `subsidy_mode = NONE` reports nothing of (§5.5) — the
+    #: gross half of the shipped gross/net perspective pair — and which MACROECONOMIC accounting
+    #: also has none of, subsidies being transfers rather than resource costs (§4.5). Note that the
+    #: evaluator realizes both by never *generating* the flows for such a perspective rather than by
+    #: filtering with this set; it names the category the two rules are about.
+    SUBSIDY_FLOW_CATEGORIES = frozenset({CostCategory.SUBSIDY})
+
+    #: What an energy carrier's bill is made of (§8) — the four charge categories `apply_tariff`
+    #: can produce for one carrier. Feed-in revenue is deliberately not one of them: it is money
+    #: the export side earns, not part of what a bought kWh costs, and including it would net two
+    #: different quantities into one "price".
+    #:
+    #: A tuple rather than a frozenset because its consumers render it in this order. It lives in
+    #: the kernel so that the plausibility panel's effective-price check and report section 4 make
+    #: the *same* statement about the same carrier; the two used to hold verbatim copies with
+    #: nothing keeping them equal, so the panel could start validating a price the report does not
+    #: show (review finding 14). `plausibility.PlausibilityCategories` and `views.ViewCategories`
+    #: now alias this attribute.
+    BILL_CATEGORIES = (
+        CostCategory.ENERGY_WORKING,
+        CostCategory.ENERGY_STANDING,
+        CostCategory.ENERGY_CAPACITY_CHARGE,
+        CostCategory.ENERGY_CO2_PRICE,
+    )
+
+
+def discount_factor(interest_rate: float, year: int) -> float:
+    """1 / (1 + i)^year — **the** discount formula of the module (cost-spec-v2 W4.3).
+
+    Every present value in `hisim/economics` routes through this function, either directly or
+    via `CashFlowTimeline.npv`/`npv_by` and `EconomicParameters.discount_factor`, which both
+    delegate here. It lives in the timeline kernel because that is the one module every layer
+    (calculators, results, exports, reports) may already import; before W4.3 the same
+    expression was written out in at least four places outside it.
+
+    `year` is an offset from the year-0 investment date under the end-of-year convention of §4.1,
+    not a calendar year, so year 0 yields exactly 1.0 and intra-year timing is out of scope. Rates
+    are nominal by default, matching the nominal cash flows; a real-terms study simply supplies real
+    rates throughout (§4.1). Negative interest rates are permitted and behave as expected — only
+    i <= -1 is rejected, and that check sits on `EconomicParameters`.
+
+    Args:
+        interest_rate: Nominal calculation interest rate as a fraction (0.03 = 3 %).
+        year: Whole years after year 0.
+
+    Returns:
+        The factor a nominal amount in that year is multiplied by to obtain its present value.
+    """
+    return 1.0 / ((1.0 + interest_rate) ** year)
+
+
+class Actor(str, enum.Enum):
+    """Payers of cash flows (§6.1).
+
+    Tagging each entry with who actually pays it is what turns one timeline into the owner, landlord
+    and tenant views without a second calculation: an allocation ruleset (`actors.py`) rewrites or
+    splits entries onto these payers, and a perspective then simply filters (`scoped_to`). Because
+    allocation only re-tags and splits, the zero-sum invariant — landlord + tenant (+ owner) NPV
+    equals the SYSTEM NPV in every slot — holds structurally and is asserted in tests (§6.5).
+
+    `SYSTEM` is both the "no allocation has happened yet" state every calculator emits and the total
+    view a system-scope perspective reports; `scoped_to(SYSTEM)` therefore returns everything rather
+    than the entries literally tagged SYSTEM.
+    """
+
+    SYSTEM = "system"  # before allocation / total view
+    OWNER_OCCUPIER = "owner_occupier"
+    LANDLORD = "landlord"
+    TENANT = "tenant"
+
+
+class SubjectKind(str, enum.Enum):
+    """What a timeline subject refers to (§3.7).
+
+    A timeline subject is a free-form string, and this says how to read it: the name of a simulation
+    component or cost subject, or an `EnergyCarrier`. The per-subject breakdowns and the frontend
+    stacks need the distinction to look up an asset class and KPI tag for components while leaving
+    carriers without one — energy is billed per carrier, not per device.
+    """
+
+    COMPONENT = "COMPONENT"
+    CARRIER = "CARRIER"
+
+
+@dataclass(frozen=True)
+class CashFlowEntry:
+    """One dated, categorized, payer-tagged cash flow (§3.6).
+
+    Sign convention: cost positive, revenue/subsidy negative. ``amount_in_euro`` carries the
+    LOW/BEST_ESTIMATE/HIGH world values (§3.9).
+
+    The atom of the whole engine: everything the calculators produce is a list of these, and every
+    result, KPI and export cell is an aggregate of some subset of them. The five tag fields are what
+    make that possible — `year` for discounting, `category` for the perspective filters and the
+    breakdowns, `subject` (+ `subject_kind`) for the per-component pivot, `payer` for the actor
+    split, and `provenance_ids` for `explain`, which unions the ledger records of the contributing
+    entries rather than re-deriving anything (§3.10).
+
+    Amounts are **nominal** euros in the entry's year — escalation has already been applied, and
+    discounting has not; the timeline is stored undiscounted so that both the economic (NPV) and the
+    liquidity (out-of-pocket per year) views can be read off the same data (§4.3). The dataclass is
+    frozen, so `with_payer`/`scaled` return copies; entries are never mutated in place, which is
+    what lets a single canonical timeline be shared by several derived views.
+    """
+
+    year: int
+    amount_in_euro: UncertainValue
+    category: CostCategory
+    subject: str  # component name or carrier
+    subject_kind: SubjectKind = SubjectKind.COMPONENT
+    payer: Actor = Actor.SYSTEM
+    subsidy_scheme_id: Optional[str] = None
+    provenance_ids: Tuple[int, ...] = ()
+
+    def with_payer(self, payer: Actor) -> "CashFlowEntry":
+        """Copy with a different payer (allocation rulesets, §6).
+
+        The re-tagging half of allocation: an entry produced as SYSTEM is assigned to whoever the
+        ruleset says bears it, with everything else — year, amount, category, subject, provenance —
+        carried over untouched, which is precisely why allocation cannot change any total.
+        """
+        return replace(self, payer=payer)
+
+    def scaled(self, factor: float) -> "CashFlowEntry":
+        """Copy with the amount scaled by a non-negative share (entry splitting, §6).
+
+        The splitting half of allocation: a cost shared between landlord and tenant becomes two
+        entries whose shares sum to one, so the zero-sum invariant is preserved by construction.
+        Scaling is slot-wise and rejects negative factors (see `UncertainValue.scale`), so a split
+        can never flip an entry's sign or invert its band.
+        """
+        return replace(self, amount_in_euro=self.amount_in_euro.scale(factor))
+
+
+class SignExpectation:
+    """The two sign expectations an entry can carry (W3.7).
+
+    A tiny namespace of string constants rather than an enum, because these values are compared and
+    printed in violation messages and nothing else. "Non-negative" and "non-positive" rather than
+    "positive"/"negative" on purpose: a zero-valued entry (a subsidy that resolved to nothing, a
+    replacement outside the horizon) is legitimate under either expectation.
+    """
+
+    NON_NEGATIVE = "non-negative"
+    NON_POSITIVE = "non-positive"
+
+
+def expected_sign(entry: CashFlowEntry) -> str:
+    """The sign the §3.9 convention requires of this entry, in every slot (W3.7).
+
+    The single authority on entry signs, consulted by `sign_violation` and therefore by every
+    `add`/`extend` on a validating timeline. It exists because the convention cannot be expressed as
+    one category set — the modernization levy is a transfer whose sign depends on which leg you are
+    looking at — and a payer-aware predicate is what finally allowed sign validation to be switched
+    on at all. Read it together with `CategoryRules`, whose `REVENUE_CATEGORIES` answers the
+    *different* question of which parameter bands get mirrored.
+
+    Cost is positive, money arriving is negative. Three cases:
+
+    * `NEGATIVE_SIGN_CATEGORIES` — non-positive (revenues, credits, loan disbursement);
+    * MODERNIZATION_LEVY — **payer-dependent**: the tenant *pays* the rent increase (positive),
+      the landlord *receives* it (negative). It is one category carrying a transfer pair, so the
+      category alone cannot decide (§6.4, §7 B11); a levy entry that has not been allocated yet
+      (payer SYSTEM) is read as the paying leg;
+    * everything else — non-negative.
+    """
+    if entry.category == CostCategory.MODERNIZATION_LEVY:
+        return SignExpectation.NON_POSITIVE if entry.payer == Actor.LANDLORD else SignExpectation.NON_NEGATIVE
+    return (
+        SignExpectation.NON_POSITIVE
+        if entry.category in CategoryRules.NEGATIVE_SIGN_CATEGORIES
+        else SignExpectation.NON_NEGATIVE
+    )
+
+
+@dataclass(frozen=True)
+class SignViolation:
+    """One entry whose sign disagrees with its category's convention (W3.7).
+
+    A reported violation rather than a bare exception message, so the batch checker can collect all
+    of them and the caller can decide how to present them. Carrying the offending entry itself keeps
+    the diagnosis specific: a violation almost always means a calculator forgot `as_revenue()` or
+    booked a credit under a cost category, and both are visible from the entry's own fields.
+    """
+
+    entry: CashFlowEntry
+    expected_sign: str  # SignExpectation.NON_NEGATIVE / NON_POSITIVE, as decided by `expected_sign`
+
+    def __str__(self) -> str:
+        """A one-line description naming the entry and what was expected."""
+        amount = self.entry.amount_in_euro
+        return (
+            f"{self.entry.category.value} entry for {self.entry.subject!r} in year "
+            f"{self.entry.year} (payer {self.entry.payer.value}) should be "
+            f"{self.expected_sign} but is ({amount.minimum}, {amount.best_estimate}, {amount.maximum})"
+        )
+
+
+def sign_violation(entry: CashFlowEntry) -> Optional[SignViolation]:
+    """Checks one entry against the §3.9 sign convention; None when it complies (W3.7).
+
+    All three slots must satisfy the expectation, not just the best_estimate: a band that straddles zero
+    means the entry is a cost in one world and a revenue in another, which no category in the
+    taxonomy legitimately is and which would break the envelope reading of the totals. Returning an
+    optional rather than raising lets `CashFlowTimeline.add` raise eagerly while
+    `sign_violations()` collects the full list for a diagnostic.
+    """
+    amount = entry.amount_in_euro
+    slots = (amount.minimum, amount.best_estimate, amount.maximum)
+    expected = expected_sign(entry)
+    if expected == SignExpectation.NON_POSITIVE:
+        if any(value > 0.0 for value in slots):
+            return SignViolation(entry=entry, expected_sign=SignExpectation.NON_POSITIVE)
+    elif any(value < 0.0 for value in slots):
+        return SignViolation(entry=entry, expected_sign=SignExpectation.NON_NEGATIVE)
+    return None
+
+
+@dataclass
+class CashFlowTimeline:
+    """The canonical timeline of one variant under one perspective.
+
+    The container the §3.6 principle rests on: an ordered list of `CashFlowEntry` objects plus the
+    handful of operations every consumer needs — filter (`filtered`, `without_categories`,
+    `scoped_to`), discount (`npv`), pivot (`npv_by`) and the undiscounted liquidity view
+    (`nominal_annual_series`). Nothing here interprets economics; the calculators build the entries
+    and `results.py`/`exports.py` name the aggregates. The methods return *new* timelines rather
+    than mutating, so the evaluator's timeline can be derived from repeatedly without copies
+    diverging.
+
+    Entries added through `add`/`extend` are sign-validated (W3.7). Construct with
+    ``validate=False`` for synthetic timelines that deliberately carry arbitrary signs — a
+    hand-written net cash-flow series booked under one neutral category, for instance. The flag
+    is inherited by `filtered`/`without_categories` so a derived view keeps the same regime.
+    """
+
+    entries: List[CashFlowEntry] = field(default_factory=list)
+    #: Whether `add`/`extend` enforce the §3.9 sign convention. Engine timelines leave this on.
+    validate: bool = True
+
+    def add(self, entry: CashFlowEntry) -> None:
+        """Appends an entry, sign-validating it first unless validation is off (W3.7).
+
+        Validating on insertion is what makes a sign mistake point at the calculator that made it
+        instead of surfacing as an implausible KPI three layers later. Insertion order is preserved
+        and is the order exports and audits walk the timeline in, so a run stays byte-reproducible.
+
+        Raises:
+            ValueError: If the entry violates the §3.9 sign convention and validation is on.
+        """
+        if self.validate:
+            violation = sign_violation(entry)
+            if violation is not None:
+                raise ValueError(f"Timeline entry violates the §3.9 sign convention: {violation}")
+        self.entries.append(entry)
+
+    def sign_violations(self) -> List["SignViolation"]:
+        """Every entry whose sign disagrees with the §3.9 sign convention (W3.7).
+
+        The non-raising, batch form of the check: it reports the full list so a diagnostic can show
+        a reviewer every offending entry at once instead of the first one. Used by
+        `validate_signs()` and available to the plausibility panel and tests.
+        """
+        violations = [sign_violation(entry) for entry in self.entries]
+        return [violation for violation in violations if violation is not None]
+
+    def validate_signs(self) -> None:
+        """Asserts the §3.9 sign convention over all entries at once (W3.7).
+
+        `add`/`extend` enforce this entry by entry, so this is only needed for timelines built
+        by passing `entries=` to the constructor, or to re-check one built with
+        ``validate=False``. What is expected of which entry is decided by `expected_sign`:
+        `NEGATIVE_SIGN_CATEGORIES` are non-positive (note it is *not* `REVENUE_CATEGORIES` —
+        band mirroring and sign are two different properties, W3.7), MODERNIZATION_LEVY is
+        payer-dependent, everything else is non-negative.
+
+        Raises:
+            ValueError: If any entry violates the convention; the message names up to ten of them.
+        """
+        violations = self.sign_violations()
+        if violations:
+            details = "; ".join(str(violation) for violation in violations[:10])
+            raise ValueError(
+                f"{len(violations)} timeline entries violate the §3.9 sign convention: {details}"
+            )
+
+    def extend(self, entries: Iterable[CashFlowEntry]) -> None:
+        """Appends entries, sign-validating each unless validation is off (W3.7).
+
+        The bulk form calculators use to hand over a whole schedule (replacements, maintenance, a
+        loan) at once. It delegates to `add`, so validation and ordering behave identically; a
+        violation aborts partway, leaving the earlier entries in place — acceptable because a
+        violation is a programming error that fails the run rather than something to recover from.
+        """
+        for entry in entries:
+            self.add(entry)
+
+    def filtered(self, predicate: Callable[[CashFlowEntry], bool]) -> "CashFlowTimeline":
+        """New timeline with the entries matching the predicate.
+
+        The generic building block behind every derived view, and the reason perspectives are cheap:
+        producing the operating-only or tenant-scope timeline is a list comprehension over entries
+        that already exist, not a second evaluation. Entries are shared, not copied — they are
+        frozen — and the `validate` regime is inherited so a derived view keeps the same contract.
+        """
+        return CashFlowTimeline(
+            entries=[entry for entry in self.entries if predicate(entry)], validate=self.validate
+        )
+
+    def without_categories(self, categories: frozenset) -> "CashFlowTimeline":
+        """New timeline without the given categories.
+
+        The category-filter form of `filtered`, used with the `CategoryRules` sets — dropping
+        `INVESTMENT_CATEGORIES` for the operating view, dropping subsidy flows for a gross view.
+        Stating the exclusion as a set keeps the perspective definitions declarative instead of
+        spreading category conditionals through the calculators.
+        """
+        return self.filtered(lambda entry: entry.category not in categories)
+
+    def scoped_to(self, payer: "Actor") -> "CashFlowTimeline":
+        """The flows a perspective scoped to `payer` reports on; SYSTEM means everything (§6).
+
+        The **single** definition of perspective scoping (§7 B4). The aggregation calculator
+        derives every scoped KPI through it, `LifecycleCostResult.scoped_timeline` returns it,
+        and `explain` filters it — three call sites that used to hold two implementations, which
+        is how `explain("total_npv_in_euro")` came to report entries the KPI did not contain.
+        """
+        if payer == Actor.SYSTEM:
+            return self
+        return self.filtered(lambda entry: entry.payer == payer)
+
+    def npv(self, interest_rate: float) -> UncertainValue:
+        """Slot-wise net present value at the given discount rate.
+
+        The headline aggregate: every entry discounted from its year to year 0 and summed within
+        each of the three worlds, yielding a net present *cost* under the package sign convention
+        (lower is better; negative means the variant nets money). Multiplied by
+        `EconomicParameters.annuity_factor()` it becomes the equivalent annual cost. Because both
+        discounting and summation are linear and act slot-wise, the LOW and HIGH results are the
+        NPVs of coherent cheap and expensive worlds — not interval bounds computed after the fact.
+
+        Args:
+            interest_rate: Nominal discount rate as a fraction; normally
+                `EconomicParameters.interest_rate`.
+
+        Returns:
+            The discounted total as a band; an empty timeline yields exact zero.
+        """
+        total = UncertainValue.exact(0.0)
+        for entry in self.entries:
+            total = total + entry.amount_in_euro.scale(discount_factor(interest_rate, entry.year))
+        return total
+
+    def npv_by(
+        self,
+        interest_rate: float,
+        key: Callable[[CashFlowEntry], Any],
+    ) -> Dict[Any, UncertainValue]:
+        """Slot-wise NPV pivot by an arbitrary key (category, subject, payer).
+
+        Every "NPV by …" figure the engine publishes — by category, by component, by payer, by cost
+        group in the reports — is this one function with a different key extractor. That is what
+        guarantees the pivots reconcile: each is a partition of exactly the same discounted entries,
+        so the buckets sum to `npv(interest_rate)` per slot by construction (§7.4), and no separate
+        code path can drift from the headline total.
+
+        Args:
+            interest_rate: Nominal discount rate, as for `npv`.
+            key: Extractor mapping an entry to its bucket; anything hashable works.
+
+        Returns:
+            Bucket -> discounted band, with buckets in first-appearance order.
+        """
+        result: Dict[Any, UncertainValue] = {}
+        for entry in self.entries:
+            discounted = entry.amount_in_euro.scale(discount_factor(interest_rate, entry.year))
+            bucket = key(entry)
+            result[bucket] = result.get(bucket, UncertainValue.exact(0.0)) + discounted
+        return result
+
+    def nominal_annual_series(self, horizon_years: int) -> List[UncertainValue]:
+        """Nominal euros per year 0..T (index = year); the liquidity view (§4.3).
+
+        The "can I afford this" counterpart of the NPV: undiscounted money in and out of pocket per
+        year, from which the year-1 monthly figure is derived (annual / 12 — intra-year timing is
+        out of scope). It matters most under financing, which barely moves the NPV but transforms
+        the liquidity profile completely. Entries outside 0..T are silently ignored, so a timeline
+        carrying flows beyond the horizon can be reported against a shorter one.
+
+        Args:
+            horizon_years: T; the returned list has T + 1 elements, index 0 being year 0.
+
+        Returns:
+            One band per year, exact zero for years with no entries.
+        """
+        series = [UncertainValue.exact(0.0) for _ in range(horizon_years + 1)]
+        for entry in self.entries:
+            if 0 <= entry.year <= horizon_years:
+                series[entry.year] = series[entry.year] + entry.amount_in_euro
+        return series
+
+    def subjects(self) -> List[str]:
+        """All distinct subjects in first-appearance order.
+
+        The row set of every per-component view: breakdowns, the stacked-bar exports and the audit
+        tables all iterate this so they cover exactly the subjects the timeline actually contains,
+        components and carriers alike. First-appearance rather than sorted order is deliberate —
+        it keeps chart series and CSV rows stable across runs and roughly in calculation order.
+        """
+        seen: Dict[str, None] = {}
+        for entry in self.entries:
+            seen.setdefault(entry.subject, None)
+        return list(seen.keys())

--- a/hisim/economics/uncertainty.py
+++ b/hisim/economics/uncertainty.py
@@ -1,0 +1,327 @@
+"""Uncertainty band type for the lifecycle cost engine (cost_spec.md §3.9).
+
+Every monetary input is a (minimum, best_estimate, maximum) triplet. The engine evaluates every
+timeline in three coherent *slots* (LOW / BEST_ESTIMATE / HIGH worlds); within signed cash-flow
+amounts the invariant ``minimum <= best_estimate <= maximum`` still holds because revenue-type
+parameters enter with their band mirrored (see :func:`UncertainValue.as_revenue`).
+
+This module is the arithmetic kernel of the package: it is the leaf every other economics module
+imports (facts, catalog entries, timeline, calculators, results, exports), and it imports nothing
+from the package itself. No cost input in this domain is known to the euro — device prices vary by
+installer and region, maintenance rates are rules of thumb, energy prices vary by supplier — so the
+engine carries the band from input to KPI rather than estimating an error bar after the fact. Because
+discounting and aggregation are linear and act slot-wise, all three valuations fall out of a single
+evaluation pass at negligible cost.
+
+**Semantics: envelope, not confidence interval.** LOW and HIGH mean "if *everything* comes in at the
+favorable respectively unfavorable end" — full correlation, not independent draws. Treating the
+inputs as independent random variables would produce a narrower and, given the data actually
+available, unjustifiable band. Distribution sampling is a deliberate non-goal of the spec (§2) and
+would be layered on the scenario hook (§4.6) rather than here.
+
+What this module deliberately does NOT own: *which* parameters count as revenue-type. That is a
+property of a cash flow's cost category and lives in `timeline.CategoryRules.REVENUE_CATEGORIES`;
+this module only provides the mirroring operation such a caller needs. It also owns no rates,
+horizons or discounting — those live in `parameters.py` and `timeline.py`.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, ClassVar, Iterable, Union
+
+
+class Slot(str, Enum):
+    """The three coherent evaluation worlds of cost_spec.md §3.9.
+
+    LOW is the optimistic world (every cost-type parameter at its minimum, every revenue-type
+    parameter at its maximum), HIGH the pessimistic mirror image, and BEST_ESTIMATE the headline world
+    reported everywhere as *the* number. The enum exists so that code which must name a slot —
+    subsidy caps that bind in one world but not another, plausibility checks, per-slot columns in
+    exports — can do so explicitly instead of passing "min"/"max" strings around.
+
+    Note that a `Slot` is a property of the whole evaluation, not of a single value: within one slot
+    every parameter is set consistently, which is what makes the LOW and HIGH totals defensible
+    envelopes of a *plan* rather than an arbitrary mix of best and worst cases.
+    """
+
+    LOW = "low"
+    BEST_ESTIMATE = "best_estimate"
+    HIGH = "high"
+
+
+@dataclass(frozen=True)
+class UncertainValue:
+    """A monetary figure with an uncertainty band. Invariant: minimum <= best_estimate <= maximum.
+
+    This is the universal value type of the cost engine: every price, rate-derived amount, cash-flow
+    entry, NPV, KPI and export cell is one of these rather than a bare float, so uncertainty can
+    never be silently dropped somewhere in the middle of the pipeline. Frozen and hashable so that
+    identical values can be interned in the provenance ledger (§3.10) and used as dictionary keys.
+
+    The three fields are the values the same quantity takes in the three worlds of `Slot`, *after*
+    any revenue mirroring: `minimum` is the value in the LOW (optimistic) world, not "the smallest
+    number this parameter could be". For a cost the two coincide; for a revenue they are opposites,
+    which is exactly what `as_revenue` is for. Arithmetic is slot-wise throughout (`__add__`,
+    `scale`, `multiply_band`, `clamp_upper`), which keeps each world internally consistent; the one
+    exception is `__sub__`, which is documented separately because a difference of two bands is not
+    monotone in the same way.
+
+    Note the field order: `best_estimate` comes first, so the positional constructor reads
+    ``UncertainValue(best_estimate, min, max)``. Loaders and callers generally use keywords or `exact`.
+    """
+
+    #: The exact zero band, reused everywhere as the neutral element. Assigned right after the
+    #: class body, because it is an instance of the class it hangs on.
+    ZERO: ClassVar["UncertainValue"]
+
+    best_estimate: float
+    minimum: float
+    maximum: float
+
+    def __post_init__(self) -> None:
+        """Validates finiteness and band ordering (with float-noise snapping).
+
+        Enforcing the invariant at construction is what makes every downstream consumer able to read
+        `minimum`/`maximum` as "LOW world"/"HIGH world" without re-checking, and it turns a mirroring
+        mistake (a revenue booked without `as_revenue`) into an immediate exception rather than a
+        quietly inverted band in a published report.
+        """
+        for value in (self.best_estimate, self.minimum, self.maximum):
+            if not math.isfinite(value):
+                raise ValueError(f"UncertainValue must be finite, got {self!r}.")
+        if not self.minimum <= self.best_estimate <= self.maximum:
+            # Slot-wise arithmetic accumulates float noise; snap violations within epsilon
+            # instead of failing (real ordering violations are far above this threshold).
+            scale = max(1.0, abs(self.best_estimate), abs(self.minimum), abs(self.maximum))
+            tolerance = 1e-9 * scale
+            if self.minimum - self.best_estimate <= tolerance and self.best_estimate - self.maximum <= tolerance:
+                object.__setattr__(self, "minimum", min(self.minimum, self.best_estimate))
+                object.__setattr__(self, "maximum", max(self.maximum, self.best_estimate))
+            else:
+                raise ValueError(f"UncertainValue band violated (min <= best_estimate <= max): {self!r}.")
+
+    @staticmethod
+    def exact(value: float) -> "UncertainValue":
+        """Degenerate band for values that are actually certain (statutory amounts, contracts).
+
+        Legally or contractually fixed figures — lump-sum grants, statutory levy caps, tax rates, an
+        EEG feed-in tariff — genuinely have no band, and forcing them through the same type keeps the
+        engine free of a second "certain value" code path. It is also how physical quantities from
+        the simulation (kWh, peaks) and engine-internal zeros enter the arithmetic.
+        """
+        return UncertainValue(value, value, value)
+
+    @staticmethod
+    def from_json(value: Any, context: str = "") -> "UncertainValue":
+        """Parses a JSON value: a bare number means exact, an object declares a band.
+
+        This is the single reader behind the universal data-file value syntax of §3.1/§3.9: every
+        monetary field of the cost database, tariff contracts, subsidy catalog and stored result
+        files accepts either `0.30` or `{"min": .., "best_estimate": .., "max": ..}`, so data authors never
+        need a second schema for certain values. Ordering and finiteness are validated by the
+        constructor, so a malformed band fails at load time rather than mid-evaluation.
+
+        Args:
+            value: A JSON scalar (int/float, but not bool) or a dict with "min", "best_estimate" and "max".
+            context: Dotted path of the field being parsed, used only to make errors locatable.
+
+        Returns:
+            The parsed band; a bare number yields min = best_estimate = max.
+
+        Raises:
+            ValueError: If the dict misses a key, or the value is neither number nor dict.
+        """
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return UncertainValue.exact(float(value))
+        if isinstance(value, dict):
+            try:
+                return UncertainValue(
+                    best_estimate=float(value["best_estimate"]),
+                    minimum=float(value["min"]),
+                    maximum=float(value["max"]),
+                )
+            except KeyError as err:
+                raise ValueError(
+                    f"Uncertainty band {context or value} must have 'min', 'best_estimate' and 'max' keys."
+                ) from err
+        raise ValueError(f"Cannot parse uncertainty value {value!r} ({context}).")
+
+    def to_json(self) -> Union[float, dict]:
+        """Serializes: degenerate bands as bare numbers, real bands as objects.
+
+        The inverse of `from_json`, and the reason exported JSON stays readable: a run whose inputs
+        are all certain produces plain numbers instead of thousands of identical triplets. Used by
+        every export (§7.2), by the provenance ledger and by `economic_inputs.json` round-trips.
+        """
+        if self.minimum == self.best_estimate == self.maximum:
+            return self.best_estimate
+        return {"min": self.minimum, "best_estimate": self.best_estimate, "max": self.maximum}
+
+    def is_exact(self) -> bool:
+        """True when the band is degenerate (min = best_estimate = max).
+
+        Reports and plausibility checks use this to decide whether showing an uncertainty band adds
+        information — a whisker around a statutory lump sum is noise, not honesty.
+        """
+        return self.minimum == self.best_estimate == self.maximum
+
+    def slot(self, slot: Slot) -> float:
+        """Value in the given evaluation world.
+
+        The accessor for code that iterates over the three worlds — per-slot cap checks, per-slot
+        exports, the zero-sum assertions of §6.5 — so no caller has to map `Slot.LOW` onto the
+        `minimum` attribute itself. Any slot other than LOW/HIGH (i.e. BEST_ESTIMATE) returns
+        `best_estimate`.
+        """
+        if slot == Slot.LOW:
+            return self.minimum
+        if slot == Slot.HIGH:
+            return self.maximum
+        return self.best_estimate
+
+    def as_revenue(self) -> "UncertainValue":
+        """Mirrors the band for revenue-type parameters (§3.9).
+
+        In the optimistic LOW world a revenue comes in at its *maximum*. Returned value is the
+        signed (negative) cash-flow band ordered LOW <= BEST_ESTIMATE <= HIGH again.
+
+        **Why mirroring is not optional.** Two conventions meet here. A revenue parameter is
+        *stated* in "how much money arrives" terms, where the band's minimum is the stingiest
+        outcome; a cash-flow entry is *signed*, cost positive and money arriving negative (§3.6).
+        Slot-wise addition then only produces meaningful totals if every summand's `minimum` field
+        already means "this entry's value in the LOW world". For a cost that is its cheapest value;
+        for a revenue the LOW world is the one where the *most* money arrives, i.e. the most
+        negative cash flow. Plain negation would put -min (the least favorable revenue) into the
+        `minimum` slot, which both breaks the min <= best_estimate <= max invariant and, worse, would silently
+        sum an optimistic-cost world with a pessimistic-revenue world — the resulting "minimum" NPV
+        would be no envelope of anything. Reversing the ends while negating fixes both at once.
+
+        Callers are the places that book a negative-signed entry from a positively-stated parameter:
+        feed-in remuneration and controllability discounts (`tariffs.py`), subsidy awards
+        (`calculators/subsidy_application.py`), residual values (`calculators/investment.py`),
+        anyway-cost credits (`calculators/context_resolution.py`), loan disbursement and repayment
+        grants (`calculators/financing_application.py`) and the landlord leg of the modernization
+        levy (`actors.py`). Which categories these are is fixed by role, never guessed per entry —
+        see `timeline.CategoryRules.REVENUE_CATEGORIES`, and note the W3.7 warning there that band
+        mirroring and entry sign are two distinct properties that do not have the same membership.
+        """
+        return UncertainValue(best_estimate=-self.best_estimate, minimum=-self.maximum, maximum=-self.minimum)
+
+    def __add__(self, other: "UncertainValue") -> "UncertainValue":
+        """Slot-wise addition — the workhorse of every aggregation in the package.
+
+        Adds the two operands within each world separately, which is correct precisely because the
+        slots are coherent scenarios: the LOW total is the sum of all LOW-world values, not an
+        interval-arithmetic lower bound. Every NPV, pivot and per-category total is built by folding
+        this operator over entries, so mirroring mistakes upstream surface as broken bands here.
+        """
+        return UncertainValue(
+            best_estimate=self.best_estimate + other.best_estimate,
+            minimum=self.minimum + other.minimum,
+            maximum=self.maximum + other.maximum,
+        )
+
+    def __sub__(self, other: "UncertainValue") -> "UncertainValue":
+        """Slot-wise difference (same-world comparison, NOT interval arithmetic; §3.9).
+
+        When the subtrahend's band is wider than the minuend's, the LOW-world delta can
+        exceed the HIGH-world delta (e.g. dropping a very uncertain gas bill); the result is
+        therefore the *envelope* of the three slot deltas — "minimum" reads "best-case
+        delta", not "LOW-world delta".
+
+        Comparing variants within the same world is the point (§3.7): a heat-pump price band that
+        appears in both variants cancels instead of inflating the delta, which is why variant
+        deltas, payback and warm-rent neutrality are all computed slot-wise. The re-sorting into an
+        envelope is the price of keeping the class invariant while the subtraction is not monotone;
+        the caveat it embodies — an extremal delta may occur in a *mixed* world that no slot
+        describes — is what the scenario axes and break-even search of §4.6 exist to explore.
+        """
+        low_world = self.minimum - other.minimum
+        high_world = self.maximum - other.maximum
+        best_estimate = self.best_estimate - other.best_estimate
+        return UncertainValue(
+            best_estimate=best_estimate,
+            minimum=min(low_world, best_estimate, high_world),
+            maximum=max(low_world, best_estimate, high_world),
+        )
+
+    def scale(self, factor: float) -> "UncertainValue":
+        """Multiplies all slots by a non-negative scalar (kWh, discount factor, escalation).
+
+        The multiplication used whenever a band meets an *exact* quantity: metered energy, a
+        discount or escalation factor, a component count, an allocation share. Non-negativity is
+        required rather than assumed, because a negative factor would swap the ends of the band and
+        break the LOW/HIGH reading of the slots; sign flips must go through `as_revenue`, which
+        reverses the ends deliberately. Note this keeps sign-carrying entries intact — scaling an
+        already-negative revenue entry by a discount factor stays a revenue.
+
+        Raises:
+            ValueError: If `factor` is negative.
+        """
+        if factor < 0:
+            raise ValueError(
+                "scale() only supports non-negative factors to preserve slot ordering; "
+                "use as_revenue() for sign flips."
+            )
+        return UncertainValue(self.best_estimate * factor, self.minimum * factor, self.maximum * factor)
+
+    def multiply_band(self, other: "UncertainValue") -> "UncertainValue":
+        """Slot-wise product of two coherent cost-type bands (e.g. maintenance rate x investment).
+
+        Both operands must be non-negative in every slot so slot ordering is preserved.
+
+        Multiplying band by band is only defensible when the two are *coherent* — the same world
+        drives both — which is exactly the §3.9 slot model: the expensive world has both the higher
+        maintenance rate and the higher investment it applies to, so their product is the
+        HIGH-world maintenance cost. This is deliberately not interval multiplication, which would
+        also consider cheap-rate-times-expensive-investment corners that no coherent world realizes.
+        Used by `calculators/maintenance.py` (rate x gross investment) and by the coupled-cost share
+        of `calculators/context_resolution.py`.
+
+        Raises:
+            ValueError: If either band dips below zero in any slot, since the ordering guarantee
+                the method relies on would no longer hold.
+        """
+        if self.minimum < 0 or other.minimum < 0:
+            raise ValueError("multiply_band() requires non-negative bands in every slot.")
+        return UncertainValue(
+            best_estimate=self.best_estimate * other.best_estimate,
+            minimum=self.minimum * other.minimum,
+            maximum=self.maximum * other.maximum,
+        )
+
+    def clamp_upper(self, cap: "UncertainValue") -> "UncertainValue":
+        """Applies a cap per slot (subsidy caps are checked per slot; §3.9, §5.4).
+
+        Caps are the main nonlinearity in the engine — an eligible-cost ceiling or a modernization
+        levy limit may bind in the HIGH world and not in LOW — and applying them within each world
+        is what keeps that behavior visible instead of averaging it away. The per-slot outcome is
+        intended and is reported: the subsidy audit records which slots a cap bound in, and the
+        input audit surfaces it per scheme (`input_audit.ResolvedInputRow.caps_binding_by_scheme`).
+        Callers are the subsidy engine (`subsidies.py`) and the German levy rules (`actors.py`).
+        """
+        return UncertainValue(
+            best_estimate=min(self.best_estimate, cap.best_estimate),
+            minimum=min(self.minimum, cap.minimum),
+            maximum=min(self.maximum, cap.maximum),
+        )
+
+    @staticmethod
+    def sum(values: Iterable["UncertainValue"]) -> "UncertainValue":
+        """Slot-wise sum; empty input yields the exact zero band.
+
+        The band-aware counterpart of the builtin `sum`, which cannot be used because it would start
+        the fold at the integer 0. Folding left in iteration order is kept deliberately, so a
+        reported total is reproducible bit for bit across runs and matches the order the audit and
+        reconciliation checks (§7.4) walk the same entries in.
+        """
+        total = UncertainValue.ZERO
+        for value in values:
+            total = total + value
+        return total
+
+
+UncertainValue.ZERO = UncertainValue.exact(0.0)

--- a/hisim/loadtypes.py
+++ b/hisim/loadtypes.py
@@ -286,6 +286,26 @@ class ComponentType(str, enum.Enum):
     HEAT_DISTRIBUTION_SYSTEM_LOW_TEMPERATURE_RADIATOR = "Low Temperature Radiator"
     NO_HDS = "No HDS"
 
+    # Building envelope measures (lifecycle cost engine, cost_spec.md Q7). These are cost
+    # subjects sized in m2 of the respective envelope element (EXTERIOR_DOOR and
+    # VENTILATION_SYSTEM per unit); the building physics sees them only as changed U-values.
+    # The taxonomy follows the renovation measure database, element by element: external wall,
+    # roof, top floor ceiling, basement ceiling, basement walls, ground-contacting components,
+    # windows (review round 3, PR 556).
+    WALL_EXTERNAL_INSULATION = "WallExternalInsulation"
+    WALL_INTERNAL_INSULATION = "WallInternalInsulation"
+    ROOF_INSULATION_BETWEEN_JOISTS = "RoofInsulationBetweenJoists"
+    ROOF_INSULATION_OVER_JOISTS = "RoofInsulationOverJoists"
+    WARM_ROOF_INSULATION = "WarmRoofInsulation"
+    TOP_CEILING_UPPER_INSULATION = "TopCeilingUpperInsulation"
+    BASEMENT_CEILING_BOTTOM_INSULATION = "BasementCeilingBottomInsulation"
+    BASEMENT_WALLS_INTERNAL_INSULATION = "BasementWallsInternalInsulation"
+    GROUND_EXTERNAL_INSULATION = "GroundExternalInsulation"
+    WINDOWS_TRIPLE_GLAZED = "WindowsTripleGlazed"
+    EXTERIOR_DOOR = "ExteriorDoor"
+    AIR_SEALING = "AirSealing"
+    VENTILATION_SYSTEM = "VentilationSystem"
+
     # different heat_pump types
     HEAT_PUMP_BUILDING = "HeatPumpBuilding"  # Heatpump for heating the house
     HEAT_PUMP_DHW = "HeatPumpDHW"  # heatpump for heating domnestic hot water

--- a/hisim/postprocessing/kpi_computation/kpi_structure.py
+++ b/hisim/postprocessing/kpi_computation/kpi_structure.py
@@ -76,6 +76,10 @@ class KpiEntry(JSONWizard):
     description: Optional[str] = None
     tag: Optional[KpiTagEnumClass] = None
     name_of_source_component: Optional[str] = None
+    # Optional uncertainty band (cost_spec.md §7.3): `value` is the AVERAGE slot. Additive —
+    # legacy KPIs leave these unset during the parallel phase of the lifecycle cost engine.
+    value_min: Optional[float] = None
+    value_max: Optional[float] = None
 
 
 class KpiHelperClass:

--- a/roadmap/cost-spec-v2.md
+++ b/roadmap/cost-spec-v2.md
@@ -1,0 +1,959 @@
+# Cost Module v2 — Reviewability & Verification Spec
+
+Status: **draft for review, rev. 2** (2026-08-12) — nothing in here is implemented yet.
+Rev. 2 incorporates a detailed review of the plan against the code; claims about
+the current state now carry file/line evidence, and a fix-or-freeze appendix (§7)
+lists the defects found during that review.
+
+Scope: restructuring `hisim/economics` for independent review/testing, plus a
+human-checkable worked-example library. This spec does not change any pricing
+methodology; it changes how the existing calculations are organized and verified.
+
+Naming note: the repo root's `cost_spec.md` (self-titled "v2") is the
+*methodology* spec; this document is the *reviewability* spec layered on top of
+it. Its §10 migration constraints (strictly parallel implementation, no legacy
+edits) continue to govern; everything below happens inside the new module and
+is releasable independently of the legacy cutover.
+
+## 1. Motivation
+
+The cost module will be the foundation of all financial analysis. An undetected
+error invalidates every research result built on top of it. The current module
+(~8,900 lines across 26 files) is correct-by-construction in intent but is
+reviewable only as a whole: a reviewer must understand simulation extraction,
+cost data, financial math, and report generation at once to sign off on any of it.
+
+Goals, in priority order:
+
+1. **Localized review** — a domain expert can verify one concern (e.g. loan math,
+   or database entries against sources) without reading the rest.
+2. **Human-checkable references** — expected results that a person can re-derive
+   with a pocket calculator or Excel, independent of the Python implementation.
+3. **Error-class isolation** — a test failure names the layer that broke
+   (extraction vs. data vs. formula vs. presentation), not just "NPV is wrong".
+4. **Tamper-evidence** — expected values cannot silently drift to match a buggy
+   implementation.
+
+## 2. Package restructuring: four seams
+
+The module is split along four seams that follow the existing data flow. Each
+seam has a serializable contract, an independent test strategy, and isolates a
+distinct error class.
+
+The code-level starting position is better than a 8,900-line module suggests:
+an import audit shows `hisim/economics` has **zero reach-back into simulation
+objects** — no `hisim.component`, no `SimRepository`, no postprocessing logic;
+only enum/dataclass imports of `hisim.loadtypes` and `kpi_structure`. And the
+evaluator's external API surface is tiny: outside `evaluator.py`, only
+`evaluate`, `evaluate_matrix` and `resolve_check` are called (`bridge.py`,
+`scenarios.py`, `__main__.py`, tests). Internals are free to reshape.
+
+### 2.1 Seam 1 — Simulation extraction ↔ economic inputs
+
+**Cut between** `bridge.py`/`adapter.py` (read HiSim outputs and component
+configs) and everything downstream. **Contract:** `EvaluationInputs` ↔
+`economic_inputs.json` (`serialization.py`).
+
+The contract *mostly* exists: `EvaluationInputs` (`evaluator.py:66-86`) is plain
+data (no component objects, no callables), serialization round-trips it, and
+the "pure function of a JSON file" path is already exercised by tests
+(round-trip with equal NPV, three CLI tests, the report CLI). What does **not**
+hold yet is faithfulness — today `economic_inputs.json` is not a pure
+simulation extract. Work items, all preconditions for the seam's error-class
+story ("wrong physical quantities in" vs. "priced them wrong"):
+
+- **W1.1 — stop post-filtering inputs against price data.** *(done; amended by
+  D7, §8.)* `compute_lifecycle_costs` used to drop `SubjectCostFacts` whose
+  subject appeared in a `resolve_check` problem string (substring match)
+  *before* writing the JSON, so extraction output depended on cost-database
+  state. Now the faithful extract is written first and unconditionally, and the
+  resolution check runs strictly downstream of the file. Per **D7** that check
+  no longer drops anything: `require_resolvable_subjects`
+  (`evaluator.py`) raises `UnresolvableSubjectsError` — a `CostDataError` —
+  listing every blocked subject with its database reason, in the bridge and in
+  the CLI alike. There is no partial cost result and no `--allow-drops` escape;
+  non-blocking problems (an override without `override_source`) keep warning.
+  Blockers without a subject (a billed carrier with no price entry) are
+  included in the same error: they already aborted evaluation deep inside the
+  database lookup, now they abort it early and typed.
+- **W1.2 — move price-basis-year policy downstream.**
+  `_pick_price_basis_year` (`bridge.py:69-87`) loads the cost database inside
+  the extraction layer and sets an economic parameter that is *not recorded in
+  the JSON*; the CLI defaults differently (`evaluator.py:154-156`), so the same
+  file prices differently per entry point. The chosen basis year is either
+  computed downstream or serialized.
+- **W1.3 — close the serialization hole** (§7, B1): `SubsidyBuildingContext.
+  existing_heating` is silently dropped (`serialization.py:163-211`), although
+  the shipped DE catalog conditions on it (`DE.json:140,145` — BEG speed
+  bonus). Re-pricing from JSON currently degrades those schemes.
+- **W1.4 — decide the tariff-contract representation.** Contracts are stored by
+  id only and re-resolved from the shipped tariffs directory
+  (`serialization.py:226-246`); in-memory contracts cannot be restored, and
+  `read_inputs` cannot take a custom tariffs path. Either embed contracts in
+  the JSON or plumb `tariffs_base_path` through — the file must be
+  self-contained or explicitly versioned against catalog state.
+- **W1.5 — unit-test the extraction side.** Inverted from what one would
+  expect, extraction is currently the *least*-tested layer: no unit test
+  constructs fake wrapped components for `build_evaluation_inputs` or
+  `adapter`; they are covered only transitively by one `extendedbase`
+  simulation test. Add fixture-based tests (fake components + in-memory
+  results frame → expected `EvaluationInputs`).
+
+Test strategy per side, once faithful:
+
+- Upstream test: compare the written `economic_inputs.json` against the
+  simulation results (note: the bridge reads the in-memory results DataFrame,
+  not the CSVs — the test should too) — pure extraction correctness, no
+  economics knowledge needed.
+- Downstream test: everything after this seam is a pure function of a JSON file.
+  Small hand-written input files (one heat pump, 10,000 kWh, no subsidies) with
+  exact expected results; fast, deterministic, no simulation run.
+- Error class: "wrong physical quantities in" vs. "priced them wrong".
+- **This seam is implemented first** — it makes the entire financial core
+  testable without HiSim and is the precondition for cheap testing of the rest.
+
+Known quirks to document at the contract (not necessarily change):
+`BillingDeterminants.energy_bought_in_kwh` used to hold liters or tons after
+`MeterSpec.quantity_conversion`, so the field name lied about its unit — **fixed
+under D26**: the conversion moved to the price side, the field is kilowatt-hours
+for every carrier, and `MeterSpec` has no `quantity_conversion` any more. What
+remains is `_peaks_from_power_series` (`bridge.py:109-127`), which bakes a
+15-minute billing grid into extraction, so a different capacity-tariff regime
+requires re-running the simulation.
+
+### 2.2 Seam 2 — Cost data ↔ calculation engine
+
+**Cut between** the data layer (`database.py`, catalog/data halves of
+`subsidies.py` and `tariffs.py`, `validation.py`, `provenance.py`) and the
+evaluator.
+
+**The contract must be built, not enforced** — rev. 1 claimed resolved entries
+"carrying `UncertainValue` + provenance" already exist; they don't. Provenance
+is a side-channel: entries hold string source-ids, `ProvenanceLedger` hands out
+int ids threaded separately (`database.py:521-551`), the subsidy loader
+resolves sources but never stores them, and the evaluator fabricates fake ids
+(`inline:subsidy scheme …`, `evaluator.py:659`). Work items:
+
+**Status (2026-08-12): every W2.x item is done.** What remains of seam 2 is the
+*physical* split of §2.5 — moving `database.py`, the catalog halves of
+`subsidies.py`/`tariffs.py` and `validation.py` into `data/`, and the evaluator,
+calculators, subsidy application and billing engine into `engine/`. Both modules
+that straddle the cut now carry a section banner naming which half each
+definition lands in (`subsidies.py` since W2.3, `tariffs.py` since the tariff
+straggler commit e52f065a), and the last data→engine dependency inversions are
+gone: no engine code fabricates provenance, and no data module imports the price
+catalog to construct contracts. The move is deferred to the stack carving so
+importers churn once (open question 1).
+
+- **W2.1 — resolved entries. Done, pragmatically** (commit d37167df). Scope
+  honestly stated: the value bands were *not* moved into a new wrapper — they
+  stay on `DeviceEntry` / `EnergyPriceEntry`, and tariff contracts and subsidy
+  schemes got no wrapper at all (their provenance is solved by W2.4 instead).
+  What was built is the half that was actually broken: resolution and provenance
+  recording became one step. `CostDatabase.resolve_device_entry(...)` /
+  `resolve_energy_price(...)` take the ledger plus the fields the caller will
+  price from, record one `DATABASE_ENTRY` record per field *at resolution time*,
+  and return `ResolvedDeviceEntry` / `ResolvedPriceEntry` (entry + field → ledger
+  id); asking for an unrequested field raises. `provenance_for_device` /
+  `provenance_for_price` have no callers outside the database any more, so a
+  calculator can no longer look an entry up and forget its provenance — the old
+  failure mode was silent (right number, empty ledger). The raw
+  `get_device_entry` / `get_energy_price` stay for verification and presentation
+  (`resolve_check`, `validation`, `audit`, the report's input-audit table), which
+  read entries without pricing and would otherwise invent records for a dry run.
+  Two pricing sites keep the raw lookup, each commented: the replaced asset's
+  removal cost and its like-for-like credit record nothing today, and recording
+  them would change ledger content instead of preserving it — the one remaining
+  gap, together with the feed-in rate of a default contract. Parity was checked
+  by dumping an evaluation's ledger before/after: NPV, EAC, the record set and
+  every entry's provenance content are identical; ids renumber only where a
+  subject mixes overrides with database fields (database records now precede the
+  override records).
+- **W2.2 — typed benefits. Done** (commit d0f6ffe4). One frozen payload per
+  kind — `ShareBenefit(rate)` (SHARE_OF_ELIGIBLE_COST + BONUS_SHARE),
+  `LumpSumBenefit(amount)`, `PerUnitBenefit(amount)`,
+  `TaxCreditBenefit(rate, years, annual_shares)`, `ReducedVatBenefit(vat_rate)`,
+  `LoanTermsBenefit(interest_rate, term, repayment_grant_rate)`,
+  `OperationalBenefit(rate_per_kwh, carrier, duration_years)` — parsed by
+  `parse_benefit` at catalog load, which rejects missing, unknown and
+  unparsable keys naming the scheme id and the key. The catalog JSON format is
+  unchanged. `SubsidyScheme.__post_init__` keeps kind and payload in sync, so
+  in-memory schemes are typed too. The divergent valuation in
+  `required_questions` is gone: `Benefit.value_estimate(gross, size)` is the
+  one simplified valuation, on the same typed fields the solver reads. Two
+  checks moved from solve time to load time (`annual_shares` sum to 1, and
+  their count matches `years`). B7 (REDUCED_VAT has no consumer) stays open:
+  typed and documented as unwired, neither wired nor deleted.
+- **W2.3 — split `Condition` into data and evaluator. Done** (commit 2cffad12).
+  `Condition` is a frozen, behavior-free AST; `parse_condition` (data side)
+  builds it, `evaluate_condition` and `referenced_fields` (engine side)
+  consume it, with a section banner separating the two halves of the module.
+  The field vocabulary is now *derived*: `_enumerate_context_fields()` walks
+  `CONTEXT_ROOTS` (the context dataclasses), one nested dataclass level and
+  their properties, so `KNOWN_CONTEXT_FIELDS` cannot fall behind a new context
+  field (18 → 23 names, a superset — no shipped condition changed meaning).
+  The two derived-field special cases collapsed into `DERIVED_CONTEXT_FIELDS`
+  + `question_targets()`, and `scheme_context_fields(scheme)` is the single
+  definition of a scheme's context dependencies (conditions plus what the
+  eligible-cost spec implies), used by both the question derivation and
+  `validation.py`. Kept in one module deliberately: the §2.5 package split
+  moves both halves at once, and splitting now would churn every importer
+  twice or create an AST ↔ context import cycle.
+- **W2.4 — subsidy provenance end-to-end. Done** (commits db688848, 3ec6e415).
+  (a) `SubsidyCatalog.load` keeps the source resolution it used to discard
+  (`SubsidyCatalog.sources`) and mints the provenance itself
+  (`provenance_for_scheme`): a catalog-loaded scheme records `DATABASE_ENTRY`
+  with its real registry ids, carrying its `legal_basis`/`url` — scheme fields,
+  not registry entries — in `detail`. In-memory schemes (tests, worked examples)
+  record the new `ParameterOrigin.IN_MEMORY_DEFINITION`, which carries no source
+  ids *by design* instead of faking one. Catalog files must now cite sources (a
+  load error, like device entries and tariff contracts). A result's
+  `source_resolver` merges both registries — cost database *and* subsidy catalog,
+  whose id spaces are disjoint — so subsidy ids resolve at a report leaf, and the
+  report's "sources used" table lists every registry entry the ledger cites.
+  (b) The last shipped `inline:` id is gone: the synthetic dynamic contract cites
+  the new `src_tariff_synthetic_fixture_2024`, labelled as the test fixture it is
+  (authored, not retrieved; replace before publishing), and an inline id in a
+  tariff *catalog file* is now a validation **error**. The convention survives
+  only for contracts built in memory, which no registry can back; the `tariffs.py`
+  module docstring states that split. `validate_all()`: 0 errors, 0 warnings.
+- **W2.5 — validate what is currently unvalidated. Done** (commit b6d865be).
+  `validate_tariff_contracts` walks `cost_database/tariffs/*.json` (§7 B9):
+  every contract parses through the §8.2 schema, its id matches its file name
+  (contracts are resolved by file name), a DYNAMIC contract's `spot_series`
+  CSV exists, and non-inline source ids resolve against the cost-database
+  registry. Inline sources (`inline:<citation>`, which the shipped dynamic
+  contract used and `results.py` renders) were accepted with a warning; W2.4b
+  (commit 3ec6e415) retired them — in a catalog file they are now an error, and
+  the shipped contract cites a registry entry. New catalog-level errors: duplicate scheme ids, `excludes`
+  naming a non-existent scheme, `annual_shares` summing to 1, and cumulation
+  groups whose members disagree on `combined_rate_cap` (the solver applies the
+  group minimum to all members). Note `cumulation_group` is a group *label*,
+  not a scheme id, so there is nothing to resolve it against; cap coherence is
+  its catalog-level invariant. Benefit key typing is enforced at load by W2.2.
+  Shipped data passes: `validate_all()` reported 0 errors and 1 warning (the
+  inline tariff source) and reports **0 errors, 0 warnings** since W2.4b.
+- **W2.6 — `legacy_flat_subsidy_share`. Done** (commit 8696c966), by marking
+  rather than moving. cost_spec.md §10.1 keeps the flat shim alive until Phase 4
+  has a catalog for every shipped country (Ireland has none), so the capability
+  stays; a separate data file for one float per entry — with its own loader,
+  validation, overlay and provenance plumbing, to be dismantled again at Phase 4
+  — would cost more than it clarifies. Instead: the field sits in a marked
+  `§10.1 migration shim` block in `database.py` and a §3.2a section of the
+  package README saying it is not device data, who reads it and when it dies; it
+  left the scenario-overlay surface (sweeping a subsidy level is a subsidy axis —
+  catalog plus subsidy mode — and an overlayable shim reads as a supported knob),
+  so overlaying it is an error; and the shim path emits its own record with the
+  new `ParameterOrigin.LEGACY_MIGRATION_SHIM`, citing no source unless the data
+  file declares `field_sources` for the share — the shipped entries' `source_ids`
+  are capex market surveys that say nothing about a 30 % subsidy.
+
+Tariffs, by contrast, were already ~80 % cut and are now fully placed (commit
+e52f065a): all escalation and multi-year projection live in the evaluator,
+`apply_tariff` is a pure year-1 billing engine, and the three functions that
+straddled the line are settled. `default_from_price_entry` moved to its only
+caller, `calculators/energy.contract_from_price_entry` — building a contract out
+of a §3.5 price entry is engine behavior, and it had made the tariff *data*
+module import the price catalog. `validate_billing_interval` stays on the data
+side (a contract-data pre-check against a simulation parameter) and
+`marginal_purchase_price_components` stays with the contract dataclass, both
+under an explicit section banner. The duplication is gone too: the simulation
+side used to reimplement FLAT/ToU/DYNAMIC selection
+(`components/tariff_provider._purchase_price`), so a controller's price and its
+bill were two implementations of one rule; both now call
+`tariffs.marginal_purchase_price_in_euro_per_kwh` (with `time_of_use_band_for`
+and `energy_price_in_euro_per_kwh` beneath it), the billing engine's semantics
+being authoritative, and `spot_factor` is applied in exactly one place.
+`tests/test_tariff_provider.py` pins per-kind agreement between the simulated
+price series and the bill.
+
+- Data side: a review problem, not a math problem — entries verified against
+  cited sources; `validate` keeps doing structural CI checks.
+- Engine side: math tests run against tiny synthetic databases with round
+  numbers, so they never break when real prices are updated.
+- Error class: "wrong number in the database" vs. "wrong formula".
+
+### 2.3 Seam 3 — Engine internals: independent domain calculators
+
+`evaluator.py` (1,093 lines) is the concentration of risk. **Split it into pure
+calculators** that each emit cash-flow entries. **Contract:** `CashFlowTimeline`
+**plus typed non-cash outputs** — the timeline alone is not sufficient: four
+results legitimately bypass it today (`sunk_cost`, the CO2 mass accounting
+`co2_result`, the modernization-levy `basis_parts`, and the subsidy
+`decisions` record). Each calculator's signature declares which of these it
+produces; none are smuggled through shared mutable accumulators as they are
+now (`co2_result` is mutated by two different phases, `ledger` by three,
+`decisions` written by subsidies and read by financing).
+
+Calculators (extended from rev. 1 — the first five existed in the plan; the
+rest are real code in `evaluator.py` that the plan missed):
+
+| Calculator | Concern | Today | Reference check |
+|---|---|---|---|
+| investment schedule | capex, replacements, residual value | `build_timeline:379-513` + `_resolve_device` | hand-computable schedules |
+| context resolution | existing assets, kept/new/replacement, `is_new_investment`, sunk cost + anyway-cost credit (§4.1, Q7 coupled cost) | `_resolve_device:274-307`, `build_timeline:416-464` | small brownfield scenarios with hand-derived credits |
+| maintenance & fixed O&M | maintenance rate × investment, fixed opex, escalation | `build_timeline:515-531` (see §7 B2) | rate × capex × escalation by hand |
+| financing | loan/annuity flows (`financing.py`, already pure) | `_apply_financing:885-947` | closed-form annuity formulas, `PMT` |
+| energy bills | tariff application, annualization, escalation | `_add_energy_flows:722-883` | year-1 bill from consumption × price |
+| subsidy application | eligibility + amounts + cumulation | `_add_subsidies` + `subsidies.py` engine half | "subsidy ≤ eligible cost" property + catalog examples |
+| CO2 accounting | embodied, operational, macro damage entries, CO2-price bill component (four kinds that must never be summed, `results.py:60-82`) | scattered: `build_timeline:411/488/564-581`, `_add_energy_flows:867-883` | mass balance by hand |
+| replacement reserve | operating-view sinking fund (a discounting computation currently inside timeline construction) | `build_timeline:548-562` | annuity closed form |
+| discounting/aggregation | timeline → NPV/EAC, pivots, LCOH | `evaluate:978-1006`, `_build_breakdowns`, plus `timeline.py:136-162` (already pure) | NPV at 0% = plain sum; annuity closed forms |
+
+Cross-cutting cleanups that make the calculators independently reviewable:
+
+- **W3.1 — escalation as one shared helper.** Escalation is applied at ~9
+  sites with 5 different rates (replacements, residual, anyway credit,
+  maintenance, energy working/standing, spread, grid fee, feed-in). One
+  audited `escalate(amount, rate, year)` + the two rate-fallback chains.
+- **W3.2 — financing takes typed inputs.** Today it is a timeline *rewriter*:
+  it derives the principal by re-scanning already-emitted year-0 entries with
+  a hardcoded category set (`evaluator.py:901-912`), reads subsidy `decisions`
+  for LOAN_TERMS overrides, and emits a further SUBSIDY entry (repayment
+  grant) *after* the subsidy calculator ran. New signature: financing receives
+  a typed "year-0 net investment" figure and the loan-terms award; ordering
+  dependencies become arguments, not conventions.
+- **W3.3 — one category-semantics map.** Three disagreeing category-set lists
+  exist (`timeline.py:43-69`, `_apply_financing:903-908`,
+  `_build_breakdowns:1055-1065`). One module-level definition, used by all.
+- **W3.4 — make the subsidy total complete and unit-consistent. Done**
+  (commit c81262ea). The defects were: `_add_subsidies` emitted OPERATIONAL
+  payouts as SUBSIDY timeline entries **without accumulating them into the
+  returned total**, `_apply_financing` emitted the repayment-grant SUBSIDY entry
+  *after* that total was closed, and tax-credit schedules entered the total
+  discounted while upfront grants entered nominal — so the modernization-levy
+  basis deducted less support than the landlord receives (real money: the tenant
+  was over-levied). Decision: the basis deducts the **nominal sum of all SUBSIDY
+  timeline entries** (§559 BGB deducts subsidies *received*). The figure is now
+  derived from the finished timeline by
+  `calculators/subsidy_application.nominal_support_from_entries`, after
+  financing has run — complete by construction and recoverable from the
+  timeline. The per-subject display figure was split into
+  `subsidies_nominal_in_euro` and `subsidies_npv_in_euro` so every reported
+  support number names its unit. Both §5.1 conservation xfails are green.
+- **W3.5 — annualization in one place.** Partial-year annualization is
+  duplicated with two different zero-guards (`_add_energy_flows:735-765` vs.
+  `_add_subsidies:635-639`).
+- **W3.6 — allocation is a producer, not a filter.** `DE2024Ruleset.allocate`
+  *mints* new MODERNIZATION_LEVY entries (`actors.py:213,222`); the
+  orchestrator's composition model must account for allocation adding money
+  movements, and the zero-sum invariant (`actors.py:246`) is its test.
+- **W3.7 — entry-level sign validation. Done** (commit 745ddfd7). The blocker
+  was that `REVENUE_CATEGORIES` conflated "band is mirrored for slot assembly"
+  with "entry is negative". Split into `REVENUE_CATEGORIES` (mirroring) and
+  `NEGATIVE_SIGN_CATEGORIES` (= the former plus LOAN_DISBURSEMENT), with a
+  payer-aware `expected_sign(entry)` for MODERNIZATION_LEVY, whose sign depends
+  on which leg of the transfer pair it is. `CashFlowTimeline.add`/`extend` now
+  validate; synthetic test timelines opt out with `CashFlowTimeline(
+  validate=False)`.
+
+The remaining evaluator becomes an orchestrator that composes timelines and
+typed side-outputs, tested via conservation invariants (§5.1), staying nearly
+logic-free. Perspective flags (`include_investment`, `macro`, `subsidy_mode`)
+remain inputs to several calculators — "pure" means deterministic in inputs,
+not perspective-free.
+
+- Error class: each financial mechanism verified in isolation instead of only
+  end-to-end.
+
+### 2.4 Seam 4 — Results ↔ presentation
+
+**Cut between** `results.py`/`LifecycleCostResult` and the presentation layer.
+**Enforceable invariant: presentation never computes.** No arithmetic beyond
+formatting; every displayed number must already exist in the result object.
+
+Rev. 1 called this "largely organizational enforcement of boundaries that
+already half-exist". The code review shows it is the largest construction job
+of the four seams; scoping it honestly:
+
+- **W4.1 — build the result view-model. Done** (commits 43968df3, 2df60f3b).
+  `hisim/economics/views.py` holds the ~15 formerly on-the-fly derivations as
+  pure functions of `LifecycleCostResult` returning plain data, each naming the
+  presentation site it replaces: cumulative discounted cost per slot,
+  the nominal year × category matrix, loan interest/principal series, the
+  (year, subject, category) detail rows with year subtotals, the payer ×
+  category NPV pivot, per-carrier year-1 bills with annualized quantity and
+  effective price, per-subject year-0 build-up and net outflow, subsidy share
+  of gross, cumulative operational CO2, per-category and
+  per-subject-per-category EAC, total subsidies received. Display grouping
+  stays presentational per the stated exception, but the sums come from
+  `fold_categories`/`fold_category_matrix`, into which presentation passes its
+  own DISPLAY_GROUPS mapping. Scenario swings/min-max/spread live on
+  `ScenarioCube` and the payback curve on `VariantComparison` (both W4.3/W4.4,
+  commit 2ea33610). Two business rules that were hiding in chart code got a
+  documented home: the `min(subsidy, gross)` clamp (formerly duplicated in
+  `reporting.py:1227` = `report_plots.py:93-96`, closing §7 B8's first half)
+  and "feed-in is shown in the electricity bill but never enters the effective
+  price". `exports.py` stopped minting its per-category EAC, per-entry discount
+  factors and support total; the written files are byte-identical.
+  Every view is pinned in `tests/test_economics_views.py` against a
+  brute-force recomputation on a banded, financed, subsidised, feed-in,
+  multi-subject, actor-allocated fixture. Presentation consumes them since
+  W4.7a (commit f6c20c82); three further views were added there for figures the
+  inventory had missed (`investment_net_of_subsidies`, `payer_npv_total`,
+  `award_total_amount`).
+- **W4.2 — plausibility checks move engine-side. Done** (commits 111a0c65,
+  fa834f6d). `hisim/economics/plausibility.py` produces a typed
+  `PlausibilityReport` of `PlausibilityFinding`s — stable `check_id`, float
+  `value` + `unit`, the `bounds` a range check required, a `context` dict for
+  the other numbers a check compared — with no formatting anywhere in it;
+  `reporting.py` keeps only `_render_finding` and the reader hints.
+  Its precondition landed first: `LifecycleCostResult` now carries
+  `annual_energy_quantities_by_carrier` (annualized through
+  `calculators/annualization.py`), `reference_areas` and
+  `simulated_period_fraction`, all serialized additively into
+  `lifecycle_costs.json`, so the checks no longer need `EvaluationInputs`.
+  Parity is pinned by `PANEL_BEFORE_W42` (the eleven rendered rows captured
+  from the pre-move implementation) and was additionally verified by diffing
+  the full `cost_summary.md`/`lifecycle_report.html` of the fixture
+  before/after — byte-identical.
+- **W4.3 — one discount formula. Done** (commit 2ea33610).
+  `timeline.discount_factor(interest_rate, year)` is the single implementation;
+  `CashFlowTimeline.npv`/`npv_by`, `EconomicParameters.discount_factor`,
+  `results.compare` and `exports.py` all route through it. The last
+  hand-written copies, in presentation (`reporting.py:691`,
+  `report_plots.py:216-229`), went with W4.7a: grepping `reporting.py` and
+  `report_plots.py` for `(1 +` / `(1.0 +` now finds nothing.
+- **W4.4 — `results.py` is engine, not DTO. Done for the comparison math**
+  (commit 2ea33610). `cumulative_discounted_savings` produces the payback curve
+  per slot through the canonical discount helper, `VariantComparison` carries
+  it (`cumulative_discounted_savings_in_euro`, serialized additively) and
+  `discounted_payback_year` derives the number *from* the curve, so the drawn
+  curve and the printed year cannot disagree. Warm-rent neutrality annuitizes
+  rather than discounts and was left as it was, with a comment saying so.
+  §7 B4, the `explain` scoping bug, was left to S4b because fixing it changes
+  `explain` output; **fixed** there (commit fb729175):
+  `CashFlowTimeline.scoped_to(payer)` is now the single definition of
+  perspective scoping, used by the aggregation calculator, by
+  `scoped_timeline()` and by `_entries_for_path`.
+- **W4.5 — the report CLI reads stored results. Done** (commit af6dba6c).
+  `serialization.py` gained the inverse of the export set —
+  `result_from_json` / `matrix_from_json` / `read_results` — rebuilding a full
+  `EvaluationMatrix` from `lifecycle_costs.json`, `cash_flow_timeline.csv` and
+  `cost_provenance.json`. Two additive extensions made the reload faithful:
+  `scope_payer` and `simulation_year` in `lifecycle_costs.json`, and a
+  `subject_kind` column appended to `cash_flow_timeline.csv`. The one field a
+  reload cannot reproduce, `source_resolver`, is a database/catalog artifact and
+  is not needed: the input audit is persisted as `cost_audit.json` and carries
+  its own resolved §3.10 sources. `report` loads and renders when a directory
+  has stored results — no evaluator, no database, no catalog, `--compare` the
+  same per directory — and falls back to re-evaluation with a printed notice
+  otherwise. `--scenarios` still evaluates, because a scenario cube *is* a fresh
+  set of evaluations (§4.6). Pinned by a round-trip test asserting the rendering
+  from reloaded files is byte-identical to the rendering from memory.
+- **W4.6 — reclassify `audit.py`. Done** (commit a597e632). `audit.py` sits on
+  the verification side of the lint and keeps computing, by design.
+  `build_input_audit` resolves every declared fact **once** into a typed
+  `InputAuditReport` (`input_audit.py`: `ResolvedInputRow` with an `ORIGIN_*`
+  kind, override source, entry key, source ids, bands, flags, plus the resolved
+  §3.10 sources); `write_cost_audit` renders it to CSV, byte-identically, and
+  the report's section 1 renders the same rows. The types live in their own
+  module so presentation can import them without importing the database and the
+  evaluator. `SourceRegistry.referenced_ids()` replaced the private-set access.
+  The duplication had a real consequence: the report dropped an override's unit
+  price whenever the asset class had no database entry, which the CSV did not —
+  now fixed and pinned.
+  **The gross-investment proposal is rejected, with measurement.**
+  `write_parity_report` keeps recomputing the legacy formula: the breakdown's
+  `investment_gross_in_euro` adds year-0 PLANNING and REMOVAL and is taken on
+  the *scoped* timeline, while the legacy CSV column it diffs against is the
+  bare device investment. They agree on shipped data only because
+  `planning_cost_in_euro` and `removal_cost_in_euro` are 0 in every data file,
+  so adopting it would have turned every row into a false discrepancy the day
+  someone priced planning. Recomputing the legacy formula is the harness's
+  purpose; the docstring says so.
+  With section 1 rendering typed rows, `reporting.py` needs neither
+  `EvaluationInputs` nor `CostDatabase`: `LifecycleCostResult.simulation_year`
+  (additive) carries the last thing it read off the inputs.
+- **W4.7 — untangle `report_plots` ← `reporting`. Done** (commit f6c20c82).
+  `presentation_style.py` holds `DISPLAY_GROUPS`, the palette and `group_of`
+  and imports nothing but `timeline.CostCategory`; both renderers take them
+  from there and `report_plots` no longer imports `reporting` at all. Its
+  duplicated payback discounting, group sums and `min(subsidy, gross)` clamp
+  are gone the same way. `CATEGORY_TO_GROUP` is total over `CostCategory`, so
+  `fold_categories`' deliberate no-gaps rule cannot turn a newly added category
+  into a report crash.
+  §7 B8's second half closed with it: `_waterfall_svg` is handed its net rather
+  than summing the steps, so the comparison waterfall's net bar reads
+  `npv_delta_in_euro`.
+
+Allowed exception, stated once: mapping the 16 cost categories onto ~8 display
+groups is a presentation concept; the *grouping* may live in presentation, but
+group **sums** are provided by the view-model.
+
+**Seam 4 is complete.** Package S4a (commits 111a0c65, fa834f6d, 2ea33610,
+43968df3, 2df60f3b) built the engine-side halves — W4.1–W4.4 — without changing a
+single number. Package S4b (commits 91b8abf9, f6c20c82, a597e632, af6dba6c,
+fb729175, 42a247cb) performed the switch-over, and also without changing one:
+the golden files landed **before** the first line of presentation was touched
+(91b8abf9) and are byte-identical through every commit since. The predicted
+float noise stayed below the display rounding, as expected — moving the detail
+table's discounted column from `amount / (1+i)**year` to
+`amount * discount_factor(...)` (observed maximum deviation 2.2e-16 relative)
+changed no rendered digit anywhere in the report.
+
+**The enforced contract**, as `tests/test_economics_import_lint.py` states and
+checks it (with `ast`, so a deferred import inside a function counts like a
+top-of-file one):
+
+* Presentation is `reporting.py`, `report_plots.py`, `presentation_style.py`.
+  From `hisim.economics` they may import only `results`, `views`,
+  `plausibility` (its *types*: `run_plausibility_checks` and
+  `PlausibilityConfig` are banned by name), `input_audit`,
+  `presentation_style`, `exports` (`build_lifecycle_kpi_entries`, so the KPI
+  table and `lifecycle_kpis.json` cannot disagree), `timeline`, `uncertainty`,
+  `carriers`, `parameters`, `provenance`. Everything else — `evaluator`,
+  `database`, `calculators.*`, `subsidies`, `tariffs`, `scenarios`, `financing`,
+  `actors`, `perspectives`, `facts`, `adapter`, `bridge`, `serialization`,
+  `validation`, `audit` — is out of reach. `scenarios` is absent rather than
+  allowed because section 9 takes its `ScenarioCube` as an untyped parameter and
+  asks it for `equivalent_annual_cost_swings` / `_spreads`.
+* `report_plots` does not import `reporting`; `presentation_style` imports
+  `timeline` and nothing else.
+* The dependency runs one way: `exports` (serialization), `audit` (the parity
+  harness, which computes by design), `input_audit`, `views`, `results` and
+  `plausibility` must not import a renderer.
+* What is left of arithmetic in presentation: SVG geometry, axis scaling and
+  `_fmt`'s rounding. Grepping the two renderers for `(1 +` / `(1.0 +` finds
+  nothing; every remaining `sum(` computes a stack height or a span.
+
+**Deferrals from S4a, settled.**
+
+* *`year_zero_build_up`, full vs. scoped timeline* — **settled: scoped**, like
+  every other view. The same section's table is built from
+  `component_breakdowns`, which the engine derives from the scoped timeline, so
+  under an actor scope the waterfall and the table beneath it disagreed: a
+  tenant perspective drew the landlord's full investment above an empty table.
+  Measured on the S4b fixture, the two readings differ for exactly that case
+  (a tenant scope has no year-0 build-up, having no year-0 flows) and are
+  identical for every other perspective, landlord included — so the goldens did
+  not move. `payer_category_npv_pivot` remains the one deliberate exception: it
+  is the view *of* the split and must see every payer.
+* *`total_subsidies_received` — award-based meaning* — **resolved by D7's
+  sibling D2 (§8): the KPI is now the timeline-based nominal figure.** It used
+  to sum the catalog's award amounts (`SubsidyDecision.applied[*]
+  .upfront_amount`) and therefore omitted every euro that reaches the timeline
+  without an upfront award — scheduled payouts, repayment grants, operational
+  support and the §10.1 flat shim. It now calls `nominal_support_from_entries`
+  on the perspective's scoped timeline, the same basis the §6.4 levy deducts
+  (W3.4). Report goldens re-baselined deliberately with that commit.
+
+- Test: `tests/test_economics_report_goldens.py` (golden `cost_summary.md` and
+  `lifecycle_report.html` from a deterministic in-memory fixture — the only
+  normalization is today's ISO date, replaced literally, so the §3.10
+  `retrieved` dates stay in the golden; plus the stored-results round trip) and
+  `tests/test_economics_import_lint.py` (the contract above).
+- Error class: a reporting bug can mislead a reader but can never corrupt
+  research numbers.
+
+### 2.5 Target package layout
+
+```
+hisim/economics/
+    uncertainty.py timeline.py provenance.py carriers.py
+    facts.py parameters.py                       # shared kernel (facts/parameters are
+                                                 # part of the seam-1 contract surface)
+    inputs/        # bridge, adapter, serialization            (seam 1, upstream)
+    data/          # database, catalogs (subsidy + tariff data halves), validation
+    engine/        # calculators/, evaluator (orchestrator), financing,
+                   # subsidies (application), tariffs (billing), actors,
+                   # perspectives, results (+ view-model), plausibility, scenarios
+    presentation/  # reporting, report_plots, presentation_style
+                   # (exports is result serialization, not presentation — W4.6)
+    verification/  # audit (legacy parity harness — computes by design);
+                   # input_audit holds its typed rows, importable from both sides
+    __main__.py    # CLI: thin orchestration over inputs/engine/presentation
+```
+
+Placement notes (modules rev. 1 left unplaced): `actors.py` and
+`perspectives.py` are engine (allocation produces entries; perspectives are
+engine configuration). `facts.py` and `parameters.py` are kernel — they are
+the vocabulary of the seam-1 contract. `financing.py` is already a pure
+engine calculator. `scenarios.py` is a *driver above* the evaluator (it
+builds a fresh `EconomicEvaluator` per scenario, `scenarios.py:239`), so it
+depends only on the frozen contract below.
+
+**Frozen contracts** through the restructuring:
+`EconomicEvaluator(database, parameters, subsidy_catalog)` with
+`evaluate(inputs, perspective)`, `evaluate_matrix(...)`, `resolve_check(...)`
+— the only evaluator surface used outside the file — and
+`EvaluationInputs` ↔ `economic_inputs.json`.
+
+Migration order: seam 1 (with W1.1–W1.5) → seam 3 → seams 2 and 4. Seams 2
+and 4 are **not** merely organizational (see W2.x, W4.x) but they depend on
+the calculator boundaries from seam 3 to know where the moved logic lands.
+
+## 3. Worked-example library
+
+A library of hand-computed reference results, authored in Excel (the tool
+humans enjoy and domain experts trust), converted to diffable YAML that the
+tests read. The Excel formulas are a genuinely **independent second
+implementation**: if Python and the spreadsheet agree, two different toolchains
+produced the same arithmetic.
+
+**Ordering dependency:** examples are grouped by calculator (seam 3). Until
+the seam-3 split lands, only `financing/` (already a pure function) and
+`end_to_end/` (through `EvaluationInputs`) examples have stable entry points;
+author those first, the rest follow the split.
+
+### 3.1 Repository layout
+
+```
+tests/worked_examples/
+    financing/loan_10y_3pct.xlsx          # source of truth, authored by humans
+    financing/loan_10y_3pct.yaml          # GENERATED, diffable, read by pytest
+    tariffs/...
+    subsidies/...
+    end_to_end/...                        # few full EvaluationInputs cases
+tools/convert_worked_examples.py          # manual run + CI drift check
+```
+
+**One example = one workbook = one YAML file** (decided, was open question):
+Excel's *Create Names from Selection* produces **workbook-scoped** names, so a
+sheet-per-example workbook would collide `principal` across examples, and
+sheet-scoping names manually in the Name Manager is exactly the fiddly step
+authors will get wrong. One `.xlsx` per example also isolates binary churn per
+example in git history. A shared `_template.xlsx` is copied to start a new one.
+
+### 3.2 Workbook authoring conventions
+
+Fixed template layout, validated by the converter:
+
+- **Metadata block:** `name`, `spec_section`, `computed_by`, `description`
+  (the description states the derivation in words).
+- **Inputs table** and **Expected table**, each using the label convention:
+  identifier in column A, value in column B, optional display text in column C.
+  Expected rows carry an explicit **tolerance column** (never guessed).
+- **Labels are valid identifiers** matching `[a-z][a-z0-9_]*`, following the
+  codebase's unit-suffix convention (`principal_in_euro`, `interest_rate`).
+  YAML keys, Excel labels, and Python field names line up 1:1, so a reviewer
+  traces one quantity through all three layers by name.
+- **Named cells:** authors select label+value columns and use Excel's
+  *Create Names from Selection* (Ctrl+Shift+F3), then write formulas directly
+  in terms of names: `=principal*interest_rate/(1-(1+interest_rate)^-duration_years)`.
+  Readable in Excel itself, before any conversion.
+- **Round numbers deliberately** (20,000 €, 3%, 10 years, 0.30 €/kWh): a
+  reviewer must be able to re-derive most steps in ten minutes, or the example
+  provides no human check.
+- **Assert intermediates, not just finals:** expected rows include intermediate
+  quantities (annuity, year-1 interest, remaining debt at year 5, …) so a
+  failure names the step that broke.
+- **Uncertainty policy (new):** worked examples use **degenerate bands only**
+  (every input an exact value; min = best_estimate = max). The engine's LOW/BEST_ESTIMATE/HIGH
+  slot mechanics — `as_revenue` band mirroring, the envelope semantics of
+  `UncertainValue.__sub__`, slot-wise caps — are verified by the property
+  tests of §5.1, *not* by worked examples. If a banded example ever becomes
+  necessary, the template grows explicit `_min`/`_best_estimate`/`_max` label triples;
+  until then the converter rejects band syntax.
+- **Sign convention (new):** the template states the engine convention (cost
+  positive, revenue/subsidy negative) next to the Expected table; the
+  converter checks the sign of expected values in known revenue-type rows.
+
+### 3.3 Converter (`tools/convert_worked_examples.py`)
+
+Reads each workbook with `openpyxl` twice — `data_only=False` (formula text)
+and `data_only=True` (cached values) — and emits deterministic YAML (stable key
+order, fixed float formatting, values rounded consistently with the declared
+tolerance).
+
+**Formula extraction and rewriting:**
+
+- Formulas written with defined names pass through as-is.
+- Raw references (`=B2*B3` from click-and-point authoring) are rewritten to
+  names using the coordinate→name map, via `openpyxl.formula.Tokenizer`
+  (never regex), so `PMT(B3,B4,B2)` → `PMT(interest_rate, duration_years, principal)`.
+- Ranges rewrite by endpoints: `SUM(B5:B14)` → `SUM(cash_flow_year_1:cash_flow_year_10)`.
+- Excel surface syntax is kept (`^`, `PMT`, `NPV`): the derivation is for human
+  verification, and Excel's finance functions are well-documented reference
+  semantics in their own right.
+
+**Validation rules (conversion fails on violation):**
+
+1. Every cell referenced by any formula has a name — no magic intermediate
+   cells; every quantity in the derivation chain is named and visible.
+2. No duplicate names within a workbook (names are workbook-scoped; one
+   workbook per example makes this the natural unit).
+3. No volatile functions (`TODAY()`, `RAND()`, `NOW()`) — they break
+   reproducibility of cached values.
+4. No external workbook references.
+5. Every expected cell contains a formula, or an explicit `note` explaining
+   where the constant comes from (e.g. a literature value) — a bare pasted
+   constant stands out.
+6. Labels must be valid identifiers (§3.2); tolerance cells must be present.
+7. Ranges must consist of individually labeled rows (or a labeled table, once
+   the template grows one for long timelines).
+8. No uncertainty-band syntax (degenerate-bands policy, §3.2).
+
+**Arithmetic cross-check (stale-cache defense):** for pure-arithmetic formulas
+(`+ - * / ^ ( )` over names — not the Excel function library), the converter
+re-evaluates the formula in Python against the named values and fails on
+mismatch with the cached value. This catches "edited an input without letting
+Excel recalculate" at conversion time. Cells using `PMT`/`NPV`/etc. skip this
+check and rely on the cached value — which is fine: they are exactly the cells
+whose Excel implementation is wanted as the independent reference.
+
+**Dependencies (clarified):** `openpyxl` is currently a *runtime* dependency
+(requirements.txt); this work moves it to a dev/test extra. PyYAML is used
+transitively today and must be declared explicitly as a dev/test dependency.
+`numpy_financial` (§5.3) is a **new** dev/test dependency.
+
+### 3.4 YAML format
+
+```yaml
+# GENERATED from loan_10y_3pct.xlsx — edit the xlsx, then run tools/convert_worked_examples.py
+name: loan_10y_3pct_round_numbers
+spec_section: "4.4"
+computed_by: "N. Pflugradt, by hand + Excel PMT, 2026-08-05"
+description: >
+  20,000 EUR loan, 10 years, 3% interest, annuity repayment.
+inputs:
+  principal_in_euro: 20000
+  interest_rate: 0.03
+  duration_in_years: 10
+expected:
+  annuity_in_euro:
+    value: 2344.61
+    abs_tol: 0.01
+    derivation: "principal_in_euro * interest_rate / (1 - (1 + interest_rate)^-duration_in_years)"
+  interest_year_1_in_euro:
+    value: 600.00
+    abs_tol: 0.01
+    derivation: "principal_in_euro * interest_rate"
+  remaining_debt_year_5_in_euro: {value: 10741.36, abs_tol: 0.01, derivation: "..."}
+  total_interest_in_euro: {value: 3446.10, abs_tol: 0.01, derivation: "..."}
+```
+
+A PR diff therefore shows *which* expected value changed **and** *how it was
+computed* — the derivation audit trail materializes automatically.
+
+### 3.5 Test collector
+
+One parametrized pytest collects every YAML, maps the example's group to the
+corresponding calculator entry point (seam 3) or to `EvaluationInputs`
+end-to-end evaluation (seam 1), runs it with the declared inputs, and compares
+each expected value within its tolerance. Marker: `worked_examples` (fast,
+part of `base`). The collector also validates each example's review
+attestation from the YAML alone (§3.8) and warns (later: fails) on unreviewed
+or stale examples.
+
+### 3.6 CI drift check
+
+CI re-runs the converter and **fails if the committed YAML differs from the
+xlsx output**. This closes both silent failure modes:
+
+- xlsx edited, YAML not regenerated → drift check fails;
+- YAML hand-edited to make a test pass without touching the xlsx → drift check
+  fails.
+
+Conversion remains a manual authoring step; CI only proves the YAML is exactly
+what the xlsx says.
+
+### 3.7 Process rules (not enforceable by tooling)
+
+- An expected value may **not** change in the same PR as engine-code changes
+  unless the YAML's description states the re-derivation. (Protects the
+  independence of the reference — the classic golden-test failure mode is
+  pasting the implementation's output back into the fixture.)
+- The formula-extraction makes a pasted constant visible (constant where a
+  formula should be, caught by validation rule 5), but the last line of defense
+  is review discipline.
+- Every discrepancy in §7 gets a fix-or-freeze decision **before** the first
+  worked example touching that code path is authored — otherwise the example
+  fossilizes the bug.
+
+### 3.8 Review attestations (in the workbook, content-addressed)
+
+Every worked example records whether *this revision* has been human-reviewed.
+Design principles: the attestation lives **in the workbook itself** — the
+reviewer must have the sheet open in Excel to attest — and it is bound to
+content by a fingerprint, never a boolean anyone must remember to reset.
+
+- **Content fingerprint** := shortened SHA-256 (12 hex chars, displayed as
+  `XXXX-XXXX-XXXX`) of the generated YAML **minus its `review:` block**. All
+  semantic content (inputs, formulas, expected values, tolerances) is inside
+  the hash; the attestation itself is not — this breaks the self-reference.
+- The workbook metadata block (§3.2) gains three optional labeled rows:
+  `reviewed_by`, `review_date`, `reviewed_fingerprint`. All three set or all
+  empty (converter validation rule).
+- **Attestation flow:** the converter prints the current fingerprint for every
+  unreviewed example; the reviewer opens the workbook (recalculated, in front
+  of them), performs the §3.2 re-derivation pass, types name + date + the
+  fingerprint into the metadata block, saves, re-runs the converter. The YAML
+  gains a `review:` block; CI's drift check (§3.6) pins it to the sheet.
+- **Auto-reset is pure logic:** any semantic change to the workbook changes
+  the YAML, so the stored fingerprint no longer matches and the example is
+  unreviewed *by definition*. Nothing is cleared; the converter warns
+  "review by &lt;name&gt; is stale (fingerprint mismatch)" until re-reviewed.
+  Cosmetic xlsx edits (formatting, layout) don't reach the YAML and leave the
+  attestation valid. A pasted typo behaves like staleness: mismatch, warning.
+- **The collector (§3.5) validates from the YAML alone** — recompute
+  hash(YAML minus `review:`), compare to the embedded fingerprint — no
+  registry file, no xlsx access in tests. Unreviewed/stale examples emit a
+  pytest warning while `tests/worked_examples/enforcement.yaml` says `warn`;
+  flipping it to `error` after the first review round is a one-line data
+  change.
+- **No tool ever writes an xlsx** (openpyxl destroys cached formula values on
+  save); attesting is always a human action inside Excel.
+- `reviewed_by` complements `computed_by`: machine-drafted examples
+  (`computed_by` naming a tool) start unreviewed by construction and gain
+  fixture-trust only through a human attestation. Attestations are
+  diff-visible despite the binary xlsx, because they appear in the generated
+  YAML.
+- Limitation, accepted: pasting the fingerprint without truly re-deriving
+  defeats the mechanism — same trust boundary as §3.7; the forcing function
+  (file open, explicit paste, attributable name in the PR diff) is the
+  strongest available short of proctoring.
+
+## 4. Deprecated alternative: hand-written YAML
+
+Authoring YAML by hand was considered and rejected: not an enjoyable human
+task, no formula audit trail, and domain experts who should review the
+economics work in Excel, not YAML. Excel-only fixtures (tests parsing xlsx
+directly) were also rejected: binary blobs are invisible in code review, and
+`openpyxl` reads stale cached values without a drift check.
+
+## 5. Complementary verification (what point examples can't catch)
+
+Worked examples are point checks; they miss errors that cancel or sit off the
+tested path.
+
+### 5.1 Invariant / property tests
+
+- **Money conservation** (the killer invariant for a cost model): every euro in
+  the aggregate NPV traces to exactly one cash-flow entry; totals equal the sum
+  of calculator outputs. **Status 2026-08-12: green.** The two conservation
+  tests were written first as strict xfails, and gated the seam-3 cleanups as
+  intended: they flipped to passing with W3.4 (commit c81262ea), which made the
+  subsidy total complete and put every reported support figure in a named unit.
+  W3.3 turned out not to break the invariant — the three category lists answer
+  three different questions and are correct as they stand.
+- Subsidy ≤ eligible cost.
+- NPV at 0% interest = plain sum of the timeline.
+- Doubling consumption doubles the variable part of the bill.
+- Zero-sum actor allocation: sum of payer NPVs = system NPV — per slot for
+  retag-only rulesets, with band-envelope containment where a ruleset mints a
+  transfer pair (B11, envelope semantics; `actors.assert_zero_sum`). A property
+  test over random timelines, in both regimes.
+- **Uncertainty-band properties** (carries the load the degenerate-band worked
+  examples deliberately don't): slot ordering preserved through every
+  operation, `as_revenue` mirroring, envelope semantics of subtraction,
+  slot-wise cap clamping. **Status 2026-08-12: green.** The last strict xfail
+  (B12, the overall subsidy cap applied per slot) flipped with commit e9f3c11a;
+  the §5.1 suite now has no xfails.
+- These hold for all inputs — run them on randomized/property-based inputs,
+  not only curated ones.
+
+### 5.2 Externally published reference examples
+
+The strongest fixtures, because nobody in the team computed them: worked
+examples from the annuity-method standards the spec follows (VDI 2067 /
+EN 15459 annex examples), finance-textbook loan tables, official subsidy
+program illustrative cases (BAFA/KfW). Stored in the same worked-example
+format with `computed_by` citing the source. One passing standard-annex
+example is worth ten homemade sheets.
+
+### 5.3 Independent implementation cross-check
+
+For closed-form parts, tests compare against `numpy_financial`
+(`pmt`, `npv`) on randomized inputs — a third implementation for free.
+(New dev/test dependency.)
+
+## 6. Open questions for review
+
+1. **Package layout depth** (§2.5): sub-packages as proposed, or flat module
+   with enforced import-lint layers only? The import audit shrinks this
+   question: only `bridge.py`, `scenarios.py`, `__main__.py` and the tests
+   import the evaluator, so path churn is minimal. Recommendation: import-lint
+   contracts from day 1 (cheap, reversible), physical sub-packages once seam 3
+   has settled the calculator boundaries.
+2. **Where the seam-2 split of `subsidies.py` lands** — *resolved 2026-08-12*:
+   W2.2/W2.3/W2.5 landed as one package of separate commits (d0f6ffe4,
+   2cffad12, b6d865be) inside `subsidies.py`, with a section banner marking the
+   data/engine cut and the two B-items on that path (B5, B12) fixed alongside
+   (16a69812, e9f3c11a). The *physical* move into `data/` and `engine/` is left
+   to the package split so importers churn once. W2.1/W2.4/W2.6 followed on the
+  same terms (d37167df, db688848, 3ec6e415, 8696c966, e52f065a): seam 2 is
+  behaviorally complete, only the physical `data/` vs `engine/` move is left.
+3. **Long-timeline examples** (§3.2): individual row labels vs. a labeled
+   two-column table convention — decide when the first 40-year example appears.
+4. **Tolerance policy**: default `abs_tol` per unit (0.01 € for money, 1e-6 for
+   rates), overridable per cell, or always explicit as currently specified?
+5. **Which existing tests migrate** into the worked-example format vs. stay as
+   plain pytest. (The VDI-2067 hand examples in `test_economics_engine.py` are
+   the natural first migrations.)
+6. **Tariff contracts in `economic_inputs.json`** (W1.4): embed full contracts
+   vs. reference-by-id + explicit catalog version stamp?
+7. **Fix-or-freeze decisions for §7** — each needs an owner and a call before
+   worked examples freeze the affected path.
+8. **What "total subsidies received" means** (carried out of seam 4, §2.4):
+   **decided (D2, §8) and implemented** — the KPI is the nominal support on the
+   perspective's scoped timeline (`nominal_support_from_entries`), unified with
+   the §6.4 levy basis, no longer the sum of the catalog's upfront award
+   amounts. `views.total_subsidies_received` documents the scoping.
+
+(Resolved since rev. 1: Excel template distribution — one workbook per
+example, §3.1.)
+
+## 7. Appendix: known discrepancies (decide fix-or-freeze before freezing references)
+
+Found while reviewing this plan against the code (2026-08-12). Worked examples
+and golden files pin behavior; each item below must be explicitly fixed, or
+frozen-as-intended with a note, before the reference covering it is authored.
+
+| # | Where | Defect | Impact | Proposed |
+|---|---|---|---|---|
+| B1 | `serialization.py:163-211` | `SubsidyBuildingContext.existing_heating` not serialized; DE catalog conditions on it (`DE.json:140,145`) | Re-pricing from JSON loses BEG speed bonus → wrong subsidies | **Fix now** (independent of refactor; W1.3) |
+| B2 | `evaluator.py:519-527` | Maintenance + fixed opex summed into one entry; category chosen by heuristic (MAINTENANCE if maintenance > 0) | Mislabels fixed opex; DE2024 splits MAINTENANCE landlord/tenant but FIXED_OPERATION is tenant-only → **real money moves between actors** | **Fixed** (commit 375f69d1): `calculators/maintenance.py` emits up to two separately categorized entries per year. No shipped number moved — only VENTILATION_SYSTEM carries both cost kinds and no test priced it — so the fix is pinned by new tests (`TestMaintenanceAndFixedOperation`) instead of a re-baseline |
+| B3 | `subsidies.py:749-750` vs `evaluator.py:915-922` | Solver values repayment grant on gross measure cost; financing applies it to the principal | Solver overstates soft loans whenever `financed_share < 1` (masked: shipped KfW rate is 0.0) | Fix in W3.2 |
+| B4 | `results.py:165-180` vs `evaluator.py:986-991` | `explain()` filters the full timeline; `total_npv` uses the payer-scoped one | `explain("total_npv_in_euro")` returns entries the KPI doesn't contain | **Fixed** (commit fb729175, package S4b — see §2.4). Scoping now has one implementation, `CashFlowTimeline.scoped_to(payer)`: `calculators/aggregation` derives every scoped KPI through it, `LifecycleCostResult.scoped_timeline` returns it, and `_entries_for_path` filters it. `total_npv_in_euro`, `equivalent_annual_cost_in_euro`, `monthly_cost_year1_in_euro`, `npv_by_category[…]` and `npv_by_component[…]` are all scope-filtered figures and now explain themselves from the scoped timeline; `npv_by_payer[actor]` is the one pivot deliberately taken over *all* payers (it exists to show the other side of the split) and stays on the full timeline, where filtering by that payer yields the same entries either way. The change is visible only for actor-scoped perspectives — a tenant-scope `explain("total_npv_in_euro")` used to list the landlord's INVESTMENT entries and no longer does. No existing test asserted the old output, so nothing was re-baselined; two new tests in `TestActorAllocation` pin the scoped and the pivot case, the first also checking that the listed entries sum back to the value they explain |
+| B5 | `evaluator.py:651` → `calculators/subsidy_application.py:149` | Perspective `subsidy_mode` filtered awards *after* the cumulation solve, no re-solve | ONLY/EXCLUDE perspectives can get a non-optimal remainder combination | **Decided 2026-08-12: fixed, filter before the solve** (commit 16a69812). `solve_cumulation`, `assess_schemes` and `required_questions` take an optional `admits(scheme_id)` predicate (a plain predicate, not a `SubsidyMode`, so the subsidy module keeps no dependency on the perspective types); `build_subsidy_flows` passes `subsidy_mode.admits` and no longer post-filters. Eligibility, cumulation, the undetermined bound and the question set now see the same admitted candidate set. Measured effect on the shipped DE catalog: an EXCLUDE perspective dropping the four BEG heat-pump schemes used to receive **0 EUR** (the solver picked the BEG stack, which excludes §35c, and the post-filter deleted it) and now receives the §35c tax credit, 20 % of the eligible cost. No existing test asserted the old behavior, so nothing was re-baselined. |
+| B6 | `subsidies.py:795` vs `:824` | Main cumulation loop enumerates 2^n subsets unguarded; only the optimistic-bound loop caps at n ≤ 16 | Pathological catalog → hang | Fix now (add the same guard) |
+| B7 | `subsidies.py:691-698` | `REDUCED_VAT` / `PayoutKind.VAT_REDUCTION` awards have no consumer anywhere | Dead feature or missing wiring | **Still open** — W2.2 (commit d0f6ffe4) typed the payload as `ReducedVatBenefit(vat_rate)` and documented it as unwired at both ends (the dataclass and the award branch), deliberately neither wiring nor deleting it. Decide: wire into `_eligible_cost_basis` VAT netting, or delete kind |
+| B8 | `reporting.py:1227`, `report_plots.py:93-96`, `:746` | Business rules in chart code: silent `min(subsidy, gross)` clamp duplicated twice; comparison waterfall computes its net bar instead of reading `npv_delta_in_euro` | Displayed numbers can diverge from result object | **Fixed**, in two halves. The clamp moved into `views.subsidy_share_of_gross` with W4.1 (commit 43968df3) and both chart helpers now read it; the waterfall's net bar was closed with W4.7a (commit f6c20c82) — `_waterfall_svg` is handed its net instead of summing its steps, so the comparison waterfall prints `npv_delta_in_euro` and the investment waterfall prints `YearZeroBuildUp.net_outflow_in_euro`. No rendered digit changed (the dropped sub-cent subject deltas were below the display rounding) |
+| B9 | `validation.py:146-158` | `validate_all` never validates `cost_database/tariffs/*.json` | Malformed tariff data ships silently | **Fixed** (commit b6d865be, W2.5): `validate_tariff_contracts` parses every contract, checks id-vs-file-name, the `spot_series` reference and source resolution. Tightened by W2.4b (commit 3ec6e415): an `inline:` source id in a catalog file is an **error**, not a warning, and the shipped dynamic contract cites `src_tariff_synthetic_fixture_2024` — a registry entry labelled as the synthetic test fixture it is. `validate_all()` is now clean of warnings as well as errors |
+| B10 | `bridge.py:266-283` | Inputs post-filtered against cost DB (substring match) and price basis year chosen at extraction, unrecorded | `economic_inputs.json` unfaithful; CLI vs. postprocessing price differently | Fix in W1.1/W1.2 — **done** (commits 7ea9509d, 78698826) |
+| B11 | `actors.py:213-226` | Modernization-levy pair: tenant pays `annual_levy`, landlord receives `annual_levy.as_revenue()` — mirroring makes the pair sum to (min−max, 0, max−min) per slot, so §6.5 zero-sum holds only in BEST_ESTIMATE. (The existing engine zero-sum test is tautological: it compares payer NPVs against the *post*-allocation timeline.) | **Not fixable by a sign flip**: the band-ordering invariant forces the mirror — a slot-coherent transfer entry would have min > max. §3.9 already defines "minimum = best case" for signed flows. | **Decided 2026-08-12: envelope semantics — implemented** (commit aadda132). `assert_zero_sum` asserts exact equality in BEST_ESTIMATE always, and containment otherwise (`payers.minimum ≤ system.minimum`, `system.maximum ≤ payers.maximum`: minting may only *widen* the payer band); `require_per_slot_equality=True` restores the strong form for retag-only rulesets and degenerate levy bases. The invariant test is no longer an xfail and pins the widening to exactly the discounted mirror gap. |
+| B12 | `subsidies.py:719-728` | EU state-aid overall cap scaled all upfront awards by the BEST_ESTIMATE-slot ratio only | With banded cost bases, LOW/HIGH-world support can exceed the same world's eligible cost (or even gross cost); latent while shipped data is degenerate | **Fixed** (commit e9f3c11a): the ratio is computed per slot (`_overall_cap_ratios`) and applied per award (`_scaled_to_cap`). Per-slot ratios are not monotone across the slots (the cap grows with gross cost, the support with the eligible bases, a statutory lump sum not at all), so a plain slot-wise product can order an award's band the wrong way round; each award is therefore capped from the HIGH slot downwards — a slot takes the smaller of its own capped value and the slot above. That gives `min <= best_estimate <= max` by construction, per-slot support ≤ per-slot cap, and award ≤ its own basis, at the price of a slot occasionally leaving support unused (the conservative direction). Degenerate bands — every shipped catalog, `overall_cap_share` being null in DE and AT, and every worked example — are bit-for-bit unchanged. The §5.1 property test is no longer an xfail and now also asserts the stronger "total ≤ gross × cap_share" per slot; the suite carries **no xfails**. |
+
+## 8. Decision log (owner interview, 2026-08-12)
+
+Every consequential call of the implementation phase, decided or ratified
+explicitly by N. Pflugradt. "Ratified" = made during implementation on stated
+rationale, confirmed unchanged; "Decided" = chosen from alternatives here.
+
+| # | Topic | Decision |
+|---|---|---|
+| D1 | B7 `REDUCED_VAT` benefit kind | **Leave typed, unwired**; wiring is a methodology question deferred until a real scheme needs it. |
+| D2 | `total_subsidies_received` KPI | **Decided: switch to the timeline-based nominal figure** (consistent with the W3.4 levy basis; includes flat-shim, operational and repayment-grant support). **Done** (post-interview fixes, commit `62a29877`): the view calls `nominal_support_from_entries` on `result.scoped_timeline()`, so a SYSTEM-scope perspective reports every SUBSIDY entry and an actor scope reports that actor's. Report goldens re-baselined deliberately, four KPI rows only: brownfield_net / financed_net / landlord 10,400.00 [8,320 \| 13,520] → 14,600.00 [11,400 \| 18,840] (the §35c tax credit's three instalments, 1,470 + 1,470 + 1,260, which carry `upfront_amount == 0`), and the tenant row disappears (a tenant receives none of the landlord's support). `cost_summary.md` is unchanged. |
+| D3 | Modernization-levy basis unit | Ratified **nominal** (§559 BGB deducts subsidies as received, undiscounted). |
+| D4 | B5 subsidy-mode filtering | Ratified **pre-solve** (optimizer sees only admitted schemes; non-admitted schemes absent from rejected/undetermined lists). |
+| D5 | B12 overall-cap design | Ratified the **per-slot, HIGH-downward conservative clamp** (cap never overrun; a slot may leave admissible support unused). |
+| D6 | B2 category split | Ratified: fixed operation apportions to tenants in full (BetrKV), maintenance splits — the old lumping was wrong. |
+| D7 | Unresolvable-subject policy | **Decided: FAIL FAST everywhere** — overrides the implemented drop-and-continue. An unresolvable cost subject is a hard error in bridge and CLI alike; `economic_inputs.json` is still written first (faithfulness unchanged). **Done** (post-interview fixes, commit `364c2315`): `drop_unresolvable_subjects` is gone, replaced by `require_resolvable_subjects` raising `UnresolvableSubjectsError(CostDataError)`; the CLI exits 2 with that message, the bridge lets it propagate into postprocessing's existing try/except (legacy outputs unaffected). No silent-drop path remains. See §2.1 W1.1. |
+| D8 | Default tariff contracts on reload | Ratified: recorded in the file, **regenerated** from price entries on reload (keeps scenario price overlays effective); explicit contracts round-trip byte-identical. |
+| D9 | §3.8 enforcement flip | **Keep `warn` indefinitely** — advisory until external/domain-expert reviews are in, not only the owner's attestations. |
+| D10 | Sequencing | Post-interview fixes package first, then carve the PR stack; attestations run in parallel at the owner's pace. |
+| D11 | Publishing | Everything prepared **locally** (branches, PR descriptions as text files); the owner pushes and opens PRs personally. |
+| D12 | Price-basis-year policy | Ratified: simulation year, else earliest covered year **with warning**; explicit parameter always wins. |
+| D13 | Timeline sign validation | Ratified: **on by default** at `CashFlowTimeline.add`, payer-aware for the levy, explicit `validate=False` escape for synthetic test timelines. |
+| D14 | PostProcessingOptions values | Ratified: renumbered 28/29 with main's scheme — values are positional, options are referenced by name. |
+| D15 | Worked-example file layout | Ratified: **one .xlsx per example** (workbook-scoped names; per-example git churn). |
+| D16 | Uncertainty bands in worked examples | Ratified degenerate-only **for now**; **planned extension**: `_min`/`_best_estimate`/`_max` label triples in the template for a few hand-checkable banded examples once the format has proven itself (converter rule 8 to be relaxed then). |
+| D17 | End-to-end example pricing | Ratified: synthetic empty country `XX` — no shipped value can leak into hand-checkable numbers. |
+| D18 | Report goldens | Ratified: normalize **only** the literal run date; every figure, coordinate and tooltip exact; PNGs not goldened. |
+| D19 | Shim / parity formula / explain | Ratified as implemented: legacy flat-subsidy shim marked-not-moved and removed from the overlay surface; parity audit keeps the bare-device-investment formula; `explain` lists scoped entries for scoped figures (B4). |
+| D20 | B11 zero-sum semantics | Decided earlier the same day (see §7 B11): **envelope semantics**, implemented. **Extension, ratified 2026-08-14 (review issue 10):** the same semantics govern the *cumulation solve*, not only the transfer pair. `solve_cumulation` (`subsidies.py`, `slot_getters`) values a candidate combination in the LOW slot at each award's band **maximum** and in the HIGH slot at its **minimum**, because §3.9 defines LOW as the best case for the applicant; the winner reported per slot in `other_slot_optimal_combination` is therefore the combination that is optimal *against the envelope*, evaluated with the most favourable value each award can take, and not the combination that would win in a coherent world where the whole cost basis is simultaneously low. Those are different questions and can have different answers: a scheme whose cap binds only at a high basis can be envelope-optimal in the LOW slot while a coherent low-cost world would have preferred another set. This is the deliberate reading, not a defect — the envelope is what §3.9 publishes everywhere else, and reporting per-slot winners on any other basis would make the slot columns of one report mean two different things. The residual limitation is the one B11 already names (slot-wise combination is not world-coherent); it is stated here so a reviewer meets it in the solver as well as in the levy pair. |
+| D21 | `database.py` module split | **Decided: split into three modules** — `catalog_entries.py` (the row dataclasses, their resolved wrappers and the parsing helpers, with `CostDataError` at the bottom of the import order), `sources.py` (the `sources.json` registry) and `database.py` (`CostDatabase` alone). Rationale: at 804 lines the data layer was the least reviewable PR of the stack, and the file did three separable jobs. Pure code motion; `database.py` re-exports every moved public name via `__all__`, so no importing module changed. |
+| D22 | No module-level constants in `hisim/economics` | **Decided as a lasting convention** (owner preference): the package holds no module-level constants and no mutable module state. Every constant is a class attribute — on the class it belongs to where one exists (`CostDatabase.DEFAULT_PATH`, `DeviceEntry.PER_UNIT_TO_SIZE_UNIT`, `SourceRegistry.SOURCE_KINDS`), otherwise on a namespace class naming the group (`ExportFileNames`, `CategoryRules`, `CheckIds`, `PresentationStyle`). Mutable module globals are banned outright: the warn-once set behind the price-basis-year policy became a class attribute. Values, orderings and file names are unchanged throughout — the goldens and worked examples pin that. Type aliases and `__all__` are not constants and stay. |
+
+| D23 | `FinancingPlan.refinance_replacements` and `ApplicantActor.from_actor` | **Decided: delete both** (review issue 21). The bool was parsed out of a perspective file, serialized and never read — it looked like a switch for financing replacements while every replacement was in fact paid cash or from the §4.2 reserve, which is the more misleading of the two failure modes. Replacement refinancing stays a **possible future feature**: it needs a schedule of its own (a second loan per replacement year, or a revolving facility) plus a decision on how the §4.2 reserve and a refinanced replacement coexist, and should be specified before any field re-appears. `from_actor` was an unused constructor mapping `timeline.Actor` onto applicant roles; the applicant is stated directly on `ApplicantProfile`, and `WEG` has no `Actor` counterpart, so the mapping was never total in the other direction either. A stale perspective file naming the removed field now fails loudly at `FinancingPlan(**raw)` (D7) instead of being silently ignored. |
+| D24 | Package A — engine correctness | **Decided: fix all nine** (review issues 1, 4, 5, 6, 7, 9, 20, 21, interview 2026-08-14). (1) The year-T residual value is emitted only for an installation the timeline actually charged — `is_new_investment` or an in-horizon replacement — so a kept brownfield asset outliving the horizon no longer credits revenue against a cost that was never booked (DIN EN 15459-1: residual value of investments made *within* the calculation period). (4) `operational_co2_by_carrier_in_kg` accumulates instead of assigning, so two meters on one carrier agree with the by-year series. (5) `ProvenanceLedger.from_json` rebuilds the interning index, so `record()` on a rehydrated ledger still deduplicates instead of renumbering ids that exported files reference. (6) The LOAN_TERMS award substitution uses `is not None` for rate, term **and** repayment grant: a stated 0.0 % soft-loan rate survives, and an award that says nothing about a Tilgungszuschuss no longer erases the plan's (`SubsidyAward.loan_repayment_grant_share` becomes `Optional[float] = None`). (7) Monthly peak blocks are sized by ceil division, so a partial-year run keeps the peak of its trailing intervals; at most twelve blocks, the last one short. (9) `robustness_summary` rejects an empty scenario list with a `ScenarioDataError` naming itself, instead of a bare `min()` failure; the slot-aware dominance flag stays defined on the equivalent annual cost. (20) **Not applicable as filed**: the inline category sets `evaluator.py:379/432` reported are gone since the seam-3 slim-down — the module contains no `CostCategory` reference at all and realizes both perspective rules by never generating the flows, which is what `CategoryRules.INVESTMENT_CATEGORIES` / `SUBSIDY_FLOW_CATEGORIES` document declaratively (see `calculators/categories.py`). No code change; the finding is closed as stale. (21) `FeedIn.spot_factor` now scales the integrated spot term of SPOT_REFERENCED feed-in revenue (the markup is unaffected); the two dead names are deleted under D23. |
+| D25 | Package B — fail-fast & diagnostics | **Decided: tighten all eight** (review issues 2, 3, 18, 22, 23, 24, 25a-c, interview 2026-08-14). (2) A component whose class *is* in `FactsExtractors.BY_CLASS_NAME` but whose extractor returns nothing is no longer dropped while counting as PRICED: it becomes an `UnresolvedSubject` on `EvaluationInputs`, is written into `economic_inputs.json` like every other extract, and blocks the D7 resolution check with a reason naming the component and its class. (3) An unmapped or missing `fuel_loadtype` raises `CostDataError` naming the meter instead of billing the fuel at heating-oil prices; the bridge catches it per component so the config error lands on the same D7 path rather than in a swallowed warning. (18) `Component.get_energy_flow_facts` is wired as the meter path — component hook first, `adapter.get_meter_spec` table second, mirroring the §9.1 precedence for cost facts; the two determinants the hook cannot express (capacity peaks, the native billing quantity) still come from the `MeterSpec`, so adopting the hook cannot silently change a fuel meter's billing unit *(the billing-unit half of this is superseded by D26: there is no quantity conversion any more, only peaks)*. (22) An INELIGIBLE scheme names the condition leaf it failed and the answer that failed it ("condition not met: building.construction_year <= 2004 (actual: 2010)"); an `all` names every failing leaf, an `any` reports as "none of: …", a `not` says the child does hold. Catalog schemas unchanged; no golden pinned the old fixed string. (23) A `--parameters` path that does not exist exits 2 with the path in the message instead of silently pricing with the defaults — an omitted flag still means defaults; every other `CostDataError` now reaches the same handler. (24) An unknown carrier in an energy-price file raises a located `CostDataError` (file, entry, known carriers) like the device loader's errors, not a bare `ValueError`. (25a) `load_spot_series` raises on a malformed line with its line number — a skipped hour shifts every later price — while blank lines and a non-numeric first line (the header) stay tolerated. (25b) The negative-flexibility clamp stays for the §8.5 arithmetic, but the raw value now travels on `LifecycleCostResult.raw_flexibility_value_by_carrier` and surfaces as a WARN finding (`CheckIds.CHECK_FLEXIBILITY_VALUE`); the calculator still imports no presentation. (25c) A registered existing asset whose class left the database raises unless the register declares `replacement_cost_override_in_euro` — that override keeps the documented `FALLBACK_SERVICE_LIFE_IN_YEARS`, which is now reachable only on that path. |
+| D26 | Uniform EUR/kWh pricing basis | **Decided: convert the price, never the quantity** (review issue 11, interview 2026-08-14). `energy_bought_in_kwh` now holds kilowatt-hours for every carrier — the adapter's kWh→tons/liters conversion is gone, so the field name, the `EUR/kWh` labels of the report and the plausibility panel, and the number underneath them finally agree. The data files keep their native quotes (EUR/t for pellets and wood chips, EUR/l for oil and diesel) because that is how the cited sources publish them and reviewability of the dataset outranks internal convenience; `CostDatabase.get_energy_price` divides the working price *and* the emission factor by the carrier's lower heating value at resolution time, taking that value from `PhysicsConfig` alone so a bill can never disagree with the physics that produced its kWh, and records the division in the provenance detail ("300 EUR/t ÷ 5000 kWh/t = 0.06 EUR/kWh (LHV: PhysicsConfig PELLETS)") so the published quote survives into the audit trail. Applying the same divisor to price and factor while the quantity gains it back leaves every product unchanged: pellet and wood-chip bills and emissions are bit-for-bit what they were, and the shipped plausibility bands were converted with the same heating values so no band changed what it admits. The only figure that can move is heating oil, whose liters used to come from the fuel meter's configurable `heating_value_of_fuel_in_kwh_per_liter` (default 9.82) rather than from `PhysicsConfig` (9.8217): a meter left on the default bills 0.017 % less than before, and that config field now serves the component's own legacy OPEX report only. |
+| D27 | §559e heating modernization levy | **Decided: implement now, data-driven, with nested caps** (review issue 15, interview 2026-08-14). The dangling `heating_levy_rate_per_year` finally has a consumer: a heating modernization measure is levied at **10 %/year** of its subsidy-reduced basis instead of §559's 8 %, and the rent increase attributable to those measures is capped at **0.50 EUR/m²/month** (`heating_cap_in_euro_per_m2_per_month`). Three sub-decisions. *(a) Classification is data.* `modernization_levy.heating_measure_component_types` in `allocation_DE_2024.json` lists the `ComponentType` names that earn the §559e rate — the §71 GEG 65-%-renewable heat-supply options that exist in `devices_DE.json` (`HEAT_PUMP`, `DISTRICT_HEATING`, `SOLAR_THERMAL_SYSTEM`, `PELLET_HEATER`, `WOOD_CHIP_HEATER`) plus the `THERMAL_ENERGY_STORAGE` installed with them. Fossil `GAS_HEATER`/`OIL_HEATER`, the conditionally compliant `HYDROGEN_HEATER`/`ELECTRIC_HEATER`, the heat emitters and the whole envelope stay at 8 % — the conservative direction, since claiming §559e for a measure that does not qualify overstates a landlord's recoverable rent. An unknown name in the list is a located `CostDataError` (D7), not a silently ignored row. *(b) Caps nest.* The §559e leg is capped first at 0.50 EUR/m²/month; the **total** of both paragraphs then has to fit the existing §559 Abs. 3a cap regime including its low-rent tier. When the total cap binds, the **non-heating leg is reduced first**: it is the larger rate base's natural residual claim, the §559e leg is already individually capped at a small figure, and reducing the heating leg first would leave a landlord with a *lower* total increase for doing the heating measure than for skipping it — the opposite of the incentive §559e exists to create. The heating leg only yields when it alone exceeds the total cap, which the shipped parameters (0.50 < 2.00 < 3.00) never produce. *(c) One booked pair, split derived.* The evaluator now hands the allocation a **per-measure** levy basis (`ModernizationLevyBasis.by_subject`, checked against the aggregate at context assembly), the ruleset classifies it and runs *one* deduction rule (§559 Abs. 2 = §559e Abs. 2) over both pools, and `compute_modernization_levy` returns both legs — but the timeline still books their **sum** as a single tenant/landlord transfer pair. Reason: the total cap couples the legs, so with a banded basis a single leg can carry a slot-reordered band while their sum cannot; booking the legs separately would publish two entries whose slot-wise sum is not the rent increase the tenant pays (the same representability limit as B11). Reports keep their paragraph-agnostic wording. *Consequences:* the zero floor of the basis now applies per paragraph pool rather than to one aggregate, so a package whose heating measure is over-subsidized no longer nets that surplus against its envelope measures; the report goldens' landlord/tenant rows move accordingly (worked example `end_to_end/heating_levy_559e_mixed_package`). |
+| D28 | Package E — honest reporting surfaces, tooling and API hygiene | **Decided: fix all eleven** (review issues 8, 12, 13, 14, 16, 17, 19, 26, 27, 28, 29, interview 2026-08-14). (8) `TariffProvider.CapacityChargeMarginal` emits the contract's capacity price only on a timestep whose draw is at or above the running billing-period peak and 0.0 below it, which is what its own output description promised and what a peak-shaving controller needs; the comparison is made against the peak before the timestep is folded in, so the convergence rollback keeps it stable. (12) `cost_audit.csv` gains a **Price basis** column in front of the three unit-price columns (`EUR/<size unit> (database)` vs `EUR absolute (override)`): the column held two different quantities under one label, and reading an override as a per-unit price understates a subject by orders of magnitude. (13) An `ORIGIN_UNRESOLVED` row is labelled `unresolved - not priced` instead of falling through to the bare string `database entry`, which reported an unpriceable component as if the database had priced it. (14) One `BILL_CATEGORIES`: the definition moves to the kernel (`timeline.CategoryRules`) and `plausibility.PlausibilityCategories` / `views.ViewCategories` bind that object, so the panel's effective-price check and report section 4 cannot drift into checking a price the report does not show. (16) The subsidy cards, the awards table and the markdown bullets de-duplicate by **decision content** (measure plus every scheme's outcome, amount, payout, binding caps and open questions) instead of by measure name, and each distinct decision is annotated with the perspectives that reached it; perspectives that differ in subsidy mode now both appear, where before the first one seen won and the rest vanished. The report goldens move by exactly those annotations and the new table column — no figure changes. (17) `plot_investment_waterfall`'s docstring said the subsidy share is "hatched off"; the code draws two colour-coded stacked segments and always did. Wording only. (19) `write_actor_kpis_into` becomes `actor_kpi_entries` and is **wired** into `build_lifecycle_kpi_entries`, hence into both `lifecycle_kpis.json` and the report's KPI table: the §6.5 actor split reached no KPI file at all. Purely additive names; the landlord/tenant KPIs still sum to the system NPV per slot, which is asserted on the written file. The HTML golden gains those rows for its two actor-scoped perspectives. (26) The worked-example converter's arithmetic cross-check parenthesizes Excel's unary minus, which binds *tighter* than `^` where Python's `**` binds tighter than unary minus: `=-A1^2` was transliterated into a Python expression of the opposite reading and accused a perfectly fresh workbook of being stale. Excel's left-associative `^` chain remains unhandled and keeps failing the check conservatively, which is documented rather than silently wrong. (27) `validation.py` cited `tests/test_economics_data_files.py`, which does not exist; it now points at `test_economics_data_and_integration.py`. (28) Two weak tests pinned: the billing-interval check asserts `CostDataError` and its message instead of bare `Exception`, and `test_break_even_finds_crossing` asserts that a crossing was found, that it lies inside the search range and that the cost difference changes sign across it — it was previously satisfied by "no crossing in range". (29) `Simulator` gains a public read-only `simulation_parameters` property and both `system_setups/economic_example/` setups use it, dropping their `# noqa: SLF001` — reference material is copied, and reaching into a private was the habit it was teaching. |
+
+The two open work items of this log are **done**, as the package "post-interview
+fixes": **D7** (fail-fast; commit `364c2315`) and **D2** (KPI switch, with the
+one sanctioned report-golden re-baseline; commit `62a29877`). D16 is a planned later
+extension, not scheduled.

--- a/tests/test_economics_kernel.py
+++ b/tests/test_economics_kernel.py
@@ -1,0 +1,525 @@
+"""Unit tests for the shared kernel of the lifecycle cost engine (cost_spec.md §3).
+
+The kernel is the part of ``hisim.economics`` that has no cost data and no evaluator behind
+it: uncertainty bands, the cash-flow timeline, the provenance ledger and the fact types the
+components declare. Everything here is verifiable by hand.
+"""
+
+# clean
+
+import pytest
+
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.facts import (
+    BillingDeterminants,
+    ComponentCostFacts,
+    EnergyFlowFacts,
+    ExistingAsset,
+    ExistingAssetRegister,
+)
+from hisim.economics.provenance import ParameterOrigin, ParameterProvenance, ProvenanceLedger
+from hisim.economics.timeline import (
+    Actor,
+    CashFlowEntry,
+    CashFlowTimeline,
+    CategoryRules,
+    CostCategory,
+    SignExpectation,
+    discount_factor,
+    expected_sign,
+    sign_violation,
+)
+from hisim.economics.uncertainty import Slot, UncertainValue
+from hisim.loadtypes import ComponentType, Units
+
+pytestmark = pytest.mark.base
+
+
+class TestUncertainValue:
+    """§3.9 semantics."""
+
+    def test_band_order_enforced(self):
+        """min <= best_estimate <= max is an invariant."""
+        with pytest.raises(ValueError):
+            UncertainValue(best_estimate=1.0, minimum=2.0, maximum=3.0)
+
+    def test_bare_number_means_exact(self):
+        """A bare JSON number is a degenerate band."""
+        band = UncertainValue.from_json(5.0)
+        assert band.is_exact() and band.best_estimate == 5.0
+
+    def test_revenue_mirroring_keeps_order(self):
+        """Optimistic world takes the revenue maximum, sign flips, order holds."""
+        revenue = UncertainValue(best_estimate=10.0, minimum=8.0, maximum=13.0).as_revenue()
+        assert (revenue.minimum, revenue.best_estimate, revenue.maximum) == (-13.0, -10.0, -8.0)
+
+    def test_slotwise_sum(self):
+        """Aggregation is slot-wise."""
+        total = UncertainValue.sum([UncertainValue(2, 1, 3), UncertainValue(20, 10, 30)])
+        assert (total.minimum, total.best_estimate, total.maximum) == (11, 22, 33)
+
+    def test_revenue_mirroring_is_an_involution_up_to_sign(self):
+        """Mirroring twice restores the original band."""
+        band = UncertainValue(best_estimate=10.0, minimum=8.0, maximum=13.0)
+        restored = band.as_revenue().as_revenue()
+        assert (restored.minimum, restored.best_estimate, restored.maximum) == (8.0, 10.0, 13.0)
+
+    def test_empty_sum_is_the_zero_band(self):
+        """Summing nothing yields exact zero, the neutral element."""
+        assert UncertainValue.sum([]).is_exact()
+        assert UncertainValue.sum([]).best_estimate == 0.0
+
+    def test_slot_accessor_matches_the_three_worlds(self):
+        """slot() maps LOW/BEST_ESTIMATE/HIGH onto minimum/best_estimate/maximum."""
+        band = UncertainValue(best_estimate=2.0, minimum=1.0, maximum=3.0)
+        assert band.slot(Slot.LOW) == 1.0
+        assert band.slot(Slot.BEST_ESTIMATE) == 2.0
+        assert band.slot(Slot.HIGH) == 3.0
+
+    def test_subtraction_is_the_envelope_of_the_slot_deltas(self):
+        """A wider subtrahend can make the LOW-world delta the largest one (§3.9)."""
+        minuend = UncertainValue(best_estimate=10.0, minimum=9.0, maximum=11.0)
+        subtrahend = UncertainValue(best_estimate=5.0, minimum=0.0, maximum=20.0)
+        delta = minuend - subtrahend
+        # slot deltas: low 9, best estimate 5, high -9 -> envelope [-9, 9] around the best estimate 5
+        assert delta.best_estimate == pytest.approx(5.0)
+        assert delta.minimum == pytest.approx(-9.0)
+        assert delta.maximum == pytest.approx(9.0)
+
+    def test_subtraction_of_equal_bands_is_exactly_zero(self):
+        """Comparing a variant with itself must not manufacture a spread."""
+        band = UncertainValue(best_estimate=10.0, minimum=8.0, maximum=13.0)
+        assert (band - band).is_exact()
+
+    def test_scale_rejects_negative_factors(self):
+        """A negative factor would invert the slot ordering; as_revenue() is the way to flip signs."""
+        with pytest.raises(ValueError):
+            UncertainValue(best_estimate=2.0, minimum=1.0, maximum=3.0).scale(-1.0)
+
+    def test_scale_is_slotwise_and_keeps_order(self):
+        """Non-negative factors scale every slot."""
+        scaled = UncertainValue(best_estimate=2.0, minimum=1.0, maximum=3.0).scale(2.5)
+        assert (scaled.minimum, scaled.best_estimate, scaled.maximum) == (2.5, 5.0, 7.5)
+
+    def test_clamp_upper_caps_every_slot_separately(self):
+        """Subsidy caps bind per slot (§5.4), so each slot is capped against its own limit."""
+        capped = UncertainValue(best_estimate=100.0, minimum=50.0, maximum=200.0).clamp_upper(
+            UncertainValue(best_estimate=80.0, minimum=80.0, maximum=80.0)
+        )
+        assert (capped.minimum, capped.best_estimate, capped.maximum) == (50.0, 80.0, 80.0)
+
+    def test_multiply_band_rejects_negative_operands(self):
+        """Slot ordering only survives products of non-negative bands."""
+        with pytest.raises(ValueError):
+            UncertainValue(best_estimate=1.0, minimum=-1.0, maximum=3.0).multiply_band(UncertainValue.exact(2.0))
+
+    def test_json_roundtrip_keeps_degenerate_and_real_bands_apart(self):
+        """Exact values serialize as bare numbers, real bands as objects."""
+        assert UncertainValue.exact(3.0).to_json() == 3.0
+        band = UncertainValue(best_estimate=2.0, minimum=1.0, maximum=3.0)
+        assert band.to_json() == {"min": 1.0, "best_estimate": 2.0, "max": 3.0}
+        assert UncertainValue.from_json(band.to_json()) == band
+
+    def test_non_finite_values_are_rejected(self):
+        """Infinities and NaNs must never enter a timeline."""
+        with pytest.raises(ValueError):
+            UncertainValue(best_estimate=float("inf"), minimum=0.0, maximum=float("inf"))
+
+
+def make_entry(year: int, amount: float, category: CostCategory, subject: str = "HeatPump") -> CashFlowEntry:
+    """A cost-positive entry with an exact amount."""
+    return CashFlowEntry(
+        year=year,
+        amount_in_euro=UncertainValue.exact(amount),
+        category=category,
+        subject=subject,
+    )
+
+
+class TestCashFlowTimeline:
+    """§3.6 timeline mechanics."""
+
+    def _timeline(self) -> CashFlowTimeline:
+        timeline = CashFlowTimeline()
+        timeline.extend(
+            [
+                make_entry(0, 16000.0, CostCategory.INVESTMENT),
+                make_entry(1, 400.0, CostCategory.MAINTENANCE),
+                make_entry(2, 400.0, CostCategory.MAINTENANCE),
+                make_entry(1, 1200.0, CostCategory.ENERGY_WORKING, subject="Electricity"),
+            ]
+        )
+        return timeline
+
+    def test_npv_at_zero_percent_is_the_plain_sum(self):
+        """Without discounting the NPV is just the sum of the nominal amounts."""
+        assert self._timeline().npv(0.0).best_estimate == pytest.approx(16000.0 + 400.0 + 400.0 + 1200.0)
+
+    def test_npv_discounts_by_year(self):
+        """Each entry is discounted with (1 + r)^-year."""
+        timeline = CashFlowTimeline()
+        timeline.add(make_entry(2, 1000.0, CostCategory.MAINTENANCE))
+        assert timeline.npv(0.05).best_estimate == pytest.approx(1000.0 / 1.05**2)
+
+    def test_empty_timeline_has_zero_npv(self):
+        """An empty timeline is worth exactly nothing."""
+        assert CashFlowTimeline().npv(0.03).is_exact()
+        assert CashFlowTimeline().npv(0.03).best_estimate == 0.0
+
+    def test_npv_by_pivot_partitions_the_total(self):
+        """The pivot buckets sum back to the undivided NPV."""
+        timeline = self._timeline()
+        by_category = timeline.npv_by(0.04, key=lambda entry: entry.category)
+        assert set(by_category) == {CostCategory.INVESTMENT, CostCategory.MAINTENANCE, CostCategory.ENERGY_WORKING}
+        total = UncertainValue.sum(by_category.values())
+        assert total.best_estimate == pytest.approx(timeline.npv(0.04).best_estimate)
+
+    def test_npv_by_pivots_on_any_key(self):
+        """The key is arbitrary - here the subject rather than the category."""
+        by_subject = self._timeline().npv_by(0.0, key=lambda entry: entry.subject)
+        assert by_subject["Electricity"].best_estimate == pytest.approx(1200.0)
+        assert by_subject["HeatPump"].best_estimate == pytest.approx(16800.0)
+
+    def test_without_categories_drops_exactly_those_categories(self):
+        """The dropped amounts leave the timeline, the rest is untouched."""
+        timeline = self._timeline()
+        reduced = timeline.without_categories(frozenset({CostCategory.ENERGY_WORKING}))
+        assert all(entry.category is not CostCategory.ENERGY_WORKING for entry in reduced.entries)
+        assert reduced.npv(0.0).best_estimate == pytest.approx(timeline.npv(0.0).best_estimate - 1200.0)
+        assert len(timeline.entries) == 4  # the source timeline is not mutated
+
+    def test_filtered_keeps_the_matching_entries(self):
+        """filtered() is the general form of without_categories()."""
+        reduced = self._timeline().filtered(lambda entry: entry.year > 0)
+        assert [entry.year for entry in reduced.entries] == [1, 2, 1]
+
+    def test_nominal_annual_series_sums_per_year(self):
+        """The liquidity view aggregates nominal euros per year, index = year."""
+        series = self._timeline().nominal_annual_series(horizon_years=3)
+        assert [value.best_estimate for value in series] == pytest.approx([16000.0, 1600.0, 400.0, 0.0])
+
+    def test_subjects_are_listed_in_first_appearance_order(self):
+        """Report tables rely on a stable subject order."""
+        assert self._timeline().subjects() == ["HeatPump", "Electricity"]
+
+    def test_entry_copies_do_not_touch_the_original(self):
+        """with_payer/scaled return copies (frozen entries)."""
+        entry = make_entry(0, 1000.0, CostCategory.INVESTMENT)
+        assert entry.with_payer(Actor.TENANT).payer is Actor.TENANT
+        assert entry.payer is Actor.SYSTEM
+        assert entry.scaled(0.25).amount_in_euro.best_estimate == pytest.approx(250.0)
+        assert entry.amount_in_euro.best_estimate == pytest.approx(1000.0)
+
+    def test_scoped_to_system_returns_the_whole_timeline(self):
+        """SYSTEM is the unscoped view - every entry stays (§6, §7 B4)."""
+        timeline = self._timeline()
+        assert timeline.scoped_to(Actor.SYSTEM) is timeline
+
+    def test_scoped_to_a_payer_keeps_only_that_payers_entries(self):
+        """A scoped perspective reports on the flows of one actor only."""
+        timeline = CashFlowTimeline()
+        timeline.extend(
+            [
+                make_entry(0, 16000.0, CostCategory.INVESTMENT).with_payer(Actor.LANDLORD),
+                make_entry(1, 400.0, CostCategory.MAINTENANCE).with_payer(Actor.TENANT),
+            ]
+        )
+        scoped = timeline.scoped_to(Actor.TENANT)
+        assert [entry.category for entry in scoped.entries] == [CostCategory.MAINTENANCE]
+        assert len(timeline.entries) == 2  # the source timeline is not mutated
+
+
+class TestDiscountFactor:
+    """W4.3: one discount formula for the whole module."""
+
+    def test_year_zero_is_undiscounted(self):
+        """Year 0 money is worth its face value."""
+        assert discount_factor(0.05, 0) == pytest.approx(1.0)
+
+    def test_zero_rate_never_discounts(self):
+        """At 0 % every year is worth face value."""
+        assert discount_factor(0.0, 17) == pytest.approx(1.0)
+
+    def test_matches_the_closed_form(self):
+        """1 / (1 + i)^year, by hand."""
+        assert discount_factor(0.04, 3) == pytest.approx(1.0 / 1.04**3)
+
+    def test_timeline_npv_delegates_to_it(self):
+        """`CashFlowTimeline.npv` must not hold a second copy of the formula."""
+        timeline = CashFlowTimeline()
+        timeline.add(make_entry(7, 500.0, CostCategory.MAINTENANCE))
+        assert timeline.npv(0.03).best_estimate == pytest.approx(500.0 * discount_factor(0.03, 7))
+
+
+class TestSignConvention:
+    """W3.7: cost is positive, money arriving is negative - and the two category sets differ."""
+
+    def test_negative_sign_set_is_revenues_plus_loan_disbursement(self):
+        """Band mirroring (REVENUE_CATEGORIES) and sign are deliberately not the same set."""
+        assert CategoryRules.NEGATIVE_SIGN_CATEGORIES == CategoryRules.REVENUE_CATEGORIES | {
+            CostCategory.LOAN_DISBURSEMENT
+        }
+        assert CostCategory.LOAN_DISBURSEMENT not in CategoryRules.REVENUE_CATEGORIES
+
+    def test_cost_categories_are_expected_non_negative(self):
+        """The ordinary case: money leaving is positive."""
+        assert expected_sign(make_entry(0, 1.0, CostCategory.INVESTMENT)) == SignExpectation.NON_NEGATIVE
+        assert expected_sign(make_entry(1, 1.0, CostCategory.ENERGY_WORKING)) == SignExpectation.NON_NEGATIVE
+
+    def test_revenue_categories_are_expected_non_positive(self):
+        """Feed-in, subsidies, residual value and anyway-cost credits arrive."""
+        for category in sorted(CategoryRules.NEGATIVE_SIGN_CATEGORIES, key=lambda item: item.value):
+            assert expected_sign(make_entry(0, -1.0, category)) == SignExpectation.NON_POSITIVE
+
+    def test_modernization_levy_sign_depends_on_the_payer(self):
+        """One category carries a transfer pair: the tenant pays, the landlord receives (§6.4)."""
+        levy = make_entry(1, 1.0, CostCategory.MODERNIZATION_LEVY)
+        assert expected_sign(levy.with_payer(Actor.TENANT)) == SignExpectation.NON_NEGATIVE
+        assert expected_sign(levy.with_payer(Actor.LANDLORD)) == SignExpectation.NON_POSITIVE
+        assert expected_sign(levy) == SignExpectation.NON_NEGATIVE  # unallocated (SYSTEM) reads as the paying leg
+
+    def test_compliant_entries_report_no_violation(self):
+        """sign_violation() returns None for entries that follow the convention."""
+        assert sign_violation(make_entry(0, 16000.0, CostCategory.INVESTMENT)) is None
+        assert sign_violation(make_entry(0, -3000.0, CostCategory.SUBSIDY)) is None
+        assert sign_violation(make_entry(0, 0.0, CostCategory.FEED_IN_REVENUE)) is None
+
+    def test_violation_is_detected_in_any_slot(self):
+        """A band is compliant only if all three slots are - not just the best estimate."""
+        entry = CashFlowEntry(
+            year=0,
+            amount_in_euro=UncertainValue(minimum=-10.0, best_estimate=5.0, maximum=20.0),
+            category=CostCategory.INVESTMENT,
+            subject="HeatPump",
+        )
+        violation = sign_violation(entry)
+        assert violation is not None and violation.expected_sign == SignExpectation.NON_NEGATIVE
+
+    def test_violation_message_names_the_entry(self):
+        """The message has to be usable in an error listing ten violations."""
+        text = str(sign_violation(make_entry(3, 42.0, CostCategory.SUBSIDY)))
+        assert "SUBSIDY" in text and "HeatPump" in text and "year 3" in text and SignExpectation.NON_POSITIVE in text
+
+    def test_add_rejects_a_violating_entry(self):
+        """Validation is on by default, so the engine cannot book a wrong-signed entry."""
+        timeline = CashFlowTimeline()
+        with pytest.raises(ValueError, match="sign convention"):
+            timeline.add(make_entry(0, 500.0, CostCategory.SUBSIDY))
+        assert timeline.entries == []  # nothing was appended
+
+    def test_extend_rejects_the_batch_at_the_first_violation(self):
+        """extend() validates entry by entry."""
+        timeline = CashFlowTimeline()
+        with pytest.raises(ValueError, match="sign convention"):
+            timeline.extend(
+                [
+                    make_entry(0, 16000.0, CostCategory.INVESTMENT),
+                    make_entry(0, 500.0, CostCategory.SUBSIDY),
+                ]
+            )
+        assert len(timeline.entries) == 1  # the compliant entry before it was kept
+
+    def test_validation_can_be_switched_off_for_synthetic_timelines(self):
+        """`validate=False` is the documented escape for hand-written net series."""
+        timeline = CashFlowTimeline(validate=False)
+        timeline.add(make_entry(0, -500.0, CostCategory.MAINTENANCE))
+        assert len(timeline.entries) == 1
+
+    def test_derived_views_inherit_the_validation_flag(self):
+        """filtered()/without_categories()/scoped_to() keep the regime of their source."""
+        timeline = CashFlowTimeline(validate=False)
+        timeline.add(make_entry(0, -500.0, CostCategory.MAINTENANCE))
+        assert timeline.filtered(lambda entry: True).validate is False
+        assert timeline.without_categories(frozenset()).validate is False
+        assert CashFlowTimeline().filtered(lambda entry: True).validate is True
+
+    def test_constructor_entries_bypass_add_and_are_caught_by_validate_signs(self):
+        """Passing `entries=` skips add(), which is exactly what validate_signs() is for."""
+        timeline = CashFlowTimeline(entries=[make_entry(0, 500.0, CostCategory.SUBSIDY)])
+        assert len(timeline.sign_violations()) == 1
+        with pytest.raises(ValueError, match="1 timeline entries violate"):
+            timeline.validate_signs()
+
+    def test_validate_signs_passes_on_a_compliant_timeline(self):
+        """The happy path raises nothing and reports no violations."""
+        timeline = CashFlowTimeline()
+        timeline.extend(
+            [
+                make_entry(0, 16000.0, CostCategory.INVESTMENT),
+                make_entry(0, -3000.0, CostCategory.SUBSIDY),
+                make_entry(0, -8000.0, CostCategory.LOAN_DISBURSEMENT),
+            ]
+        )
+        assert timeline.sign_violations() == []
+        timeline.validate_signs()
+
+
+class TestProvenanceLedger:
+    """§3.10: every number in a result is traceable to a source."""
+
+    def _record(self, parameter: str = "devices_DE.HEAT_PUMP@2024.specific_investment") -> ParameterProvenance:
+        return ParameterProvenance(
+            parameter=parameter,
+            value=UncertainValue(best_estimate=1600.0, minimum=1400.0, maximum=1900.0),
+            origin=ParameterOrigin.DATABASE_ENTRY,
+            data_file="devices_DE.json",
+            source_ids=("DE_BWP_2024",),
+        )
+
+    def test_identical_records_are_interned_under_one_id(self):
+        """Interning keeps cost_provenance.json small and ids stable."""
+        ledger = ProvenanceLedger()
+        first = ledger.record(self._record())
+        second = ledger.record(self._record())
+        assert first == second == 0
+        assert len(ledger) == 1
+
+    def test_different_records_get_ascending_ids(self):
+        """Ids are assigned in insertion order."""
+        ledger = ProvenanceLedger()
+        assert ledger.record(self._record("a")) == 0
+        assert ledger.record(self._record("b")) == 1
+        assert [record.parameter for record in ledger.records] == ["a", "b"]
+        assert ledger.get(1).parameter == "b"
+
+    def test_sourced_origins_without_source_ids_are_rejected(self):
+        """A datapoint without a source cannot enter a calculation."""
+        ledger = ProvenanceLedger()
+        with pytest.raises(ValueError, match="source"):
+            ledger.record(
+                ParameterProvenance(
+                    parameter="devices_DE.HEAT_PUMP@2024.specific_investment",
+                    value=1600.0,
+                    origin=ParameterOrigin.DATABASE_ENTRY,
+                )
+            )
+
+    def test_simulation_outputs_and_engine_defaults_need_no_sources(self):
+        """Those two origins legitimately carry no source ids."""
+        ledger = ProvenanceLedger()
+        for origin in (ParameterOrigin.SIMULATION_OUTPUT, ParameterOrigin.ENGINE_DEFAULT):
+            assert not origin.requires_sources
+            ledger.record(ParameterProvenance(parameter=f"x.{origin.value}", value=1.0, origin=origin))
+        assert len(ledger) == 2
+
+    def test_json_roundtrip_restores_records_and_bands(self):
+        """Archived results stay explainable offline."""
+        ledger = ProvenanceLedger()
+        ledger.record(self._record())
+        restored = ProvenanceLedger.from_json(ledger.to_json())
+        assert restored.records == ledger.records
+        assert isinstance(restored.get(0).value, UncertainValue)
+
+
+class TestFactValidation:
+    """§9.3: components fail fast on their own declarations."""
+
+    def _facts(self, **overrides) -> ComponentCostFacts:
+        arguments = {
+            "asset_class": ComponentType.HEAT_PUMP,
+            "size": 10.0,
+            "size_unit": Units.KILOWATT,
+        }
+        arguments.update(overrides)
+        return ComponentCostFacts(**arguments)
+
+    def test_scalar_overrides_are_coerced_to_exact_bands(self):
+        """A plain number means a degenerate band, so downstream code sees one type."""
+        facts = self._facts(investment_cost_override_in_euro=16000.0, override_source="quote")
+        assert isinstance(facts.investment_cost_override_in_euro, UncertainValue)
+        assert facts.investment_cost_override_in_euro.is_exact()
+
+    def test_non_positive_size_is_rejected(self):
+        """A component with no size cannot be priced."""
+        with pytest.raises(ValueError, match="size"):
+            self._facts(size=0.0)
+
+    def test_unsupported_size_unit_is_rejected(self):
+        """Only the costing units of the database are accepted."""
+        with pytest.raises(ValueError, match="size_unit"):
+            self._facts(size_unit=Units.CELSIUS)
+
+    def test_asset_class_must_be_a_component_type(self):
+        """Raw strings never enter the asset-class field."""
+        with pytest.raises(ValueError, match="asset_class"):
+            self._facts(asset_class="HeatPump")
+
+    def test_count_below_one_is_rejected(self):
+        """Zero devices would silently zero out the investment."""
+        with pytest.raises(ValueError, match="count"):
+            self._facts(count=0)
+
+    def test_negative_maintenance_rate_is_rejected(self):
+        """Maintenance can never be a revenue."""
+        with pytest.raises(ValueError, match="maintenance_rate_override"):
+            self._facts(maintenance_rate_override=UncertainValue(best_estimate=0.01, minimum=-0.01, maximum=0.02))
+
+    def test_non_positive_lifetime_is_rejected(self):
+        """A zero lifetime would divide by zero in the replacement schedule."""
+        with pytest.raises(ValueError, match="lifetime"):
+            self._facts(lifetime_override_in_years=0.0)
+
+    def test_technical_attributes_must_be_json_serializable(self):
+        """They are written to economic_inputs.json and read by subsidy conditions."""
+        with pytest.raises(ValueError, match="JSON"):
+            self._facts(technical_attributes={"scop": object()})
+
+    def test_has_overrides_reports_every_override_field(self):
+        """`override_source` is only required once something is overridden."""
+        assert not self._facts().has_overrides()
+        assert self._facts(lifetime_override_in_years=25.0).has_overrides()
+        assert self._facts(embodied_co2_override_in_kg=1200.0).has_overrides()
+
+    def test_energy_flows_must_be_finite(self):
+        """A NaN meter reading must not reach the billing engine."""
+        with pytest.raises(ValueError, match="finite"):
+            EnergyFlowFacts(carrier=EnergyCarrier.ELECTRICITY, energy_bought_in_kwh=float("nan"))
+
+    def test_billing_determinants_wrap_plain_annual_flows(self):
+        """Flat contracts reuse the simpler EnergyFlowFacts."""
+        determinants = BillingDeterminants.from_energy_flow(
+            EnergyFlowFacts(
+                carrier=EnergyCarrier.ELECTRICITY,
+                energy_bought_in_kwh=2500.0,
+                energy_sold_in_kwh=100.0,
+                simulated_cost_in_euro=800.0,
+            )
+        )
+        assert determinants.carrier is EnergyCarrier.ELECTRICITY
+        assert determinants.energy_bought_in_kwh == pytest.approx(2500.0)
+        assert determinants.energy_sold_in_kwh == pytest.approx(100.0)
+        assert determinants.cost_integrated_in_euro == pytest.approx(800.0)
+
+    def test_existing_asset_age_is_floored_at_zero(self):
+        """A future installation year must not produce a negative age."""
+        asset = ExistingAsset(
+            asset_class=ComponentType.GAS_HEATER,
+            size=15.0,
+            size_unit=Units.KILOWATT,
+            installation_year=2030,
+            energy_carrier=EnergyCarrier.NATURAL_GAS,
+        )
+        assert asset.age_in_years(2024) == 0
+        assert asset.age_in_years(2035) == 5
+
+    def test_existing_asset_size_is_validated(self):
+        """The register uses the same fail-fast rules as the facts."""
+        with pytest.raises(ValueError, match="size"):
+            ExistingAsset(
+                asset_class=ComponentType.GAS_HEATER,
+                size=0.0,
+                size_unit=Units.KILOWATT,
+                installation_year=2005,
+            )
+
+    def test_register_finds_assets_by_class(self):
+        """Brownfield lookups are by asset class."""
+        asset = ExistingAsset(
+            asset_class=ComponentType.GAS_HEATER,
+            size=15.0,
+            size_unit=Units.KILOWATT,
+            installation_year=2005,
+        )
+        register = ExistingAssetRegister(assets=[asset])
+        assert register.find(ComponentType.GAS_HEATER) is asset
+        assert register.find(ComponentType.HEAT_PUMP) is None


### PR DESCRIPTION
# PR 1/8 — Cost module stack: shared kernel

- **Branch:** `cost/01-kernel` (`eedc11ce`)
- **Base:** `main` (`c0e39eb9`)
- **Files:** 14 · **Tests:** 63 passed (`tests/test_economics_kernel.py`)

## What this is

The bottom of the lifecycle cost engine (`cost_spec.md`): the types every later slice is built
from. No cost data, no evaluator, nothing that reads a file. Everything here is verifiable by
hand.

| Module | Spec | What it holds |
|---|---|---|
| `uncertainty.py` | §3.9 | the `(min, avg, max)` band and its slot-wise arithmetic |
| `timeline.py` | §3.6 | cash-flow entries, categories, actors, NPV/pivot/liquidity views, `discount_factor()`, the sign convention |
| `provenance.py` | §3.10 | the interning ledger tying every number to a source |
| `carriers.py` | — | the energy-carrier enum |
| `facts.py` | §3.4, §9.3 | what a component declares about itself, with fail-fast validation |
| `parameters.py` | §3.2 | the economic parameter set |

Also: `cost_spec.md` (methodology), `roadmap/cost-spec-v2.md` (reviewability spec),
`cost_module_issues.md` (defect list), `hisim/economics/README.md` (package overview).

## Changes to existing files — additive only

Two files outside `hisim/economics/` are touched. Both were verified additive by diffing against
`main`; the whole file is taken, and the diff is nothing but the added lines:

- `hisim/loadtypes.py` — eight envelope-measure `ComponentType` members (+12 lines)
- `hisim/postprocessing/kpi_computation/kpi_structure.py` — optional `value_min` / `value_max` on
  `KpiEntry`, so a KPI can carry its uncertainty band (+4 lines)

## Review guide

**Read `uncertainty.py` first and slowly.** Every monetary figure in the other seven PRs is built
out of this type, so an error here is an error everywhere. Check in particular that the band
order invariant (`min <= avg <= max`) cannot be violated by any operation, and that `scale`,
`clamp_upper` and multiplication behave slot-wise.

**Then the sign convention in `timeline.py` (cost-spec-v2 W3.7).** The subtle part, and the
reason sign validation could not be switched on before: `CategoryRules.REVENUE_CATEGORIES` (which
bands get *mirrored* for slot assembly) and `CategoryRules.NEGATIVE_SIGN_CATEGORIES` (which
entries are *negative*) are deliberately **different sets**. `LOAN_DISBURSEMENT` is negative but
not mirrored;
`MODERNIZATION_LEVY` is in neither, because its sign depends on the payer — the tenant pays the
rent increase, the landlord receives it (§6.4). Confirm that reading against §3.9.

**Then `facts.py`.** This is the contract the four adopted components implement in PR 8. Ask
whether the validation is strict enough to catch a component that declares nonsense, because
nothing downstream re-checks it.

### Spec sections
§3.2, §3.4, §3.6, §3.9, §3.10, §9.3 of `cost_spec.md`; W3.7 and W4.3 of `roadmap/cost-spec-v2.md`.

### Test coverage
`tests/test_economics_kernel.py` — 63 tests, all hand-checkable:
`TestUncertainValue` (band arithmetic), `TestCashFlowTimeline` (NPV, pivots, scoping),
`TestDiscountFactor` (W4.3 — one formula for the whole module), `TestSignConvention` (W3.7 — the
payer-dependent levy, per-slot violation detection, the `validate=False` escape),
`TestProvenanceLedger`, `TestFactValidation`.

No worked examples apply yet — those arrive in PR 6 and exercise PRs 3–4.

### Review round 2 in this slice
The kernel category sets moved onto `CategoryRules`, and `BILL_CATEGORIES` is now defined here
**once** (D28 finding 14) — plausibility and views bind that object instead of each holding a
verbatim copy that could drift. Worth confirming the membership is right, since two modules now
depend on it rather than on their own list.

### Package convention introduced here
There are no module-level constants anywhere in `hisim/economics` (spec §8 **D22**). A constant
lives on the class that owns the concept (`UncertainValue.ZERO`) or on a namespace class naming
the group (`CategoryRules`, `SignExpectation`), so each taxonomy is greppable and has one
documented home. Worth checking that the grouping reads naturally — every later PR follows it.

## Push

```bash
git push origin cost/01-kernel

gh pr create --base main --head cost/01-kernel \
  --title "Cost module stack 1/8: shared kernel (uncertainty, timeline, provenance, facts, parameters)" \
  --body-file roadmap/pr_descriptions/01-kernel.md
```
