### PR TITLE
Cost module stack 3/8: subsidy engine, tariff engine, data validation

### DIFF
--- a/cost_module_issues.md
+++ b/cost_module_issues.md
@@ -91,7 +91,7 @@ were resolved with a documented default to keep the implementation moving; they 
     BASEMENT_CEILING_BOTTOM_INSULATION, BASEMENT_WALLS_INTERNAL_INSULATION,
     GROUND_EXTERNAL_INSULATION, WINDOWS_TRIPLE_GLAZED) plus EXTERIOR_DOOR, AIR_SEALING and
     VENTILATION_SYSTEM — with AI-estimate entries for DE/IE 2026/2035, BEG EM envelope schemes
-    (15 % + 5 % iSFP, U-value conditions) plus the `building.has_isfp` question, and three
+    (15 % + 5 % iSFP, U-value conditions) plus the `building.has_renovation_roadmap` question (iSFP in the German catalog; renamed 2026-08-18 per PR-3 review), and three
     engine mechanics (see README §3.2b).
     Decisions taken:
     - **(a)** `energy_related_cost_share` implemented as the coupled-cost (Ohnehin-Kosten)

--- a/hisim/economics/README.md
+++ b/hisim/economics/README.md
@@ -287,7 +287,7 @@ With 35–50 a service lives inside a 20 a horizon, envelope economics are domin
 **residual value** (half the wall insulation cost is credited back at year 20 of a 40 a life)
 — that is the intended VDI 2067 treatment, not a bug. The DE catalog contains the BEG EM
 envelope schemes (15 % base with per-class U-value conditions + 5 % iSFP bonus, capped at
-20 %, mutually exclusive with §35c) and the `building.has_isfp` questionnaire entry.
+20 %, mutually exclusive with §35c) and the `building.has_renovation_roadmap` questionnaire entry (iSFP in the German catalog).
 
 `per_unit` is one of `"kW"`, `"kWh"`, `"liter"`, `"m2"` or `null` (absolute price per device);
 it must match the `size_unit` the component declares — the pre-run resolution check enforces

--- a/hisim/economics/subsidies/__init__.py
+++ b/hisim/economics/subsidies/__init__.py
@@ -1,0 +1,128 @@
+"""Data-driven subsidy engine: EU scheme modeling (cost_spec.md §5).
+
+Schemes live in ``hisim/subsidy_catalog/<COUNTRY>.json``. Eligibility is a small data-only
+predicate language over a typed context; unanswered questions yield tri-state eligibility
+(§5.7). The cumulation solver enumerates admissible combinations and picks the
+NPV-maximizing one on the BEST_ESTIMATE slot, then values it in all three slots (§5.4).
+
+This module answers one question — *how much support does this measure get, from which schemes,
+and on what evidence* — and answers it entirely from data, so that adding a country or a funding
+programme is a catalog edit rather than a code change (§10.1: if the engine needs changing for a
+new country, the schema failed). It is split into two halves by the ``=== engine`` banner in the
+middle of the file: above it the inert catalog payload (schemes, benefits, conditions as data,
+the loader), below it everything that reads a *context* and decides anything (condition
+evaluation, eligibility assessment, cumulation solving, question derivation). The cut is
+deliberate and prepares the §2.5 package split into ``economics/data/`` and ``economics/engine/``.
+
+What the module deliberately does NOT own: cash flows, timelines, discounting policy, perspective
+types and VAT netting. It returns a :class:`SubsidyDecision` of abstract awards; turning those
+into signed timeline entries — and deciding *when* each payout kind lands — is
+``calculators/subsidy_application.py``, the only production caller of :func:`solve_cumulation`.
+The perspective's subsidy mode (§5.5) reaches the solver as a plain ``admits(scheme_id)``
+predicate for the same reason: this module must not depend on ``perspectives.py``. Its other
+consumers are ``validation.py`` (question-coverage and catalog CI, §9.6) and
+``serialization.py`` (round-tripping the context into ``economic_inputs.json``).
+"""
+
+
+from hisim.economics.subsidies.assessment import (
+    EligibilityStatus,
+    MeasureForSubsidy,
+    SchemeAssessment,
+    SubsidyAward,
+    SubsidyContext,
+    SubsidyDecision,
+    describe_condition,
+    evaluate_condition,
+    failed_condition_descriptions,
+    ineligibility_reason,
+    required_questions,
+    assess_schemes,
+)
+from hisim.economics.subsidies.catalog import (
+    Benefit,
+    BenefitField,
+    BenefitKind,
+    BenefitTypes,
+    Condition,
+    EligibleCostSpec,
+    LoanTermsBenefit,
+    LumpSumBenefit,
+    OperationalBenefit,
+    PayoutKind,
+    PerUnitBenefit,
+    Question,
+    QuestionEntry,
+    ReducedVatBenefit,
+    ShareBenefit,
+    SubsidyCatalog,
+    SubsidyScheme,
+    TaxCreditBenefit,
+    parse_benefit,
+    parse_condition,
+    referenced_fields,
+    scheme_context_fields,
+)
+from hisim.economics.subsidies.context import _enumerate_context_fields  # noqa: F401 — unit-tested directly
+from hisim.economics.subsidies.context import (
+    ApplicantActor,
+    ApplicantProfile,
+    HeritageStatus,
+    SubsidyBuildingContext,
+    SubsidyContextFields,
+    SubsidyDataError,
+    question_targets,
+)
+from hisim.economics.subsidies.solver import _combination_awards, _eligible_cost_basis  # noqa: F401 — unit-tested directly
+from hisim.economics.subsidies.solver import (
+    CapRatios,
+    CumulationLimits,
+    solve_cumulation,
+)
+
+__all__ = [
+    "ApplicantActor",
+    "ApplicantProfile",
+    "Benefit",
+    "BenefitField",
+    "BenefitKind",
+    "BenefitTypes",
+    "CapRatios",
+    "Condition",
+    "CumulationLimits",
+    "EligibilityStatus",
+    "EligibleCostSpec",
+    "HeritageStatus",
+    "LoanTermsBenefit",
+    "LumpSumBenefit",
+    "MeasureForSubsidy",
+    "OperationalBenefit",
+    "PayoutKind",
+    "PerUnitBenefit",
+    "Question",
+    "QuestionEntry",
+    "ReducedVatBenefit",
+    "SchemeAssessment",
+    "ShareBenefit",
+    "SubsidyAward",
+    "SubsidyBuildingContext",
+    "SubsidyCatalog",
+    "SubsidyContext",
+    "SubsidyContextFields",
+    "SubsidyDataError",
+    "SubsidyDecision",
+    "SubsidyScheme",
+    "TaxCreditBenefit",
+    "assess_schemes",
+    "describe_condition",
+    "evaluate_condition",
+    "failed_condition_descriptions",
+    "ineligibility_reason",
+    "parse_benefit",
+    "parse_condition",
+    "question_targets",
+    "referenced_fields",
+    "required_questions",
+    "scheme_context_fields",
+    "solve_cumulation",
+]

--- a/hisim/economics/subsidies/assessment.py
+++ b/hisim/economics/subsidies/assessment.py
@@ -1,0 +1,567 @@
+"""Per-scheme eligibility assessment and the questionnaire derivation (cost_spec.md §5.3-§5.5, §5.7).
+
+`SubsidyContext` carries the answers, `evaluate_condition`/`describe_condition` judge and
+explain each condition (D25: an INELIGIBLE scheme names the conditions that failed),
+`assess_schemes` produces one `SchemeAssessment` per scheme, and `required_questions`
+derives what a half-filled context still needs to ask. The award/cumulation math lives
+in `solver`. Split out of the former single-module `subsidies.py` (PR-3 review); the
+package `__init__` re-exports everything.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.facts import ComponentCostFacts
+from hisim.economics.timeline import CostCategory
+from hisim.economics.uncertainty import UncertainValue
+
+
+
+from hisim.economics.subsidies.catalog import (
+    Condition,
+    PayoutKind,
+    Question,
+    SubsidyCatalog,
+    SubsidyScheme,
+    scheme_context_fields,
+)
+from hisim.economics.subsidies.context import (
+    ApplicantProfile,
+    SubsidyBuildingContext,
+    SubsidyDataError,
+    question_targets,
+)
+
+
+@dataclass
+class SubsidyContext:
+    """Full context conditions resolve against: applicant.*, building.*, measure.*.
+
+    The complete set of answers one case supplies — the applicant profile and the building facts —
+    which the caller attaches to a run through ``bridge.EconomicContext`` and which round-trips
+    through ``economic_inputs.json`` so a stored result can be re-priced without re-simulating.
+    The third root, ``measure.*``, is deliberately not stored here: it is the cost facts of the
+    measure currently being assessed and is passed in per call, since one context is evaluated
+    against many measures.
+
+    The context is answered *partially* by design: every unanswered field makes the conditions
+    that touch it undetermined rather than false (§5.7), which is what turns the questionnaire into
+    progressive disclosure instead of a mandatory form.
+    """
+
+    applicant: ApplicantProfile = field(default_factory=ApplicantProfile)
+    building: SubsidyBuildingContext = field(default_factory=SubsidyBuildingContext)
+
+    def resolve_field(self, dotted: str, measure: Optional[ComponentCostFacts]) -> Tuple[bool, Any]:
+        """Resolves a condition field; returns (known, value). Unknown fields raise, unanswered
+        (None) values return (False, None) — the tri-state input (§5.7).
+
+        The single place a dotted condition path becomes a value, and therefore the place the
+        three-valued logic *originates*: a `False` in the first element means "this case has not
+        told us", and it propagates through :func:`evaluate_condition` as UNDETERMINED rather than
+        as a failed condition. Two failure modes are kept strictly apart — an unanswered field is
+        normal and expected, whereas a path the context does not have at all is a catalog defect
+        and raises. Walking stops at the first ``None`` on the path, so a building with no existing
+        heating registered makes ``building.existing_heating.energy_carrier`` — the field the BEG
+        speed bonus tests — unanswered instead of raising, and dictionary hops (the
+        ``measure.technical_attributes.*`` case) treat a missing key the same way. Enum values are
+        unwrapped to their ``.value`` so catalog conditions compare against plain JSON strings.
+
+        Args:
+            dotted: The condition's field path, rooted at applicant, building or measure.
+            measure: Cost facts of the measure under assessment; ``None`` makes every
+                ``measure.*`` path unanswered, which is how :func:`required_questions` resolves
+                fields without a measure at hand.
+
+        Returns:
+            ``(known, value)`` — ``known`` is False exactly when the value is unanswered.
+
+        Raises:
+            SubsidyDataError: On an unknown root or an attribute the context object does not have.
+        """
+        parts = dotted.split(".")
+        root, rest = parts[0], parts[1:]
+        if root == "applicant":
+            value: Any = self.applicant
+        elif root == "building":
+            value = self.building
+        elif root == "measure":
+            if measure is None:
+                return False, None
+            value = measure
+        else:
+            raise SubsidyDataError(f"Unknown condition root {root!r} in field {dotted!r}.")
+        for part in rest:
+            if isinstance(value, dict):
+                if part not in value:
+                    return False, None
+                value = value[part]
+                continue
+            if not hasattr(value, part) and not isinstance(value, dict):
+                raise SubsidyDataError(f"Unknown condition field {dotted!r} (no attribute {part!r}).")
+            value = getattr(value, part)
+            if value is None:
+                return False, None
+        if isinstance(value, enum.Enum):
+            value = value.value
+        return (value is not None), value
+
+
+def evaluate_condition(
+    condition: Condition, context: SubsidyContext, measure: Optional[ComponentCostFacts]
+) -> Tuple[Optional[bool], List[str]]:
+    """Tri-state evaluation: (True/False/None, missing_fields). None = undetermined (§5.7).
+
+    W2.3: the evaluator of the inert :class:`Condition` AST, engine side. Semantics unchanged —
+    a leaf whose field is unanswered (or whose comparison raises `TypeError` on a mistyped
+    answer) is undetermined and reports the field; `all` short-circuits on a definite False,
+    `any` on a definite True; `not` propagates undetermined.
+
+    This tri-state is the heart of §5.7 and the reason eligibility is not a plain boolean: treating
+    "not asked yet" as "does not qualify" would quietly deny support, and treating it as "qualifies"
+    would promise money that may not exist. The `all`/`any` short-circuits mean the missing-field
+    list is deliberately *empty whenever the verdict is definite* — a scheme ruled out by the one
+    answered condition needs no further questions, even if other branches were undetermined. The
+    ``exists`` operator is the one leaf that is never undetermined: it tests answeredness itself
+    and returns a definite verdict either way (its ``value`` is ignored).
+
+    Args:
+        condition: The parsed eligibility tree, or any subtree of it.
+        context: The applicant/building answers available for this case.
+        measure: Cost facts backing the ``measure.*`` paths; ``None`` makes them unanswered.
+
+    Returns:
+        ``(verdict, missing_fields)`` with verdict True/False/None (None = undetermined), and the
+        field names whose answers would settle an undetermined verdict. The list may contain
+        duplicates; callers deduplicate for reporting.
+    """
+    if condition.kind == "leaf":
+        assert condition.fieldname is not None and condition.op is not None
+        known, value = context.resolve_field(condition.fieldname, measure)
+        if condition.op == "exists":
+            return value is not None, []
+        if not known:
+            return None, [condition.fieldname]
+        try:
+            return bool(Condition.CONDITION_OPS[condition.op](value, condition.value)), []
+        except TypeError:
+            return None, [condition.fieldname]
+    results = [evaluate_condition(child, context, measure) for child in condition.children]
+    if condition.kind == "not":
+        verdict, missing = results[0]
+        return (None if verdict is None else not verdict), missing
+    verdicts = [verdict for verdict, _ in results]
+    missing_fields = [fieldname for _, missing in results for fieldname in missing]
+    if condition.kind == "all":
+        if any(verdict is False for verdict in verdicts):
+            return False, []
+        if any(verdict is None for verdict in verdicts):
+            return None, missing_fields
+        return True, []
+    # any
+    if any(verdict is True for verdict in verdicts):
+        return True, []
+    if any(verdict is None for verdict in verdicts):
+        return None, missing_fields
+    return False, []
+
+
+def describe_condition(
+    condition: Condition, context: SubsidyContext, measure: Optional[ComponentCostFacts]
+) -> str:
+    """Renders one condition node as the text an audit trail shows (§5.4, issue #22).
+
+    A leaf becomes ``field op value (actual: answer)`` — the comparison the catalog asked for
+    next to the answer this case gave, which is what makes a rejection checkable without opening
+    the catalog file. Combinators are rendered structurally (``all of``, ``any of``, ``not``) so a
+    nested condition stays readable as one line. Unanswered fields print as ``unanswered`` rather
+    than ``None``, keeping the §5.7 distinction visible in prose too.
+
+    Args:
+        condition: The node to render; any subtree of a scheme's eligibility predicate.
+        context: The case's answers, read only to fill in the ``actual`` part.
+        measure: Cost facts backing ``measure.*`` paths, as in :func:`evaluate_condition`.
+
+    Returns:
+        A single-line description; never empty, so it can always be embedded in a reason.
+    """
+    if condition.kind == "leaf":
+        known, value = context.resolve_field(condition.fieldname or "", measure)
+        actual = repr(value) if known else "unanswered"
+        if condition.op == "exists":
+            return f"{condition.fieldname} exists (actual: {actual})"
+        return f"{condition.fieldname} {condition.op} {condition.value!r} (actual: {actual})"
+    rendered = "; ".join(describe_condition(child, context, measure) for child in condition.children)
+    if condition.kind == "not":
+        return f"not ({rendered})"
+    return f"{condition.kind} of ({rendered})"
+
+
+def failed_condition_descriptions(
+    condition: Condition, context: SubsidyContext, measure: Optional[ComponentCostFacts]
+) -> List[str]:
+    """The leaves responsible for a definite ``False`` verdict, described (§5.4, issue #22).
+
+    Every INELIGIBLE scheme used to carry the same fixed string, so the audit trail could say that
+    a scheme was ruled out but never why — the §5.4 weakening this closes. The walk mirrors
+    :func:`evaluate_condition` exactly, which is what keeps the explanation and the verdict from
+    drifting: it descends only into subtrees that are themselves definitely False.
+
+    The three combinators are described the way they actually fail. An ``all`` fails through
+    *every* failing child, so all of them are named — a case may miss two criteria at once and
+    fixing one would not help. An ``any`` fails only when nothing in it holds, which is one fact
+    about the group rather than several about its members, so it is reported as a single
+    ``none of: …`` line. A ``not`` fails because its child *does* hold, and is reported honestly
+    as such instead of pretending the child failed.
+
+    Args:
+        condition: The scheme's eligibility predicate, or any subtree.
+        context: The applicant/building answers the verdict was reached with.
+        measure: The measure under assessment, backing ``measure.*`` paths.
+
+    Returns:
+        One description per responsible condition, in tree order; empty when this subtree is not
+        definitely False (an undetermined or satisfied branch explains nothing).
+    """
+    verdict, _ = evaluate_condition(condition, context, measure)
+    if verdict is not False:
+        return []
+    if condition.kind == "leaf":
+        return [describe_condition(condition, context, measure)]
+    if condition.kind == "not":
+        return [f"must not hold, but does: {describe_condition(condition.children[0], context, measure)}"]
+    if condition.kind == "any":
+        alternatives = "; ".join(
+            describe_condition(child, context, measure) for child in condition.children
+        )
+        return [f"none of: {alternatives}"]
+    descriptions: List[str] = []
+    for child in condition.children:
+        descriptions.extend(failed_condition_descriptions(child, context, measure))
+    return descriptions
+
+
+def ineligibility_reason(
+    condition: Condition, context: SubsidyContext, measure: Optional[ComponentCostFacts]
+) -> str:
+    """The `rejected_reason` of an INELIGIBLE scheme: which condition(s) it failed (issue #22).
+
+    Wraps :func:`failed_condition_descriptions` into the one string that lands in the decision
+    record, in `cost_summary.md` and in the report's subsidy section. The generic fallback is kept
+    for the case that no leaf can be blamed — an empty ``all`` node, or a tree whose verdict and
+    explanation disagree — so this function always yields a usable reason rather than an empty
+    one.
+    """
+    descriptions = failed_condition_descriptions(condition, context, measure)
+    if not descriptions:
+        return "failed eligibility condition"
+    return "condition not met: " + "; ".join(descriptions)
+
+
+class EligibilityStatus(str, enum.Enum):
+    """Tri-state eligibility (§5.7).
+
+    The verdict of :func:`evaluate_condition` lifted to the scheme level. UNDETERMINED is the
+    member that carries the design: it separates "this case does not qualify" from "we have not
+    asked enough to tell", so the solver can award only what is certain while the decision still
+    reports what the unanswered questions might unlock. Only ELIGIBLE schemes are ever awarded.
+    """
+
+    ELIGIBLE = "ELIGIBLE"
+    INELIGIBLE = "INELIGIBLE"
+    UNDETERMINED = "UNDETERMINED"
+
+
+@dataclass
+class MeasureForSubsidy:
+    """What the evaluator hands the subsidy engine per subsidized measure.
+
+    The request object of the whole engine: one funded thing (a heat pump, a wall insulation), its
+    cost split into the categories a scheme may count, and the technical facts its conditions test.
+    It is assembled by ``calculators/subsidy_application.py`` from the resolved device costing, and
+    it is the boundary that keeps this module free of timelines — the costs arrive as year-0 gross
+    bands, and nothing here knows how or when they will be booked.
+
+    Units, since they are not visible in the field names: ``cost_by_category`` is in euro at year 0,
+    gross of VAT and before any support, per uncertainty slot; ``vat_rate`` is the fraction used to
+    strip VAT when a scheme's basis is NET; the two energy dictionaries are annual kWh per carrier
+    (already annualized from a possibly shorter simulated period) and are read only by OPERATIONAL
+    benefits.
+    """
+
+    subject: str  # the cost subject / component this measure belongs to
+    facts: ComponentCostFacts
+    measure_kind: str  # INSTALL | REPLACE
+    # Year-0 gross cost basis by category (per slot); the eligible-cost basis (§5.2):
+    cost_by_category: Dict[CostCategory, UncertainValue]
+    vat_rate: float = 0.0
+    # Annual bought energy per carrier for OPERATIONAL benefits and sold energy for feed-in style
+    # support (filled by the evaluator):
+    annual_energy_sold_in_kwh: Dict[EnergyCarrier, float] = field(default_factory=dict)
+    annual_energy_bought_in_kwh: Dict[EnergyCarrier, float] = field(default_factory=dict)
+
+
+@dataclass
+class SchemeAssessment:
+    """Eligibility verdict for one scheme applied to one measure.
+
+    The intermediate record between :func:`assess_schemes` and the cumulation solver: it keeps the
+    scheme together with *why* it got its verdict, so that the eventual audit trail can report a
+    rejection or an open question rather than just an absence. Only ELIGIBLE assessments feed the
+    optimization; INELIGIBLE and UNDETERMINED ones are carried into the :class:`SubsidyDecision`.
+    """
+
+    scheme: SubsidyScheme
+    status: EligibilityStatus
+    missing_fields: List[str] = field(default_factory=list)  # set only for UNDETERMINED
+    rejected_reason: Optional[str] = None  # set only for INELIGIBLE
+
+
+@dataclass
+class SubsidyAward:
+    """One awarded benefit, ready to be materialized as timeline entries.
+
+    The solver's output unit: one scheme's support for one measure, already valued in all three
+    uncertainty slots but not yet placed in time or signed. Which fields carry meaning depends
+    entirely on ``payout_kind`` — the record is a flat union rather than a class hierarchy because
+    it has to serialize into the audit trail — and the consumer that reads them is
+    ``calculators/subsidy_application.py`` (grants, schedules, operational payments) together with
+    ``calculators/financing_application.py`` (loan terms).
+
+    All amounts are in **nominal euro, positive, undiscounted, gross of any mirroring**: the sign
+    flip to a revenue-type cash flow happens when the entry is booked (`as_revenue`), not here.
+    """
+
+    scheme_id: str
+    payout_kind: PayoutKind
+    # For UPFRONT_GRANT: amount at year 0. For TAX_CREDIT_SCHEDULE: per-year amounts (years 1..N).
+    upfront_amount: UncertainValue = field(default_factory=lambda: UncertainValue.exact(0.0))
+    schedule_amounts: List[UncertainValue] = field(default_factory=list)
+    # For OPERATIONAL: rate, carrier and duration; amounts are energy-dependent.
+    operational_rate_per_kwh: float = 0.0
+    operational_carrier: Optional[EnergyCarrier] = None
+    operational_duration_years: int = 0
+    # For LOAN_TERMS: FinancingPlan overrides. All three are `None` when the award does not state
+    # them, which `calculators/financing_application.py` reads as "inherit the plan's value" — a
+    # stated 0.0 is an override to zero, not an absent field.
+    loan_interest_rate: Optional[float] = None
+    loan_term_in_years: Optional[int] = None
+    loan_repayment_grant_share: Optional[float] = None
+    # For VAT_REDUCTION:
+    reduced_vat_rate: Optional[float] = None
+    caps_binding_per_slot: Dict[str, bool] = field(default_factory=dict)
+
+
+@dataclass
+class SubsidyDecision:
+    """Fully reported outcome of the cumulation solver (§5.4) — the audit trail.
+
+    Everything the solver did for one measure, not only what it awarded: which schemes applied,
+    which were rejected and why, which stayed undetermined and on which unanswered fields, how much
+    those could still unlock, and whether a *different* combination would have won in the LOW or
+    HIGH world. §5.4 calls this audit trail a research deliverable in its own right and
+    non-negotiable for trust in the results — a subsidy figure that cannot be traced back to named
+    schemes is not reviewable.
+
+    Produced by :func:`solve_cumulation`, carried on the subsidy application result, and surfaced
+    to users in three places: the subsidy decision cards of the HTML report, the ``cost_audit.csv``
+    row of the measure, and the exported JSON via :meth:`to_json`.
+    """
+
+    measure_subject: str
+    applied: List[SubsidyAward] = field(default_factory=list)
+    rejected: List[Dict[str, Any]] = field(default_factory=list)  # scheme id, reason
+    undetermined: List[Dict[str, Any]] = field(default_factory=list)  # scheme id, missing fields
+    # Optimistic upper bound over undetermined schemes ("answering these questions could
+    # unlock up to X", §5.7):
+    undetermined_upper_bound_in_euro: float = 0.0
+    # Whether a different combination would have been optimal in LOW or HIGH (§3.9):
+    other_slot_optimal_combination: Dict[str, Optional[str]] = field(default_factory=dict)
+
+    def to_json(self) -> dict:
+        """Serializes the audit trail.
+
+        The exported form of the decision, embedded under ``subsidy_decisions`` in the result JSON
+        (``results.py``) and from there in ``lifecycle_costs.json``. Every award field is written
+        out regardless of payout kind — including the ones that are meaningless for that kind — so
+        the export schema is stable and a reader can diff two runs field by field; amounts keep
+        their min/best_estimate/max band.
+        """
+        return {
+            "measure_subject": self.measure_subject,
+            "applied": [
+                {
+                    "scheme_id": award.scheme_id,
+                    "payout_kind": award.payout_kind.value,
+                    "upfront_amount": award.upfront_amount.to_json(),
+                    "schedule_amounts": [amount.to_json() for amount in award.schedule_amounts],
+                    "operational_rate_per_kwh": award.operational_rate_per_kwh,
+                    "operational_carrier": award.operational_carrier.value if award.operational_carrier else None,
+                    "operational_duration_years": award.operational_duration_years,
+                    "loan_interest_rate": award.loan_interest_rate,
+                    "loan_term_in_years": award.loan_term_in_years,
+                    "loan_repayment_grant_share": award.loan_repayment_grant_share,
+                    "reduced_vat_rate": award.reduced_vat_rate,
+                    "caps_binding_per_slot": award.caps_binding_per_slot,
+                }
+                for award in self.applied
+            ],
+            "rejected": self.rejected,
+            "undetermined": self.undetermined,
+            "undetermined_upper_bound_in_euro": self.undetermined_upper_bound_in_euro,
+            "other_slot_optimal_combination": self.other_slot_optimal_combination,
+        }
+
+
+
+def assess_schemes(
+    catalog: SubsidyCatalog,
+    measure: MeasureForSubsidy,
+    context: SubsidyContext,
+    year: int,
+    admits: Optional[Callable[[str], bool]] = None,
+) -> List[SchemeAssessment]:
+    """Tri-state eligibility for all candidate schemes of one measure.
+
+    `admits` is the perspective's subsidy-mode filter (§5.5, §7 B5): a scheme it rejects is not
+    assessed at all, so it can neither enter the cumulation solver nor the undetermined bound.
+
+    The step between the jurisdictional pre-filter and the cumulation solver: every candidate is
+    evaluated against the case's answers and classified ELIGIBLE / INELIGIBLE / UNDETERMINED, with
+    the missing fields recorded for the last group. It returns *all three* classes rather than only
+    the winners, because the rejected and undetermined ones are what the audit trail (§5.4) and the
+    questionnaire (§5.7) are built from.
+
+    Args:
+        catalog: The country catalog to draw candidates from.
+        measure: The measure being assessed; its asset class and kind drive the pre-filter and its
+            facts back the ``measure.*`` condition paths.
+        context: The applicant/building answers.
+        year: The year scheme validity is tested against (the price basis year in production).
+        admits: Optional predicate on scheme ids; ``None`` admits everything.
+
+    Returns:
+        One assessment per admitted candidate, in catalog order. A rejection names the condition
+        leaf (or leaves) responsible for it — see :func:`ineligibility_reason` — so the §5.4 audit
+        trail says *why* a scheme was ruled out and not merely that it was.
+    """
+    assessments = []
+    for scheme in catalog.candidate_schemes(
+        measure.facts.asset_class, measure.measure_kind, context.applicant.region, year
+    ):
+        if admits is not None and not admits(scheme.id):
+            continue
+        verdict, missing = evaluate_condition(scheme.eligibility, context, measure.facts)
+        if verdict is True:
+            assessments.append(SchemeAssessment(scheme=scheme, status=EligibilityStatus.ELIGIBLE))
+        elif verdict is False:
+            assessments.append(
+                SchemeAssessment(
+                    scheme=scheme,
+                    status=EligibilityStatus.INELIGIBLE,
+                    rejected_reason=ineligibility_reason(scheme.eligibility, context, measure.facts),
+                )
+            )
+        else:
+            assessments.append(
+                SchemeAssessment(
+                    scheme=scheme, status=EligibilityStatus.UNDETERMINED, missing_fields=sorted(set(missing))
+                )
+            )
+    return assessments
+
+
+
+def required_questions(
+    catalog: SubsidyCatalog,
+    planned_measures: List[MeasureForSubsidy],
+    context: SubsidyContext,
+    year: int,
+    admits: Optional[Callable[[str], bool]] = None,
+) -> List[Question]:
+    """Computes the minimal question set for the candidate schemes (§5.7).
+
+    Collects every context field referenced by the eligibility conditions of candidate
+    schemes, drops already-answered/derivable ones, and orders by pruning power. `admits` is
+    the same subsidy-mode filter the solver takes (§7 B5): a question is only worth asking for
+    a scheme the perspective would actually award.
+
+    This is the "ask exactly the questions that matter for *your* case" half of §5.7, and it is
+    computed rather than curated: because conditions are data over a statically enumerable
+    vocabulary, the question set is derived from the catalog and can never go stale relative to it.
+    Fields are collected via :func:`scheme_context_fields`, so implied dependencies count too — a
+    scheme that prorates by residential share or caps per dwelling unit asks for those even though
+    no condition names them. ``measure.*`` fields are never asked: they come from the simulation and
+    the cost facts. Derived fields are replaced by the user-answerable ones behind them
+    (:func:`question_targets`), and a field with no catalog entry is skipped here and reported by
+    the question-coverage CI instead (§9.6).
+
+    Ordering is by *pruning power*: each candidate scheme's simplified, uncapped, undiscounted
+    support estimate (:meth:`Benefit.value_estimate`) is attributed to every field it depends on, so
+    the questions that gate the most money come first and a user who abandons the form early has
+    still answered the ones that matter. The estimate is deliberately cruder than the solver's
+    valuation — it only has to rank.
+
+    Who renders the result: nothing inside HiSim. The list is designed for a frontend questionnaire,
+    which §5.7 plans to reach through an additive RenoVisor endpoint (§10.1 Phase 4) so the UI needs
+    no scheme knowledge of its own; today the function's in-tree consumers are the tests and, for
+    coverage checking, ``validation.py``.
+
+    Args:
+        catalog: The country catalog whose schemes and question entries are used.
+        planned_measures: The measures the case intends to carry out — they select the candidate
+            schemes and supply the cost/size the pruning estimate is scaled on.
+        context: The answers already given; anything resolvable is not asked again.
+        year: The year scheme validity is tested against.
+        admits: Optional scheme-id predicate implementing the perspective's subsidy mode.
+
+    Returns:
+        The questions to ask, highest pruning power first, each carrying the deduplicated, sorted
+        ids of the schemes that made it necessary.
+    """
+    field_to_schemes: Dict[str, List[str]] = {}
+    scheme_support: Dict[str, float] = {}
+    for measure in planned_measures:
+        for scheme in catalog.candidate_schemes(
+            measure.facts.asset_class, measure.measure_kind, context.applicant.region, year
+        ):
+            if admits is not None and not admits(scheme.id):
+                continue
+            gross = UncertainValue.sum(measure.cost_by_category.values()).best_estimate
+            support = scheme.benefit.value_estimate(gross, measure.facts.size)
+            scheme_support[scheme.id] = max(scheme_support.get(scheme.id, 0.0), support)
+            for fieldname in scheme_context_fields(scheme):
+                field_to_schemes.setdefault(fieldname, []).append(scheme.id)
+    questions: List[Question] = []
+    for fieldname, scheme_ids in field_to_schemes.items():
+        if fieldname.startswith("measure."):
+            continue  # known from the simulation / cost facts, never asked
+        known, _value = context.resolve_field(fieldname, None)
+        if known:
+            continue
+        # Derived fields are asked through the friendly questions behind them (§5.7):
+        for target in question_targets(fieldname):
+            entry = catalog.questions.get(target)
+            if entry is None:
+                continue  # question-coverage CI flags this (§9.6)
+            existing = next((question for question in questions if question.entry.fieldname == target), None)
+            if existing is None:
+                existing = Question(entry=entry)
+                questions.append(existing)
+            existing.asked_because.extend(scheme_ids)
+            existing.pruning_power_in_euro += sum(scheme_support.get(scheme_id, 0.0) for scheme_id in scheme_ids)
+    for question in questions:
+        question.asked_because = sorted(set(question.asked_because))
+    questions.sort(key=lambda question: -question.pruning_power_in_euro)
+    return questions

--- a/hisim/economics/subsidies/catalog.py
+++ b/hisim/economics/subsidies/catalog.py
@@ -1,0 +1,951 @@
+"""Subsidy catalog schema and parsing (cost_spec.md §5.1-§5.2, §5.6).
+
+Everything that turns a `subsidy_catalog/<COUNTRY>.json` file into typed objects:
+conditions, the benefit-kind hierarchy, eligible-cost specs, `SubsidyScheme`,
+questionnaire entries and the `SubsidyCatalog` loader itself. No evaluation happens
+here — that lives in `assessment` and `solver`. Split out of the former single-module
+`subsidies.py` (PR-3 review); the package `__init__` re-exports everything.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import os
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+)
+
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.database import SourceEntry, SourceRegistry
+from hisim.economics.provenance import (
+    ParameterOrigin,
+    ParameterProvenance,
+    ProvenanceLedger,
+    ResolvedSource,
+)
+from hisim.economics.timeline import CostCategory
+from hisim.loadtypes import ComponentType
+
+
+
+from hisim.economics.subsidies.context import SubsidyContextFields, SubsidyDataError
+
+
+@dataclass(frozen=True)
+class Condition:
+    """One node of the eligibility predicate tree (§5.3) — inert catalog payload.
+
+    W2.3: the node carries data only. Parsing it lives in :func:`parse_condition` (data side,
+    called by the catalog loader) and evaluating it in :func:`evaluate_condition` (engine side,
+    below), so the catalog half of this module has no behavior an evaluator could diverge from.
+    """
+
+    #: The comparison operators a leaf may use, and what each one means.
+    CONDITION_OPS: ClassVar[Dict[str, Callable[[Any, Any], bool]]] = {
+        "==": lambda a, b: a == b,
+        "!=": lambda a, b: a != b,
+        "<": lambda a, b: a < b,
+        "<=": lambda a, b: a <= b,
+        ">": lambda a, b: a > b,
+        ">=": lambda a, b: a >= b,
+        "in": lambda a, b: a in b,
+        "contains": lambda a, b: b in a,
+        "exists": lambda a, b: a is not None,
+    }
+
+    kind: str  # "all" | "any" | "not" | "leaf"
+    children: Tuple["Condition", ...] = ()
+    fieldname: Optional[str] = None
+    op: Optional[str] = None
+    value: Any = None
+
+
+def parse_condition(raw: dict, scheme_id: str) -> Condition:
+    """Parses and validates a condition node with clear errors (data side).
+
+    Recursively turns the catalog's ``{"all": [...]}`` / ``{"any": [...]}`` / ``{"not": {...}}`` /
+    ``{"field": ..., "op": ..., "value": ...}`` JSON into the inert :class:`Condition` AST, checking
+    as it goes that the operator is one of the nine allowed ones and that the field name is either
+    part of the statically known vocabulary or a ``measure.*`` path (those address arbitrary
+    ``technical_attributes`` keys and can only be checked when a measure is at hand). Validating at
+    load time rather than at solve time is the whole point of the data-only predicate language:
+    there is no Python ``eval`` anywhere, and a mistyped catalog fails with the scheme id in the
+    message instead of quietly never matching.
+
+    Args:
+        raw: One condition node from the catalog JSON.
+        scheme_id: Owning scheme, used only to make error messages actionable.
+
+    Returns:
+        The parsed node; children are parsed depth-first, so the returned tree is complete.
+
+    Raises:
+        SubsidyDataError: On an unknown operator, an unknown field name, or a node that is neither
+            an ``all``/``any``/``not`` combinator nor a leaf.
+    """
+    if "all" in raw:
+        return Condition(kind="all", children=tuple(parse_condition(child, scheme_id) for child in raw["all"]))
+    if "any" in raw:
+        return Condition(kind="any", children=tuple(parse_condition(child, scheme_id) for child in raw["any"]))
+    if "not" in raw:
+        return Condition(kind="not", children=(parse_condition(raw["not"], scheme_id),))
+    if "field" in raw:
+        fieldname = raw["field"]
+        operator = raw.get("op")
+        if operator not in Condition.CONDITION_OPS:
+            raise SubsidyDataError(f"Scheme {scheme_id}: unknown op {operator!r} in condition on {fieldname!r}.")
+        if not (fieldname in SubsidyContextFields.KNOWN_CONTEXT_FIELDS or fieldname.startswith("measure.")):
+            raise SubsidyDataError(f"Scheme {scheme_id} references unknown field {fieldname!r}.")
+        return Condition(kind="leaf", fieldname=fieldname, op=operator, value=raw.get("value"))
+    raise SubsidyDataError(f"Scheme {scheme_id}: condition node {raw!r} is neither all/any/not nor a leaf.")
+
+
+def referenced_fields(condition: Condition) -> List[str]:
+    """All context fields referenced anywhere in the tree, in tree order (§5.7).
+
+    Duplicates are kept: a field two schemes' conditions test twice weighs twice in the
+    question-ordering heuristic, which is the established behavior.
+    """
+    if condition.kind == "leaf":
+        return [condition.fieldname] if condition.fieldname else []
+    names: List[str] = []
+    for child in condition.children:
+        names.extend(referenced_fields(child))
+    return names
+
+
+class BenefitKind(str, enum.Enum):
+    """Tagged union of benefit kinds (§5.2).
+
+    The *mechanism* a scheme uses to compute its support, surveyed from the schemes actually
+    running in the EU (§5.1): a share of the eligible cost, a stackable bonus share, a fixed lump
+    sum, an amount per unit of size, a multi-year tax credit, a reduced VAT rate, soft-loan terms,
+    or a per-kWh operational payment. The tag selects the typed payload class
+    (:attr:`BenefitTypes.BY_KIND`) that carries the mechanism's parameters, so adding a mechanism
+    means adding a payload type here — adding a *programme* means editing a catalog file only.
+
+    Note the deliberate distinction from :class:`PayoutKind`: a kind here says how much support is
+    computed, a payout kind says when and in what form the money reaches the applicant.
+    ``SHARE_OF_ELIGIBLE_COST`` and ``BONUS_SHARE`` share one payload type and differ only in
+    intent — bonuses are the ones meant to stack on a base rate within a cumulation group.
+    """
+
+    SHARE_OF_ELIGIBLE_COST = "SHARE_OF_ELIGIBLE_COST"
+    BONUS_SHARE = "BONUS_SHARE"
+    LUMP_SUM = "LUMP_SUM"
+    PER_UNIT = "PER_UNIT"
+    TAX_CREDIT = "TAX_CREDIT"
+    REDUCED_VAT = "REDUCED_VAT"
+    SOFT_LOAN = "SOFT_LOAN"
+    OPERATIONAL = "OPERATIONAL"
+
+
+@dataclass(frozen=True)
+class BenefitField:
+    """One JSON key of a benefit payload: how it is named, converted and defaulted.
+
+    The declarative description each benefit payload uses to state its JSON surface (its ``SPEC``),
+    so that :meth:`Benefit.parse` can validate any payload generically — required keys present,
+    unknown keys rejected, values convertible — instead of every kind hand-rolling its own parsing.
+    Keeping the mapping declarative is what lets the loader name both the scheme and the offending
+    key in an error message (W2.2).
+    """
+
+    key: str  # key in the catalog JSON
+    name: str  # field name on the benefit dataclass
+    convert: Callable[[Any], Any]
+    required: bool = True
+    default: Any = None
+
+
+def _shares(raw: Any) -> Tuple[float, ...]:
+    """Converts a JSON list of annual shares into a tuple of floats.
+
+    The converter for :class:`TaxCreditBenefit`'s optional uneven payout schedule. It rejects
+    strings and bytes explicitly because both are iterable and would otherwise be silently
+    accepted character by character; the resulting `TypeError` is turned into a
+    :class:`SubsidyDataError` naming the scheme by :meth:`Benefit.parse`.
+    """
+    if isinstance(raw, (str, bytes)) or not isinstance(raw, Iterable):
+        raise TypeError(f"expected a list of annual shares, got {raw!r}")
+    return tuple(float(item) for item in raw)
+
+
+@dataclass(frozen=True)
+class Benefit:
+    """Typed benefit payload of a scheme (§5.2, W2.2).
+
+    The catalog JSON format is unchanged — ``benefit: {"kind": ..., <parameters>}`` — but the
+    loader parses that dict into one of the frozen subclasses below, so a misspelled or missing
+    parameter fails at load time naming the scheme and the key, instead of surfacing as a
+    ``KeyError`` deep inside the cumulation solver.
+
+    Subclasses declare their JSON surface in :attr:`SPEC`; :attr:`BenefitTypes.BY_KIND` maps each
+    :class:`BenefitKind` to the payload type that implements it.
+    """
+
+    #: The payload's JSON keys, in documentation order.
+    SPEC: ClassVar[Tuple[BenefitField, ...]] = ()
+
+    @classmethod
+    def parse(cls, raw: Dict[str, Any], scheme_id: str, kind: "BenefitKind") -> "Benefit":
+        """Builds the payload from the catalog dict, rejecting missing/unknown/unparsable keys.
+
+        The generic loader for every benefit kind, driven by the subclass's :attr:`SPEC`. Rejecting
+        *unknown* keys as hard as missing ones is deliberate: a typo in a catalog would otherwise be
+        dropped silently and the scheme would pay out at a default rate nobody intended.
+
+        Args:
+            raw: The ``benefit`` object from the catalog with its ``kind`` key already removed.
+            scheme_id: Owning scheme, for error messages.
+            kind: The declared benefit kind, likewise only used in error messages.
+
+        Returns:
+            An instance of the concrete payload class this was called on.
+
+        Raises:
+            SubsidyDataError: If a mandatory key is missing, an unknown key is present, or a value
+                does not convert; the message always names the scheme and the key.
+        """
+        values: Dict[str, Any] = {}
+        for spec in cls.SPEC:
+            if spec.key in raw:
+                try:
+                    values[spec.name] = spec.convert(raw[spec.key])
+                except (TypeError, ValueError, KeyError) as err:
+                    raise SubsidyDataError(
+                        f"Scheme {scheme_id}: benefit key {spec.key!r} of kind {kind.value} is not "
+                        f"a valid {spec.convert.__name__ if hasattr(spec.convert, '__name__') else 'value'} "
+                        f"({raw[spec.key]!r}): {err}."
+                    ) from err
+            elif spec.required:
+                raise SubsidyDataError(
+                    f"Scheme {scheme_id}: benefit of kind {kind.value} misses the mandatory key "
+                    f"{spec.key!r} (expected keys: {[item.key for item in cls.SPEC]})."
+                )
+            else:
+                values[spec.name] = spec.default
+        unknown = sorted(set(raw) - {spec.key for spec in cls.SPEC})
+        if unknown:
+            raise SubsidyDataError(
+                f"Scheme {scheme_id}: benefit of kind {kind.value} has unknown key(s) {unknown} "
+                f"(expected keys: {[item.key for item in cls.SPEC]})."
+            )
+        return cls(**values)
+
+    def value_estimate(self, gross_cost_in_euro: float, measure_size: float) -> float:
+        """Rough upper bound of the support this benefit could unlock, for question ordering.
+
+        The single definition of the *simplified* valuation (§5.7 pruning power): undiscounted,
+        uncapped, on the gross measure cost. The exact, per-slot, capped valuation lives in the
+        cumulation solver (:func:`_combination_awards`); both now read the same typed fields, so
+        the two can no longer drift apart on key names or defaults.
+        """
+        del gross_cost_in_euro, measure_size  # unvalued kinds (loans, VAT, operational support)
+        return 0.0
+
+
+@dataclass(frozen=True)
+class ShareBenefit(Benefit):
+    """A share of the eligible cost — base rate (SHARE_OF_ELIGIBLE_COST) or bonus (BONUS_SHARE).
+
+    The workhorse mechanism of the EU programmes surveyed in §5.1 (BEG EM: 30 % base plus speed,
+    income and efficiency bonuses). It is the only payload the cumulation solver stacks: schemes
+    sharing a ``cumulation_group`` have their rates added and then scaled back to the group's
+    ``combined_rate_cap`` (§5.4), which is why base rate and bonus need no structural distinction
+    here. The rate applies to the *eligible* cost basis of its own scheme — categories, VAT basis,
+    proration and cap are per scheme, so two stacked schemes may compute on different bases.
+    """
+
+    rate: float  # fraction of the eligible cost basis, e.g. 0.30
+
+    SPEC: ClassVar[Tuple[BenefitField, ...]] = (BenefitField("rate", "rate", float),)
+
+    def value_estimate(self, gross_cost_in_euro: float, measure_size: float) -> float:
+        """Rate on the gross cost."""
+        del measure_size
+        return gross_cost_in_euro * self.rate
+
+
+@dataclass(frozen=True)
+class LumpSumBenefit(Benefit):
+    """A fixed amount, clamped to the eligible cost basis when the scheme declares one.
+
+    Models the fixed-grant programmes of §5.1 — Austria's "Raus aus Öl und Gas" boiler-replacement
+    grant, income-banded MaPrimeRénov' amounts — where the support does not scale with what the
+    measure cost. The amount is *exact* in all three uncertainty slots (a statutory number has no
+    band), which is why a lump sum can be the binding constraint in one slot and not another once
+    the overall cap scales it; see :func:`_scaled_to_cap`.
+    """
+
+    amount: float  # euro, year-0 nominal, exact in all slots
+
+    SPEC: ClassVar[Tuple[BenefitField, ...]] = (BenefitField("amount", "amount", float),)
+
+    def value_estimate(self, gross_cost_in_euro: float, measure_size: float) -> float:
+        """The amount itself."""
+        del gross_cost_in_euro, measure_size
+        return self.amount
+
+
+@dataclass(frozen=True)
+class PerUnitBenefit(Benefit):
+    """An amount per unit of measure size (EUR/kW, EUR/m², ... — the unit of the cost facts).
+
+    Covers €/m² insulation grants and €/kWp PV programmes (§5.1). The unit is *not* stated in the
+    catalog: the amount is multiplied by ``ComponentCostFacts.size``, so it silently inherits
+    whatever ``size_unit`` the asset class declares — which is the same unit the device price is
+    quoted in, and is enforced consistent by the pre-run resolution check. Like a lump sum the
+    result is exact in all slots and clamped to the eligible-cost basis.
+    """
+
+    amount: float  # euro per unit of `ComponentCostFacts.size` (kW, m², liter, ...)
+
+    SPEC: ClassVar[Tuple[BenefitField, ...]] = (BenefitField("amount", "amount", float),)
+
+    def value_estimate(self, gross_cost_in_euro: float, measure_size: float) -> float:
+        """Amount times measure size."""
+        del gross_cost_in_euro
+        return self.amount * measure_size
+
+
+@dataclass(frozen=True)
+class TaxCreditBenefit(Benefit):
+    """A share of the eligible cost, paid out over `years` (optionally unevenly).
+
+    Models income-tax deduction programmes — Italy's Ecobonus over ten installments, Germany's
+    §35c EStG (shipped as 20 % over three unevenly split years) — where the *timing* of the payout
+    materially changes the NPV and is therefore not a detail: the solver discounts each installment
+    before comparing combinations. Unlike the share kinds this one does not stack additively in a
+    cumulation group; §35c is expressed as mutually exclusive with the grant programmes via
+    ``excludes``.
+    """
+
+    rate: float  # fraction of the eligible cost basis, spread over `years`
+    years: int  # number of annual installments, starting in year 1
+    annual_shares: Tuple[float, ...] = ()  # optional uneven split; must sum to 1 and match `years`
+
+    SPEC: ClassVar[Tuple[BenefitField, ...]] = (
+        BenefitField("rate", "rate", float),
+        BenefitField("years", "years", int),
+        BenefitField("annual_shares", "annual_shares", _shares, required=False, default=()),
+    )
+
+    def __post_init__(self) -> None:
+        """Validates the payout schedule (§5.2): whole years, shares summing to 1."""
+        if self.years < 1:
+            raise SubsidyDataError(f"Tax credit benefit needs years >= 1, got {self.years}.")
+        if self.annual_shares:
+            if len(self.annual_shares) != self.years:
+                raise SubsidyDataError(
+                    f"Tax credit benefit declares {len(self.annual_shares)} annual_shares for "
+                    f"{self.years} years — the two must agree."
+                )
+            if abs(sum(self.annual_shares) - 1.0) > 1e-9:
+                raise SubsidyDataError(
+                    f"Tax credit benefit annual_shares must sum to 1, got {sum(self.annual_shares)}."
+                )
+
+    def schedule_shares(self) -> Tuple[float, ...]:
+        """Per-year shares of the total credit; even split unless the catalog says otherwise.
+
+        Returns one share per installment year, in order, always summing to 1 (enforced in
+        :meth:`__post_init__`). The cumulation solver multiplies the total credit by these to build
+        the award's ``schedule_amounts``, which land on the timeline in years 1..N — so this is the
+        function that decides how much of a tax credit survives discounting.
+        """
+        if self.annual_shares:
+            return self.annual_shares
+        return tuple(1.0 / self.years for _ in range(self.years))
+
+    def value_estimate(self, gross_cost_in_euro: float, measure_size: float) -> float:
+        """Rate on the gross cost (undiscounted, like the other kinds)."""
+        del measure_size
+        return gross_cost_in_euro * self.rate
+
+
+@dataclass(frozen=True)
+class ReducedVatBenefit(Benefit):
+    """A reduced VAT rate on the measure.
+
+    **Unwired (§7 B7):** the resulting `PayoutKind.VAT_REDUCTION` award has no consumer anywhere
+    in the engine — no VAT netting reads `reduced_vat_rate`. The kind is typed here so a catalog
+    entry is at least well-formed; wiring it (or deleting it) is a separate fix-or-freeze call.
+    """
+
+    vat_rate: float
+
+    SPEC: ClassVar[Tuple[BenefitField, ...]] = (BenefitField("vat_rate", "vat_rate", float),)
+
+
+@dataclass(frozen=True)
+class LoanTermsBenefit(Benefit):
+    """Soft-loan terms: interest rate, term and an optional repayment grant (Tilgungszuschuss).
+
+    A subsidized loan is not a cash grant but an *override of the financing plan* (§4.4): the award
+    carries these terms, ``calculators/financing_application.py`` substitutes them into the
+    :class:`~hisim.economics.financing.FinancingPlan`, and the benefit shows up as the interest the
+    applicant does not pay. The optional repayment grant is the one part that is genuine support in
+    year 0 — note §7 B3: the solver values it on the gross measure cost while financing applies it
+    to the loan principal, which disagree whenever less than the full cost is financed (masked
+    today because the shipped KfW rate is 0.0).
+    """
+
+    interest_rate: float  # nominal annual rate of the subsidized loan
+    term: int  # years
+    repayment_grant_rate: float = 0.0  # share of the principal written off (Tilgungszuschuss)
+
+    SPEC: ClassVar[Tuple[BenefitField, ...]] = (
+        BenefitField("interest_rate", "interest_rate", float),
+        BenefitField("term", "term", int),
+        BenefitField("repayment_grant_rate", "repayment_grant_rate", float, required=False, default=0.0),
+    )
+
+
+@dataclass(frozen=True)
+class OperationalBenefit(Benefit):
+    """A per-kWh payment on one carrier for a number of years (feed-in style support).
+
+    The one benefit kind whose value depends on the *simulation* rather than on the investment:
+    EEG-style feed-in remuneration and heat-generation premiums are paid per kWh actually sold (or,
+    where no sold energy is recorded, bought — see :func:`_support_value`), so the engine can only
+    value it once the meters have reported. Payments run for ``duration_years`` from year 1 and are
+    truncated by the observation horizon when the flows are laid out; the rate is nominal and does
+    not escalate, matching the fixed-for-20-years EEG contract convention (§8.5).
+    """
+
+    rate_per_kwh: float  # euro per kWh of the named carrier, nominal, fixed for the duration
+    carrier: EnergyCarrier  # the carrier whose sold (or bought) energy is paid on
+    duration_years: int  # payment years, counted from year 1
+
+    SPEC: ClassVar[Tuple[BenefitField, ...]] = (
+        BenefitField("rate_per_kwh", "rate_per_kwh", float),
+        BenefitField("carrier", "carrier", EnergyCarrier),
+        BenefitField("duration_years", "duration_years", int),
+    )
+
+
+class BenefitTypes:
+    """The benefit payload type of each kind — the single dispatch table used by loader and
+    engine.
+
+    One table serves both directions: :func:`parse_benefit` uses it to pick the payload class for a
+    catalog entry, and :meth:`SubsidyScheme.__post_init__` uses it to verify that a scheme built in
+    Python pairs its declared kind with the matching payload. Having exactly one mapping is what
+    lets the rest of the module narrow a payload by ``isinstance`` without defensive re-checks.
+    """
+
+    BY_KIND: Dict[BenefitKind, type] = {
+        BenefitKind.SHARE_OF_ELIGIBLE_COST: ShareBenefit,
+        BenefitKind.BONUS_SHARE: ShareBenefit,
+        BenefitKind.LUMP_SUM: LumpSumBenefit,
+        BenefitKind.PER_UNIT: PerUnitBenefit,
+        BenefitKind.TAX_CREDIT: TaxCreditBenefit,
+        BenefitKind.REDUCED_VAT: ReducedVatBenefit,
+        BenefitKind.SOFT_LOAN: LoanTermsBenefit,
+        BenefitKind.OPERATIONAL: OperationalBenefit,
+    }
+
+
+def parse_benefit(raw: Dict[str, Any], scheme_id: str) -> Tuple[BenefitKind, Benefit]:
+    """Parses a catalog `benefit` object into its kind and typed payload (§5.2).
+
+    The entry point the catalog loader uses for the ``benefit`` block: it reads the ``kind`` tag,
+    looks the payload class up in :attr:`BenefitTypes.BY_KIND` and delegates the remaining keys to
+    :meth:`Benefit.parse`. The pair it returns is stored on the scheme as-is, so from here on the
+    engine works with typed fields and never with raw dictionary lookups (W2.2).
+
+    Args:
+        raw: The catalog's ``benefit`` object, including its ``kind`` key.
+        scheme_id: Owning scheme, for error messages.
+
+    Returns:
+        The declared kind and its parsed, frozen payload.
+
+    Raises:
+        SubsidyDataError: If ``kind`` is missing or unknown, or the payload fails to parse.
+    """
+    if "kind" not in raw:
+        raise SubsidyDataError(f"Scheme {scheme_id}: benefit misses the mandatory key 'kind'.")
+    try:
+        kind = BenefitKind(raw["kind"])
+    except ValueError as err:
+        raise SubsidyDataError(
+            f"Scheme {scheme_id}: unknown benefit kind {raw['kind']!r} "
+            f"(known kinds: {[item.value for item in BenefitKind]})."
+        ) from err
+    payload = {key: value for key, value in raw.items() if key != "kind"}
+    return kind, BenefitTypes.BY_KIND[kind].parse(payload, scheme_id, kind)  # type: ignore[attr-defined]
+
+
+class PayoutKind(str, enum.Enum):
+    """How benefits map to timeline entries (§5.2).
+
+    The second half of the benefit model: :class:`BenefitKind` says how much support is computed,
+    this says *when and in what form* it arrives, which is what the timeline needs. The separation
+    matters because the two are not in bijection — the same 30 % share can be paid as a year-0
+    grant in one country and as a multi-year tax deduction in another, and NPV distinguishes them
+    sharply. A scheme declares its payout in the catalog's ``payout.kind`` and defaults to
+    ``UPFRONT_GRANT``; ``calculators/subsidy_application.py`` is the sole interpreter.
+
+    The mapping it implements: ``UPFRONT_GRANT`` → one negative SUBSIDY entry at year 0;
+    ``TAX_CREDIT_SCHEDULE`` → one entry per scheduled year 1..N, truncated at the horizon;
+    ``OPERATIONAL`` → one entry per year of the award's duration, valued on the annualized energy;
+    ``LOAN_TERMS`` → no entry of its own, it overrides the financing plan (§4.4);
+    ``VAT_REDUCTION`` → typed but deliberately unwired, see :class:`ReducedVatBenefit` (§7 B7).
+    """
+
+    UPFRONT_GRANT = "UPFRONT_GRANT"
+    TAX_CREDIT_SCHEDULE = "TAX_CREDIT_SCHEDULE"
+    LOAN_TERMS = "LOAN_TERMS"
+    OPERATIONAL = "OPERATIONAL"
+    VAT_REDUCTION = "VAT_REDUCTION"
+
+
+@dataclass
+class EligibleCostSpec:
+    """Which cost categories count, capped and prorated how (§5.2).
+
+    Defines a scheme's *cost basis* — the euro figure its rate, lump sum or credit is computed on —
+    and it is per scheme, not per measure: two schemes stacking on the same heat pump may count
+    different categories or cap at different ceilings. Four dials, all data: which timeline
+    categories count (investment, planning, removal by default — the removal of the old boiler is
+    fundable, its maintenance is not), whether the basis is gross or net of VAT, whether mixed-use
+    buildings are prorated down to their residential share, and a per-dwelling-unit ceiling.
+    :func:`_eligible_cost_basis` is the one place that applies all four, in that order.
+    """
+
+    categories: List[CostCategory] = field(
+        default_factory=lambda: [CostCategory.INVESTMENT, CostCategory.PLANNING, CostCategory.REMOVAL]
+    )
+    cap_per_dwelling_unit_in_euro: List[float] = field(default_factory=list)  # tiered; empty = uncapped
+    basis: str = "GROSS"  # GROSS | NET (of VAT)
+    proration: str = "NONE"  # NONE | RESIDENTIAL_SHARE
+
+    def cap_for_units(self, dwelling_units: int) -> Optional[float]:
+        """Total eligible-cost cap; tier list, last value repeated for further units.
+
+        Programmes cap the eligible cost per dwelling unit in descending tiers — the shipped BEG
+        entry is 30 k€ for the first unit, 15 k€ for the next five and 8 k€ for every further one —
+        so the building-wide ceiling is the tiered sum, not a flat multiple. Repeating the last
+        tier for all remaining units is the standard "and further units" clause of those directives.
+
+        Args:
+            dwelling_units: Number of dwelling units in the building; values below 1 count as 1.
+
+        Returns:
+            The total cap in euro, or ``None`` when the scheme declares no cap at all — which the
+            caller must distinguish from a cap of 0.
+        """
+        if not self.cap_per_dwelling_unit_in_euro:
+            return None
+        total = 0.0
+        for unit_index in range(max(1, dwelling_units)):
+            tier = min(unit_index, len(self.cap_per_dwelling_unit_in_euro) - 1)
+            total += self.cap_per_dwelling_unit_in_euro[tier]
+        return total
+
+
+@dataclass
+class SubsidyScheme:
+    """One scheme of the catalog (§5.2).
+
+    The in-memory image of one funding programme: where and when it applies, what it applies to,
+    who qualifies, what it pays, on which cost basis, and how it interacts with other schemes.
+    Everything a reviewer needs to check a euro amount against the directive is on this object,
+    including the mandatory ``legal_basis`` and ``url`` — a scheme is a STATUTE-kind source in the
+    sense of §3.10, which is why an unsourced one is refused at load time.
+
+    Schemes are inert: they are read by :meth:`SubsidyCatalog.candidate_schemes` (jurisdiction and
+    validity pre-filter), by :func:`assess_schemes` (eligibility) and by the cumulation solver
+    (stacking, exclusions, valuation). Note that ``cumulation_group`` is a free-text *label*, not a
+    reference to anything, whereas every id in ``excludes`` must name a real scheme — the data-file
+    CI checks the latter.
+    """
+
+    id: str
+    country: str
+    region: Optional[str]  # NUTS code; None = nationwide, matches any applicant region
+    valid_from: str  # ISO date; only the year is used for the validity test
+    valid_to: Optional[str]  # ISO date, None = open-ended
+    legal_basis: str  # mandatory: the directive/statute this encodes
+    url: str  # mandatory: where that text can be read
+    asset_classes: List[ComponentType]
+    measure_kinds: List[str]  # INSTALL | REPLACE
+    eligibility: Condition
+    benefit_kind: BenefitKind
+    benefit: Benefit  # typed, kind-specific parameters (W2.2)
+    eligible_cost: EligibleCostSpec
+    cumulation_group: Optional[str]  # label; schemes sharing it stack additively (share kinds)
+    combined_rate_cap: Optional[float]  # cap on the group's summed rate, e.g. 0.70
+    excludes: List[str]  # scheme ids this one cannot be combined with (symmetric in effect)
+    payout_kind: PayoutKind
+    source_ids: Tuple[str, ...] = ()  # registry ids; mandatory for catalog-loaded schemes (W2.4)
+
+    def __post_init__(self) -> None:
+        """Keeps `benefit_kind` and the typed payload in sync (W2.2)."""
+        expected = BenefitTypes.BY_KIND[self.benefit_kind]
+        if not isinstance(self.benefit, expected):
+            raise SubsidyDataError(
+                f"Scheme {self.id}: benefit kind {self.benefit_kind.value} needs a "
+                f"{expected.__name__}, got {type(self.benefit).__name__}."
+            )
+
+    def applies_to(self, asset_class: ComponentType, measure_kind: str) -> bool:
+        """Whether the scheme covers the measure at all.
+
+        The cheapest of the pre-filters: a scheme only enters the candidate set for an asset class
+        it names and a measure kind (INSTALL / REPLACE) it funds. The distinction matters because
+        several programmes — the BEG speed bonus is the obvious one — exist precisely to reward
+        *replacing* a working fossil system and must not pay for a new-build installation.
+        """
+        return asset_class in self.asset_classes and measure_kind in self.measure_kinds
+
+
+def scheme_context_fields(scheme: SubsidyScheme) -> List[str]:
+    """Every context field a scheme depends on (§5.7) — the one definition of that set.
+
+    Two sources: the eligibility conditions, and the eligible-cost spec, which needs the
+    residential share when it prorates and the dwelling-unit count when it caps per unit.
+    Question derivation and question-coverage validation both read this, so a new implied
+    dependency is added once.
+    """
+    names = list(referenced_fields(scheme.eligibility))
+    if scheme.eligible_cost.proration == "RESIDENTIAL_SHARE":
+        names.append("building.residential_share")
+    if scheme.eligible_cost.cap_per_dwelling_unit_in_euro:
+        names.append("building.dwelling_units")
+    return names
+
+
+@dataclass
+class QuestionEntry:
+    """One localized question of the questionnaire catalog (§5.7).
+
+    The presentation half of a context field: how to ask a user for it, in every supported
+    language, with the answer options and the help text that explains why it matters. Entries live
+    in ``subsidy_catalog/questions_<COUNTRY>.json`` keyed by the context field they fill, and the
+    data-file CI (§9.6) fails if any field referenced by a shipped scheme has no entry — that check
+    is what keeps the questionnaire complete by construction rather than by review.
+    """
+
+    fieldname: str  # the context field this answer fills, e.g. "building.heritage_status"
+    answer_kind: str  # BOOLEAN | CHOICE | NUMBER | YEAR | INCOME_BAND
+    question: Dict[str, str]  # language code -> question text (de, en)
+    options: List[str] = field(default_factory=list)  # CHOICE: the admissible raw values
+    option_labels: Dict[str, Dict[str, str]] = field(default_factory=dict)  # language -> value -> label
+    help_text: Dict[str, str] = field(default_factory=dict)  # language -> explanatory text
+    unit: Optional[str] = None  # NUMBER: the unit to display, e.g. "m2"
+
+
+@dataclass
+class Question:
+    """A question to ask, with the schemes that made it necessary ("asked because").
+
+    What :func:`required_questions` returns: a catalog entry plus the derived justification for
+    asking it. ``asked_because`` lets a frontend show *why* a question appears and can never go
+    stale relative to the catalog, since it is computed from the conditions rather than curated;
+    ``pruning_power_in_euro`` is the ordering key that puts the most consequential question first,
+    so a user who stops answering early has still answered the questions that mattered most.
+    """
+
+    entry: QuestionEntry
+    asked_because: List[str] = field(default_factory=list)  # scheme ids
+    # Upper bound of support the answer could unlock (ordering heuristic, §5.7):
+    pruning_power_in_euro: float = 0.0
+
+
+class SubsidyCatalog:
+    """One country catalog plus the question catalog and source registry.
+
+    The loaded, validated content of ``subsidy_catalog/<COUNTRY>.json`` and its companion
+    ``questions_<COUNTRY>.json``: every scheme of that jurisdiction, the localized questionnaire
+    entries, the country-level state-aid ceiling and the ``sources.json`` entries the schemes cite.
+    It is the sole entry point to catalog data — the engine below never opens a file — and is
+    attached to an evaluation through ``EconomicParameters.subsidy_catalog_path``; where no path is
+    set, no catalog is loaded at all and the §10.1 legacy flat shim applies instead.
+
+    A catalog can also be built in Python (tests, worked examples), in which case it carries no
+    registry and its schemes record ``IN_MEMORY_DEFINITION`` provenance rather than citing sources.
+    """
+
+    #: Default on-disk location of the shipped subsidy catalogs — `hisim/subsidy_catalog`,
+    #: three levels up from this file now that `subsidies` is a package.
+    DEFAULT_PATH: ClassVar[str] = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "subsidy_catalog"
+    )
+
+    def __init__(
+        self,
+        schemes: List[SubsidyScheme],
+        questions: Dict[str, QuestionEntry],
+        snapshot_date: Optional[str],
+        overall_cap_share: Optional[float],
+        base_path: str,
+        country: str,
+        sources: Optional[Dict[str, SourceEntry]] = None,
+    ) -> None:
+        """Built by :meth:`load`.
+
+        `sources` are the registry entries the loader resolved this catalog's `source_ids`
+        against (W2.4). A catalog built in Python (tests, worked examples) passes none: its
+        schemes then mint `IN_MEMORY_DEFINITION` provenance instead of citing registry ids.
+        """
+        self.schemes = schemes
+        self.questions = questions
+        self.snapshot_date = snapshot_date
+        self.overall_cap_share = overall_cap_share
+        self.base_path = base_path
+        self.country = country
+        #: Resolved `sources.json` entries by id — the resolution `load` used to be thrown away
+        #: (W2.4), which is why the evaluator had to fabricate `inline:` ids.
+        self.sources: Dict[str, SourceEntry] = dict(sources or {})
+
+    @classmethod
+    def load(cls, country: str, base_path: Optional[str] = None) -> "SubsidyCatalog":
+        """Loads and validates `<base_path>/<COUNTRY>.json` plus `questions_<COUNTRY>.json`.
+
+        Everything the catalog schema can be checked for statically is checked here, so that a
+        malformed programme is a load error naming the scheme rather than a wrong euro amount much
+        later: ``legal_basis``, ``url``, ``benefit`` and ``source_ids`` are mandatory, the benefit
+        payload is parsed into its typed form (§5.2, W2.2), the eligibility tree is parsed and its
+        field names checked against the context vocabulary (§5.3), and every cited source id is
+        resolved against ``sources.json`` and kept for the provenance ledger (W2.4). The question
+        file is optional at this level — its *completeness* is a CI check (§9.6), not a load error,
+        so a catalog under development still loads.
+
+        Args:
+            country: ISO country code selecting both file names.
+            base_path: Directory holding the catalog; defaults to the shipped
+                :attr:`DEFAULT_PATH`.
+
+        Returns:
+            The loaded catalog, with resolved source entries attached.
+
+        Raises:
+            SubsidyDataError: If no catalog file exists for the country, or any scheme violates the
+                schema (missing mandatory field, unknown benefit kind or asset class, unparsable
+                condition, no source ids).
+        """
+        base = base_path or SubsidyCatalog.DEFAULT_PATH
+        catalog_path = os.path.join(base, f"{country}.json")
+        if not os.path.isfile(catalog_path):
+            raise SubsidyDataError(f"No subsidy catalog for country {country!r} at {catalog_path}.")
+        with open(catalog_path, encoding="utf-8") as file:
+            raw = json.load(file)
+        sources_path = os.path.join(base, "sources.json")
+        registry = SourceRegistry.load(sources_path) if os.path.isfile(sources_path) else None
+        resolved_sources: Dict[str, SourceEntry] = {}
+        schemes = []
+        for item in raw.get("schemes", []):
+            scheme_id = item.get("id", "<missing id>")
+            for mandatory in ("legal_basis", "url"):
+                if not item.get(mandatory):
+                    raise SubsidyDataError(f"Scheme {scheme_id}: mandatory field {mandatory!r} missing (§5.2).")
+            if "benefit" not in item:
+                raise SubsidyDataError(f"Scheme {scheme_id}: mandatory field 'benefit' missing (§5.2).")
+            benefit_kind, benefit = parse_benefit(dict(item["benefit"]), scheme_id)
+            eligible_raw = item.get("eligible_cost", {})
+            cumulation = item.get("cumulation", {})
+            source_ids = tuple(item.get("source_ids", []))
+            if not source_ids:
+                raise SubsidyDataError(
+                    f"Scheme {scheme_id}: source_ids are mandatory for catalog schemes — an "
+                    "unsourced scheme is not admissible (§3.10, W2.4)."
+                )
+            if registry is not None:
+                for entry in registry.resolve(source_ids, f"scheme {scheme_id}"):
+                    resolved_sources[entry.source_id] = entry
+            schemes.append(
+                SubsidyScheme(
+                    id=scheme_id,
+                    country=item["jurisdiction"]["country"],
+                    region=item["jurisdiction"].get("region"),
+                    valid_from=item.get("valid_from", "1900-01-01"),
+                    valid_to=item.get("valid_to"),
+                    legal_basis=item["legal_basis"],
+                    url=item["url"],
+                    asset_classes=[
+                        _component_type(name, scheme_id) for name in item["applies_to"]["asset_classes"]
+                    ],
+                    measure_kinds=list(item["applies_to"].get("measure_kinds", ["INSTALL", "REPLACE"])),
+                    eligibility=parse_condition(item.get("eligibility", {"all": []}), scheme_id),
+                    benefit_kind=benefit_kind,
+                    benefit=benefit,
+                    eligible_cost=EligibleCostSpec(
+                        categories=[
+                            CostCategory(cat)
+                            for cat in eligible_raw.get("categories", ["INVESTMENT", "PLANNING", "REMOVAL"])
+                        ],
+                        cap_per_dwelling_unit_in_euro=list(eligible_raw.get("cap_per_dwelling_unit_in_euro", [])),
+                        basis=eligible_raw.get("basis", "GROSS"),
+                        proration=eligible_raw.get("proration", "NONE"),
+                    ),
+                    cumulation_group=cumulation.get("group"),
+                    combined_rate_cap=cumulation.get("combined_rate_cap"),
+                    excludes=list(cumulation.get("excludes", [])),
+                    payout_kind=PayoutKind(item.get("payout", {}).get("kind", "UPFRONT_GRANT")),
+                    source_ids=source_ids,
+                )
+            )
+        questions = {}
+        questions_path = os.path.join(base, f"questions_{country}.json")
+        if os.path.isfile(questions_path):
+            with open(questions_path, encoding="utf-8") as file:
+                questions_raw = json.load(file)
+            for item in questions_raw.get("questions", []):
+                questions[item["field"]] = QuestionEntry(
+                    fieldname=item["field"],
+                    answer_kind=item["answer_kind"],
+                    question=item["question"],
+                    options=item.get("options", []),
+                    option_labels=item.get("option_labels", {}),
+                    help_text=item.get("help", {}),
+                    unit=item.get("unit"),
+                )
+        return cls(
+            schemes=schemes,
+            questions=questions,
+            snapshot_date=raw.get("catalog_snapshot_date"),
+            overall_cap_share=raw.get("overall_cap_share"),
+            base_path=base,
+            country=country,
+            sources=resolved_sources,
+        )
+
+    # ------------------------------------------------------------------ provenance (§3.10, W2.4)
+
+    def scheme_by_id(self, scheme_id: str) -> Optional[SubsidyScheme]:
+        """The scheme with that id, or None (awards carry ids, not scheme objects).
+
+        A :class:`SubsidyAward` deliberately references its scheme by id so that decisions stay
+        serializable into the audit trail; this is how a consumer gets back to the scheme's legal
+        basis, most importantly ``calculators/subsidy_application.py`` when it mints an award's
+        provenance record.
+        """
+        return next((scheme for scheme in self.schemes if scheme.id == scheme_id), None)
+
+    def resolved_sources(self, scheme: SubsidyScheme) -> List[SourceEntry]:
+        """Registry entries backing one scheme — empty for in-memory catalogs.
+
+        Returns the ``sources.json`` entries this catalog resolved for the scheme's ``source_ids``
+        at load time, skipping any id the registry did not contain. An empty result is meaningful
+        rather than an error: it identifies a scheme defined in Python, which has no registry
+        behind it and is recorded as :attr:`ParameterOrigin.IN_MEMORY_DEFINITION`.
+        """
+        return [self.sources[source_id] for source_id in scheme.source_ids if source_id in self.sources]
+
+    def source_resolver(self) -> Dict[str, ResolvedSource]:
+        """This catalog's registry entries in the report representation (§3.10).
+
+        Hands the subsidy registry to the result object, which merges it with the cost database's
+        registry — the two id spaces are disjoint — so that a subsidy flow explained through the
+        provenance ledger resolves to a real citation instead of a bare id. Consumed by the
+        "sources used" table of the report and by the ``explain`` CLI.
+        """
+        return {source_id: entry.to_resolved() for source_id, entry in self.sources.items()}
+
+    def provenance_for_scheme(
+        self, scheme: SubsidyScheme, ledger: ProvenanceLedger, value: Any
+    ) -> int:
+        """Records the ledger entry backing one award of `scheme` (W2.4).
+
+        A catalog-loaded scheme cites the registry ids its `sources.json` resolution produced at
+        load time, so `explain` reaches the legal text a subsidy came from; the scheme's own
+        `legal_basis` and `url` — which are scheme *fields*, not registry entries — ride along in
+        `detail`. A scheme defined in Python (tests, worked examples) has no registry behind it
+        and is recorded as :attr:`ParameterOrigin.IN_MEMORY_DEFINITION`, which is honest about
+        having no source, instead of the `inline:` pseudo-ids this replaced.
+        """
+        detail = f"{scheme.legal_basis} <{scheme.url}>"
+        if scheme.source_ids:
+            return ledger.record(
+                ParameterProvenance(
+                    parameter=f"subsidy.{scheme.id}",
+                    value=value,
+                    origin=ParameterOrigin.DATABASE_ENTRY,
+                    data_file=f"subsidy_catalog/{self.country}.json#{scheme.id}",
+                    source_ids=scheme.source_ids,
+                    detail=detail,
+                )
+            )
+        return ledger.record(
+            ParameterProvenance(
+                parameter=f"subsidy.{scheme.id}",
+                value=value,
+                origin=ParameterOrigin.IN_MEMORY_DEFINITION,
+                data_file=None,
+                source_ids=(),
+                detail=detail,
+            )
+        )
+
+    def candidate_schemes(
+        self, asset_class: ComponentType, measure_kind: str, region: Optional[str], year: int
+    ) -> List[SubsidyScheme]:
+        """Pre-filter by jurisdiction, asset class and validity (§5.7).
+
+        The first stage of every subsidy computation: it narrows the whole catalog to the schemes
+        that *could* apply to one measure before any context is looked at, which keeps the
+        exponential cumulation solver working on a handful of schemes and keeps the question
+        derivation from asking about programmes the case can never reach. A scheme with no region
+        is nationwide and matches any applicant; a regional scheme matches only its own region, and
+        an applicant who did not state a region is offered regional schemes too (the eligibility
+        conditions can still reject them). Validity is tested on the *year* parsed from the ISO
+        dates against the price basis year, i.e. against the economic "today" rather than the
+        possibly historical weather year of the simulation.
+
+        Args:
+            asset_class: The measure's asset class.
+            measure_kind: "INSTALL" or "REPLACE".
+            region: The applicant's region key, or None if unstated.
+            year: The year scheme validity is tested against.
+
+        Returns:
+            The candidate schemes, in catalog file order — which is also the order the cumulation
+            solver enumerates them in and therefore its tie-break order.
+        """
+        result = []
+        for scheme in self.schemes:
+            if not scheme.applies_to(asset_class, measure_kind):
+                continue
+            if scheme.region is not None and region is not None and scheme.region != region:
+                continue
+            valid_from_year = int(scheme.valid_from[:4])
+            valid_to_year = int(scheme.valid_to[:4]) if scheme.valid_to else 9999
+            if not valid_from_year <= year <= valid_to_year:
+                continue
+            result.append(scheme)
+        return result
+
+
+def _component_type(name: str, scheme_id: str) -> ComponentType:
+    """Resolves a catalog asset-class string to its `ComponentType`, by enum name or value.
+
+    Accepting both spellings keeps catalog files readable while tolerating the enum's value
+    strings; anything else is a data error rather than a silently unfunded asset class, which is
+    why it raises instead of returning None (a scheme that quietly applies to nothing would look
+    exactly like a scheme whose conditions failed).
+    """
+    for member in ComponentType:
+        if name in (member.name, member.value):
+            return member
+    raise SubsidyDataError(f"Scheme {scheme_id}: unknown asset class {name!r}.")
+
+
+# =========================================================================== engine
+# Everything below consumes the catalog data above: the applicant/building context conditions
+# resolve against, the condition evaluator, the eligibility assessment and the cumulation
+# solver. Nothing above this line reads a context or evaluates anything (§2.5: the data half
+# becomes `economics/data/`, this half `economics/engine/`; the cut is prepared, the physical
+# move is deliberately left to the package split so imports churn once, not twice).
+

--- a/hisim/economics/subsidies/context.py
+++ b/hisim/economics/subsidies/context.py
@@ -1,0 +1,259 @@
+"""Applicant and building context for subsidy eligibility (cost_spec.md §5.3, §5.7).
+
+The country-neutral vocabulary the questionnaire fills and eligibility conditions read:
+who applies (`ApplicantActor`, `ApplicantProfile`), the building facts
+(`SubsidyBuildingContext`, `HeritageStatus`), and the derived field vocabulary
+(`SubsidyContextFields`) that keeps condition/question field names honest (W2.3).
+Split out of the former single-module `subsidies.py` (PR-3 review); the package
+`__init__` re-exports everything, so `from hisim.economics.subsidies import ...` is
+unchanged.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import typing
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Dict,
+    FrozenSet,
+    Optional,
+    Set,
+    Tuple,
+)
+
+from hisim.economics.facts import ExistingAsset
+
+
+
+
+class SubsidyDataError(ValueError):
+    """Raised for malformed subsidy catalogs.
+
+    The single error type of this module, used both at load time (unknown benefit kind, missing
+    ``legal_basis``, a condition on a field no context provides, unsourced scheme) and at solve
+    time (a candidate set too large for the cumulation solver). Failing loudly on catalog data is
+    the point: a scheme that silently parsed wrong would produce a plausible-looking euro amount
+    that no legal text backs, which is exactly what the provenance requirements of §3.10 exist to
+    prevent.
+    """
+
+
+class HeritageStatus(str, enum.Enum):
+    """Heritage-protection status (§5.3).
+
+    Heritage protection is a first-class eligibility input because German (and several other EU)
+    programmes *relax* their technical thresholds for protected buildings — the BEG for instance
+    accepts a lower SCOP for a listed monument — and because it caps what an envelope retrofit may
+    physically do. The member names follow the legal categories rather than a severity ordering;
+    conditions test them with ``==`` / ``!=`` / ``in``, never with ``<``.
+    """
+
+    NONE = "NONE"
+    LISTED_MONUMENT = "LISTED_MONUMENT"  # Einzeldenkmal
+    ENSEMBLE_PROTECTED = "ENSEMBLE_PROTECTED"  # Ensembleschutz
+    PRESERVATION_WORTHY = "PRESERVATION_WORTHY"  # besonders erhaltenswerte Bausubstanz
+
+
+class ApplicantActor(str, enum.Enum):
+    """Applicant roles for eligibility conditions.
+
+    Who applies decides what is on offer: most residential programmes are open to owner-occupiers,
+    landlords and condominium associations but not to tenants, and several bonuses (the BEG
+    income bonus, for example) require self-occupation. The vocabulary is deliberately
+    country-neutral — a condominium association is a "Wohnungseigentümergemeinschaft (WEG)" in
+    Germany, an "owners' management company" in Ireland — so the same context serves every
+    country catalog. This is also deliberately *not* ``timeline.Actor``: that enum is about who
+    pays a cash flow and includes the pre-allocation ``SYSTEM`` view, whereas this one is about
+    who signs the funding application. The two are not convertible into each other, and nothing
+    tries: the applicant is stated directly on the :class:`ApplicantProfile` of the economic
+    context, and ``CONDOMINIUM_ASSOCIATION`` has no ``Actor`` counterpart to map back to at all
+    (§8 D23).
+    """
+
+    OWNER_OCCUPIER = "OWNER_OCCUPIER"
+    LANDLORD = "LANDLORD"
+    CONDOMINIUM_ASSOCIATION = "CONDOMINIUM_ASSOCIATION"  # the owners of a multi-dwelling building applying as one body
+    TENANT = "TENANT"
+
+
+@dataclass
+class ApplicantProfile:
+    """Who applies for the subsidy (§5.3).
+
+    One half of the eligibility context (the other is :class:`SubsidyBuildingContext`): the facts
+    about the *person* that no simulation can produce and that the §5.7 questionnaire therefore
+    asks. Every optional field defaults to ``None``, and ``None`` means *unanswered* rather than
+    "not applicable" — a condition touching it makes its scheme UNDETERMINED instead of ineligible,
+    which is what keeps a half-filled questionnaire from silently costing the user money.
+    """
+
+    actor: ApplicantActor = ApplicantActor.OWNER_OCCUPIER
+    taxable_household_income_in_euro: Optional[float] = None  # per year, gross of tax; None = unanswered
+    household_size: Optional[int] = None  # persons; some income thresholds scale with it
+    main_residence: Optional[bool] = True  # self-occupation, required by several bonuses
+    region: Optional[str] = None  # NUTS-3 or municipality key for regional schemes
+
+
+@dataclass
+class SubsidyBuildingContext:
+    """Building facts consumed by eligibility conditions (§5.3).
+
+    The building half of the eligibility context: age, size, usage split, heritage status and the
+    heating system being replaced — the facts programmes key their thresholds on. Some of these the
+    simulation or the building model already knows (construction year, floor areas) and the caller
+    fills them in; the rest are questionnaire answers (§5.7). As on :class:`ApplicantProfile`,
+    ``None`` means unanswered and propagates as UNDETERMINED, whereas the non-optional fields carry
+    defaults that are assertions: a single dwelling unit and no commercial floor area.
+    """
+
+    construction_year: Optional[int] = None
+    dwelling_units: int = 1
+    heated_floor_area_in_m2: Optional[float] = None
+    residential_floor_area_in_m2: Optional[float] = None
+    commercial_floor_area_in_m2: float = 0.0
+    heritage_status: Optional[HeritageStatus] = HeritageStatus.NONE
+    energy_performance_class: Optional[str] = None
+    existing_heating: Optional[ExistingAsset] = None
+    # Whether an individual renovation roadmap exists for the building. Country-neutral concept
+    # (Sánchez Ramos et al. 2025, Sustainability 17(5):2289 surveys the EU instruments); in the
+    # German catalog it is the "individueller Sanierungsfahrplan (iSFP)" behind the BEG envelope
+    # bonus.
+    has_renovation_roadmap: Optional[bool] = None
+
+    @property
+    def residential_share(self) -> Optional[float]:
+        """Derived, never asked separately (§5.7).
+
+        The residential fraction of the floor area, in [0, 1]. Two things read it: eligibility
+        conditions of residential-only programmes (``building.residential_share >= 0.5``) and the
+        ``RESIDENTIAL_SHARE`` proration of the eligible-cost basis in mixed-use buildings (§5.2).
+        Returning ``None`` when the residential area is unanswered — or when both areas are zero —
+        is what makes those conditions UNDETERMINED rather than false; see
+        :attr:`SubsidyContextFields.DERIVED_CONTEXT_FIELDS` for how the questionnaire asks the two
+        areas behind it instead.
+        """
+        if self.residential_floor_area_in_m2 is None:
+            return None
+        total = self.residential_floor_area_in_m2 + self.commercial_floor_area_in_m2
+        if total <= 0:
+            return None
+        return self.residential_floor_area_in_m2 / total
+
+
+# --------------------------------------------------------------------------- field vocabulary
+# W2.3: ONE source of truth for the names conditions and questions may use. The vocabulary is
+# derived from the context dataclasses themselves, so a field added to `ApplicantProfile` or
+# `SubsidyBuildingContext` cannot be forgotten in a hand-maintained whitelist.
+
+def _dataclass_of(annotation: Any) -> Optional[type]:
+    """The dataclass behind a (possibly `Optional[...]`) annotation, if there is one.
+
+    Lets :func:`_enumerate_context_fields` descend one level into nested context objects, which is
+    what makes ``building.existing_heating.energy_carrier`` an addressable condition field. Returns
+    ``None`` for plain scalars, so a non-dataclass annotation simply contributes no sub-fields.
+    """
+    if dataclasses.is_dataclass(annotation) and isinstance(annotation, type):
+        return annotation
+    for argument in typing.get_args(annotation):
+        if dataclasses.is_dataclass(argument) and isinstance(argument, type):
+            return argument
+    return None
+
+
+def _enumerate_context_fields(context_roots: Optional[Dict[str, type]] = None) -> FrozenSet[str]:
+    """Every addressable context field: dataclass fields, one nested level, and properties.
+
+    Derives the condition vocabulary from the context dataclasses by reflection instead of a
+    hand-maintained whitelist (W2.3), so a field added to :class:`ApplicantProfile` or
+    :class:`SubsidyBuildingContext` is immediately addressable and cannot be forgotten. Properties
+    are included because derived fields such as ``building.residential_share`` are legitimate
+    condition targets. Exactly one nesting level is walked — deeper paths are not expressible in
+    the catalog today, and unbounded recursion would admit names no question could ever cover.
+    """
+    names: Set[str] = set()
+    for root, context_class in (context_roots or SubsidyContextFields.CONTEXT_ROOTS).items():
+        hints = typing.get_type_hints(context_class)
+        for context_field in dataclasses.fields(context_class):
+            names.add(f"{root}.{context_field.name}")
+            nested = _dataclass_of(hints.get(context_field.name))
+            if nested is not None:
+                for sub_field in dataclasses.fields(nested):
+                    names.add(f"{root}.{context_field.name}.{sub_field.name}")
+        for attribute, member in vars(context_class).items():
+            if isinstance(member, property):  # derived fields such as `building.residential_share`
+                names.add(f"{root}.{attribute}")
+    return frozenset(names)
+
+
+def _known_context_fields(context_roots: Dict[str, type], derived: Dict[str, Tuple[str, ...]]) -> FrozenSet[str]:
+    """The vocabulary, with the derived-field registry checked against it.
+
+    Runs at import time to build :attr:`SubsidyContextFields.KNOWN_CONTEXT_FIELDS`, and takes the
+    opportunity to verify that every name in ``DERIVED_CONTEXT_FIELDS`` — both the derived fields
+    and the user-answerable targets they point at — actually exists in the enumerated vocabulary.
+    A stale registry entry would otherwise surface much later as a question that can never be
+    answered, so it is caught as an import-time coding error instead.
+
+    Raises:
+        SubsidyDataError: If the derived-field registry references a name the context does not have.
+    """
+    names = _enumerate_context_fields(context_roots)
+    unknown_derived = sorted(
+        {name for name in derived if name not in names}
+        | {target for targets in derived.values() for target in targets}
+        - names
+    )
+    if unknown_derived:  # pragma: no cover — a coding error in the registry, not a data error
+        raise SubsidyDataError(f"DERIVED_CONTEXT_FIELDS references unknown context fields: {unknown_derived}.")
+    return names
+
+
+class SubsidyContextFields:
+    """The addressable eligibility-context vocabulary (§5.7).
+
+    A namespace, not a value type: it holds the three pieces of knowledge about *what a condition
+    may talk about* — which roots resolve against which dataclass, which fields are computed rather
+    than asked, and the resulting set of legal field names. Keeping them together is what lets the
+    catalog loader reject a typo like ``applicant.incom`` at load time (§5.3) and lets the data-file
+    CI prove that every field any shipped scheme references has a localized question (§9.6).
+    """
+
+    #: Condition roots and the dataclass each resolves against. `measure.*` is deliberately
+    #: absent: it addresses arbitrary `ComponentCostFacts.technical_attributes` keys and is
+    #: checked at resolve time, not against a vocabulary.
+    CONTEXT_ROOTS: Dict[str, type] = {
+        "applicant": ApplicantProfile,
+        "building": SubsidyBuildingContext,
+    }
+
+    #: Fields that are computed from other fields and therefore never asked directly: the
+    #: derived field maps to the user-answerable fields whose answers determine it (§5.7). This
+    #: registry is the *only* place that knowledge lives — the question derivation
+    #: (`required_questions`) and the question-coverage validation
+    #: (`validation.validate_subsidy_catalog`) both read it.
+    DERIVED_CONTEXT_FIELDS: Dict[str, Tuple[str, ...]] = {
+        "building.residential_share": (
+            "building.residential_floor_area_in_m2",
+            "building.commercial_floor_area_in_m2",
+        ),
+    }
+
+    #: Statically enumerable context fields conditions may reference (§5.7) — derived, not
+    #: typed out.
+    KNOWN_CONTEXT_FIELDS: FrozenSet[str] = _known_context_fields(CONTEXT_ROOTS, DERIVED_CONTEXT_FIELDS)
+
+
+def question_targets(fieldname: str) -> Tuple[str, ...]:
+    """The user-answerable field(s) whose answers determine `fieldname` (§5.7).
+
+    Plain fields map to themselves; derived fields map to the friendly questions behind them.
+    A condition on ``building.residential_share`` thus turns into two area questions rather than a
+    percentage nobody can state off-hand. Both the question derivation (:func:`required_questions`)
+    and the question-coverage check in ``validation.py`` route through this function, so the two
+    can never disagree about which entry a catalog must ship.
+    """
+    return SubsidyContextFields.DERIVED_CONTEXT_FIELDS.get(fieldname, (fieldname,))
+

--- a/hisim/economics/subsidies/solver.py
+++ b/hisim/economics/subsidies/solver.py
@@ -1,0 +1,530 @@
+"""Award computation and the cumulation solver (cost_spec.md §5.4-§5.5).
+
+Turns assessed schemes into concrete `SubsidyAward`s and picks the best admissible
+combination: eligible-cost bases, per-slot cap arithmetic (see D20/D28 — the per-slot
+choice is envelope semantics), `_combination_awards`, the support-value objective and
+`solve_cumulation`. Split out of the former single-module `subsidies.py` (PR-3 review);
+the package `__init__` re-exports everything.
+"""
+
+from __future__ import annotations
+
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from hisim.economics.uncertainty import UncertainValue
+
+from hisim.economics.subsidies.assessment import (
+    EligibilityStatus,
+    MeasureForSubsidy,
+    SubsidyAward,
+    SubsidyContext,
+    SubsidyDecision,
+    assess_schemes,
+)
+from hisim.economics.subsidies.catalog import (
+    BenefitKind,
+    LoanTermsBenefit,
+    LumpSumBenefit,
+    OperationalBenefit,
+    PayoutKind,
+    PerUnitBenefit,
+    ReducedVatBenefit,
+    ShareBenefit,
+    SubsidyCatalog,
+    SubsidyScheme,
+    TaxCreditBenefit,
+)
+from hisim.economics.subsidies.context import SubsidyDataError
+
+class CumulationLimits:
+    """Bounds the exponential cumulation solver is guarded by (§5.4).
+
+    The solver enumerates *every* subset of the schemes that apply to one measure, so its cost is
+    2^n in that number; this class is the one place that bound is stated. It exists as a named
+    constant rather than a magic number because the guard's failure mode is a policy decision — a
+    catalog that trips it is treated as a data defect (see :func:`_check_cumulation_size`) rather
+    than silently truncated, since truncation would understate the support a user is entitled to.
+    """
+
+    #: Upper bound on the number of schemes handed to a subset enumeration in the cumulation
+    #: solver (§5.4). The solver is exponential in that number, so a catalog that made many
+    #: schemes apply to one measure would hang instead of returning a wrong answer. Real
+    #: catalogs stay far below the limit (the shipped DE catalog holds nine schemes in total).
+    MAX_CUMULATION_SCHEMES = 16
+
+
+
+def _eligible_cost_basis(
+    scheme: SubsidyScheme, measure: MeasureForSubsidy, context: SubsidyContext
+) -> Tuple[UncertainValue, Dict[str, bool]]:
+    """Eligible cost per slot, with per-slot cap-binding flags (§3.9, §5.4).
+
+    Turns the measure's gross year-0 cost into the basis *this* scheme computes on, applying the
+    four dials of :class:`EligibleCostSpec` in a fixed order: sum the counted categories, strip VAT
+    if the scheme's basis is NET, prorate to the residential share for a residential-only programme
+    in a mixed-use building, then clamp to the per-dwelling-unit cap. The order matters — capping
+    last means the ceiling is compared against the already prorated, already net figure, which is
+    how the directives read.
+
+    Both proration and capping degrade gracefully in the direction of *not* inventing support: an
+    unanswered residential share leaves the basis unprorated, and a scheme with no cap list is
+    uncapped. The cap is applied per slot (`clamp_upper`), so it can bind in the HIGH-cost world
+    and not in LOW; the returned flags record exactly that and end up in the audit trail and in the
+    input-audit table, because "the cap bound" is usually the single most important thing to know
+    about a subsidy result.
+
+    Args:
+        scheme: The scheme whose eligible-cost rules apply.
+        measure: The measure, supplying the year-0 gross cost per category and the VAT rate.
+        context: The building context, read for the residential share and the dwelling-unit count.
+
+    Returns:
+        The eligible-cost band in euro, and a ``{"low"/"best_estimate"/"high": bool}`` map saying in which
+        slots the cap was binding (computed *before* clamping).
+    """
+    basis = UncertainValue.sum(
+        measure.cost_by_category.get(category, UncertainValue.exact(0.0))
+        for category in scheme.eligible_cost.categories
+    )
+    if scheme.eligible_cost.basis == "NET" and measure.vat_rate > 0:
+        basis = basis.scale(1.0 / (1.0 + measure.vat_rate))
+    if scheme.eligible_cost.proration == "RESIDENTIAL_SHARE":
+        share = context.building.residential_share
+        if share is not None:
+            basis = basis.scale(share)
+    cap = scheme.eligible_cost.cap_for_units(context.building.dwelling_units)
+    binding = {"low": False, "best_estimate": False, "high": False}
+    if cap is not None:
+        binding = {
+            "low": basis.minimum > cap,
+            "best_estimate": basis.best_estimate > cap,
+            "high": basis.maximum > cap,
+        }
+        basis = basis.clamp_upper(UncertainValue.exact(cap))
+    return basis, binding
+
+
+
+def _share_benefit(scheme: SubsidyScheme) -> ShareBenefit:
+    """The share payload of a SHARE_OF_ELIGIBLE_COST / BONUS_SHARE scheme.
+
+    The pairing of kind and payload type is enforced by `SubsidyScheme.__post_init__`, so this
+    is a narrowing helper for the type checker, not a runtime check.
+    """
+    assert isinstance(scheme.benefit, ShareBenefit)
+    return scheme.benefit
+
+
+#: The three cap ratios of :func:`_overall_cap_ratios`, in slot order LOW, BEST_ESTIMATE, HIGH.
+CapRatios = Tuple[float, float, float]
+
+
+def _overall_cap_ratios(total_upfront: UncertainValue, cap: UncertainValue) -> CapRatios:
+    """How much of the upfront support survives the overall cap, **per slot** (§5.4, §7 B12).
+
+    Each slot is a coherent world: in the LOW-cost world both the support and the state-aid cap
+    (a share of that world's gross cost) are smaller, so the binding ratio is a per-slot figure.
+    Scaling every slot by the BEST_ESTIMATE-slot ratio — what this did before — let the LOW/HIGH-world
+    support exceed the same world's cap, and with wide cost bands even its gross cost.
+    """
+
+    def ratio(total_slot: float, cap_slot: float) -> float:
+        if total_slot <= 0.0:
+            return 1.0
+        return min(1.0, max(0.0, cap_slot) / total_slot)
+
+    return (
+        ratio(total_upfront.minimum, cap.minimum),
+        ratio(total_upfront.best_estimate, cap.best_estimate),
+        ratio(total_upfront.maximum, cap.maximum),
+    )
+
+
+def _scaled_to_cap(amount: UncertainValue, ratios: CapRatios) -> UncertainValue:
+    """Applies the per-slot cap ratios to one award, keeping the band ordered (§3.9, §7 B12).
+
+    Per-slot ratios are *not* monotone across the slots: the cap grows with the gross cost while
+    the support grows with the eligible-cost bases, and a scheme paying a statutory lump sum does
+    not grow at all. Where the ratio falls from one slot to the next, a plain slot-wise product
+    would order an award's band the wrong way round (an exact lump sum keeping its full amount in
+    LOW but being cut in BEST_ESTIMATE), which is not representable as an `UncertainValue`.
+
+    The award is therefore capped from the HIGH slot downwards: each slot takes the smaller of
+    its own capped value and the slot above it. That keeps three properties at once —
+
+    * ``minimum <= best_estimate <= maximum`` by construction (no reliance on snapping tolerance);
+    * per-slot support never exceeds the per-slot cap, because every slot is at most its own
+      ``amount_slot * ratio_slot`` and those sum to at most the slot's cap;
+    * no award exceeds its own eligible basis, because the ratios are at most 1 and the
+      downward clamp only ever lowers a slot.
+
+    The price is a slot that gives up support it could have received in isolation (the LOW world
+    in the example above), which is the conservative direction: the cap is never overrun. Where
+    the ratios *are* monotone — always, when the cost bands are degenerate, as in every shipped
+    catalog and worked example — the result is exactly the plain per-slot product.
+    """
+    low_ratio, best_estimate_ratio, high_ratio = ratios
+    maximum = amount.maximum * high_ratio
+    best_estimate = min(amount.best_estimate * best_estimate_ratio, maximum)
+    minimum = min(amount.minimum * low_ratio, best_estimate)
+    return UncertainValue(best_estimate=best_estimate, minimum=minimum, maximum=maximum)
+
+
+def _combination_awards(
+    schemes: List[SubsidyScheme],
+    measure: MeasureForSubsidy,
+    context: SubsidyContext,
+    overall_cap_share: Optional[float],
+) -> List[SubsidyAward]:
+    """Values one admissible combination in all three slots (§5.4).
+
+    The valuation kernel: given a set of schemes that may legally be combined, it produces one
+    :class:`SubsidyAward` per scheme with the amounts each would actually pay. It is called once
+    per enumerated subset by the solver, so it must be free of side effects on its inputs and is
+    the only place the cumulation *rules* — group stacking, the combined rate cap, the state-aid
+    ceiling — turn into euros.
+
+    Three stages, in this order. **Share kinds** (base rates and bonuses) are grouped by
+    ``cumulation_group``: their rates are summed, the sum is limited by the smallest
+    ``combined_rate_cap`` declared in the group (the BEG's 70 %), and the limit is distributed back
+    over the members *proportionally* — so a capped stack reports each scheme's pro-rata share
+    rather than dropping the last bonus, which is what makes the composition chart add up. Note
+    that grouping is by group label only: schemes with no group share the ``None`` group and stack
+    together. **Non-share kinds** are valued individually against their own eligible-cost basis —
+    lump sums and per-unit amounts are clamped to it, tax credits are spread over their schedule,
+    loan terms and reduced VAT carry parameters rather than amounts. **The overall cap** finally
+    bounds the total *upfront* support (grants and clamped lump sums; not tax-credit schedules, not
+    loans) by the country-level state-aid share of the gross cost, per slot.
+
+    Args:
+        schemes: One admissible combination — assumed already checked against ``excludes``.
+        measure: The measure being funded, supplying the cost basis and its size.
+        context: The building context the eligible-cost rules read.
+        overall_cap_share: The catalog's state-aid ceiling as a share of gross cost, or ``None``
+            for no ceiling (the shipped DE catalog declares none).
+
+    Returns:
+        One award per scheme, amounts in nominal year-0 euro per slot. Awards may legitimately be
+        zero-valued (a loan or VAT award carries terms only).
+    """
+    awards: List[SubsidyAward] = []
+    # Share-based schemes stack additively per cumulation group, capped by combined_rate_cap.
+    share_groups: Dict[Optional[str], List[SubsidyScheme]] = {}
+    for scheme in schemes:
+        if scheme.benefit_kind in (BenefitKind.SHARE_OF_ELIGIBLE_COST, BenefitKind.BONUS_SHARE):
+            share_groups.setdefault(scheme.cumulation_group, []).append(scheme)
+    for _group, group_schemes in share_groups.items():
+        rates = [_share_benefit(scheme).rate for scheme in group_schemes]
+        total_rate = sum(rates)
+        rate_caps = [scheme.combined_rate_cap for scheme in group_schemes if scheme.combined_rate_cap is not None]
+        capped_rate = min([total_rate] + rate_caps)
+        scale_down = capped_rate / total_rate if total_rate > 0 else 0.0
+        for scheme, scheme_rate in zip(group_schemes, rates):
+            basis, binding = _eligible_cost_basis(scheme, measure, context)
+            rate = scheme_rate * scale_down
+            awards.append(
+                SubsidyAward(
+                    scheme_id=scheme.id,
+                    payout_kind=scheme.payout_kind,
+                    upfront_amount=basis.scale(rate),
+                    caps_binding_per_slot=binding,
+                )
+            )
+    for scheme in schemes:
+        if scheme.benefit_kind in (BenefitKind.SHARE_OF_ELIGIBLE_COST, BenefitKind.BONUS_SHARE):
+            continue
+        basis, binding = _eligible_cost_basis(scheme, measure, context)
+        benefit = scheme.benefit
+        if isinstance(benefit, LumpSumBenefit):
+            # A grant never exceeds the cost it funds, so the lump sum is clamped to the eligible
+            # basis — unless the scheme declares no eligible-cost categories at all, which is the
+            # explicit way of saying "this amount is unconditional" (an empty basis would otherwise
+            # clamp every lump sum to zero).
+            amount = UncertainValue.exact(benefit.amount)
+            awards.append(
+                SubsidyAward(
+                    scheme_id=scheme.id,
+                    payout_kind=scheme.payout_kind,
+                    upfront_amount=amount.clamp_upper(basis) if scheme.eligible_cost.categories else amount,
+                    caps_binding_per_slot=binding,
+                )
+            )
+        elif isinstance(benefit, PerUnitBenefit):
+            amount = UncertainValue.exact(benefit.amount * measure.facts.size)
+            awards.append(
+                SubsidyAward(
+                    scheme_id=scheme.id,
+                    payout_kind=scheme.payout_kind,
+                    upfront_amount=amount.clamp_upper(basis),
+                    caps_binding_per_slot=binding,
+                )
+            )
+        elif isinstance(benefit, TaxCreditBenefit):
+            total = basis.scale(benefit.rate)
+            schedule = [total.scale(share) for share in benefit.schedule_shares()]
+            awards.append(
+                SubsidyAward(
+                    scheme_id=scheme.id,
+                    payout_kind=PayoutKind.TAX_CREDIT_SCHEDULE,
+                    schedule_amounts=schedule,
+                    caps_binding_per_slot=binding,
+                )
+            )
+        elif isinstance(benefit, ReducedVatBenefit):
+            # §7 B7: no consumer reads this award — typed, but deliberately left unwired.
+            awards.append(
+                SubsidyAward(
+                    scheme_id=scheme.id,
+                    payout_kind=PayoutKind.VAT_REDUCTION,
+                    reduced_vat_rate=benefit.vat_rate,
+                )
+            )
+        elif isinstance(benefit, LoanTermsBenefit):
+            awards.append(
+                SubsidyAward(
+                    scheme_id=scheme.id,
+                    payout_kind=PayoutKind.LOAN_TERMS,
+                    loan_interest_rate=benefit.interest_rate,
+                    loan_term_in_years=benefit.term,
+                    loan_repayment_grant_share=benefit.repayment_grant_rate,
+                )
+            )
+        elif isinstance(benefit, OperationalBenefit):
+            awards.append(
+                SubsidyAward(
+                    scheme_id=scheme.id,
+                    payout_kind=PayoutKind.OPERATIONAL,
+                    operational_rate_per_kwh=benefit.rate_per_kwh,
+                    operational_carrier=benefit.carrier,
+                    operational_duration_years=benefit.duration_years,
+                )
+            )
+    # EU state-aid overall cap: bounds total *upfront* support per measure (§5.4), per slot.
+    if overall_cap_share is not None:
+        gross = UncertainValue.sum(measure.cost_by_category.values())
+        cap = gross.scale(overall_cap_share)
+        total_upfront = UncertainValue.sum(award.upfront_amount for award in awards)
+        ratios = _overall_cap_ratios(total_upfront, cap)
+        if any(ratio < 1.0 for ratio in ratios):
+            for award in awards:
+                award.upfront_amount = _scaled_to_cap(award.upfront_amount, ratios)
+    return awards
+
+
+def _support_value(
+    awards: List[SubsidyAward],
+    measure: MeasureForSubsidy,
+    discount: Callable[[int], float],
+    slot_getter: Callable[[UncertainValue], float],
+) -> float:
+    """Discounted value of a combination's support in one slot (solver objective).
+
+    The scalar the cumulation solver maximizes: the present value, to the applicant, of everything a
+    combination pays — grants at year 0 undiscounted, tax-credit installments discounted by their
+    year, operational per-kWh payments discounted over their duration, plus a soft loan's repayment
+    grant. Discounting is what makes the comparison meaningful at all, since §5.1's mechanisms pay
+    at very different times: a 20 % credit over ten years is not worth a 20 % grant today.
+
+    Two details a reviewer should note. Operational support falls back from *sold* to *bought*
+    energy for the carrier, so a heat-generation premium on consumed energy is valued even though
+    the field is named after feed-in. And the repayment grant is valued on the measure's **gross**
+    cost here while ``calculators/financing_application.py`` applies the same share to the loan
+    principal — §7 B3, preserved unfixed and currently masked by the shipped KfW rate of 0.0.
+
+    Args:
+        awards: The valued awards of one combination.
+        measure: The measure, read for the annual energy an OPERATIONAL award is paid on and for
+            the gross cost a repayment grant is valued on.
+        discount: Year → discount factor, supplied by the caller (``EconomicParameters``).
+        slot_getter: Picks the slot to value in; see :func:`solve_cumulation` for why the LOW slot
+            reads the band's *maximum*.
+
+    Returns:
+        The discounted support in euro — a positive number, larger is better for the applicant.
+    """
+    value = 0.0
+    for award in awards:
+        value += slot_getter(award.upfront_amount)
+        for offset, amount in enumerate(award.schedule_amounts, start=1):
+            value += slot_getter(amount) * discount(offset)
+        if award.payout_kind == PayoutKind.OPERATIONAL and award.operational_carrier is not None:
+            energy = measure.annual_energy_sold_in_kwh.get(
+                award.operational_carrier, 0.0
+            ) or measure.annual_energy_bought_in_kwh.get(award.operational_carrier, 0.0)
+            for year in range(1, award.operational_duration_years + 1):
+                value += award.operational_rate_per_kwh * energy * discount(year)
+        if award.loan_repayment_grant_share:
+            gross = slot_getter(UncertainValue.sum(measure.cost_by_category.values()))
+            value += gross * award.loan_repayment_grant_share
+    return value
+
+
+def _check_cumulation_size(count: int, what: str) -> None:
+    """Guards the 2^n subset enumerations of the cumulation solver.
+
+    Args:
+        count: Number of schemes about to be enumerated.
+        what: Human-readable name of that set, used in the error message.
+
+    Raises:
+        SubsidyDataError: If count exceeds MAX_CUMULATION_SCHEMES.
+    """
+    if count > CumulationLimits.MAX_CUMULATION_SCHEMES:
+        raise SubsidyDataError(
+            f"{count} {what} exceeds the cumulation solver limit of "
+            f"{CumulationLimits.MAX_CUMULATION_SCHEMES}. "
+            "The solver enumerates every subset of them, so a set this large would not finish "
+            "in reasonable time. Narrow the catalog's candidate schemes for this measure "
+            "(applies_to_asset_classes, measure kinds, region, validity years) or split it."
+        )
+
+
+def solve_cumulation(
+    catalog: SubsidyCatalog,
+    measure: MeasureForSubsidy,
+    context: SubsidyContext,
+    year: int,
+    discount: Callable[[int], float],
+    admits: Optional[Callable[[str], bool]] = None,
+) -> SubsidyDecision:
+    """Enumerates admissible combinations of ELIGIBLE schemes and picks the best (§5.4).
+
+    The decision is made on the BEST_ESTIMATE slot; the chosen combination is then valued in all
+    three slots. UNDETERMINED schemes are excluded but reported with the optimistic upper
+    bound they could unlock (§5.7).
+
+    `admits` restricts the candidate set *before* the optimization (§5.5 subsidy modes; §7 B5).
+    It is a plain predicate on scheme ids rather than a `SubsidyMode` so this module keeps no
+    dependency on the perspective types. Filtering afterwards — what the evaluator used to do —
+    left ONLY/EXCLUDE perspectives with the remainder of a combination that was optimal for a
+    different (unrestricted) candidate set, which is not the best admissible combination.
+
+    Both enumerations are exponential in the number of schemes and are therefore capped at
+    MAX_CUMULATION_SCHEMES: more than that many eligible schemes (or, for the optimistic
+    bound, eligible plus undetermined ones) is treated as a catalog defect rather than
+    silently truncated, because truncating would understate the support.
+
+    **What is optimized, over what, and how ties break.** The objective is
+    :func:`_support_value` — the discounted euro value of a combination to the applicant, maximized
+    (the applicant is assumed to claim what is available to them, §5.4). The candidate set is the
+    power set of the ELIGIBLE schemes for this one measure: all 2^n subsets are enumerated in
+    increasing bitmask order, the ones violating an ``excludes`` relation are skipped, and each
+    survivor is fully valued through :func:`_combination_awards` — no greedy or incremental
+    shortcut, because caps and exclusions make the objective non-additive. Note the empty subset is
+    included, so "no subsidy at all" is always an admissible answer. A candidate replaces the
+    incumbent only if it beats it by more than 1e-9 euro, which makes the tie-break *first one
+    wins* in enumeration order: since the bits index the eligible list, which is in catalog file
+    order, an exact tie is resolved toward the combination using the fewer / earlier-listed
+    schemes. That is what makes the result reproducible across runs rather than dependent on set
+    iteration order.
+
+    **The per-slot report.** The same enumeration also tracks the best combination in the LOW and
+    HIGH slots, and ``other_slot_optimal_combination`` names it where it differs from the chosen
+    one — the honest disclosure that the plan is optimal for the best-estimate world only. The slot
+    getters map LOW to the band's *maximum* and HIGH to its *minimum*, matching the mirroring that
+    turns support into a revenue-type cash flow (`as_revenue`): in the optimistic slot the most
+    support arrives.
+
+    Args:
+        catalog: The country catalog.
+        measure: The single measure being funded; the solver has no cross-measure view.
+        context: The applicant/building answers.
+        year: The year scheme validity is tested against (the price basis year in production).
+        discount: Year → discount factor used to compare payout timings.
+        admits: Optional scheme-id predicate implementing the perspective's subsidy mode.
+
+    Returns:
+        The full :class:`SubsidyDecision`: the chosen combination's awards, plus rejected,
+        undetermined, the optimistic bound and the per-slot alternatives.
+
+    Raises:
+        SubsidyDataError: If either scheme set exceeds MAX_CUMULATION_SCHEMES.
+    """
+    assessments = assess_schemes(catalog, measure, context, year, admits)
+    eligible = [assessment.scheme for assessment in assessments if assessment.status == EligibilityStatus.ELIGIBLE]
+    decision = SubsidyDecision(measure_subject=measure.subject)
+    for assessment in assessments:
+        if assessment.status == EligibilityStatus.INELIGIBLE:
+            decision.rejected.append({"scheme_id": assessment.scheme.id, "reason": assessment.rejected_reason})
+        elif assessment.status == EligibilityStatus.UNDETERMINED:
+            decision.undetermined.append(
+                {"scheme_id": assessment.scheme.id, "missing_fields": assessment.missing_fields}
+            )
+
+    def admissible(combination: List[SubsidyScheme]) -> bool:
+        """Whether the combination violates no `excludes` relation.
+
+        Declaring the exclusion on one side is enough: the check asks every member whether any
+        other member is on its exclusion list, so `excludes` acts symmetrically even though the
+        catalog states it once (the DE catalog states it on both sides anyway).
+        """
+        ids = {scheme.id for scheme in combination}
+        for scheme in combination:
+            if ids & set(scheme.excludes):
+                return False
+        return True
+
+    # Enumerate subsets (scheme sets are small, typically < 10 per measure).
+    _check_cumulation_size(len(eligible), "eligible schemes")
+    best: Optional[Tuple[float, List[SubsidyScheme], List[SubsidyAward]]] = None
+    best_per_slot: Dict[str, Optional[str]] = {}
+    slot_getters = {
+        "low": lambda value: value.maximum,  # optimistic world: max support
+        "best_estimate": lambda value: value.best_estimate,
+        "high": lambda value: value.minimum,
+    }
+    best_by_slot: Dict[str, Tuple[float, str]] = {}
+    count = len(eligible)
+    for mask in range(1 << count):
+        combination = [eligible[index] for index in range(count) if mask & (1 << index)]
+        if not admissible(combination):
+            continue
+        awards = _combination_awards(combination, measure, context, catalog.overall_cap_share)
+        for slot_name, getter in slot_getters.items():
+            slot_value = _support_value(awards, measure, discount, getter)
+            key = "|".join(sorted(scheme.id for scheme in combination)) or "<none>"
+            if slot_name not in best_by_slot or slot_value > best_by_slot[slot_name][0] + 1e-9:
+                best_by_slot[slot_name] = (slot_value, key)
+        best_estimate_value = _support_value(awards, measure, discount, slot_getters["best_estimate"])
+        if best is None or best_estimate_value > best[0] + 1e-9:
+            best = (best_estimate_value, combination, awards)
+    if best is None:
+        best = (0.0, [], [])
+    chosen_key = "|".join(sorted(scheme.id for scheme in best[1])) or "<none>"
+    for slot_name in ("low", "high"):
+        slot_best = best_by_slot.get(slot_name)
+        best_per_slot[slot_name] = slot_best[1] if slot_best and slot_best[1] != chosen_key else None
+    decision.applied = best[2]
+    decision.other_slot_optimal_combination = best_per_slot
+    # Optimistic upper bound over undetermined schemes: value if they all were eligible too.
+    # Re-solving over eligible + undetermined (rather than adding the undetermined schemes' values)
+    # is necessary because exclusions and caps make the best combination change, not just grow. The
+    # reported figure is the *increment* over the chosen combination on the BEST_ESTIMATE slot — "answering
+    # these questions could unlock up to X on top of what you already get" (§5.7) — floored at 0,
+    # since an undetermined scheme can never make the applicant worse off.
+    if decision.undetermined:
+        undetermined_schemes = [
+            assessment.scheme for assessment in assessments if assessment.status == EligibilityStatus.UNDETERMINED
+        ]
+        optimistic = eligible + undetermined_schemes
+        best_optimistic = 0.0
+        opt_count = len(optimistic)
+        _check_cumulation_size(opt_count, "eligible and undetermined schemes")
+        for mask in range(1 << opt_count):
+            combination = [optimistic[index] for index in range(opt_count) if mask & (1 << index)]
+            if not admissible(combination):
+                continue
+            awards = _combination_awards(combination, measure, context, catalog.overall_cap_share)
+            best_optimistic = max(
+                best_optimistic, _support_value(awards, measure, discount, slot_getters["best_estimate"])
+            )
+        decision.undetermined_upper_bound_in_euro = max(0.0, best_optimistic - best[0])
+    return decision
+
+

--- a/hisim/economics/tariffs.py
+++ b/hisim/economics/tariffs.py
@@ -1,0 +1,849 @@
+"""Tariff contracts and the pure billing engine (cost_spec.md §8).
+
+One :class:`TariffContract` per carrier is the single source of truth: the in-simulation
+price provider (``hisim/components/tariff_provider.py``) and the postprocessing billing
+engine both read it; neither carries its own price data.
+
+That rule exists because of the consistency problem §8.1 opens with: if an energy management
+system optimizes against one price signal and the evaluation bills against another, the resulting
+"savings from smart control" are an artifact of the mismatch rather than a result. Everything in
+this module therefore serves one of two roles — describing a contract (the §8.2 schema, its
+loaders, the spot series) or *applying* it (:func:`apply_tariff`, plus the price-selection
+functions the simulation side calls per timestep) — and the two halves are separated by the
+``=== engine`` banner, in preparation for the §2.5 package split.
+
+What this module deliberately does NOT own: the horizon projection and escalation of a bill
+(§8.5 lives in ``calculators/energy.py``, which also builds the default flat contract from a §3.5
+price entry), the CO2 price component, the timeline, and any notion of who pays. It bills exactly
+one year of one carrier from measured determinants and returns a :class:`Year1Bill`; that bill is
+then decomposed, escalated and booked elsewhere.
+
+**Source ids and the `inline:` convention (W2.4).** Every contract must cite sources (§3.10).
+A contract loaded from ``cost_database/tariffs/*.json`` must name entries of the cost
+database's ``sources.json``; citing a source in prose as ``inline:<citation>`` is a
+validation *error* there (`validation.validate_tariff_contracts`), because a prose citation
+cannot be reviewed, deduplicated or checked for staleness. Contracts constructed **in
+memory** — worked examples, test fixtures, the provider's ``SYNTHETIC_TEST`` contract — have
+no registry behind them and keep using ``inline:<citation>``: it is rendered verbatim as an
+``INLINE`` source at a report leaf (`results.LifecycleCostResult.explain`) and never enters a
+shipped data file. That is the whole scope of the convention; catalog data does not use it.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
+
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.database import CostDataError, SourceRegistry
+from hisim.economics.facts import BillingDeterminants
+from hisim.economics.timeline import CostCategory
+from hisim.economics.uncertainty import UncertainValue
+
+# =========================================================================== data
+# Contract data, the §8.2 schema and catalog loading. This half moves to `economics/data/`
+# in the §2.5 package split; it knows nothing about bills. (`TariffContract`'s own
+# `marginal_purchase_price_components` stays with the data: it is a derived property of the
+# contract's own fields, and both halves read it.)
+
+
+class SupplyKind(str, enum.Enum):
+    """Supply price structures (§8.2).
+
+    How the energy part of the price varies over time, which is the single most consequential
+    choice in a tariff because it decides what a bill can even see: FLAT needs annual kWh only,
+    TIME_OF_USE needs kWh per band, and DYNAMIC needs the integral of load times the spot series at
+    native resolution. The kind therefore selects both the price-selection rule
+    (:func:`energy_price_in_euro_per_kwh`) and which billing determinants the meter must have
+    produced — the whole reason §8.4 extends the meters at all.
+    """
+
+    FLAT = "FLAT"
+    TIME_OF_USE = "TIME_OF_USE"
+    DYNAMIC = "DYNAMIC"
+
+
+class CapacityChargeKind(str, enum.Enum):
+    """Capacity charge structures (§8.2).
+
+    Capacity (demand) charges bill *power* rather than energy, which is what makes peak shaving
+    worth money and is why the engine models them explicitly. The kinds differ only in which peaks
+    are counted: the single annual maximum, one per month, or only those inside declared
+    high-load windows. In every case a peak is the mean power over the billing interval, never an
+    instantaneous timestep value (§8.4).
+    """
+
+    NONE = "NONE"
+    ANNUAL_PEAK = "ANNUAL_PEAK"
+    MONTHLY_PEAK = "MONTHLY_PEAK"
+    PEAK_WINDOW = "PEAK_WINDOW"
+
+
+class FeedInKind(str, enum.Enum):
+    """Feed-in remuneration structures (§8.2).
+
+    How exported energy is paid for, which matters over a 20-year horizon mostly through the
+    escalation it implies: a fixed statutory tariff stays *nominally* constant for its contract
+    duration — and therefore loses real value every year — while a spot-referenced direct-marketing
+    revenue follows the market. The kind selects how the year-1 revenue is computed here; the
+    projection in ``calculators/energy.py`` then holds that revenue nominally fixed for
+    ``duration_in_years`` and escalates it only afterwards (§8.5, spec Q10).
+    """
+
+    NONE = "NONE"
+    FIXED_TARIFF = "FIXED_TARIFF"  # EEG, nominally constant for its duration
+    SPOT_REFERENCED = "SPOT_REFERENCED"  # direct marketing
+
+
+@dataclass
+class TimeOfUseBand:
+    """One ToU band: weekday/hour masks with a working price.
+
+    A band is a named set of hours (day/night, peak/off-peak) with its own energy price, and the
+    name is load-bearing: the meter reports energy *per band name*, so a band renamed in the
+    contract silently stops matching the determinants and its energy falls through to the fallback
+    band. Masks may overlap — the first declared match wins (:func:`time_of_use_band_for`) — which
+    makes a broad catch-all band declared last a valid way to express "everything else".
+    """
+
+    name: str  # must match the key the meter reports energy under
+    price_in_euro_per_kwh: UncertainValue  # energy-only; the additive components are added on top
+    weekdays: List[int] = field(default_factory=lambda: list(range(7)))  # 0 = Monday
+    hours: List[int] = field(default_factory=lambda: list(range(24)))  # local clock hour of the day
+
+
+@dataclass
+class TariffSupply:
+    """Supply side of a contract; non-energy components kept separate (§8.2).
+
+    Everything that prices a purchased kWh, split into the time-varying energy part (flat price,
+    bands, or spot series times a factor) and three per-kWh components that do *not* vary with the
+    moment — supplier markup, grid fee, taxes and levies. The split is not cosmetic: §8.2 keeps the
+    components separate so that the macroeconomic view (§4.5) can strip taxes and levies, a §14a
+    discount can reduce the grid fee alone, and the flexibility decomposition can attribute value
+    to the energy part only. Of those, the grid-fee discount and the decomposition are wired today;
+    the macroeconomic view currently strips taxes via the §3.5 price entry's ``tax_and_levy_share``
+    rather than through these fields.
+    """
+
+    kind: SupplyKind
+    # FLAT: the all-in energy price; TIME_OF_USE/DYNAMIC: energy-only parts below.
+    working_price_in_euro_per_kwh: UncertainValue = field(default_factory=lambda: UncertainValue.exact(0.0))
+    bands: List[TimeOfUseBand] = field(default_factory=list)  # TIME_OF_USE only
+    spot_series: Optional[str] = None  # reference to a price series in the database
+    spot_factor: float = 1.0  # DYNAMIC: multiplier on the spot price (1.0 = pass-through)
+    markup_in_euro_per_kwh: UncertainValue = field(default_factory=lambda: UncertainValue.exact(0.0))
+    grid_fee_in_euro_per_kwh: UncertainValue = field(default_factory=lambda: UncertainValue.exact(0.0))
+    taxes_and_levies_in_euro_per_kwh: UncertainValue = field(default_factory=lambda: UncertainValue.exact(0.0))
+    vat_rate: float = 0.0
+
+
+@dataclass
+class CapacityCharge:
+    """Capacity charge terms; peaks are billing-interval means, never instantaneous (§8.4).
+
+    The power-based part of a bill: a price per kW applied to the peaks the meter measured. The
+    billing interval is part of the contract because it decides what "a peak" means — a 15-minute
+    mean is a very different number from a one-minute spike, and billing the latter would reward
+    peak shaving that no supplier actually pays for. That interval must be a whole multiple of the
+    simulation timestep, checked before the run by :func:`validate_billing_interval`.
+    """
+
+    kind: CapacityChargeKind = CapacityChargeKind.NONE
+    price_in_euro_per_kw: UncertainValue = field(default_factory=lambda: UncertainValue.exact(0.0))
+    billing_interval_in_minutes: int = 15  # peaks are means over this interval
+    window_hours: List[int] = field(default_factory=list)  # PEAK_WINDOW only
+    window_weekdays: List[int] = field(default_factory=list)  # PEAK_WINDOW only
+
+
+@dataclass
+class FeedIn:
+    """Feed-in remuneration terms.
+
+    The export side of the contract: what the building is paid per kWh it sells, for how long, and
+    whether that payment is a fixed tariff or spot-referenced direct marketing. It sits on the
+    contract rather than in a separate price entry so that one object answers both "what does a kWh
+    cost" and "what does a kWh earn" — the two the PV/battery economics turn on.
+
+    Under ``SPOT_REFERENCED`` the payment is `spot_factor` times the natively integrated spot
+    revenue plus `markup_in_euro_per_kwh` per kWh sold: the factor is the share of the spot
+    proceeds the direct marketer passes on (1.0 = all of it), and it applies to the spot term
+    alone, the markup being agreed independently of the price.
+    """
+
+    kind: FeedInKind = FeedInKind.NONE
+    rate_in_euro_per_kwh: UncertainValue = field(default_factory=lambda: UncertainValue.exact(0.0))
+    duration_in_years: int = 20  # nominal-fixed period for FIXED_TARIFF (EEG convention)
+    spot_factor: float = 1.0  # SPOT_REFERENCED: share of the spot proceeds paid out (1.0 = all)
+    markup_in_euro_per_kwh: UncertainValue = field(default_factory=lambda: UncertainValue.exact(0.0))
+
+
+@dataclass
+class ControllabilityDiscount:
+    """§14a-EnWG-style grid-fee discount, as data only (v1, spec Q19).
+
+    German §14a EnWG grants operators of dimmable devices (heat pumps, wallboxes) a reduced grid
+    fee in exchange for accepting curtailment — either as a fixed annual credit or as a percentage
+    off the grid-fee component. Only the *money* side is modeled in v1: the dimming events
+    themselves are a control-side work item, so a run claims the discount without ever simulating
+    the curtailment it is paid for, which overstates the benefit and is flagged as such in the spec.
+    """
+
+    kind: str = "NONE"  # NONE | FIXED_ANNUAL | GRID_FEE_SHARE
+    annual_amount_in_euro: UncertainValue = field(default_factory=lambda: UncertainValue.exact(0.0))
+    grid_fee_reduction_share: float = 0.0  # GRID_FEE_SHARE: fraction taken off the grid fee
+
+
+@dataclass
+class TariffContract:
+    """One tariff contract per carrier (§8.2). Data-driven, referenced by id.
+
+    The complete commercial relationship for one energy carrier — supply price structure, standing
+    charge, capacity charge, feed-in terms and any controllability discount — in one object that
+    both the simulation and the billing engine read. This is the answer to §8.1: a contract is
+    referenced by id from a scenario or a RenoVisor request, loaded once, and handed to both sides,
+    so no price can exist in one of them without existing in the other.
+
+    Contracts come from three places: ``cost_database/tariffs/<id>.json`` (the file name *is* the
+    id, which is how :func:`load_tariff_contract` resolves it), an in-memory construction in tests
+    and worked examples, or — when a carrier has no contract at all — a default flat contract
+    generated from the §3.5 price entries by ``calculators/energy.default_contract``, which is
+    behaviorally identical to the plain price lookup and is marked ``is_default_contract``.
+    """
+
+    #: Default location of shipped tariff contracts.
+    DEFAULT_PATH: ClassVar[str] = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "cost_database", "tariffs"
+    )
+
+    id: str  # equals the file name for catalog contracts
+    carrier: EnergyCarrier
+    country: str
+    region: Optional[str]  # NUTS code or None for nationwide
+    valid_from_year: int
+    supply: TariffSupply
+    standing_charge_in_euro_per_year: UncertainValue  # Grundpreis, independent of consumption
+    capacity_charge: CapacityCharge = field(default_factory=CapacityCharge)
+    feed_in: FeedIn = field(default_factory=FeedIn)
+    controllability_discount: ControllabilityDiscount = field(default_factory=ControllabilityDiscount)
+    source_ids: Tuple[str, ...] = ()
+    is_default_contract: bool = False  # generated from the §3.5 price entries
+
+    @classmethod
+    def from_json(cls, raw: dict, registry: Optional[SourceRegistry] = None) -> "TariffContract":
+        """Parses a tariff contract JSON (§8.2 schema).
+
+        The one parser for the contract schema, used by the file loader, by the round-trip in
+        ``serialization.py`` and by the data-file CI. Every monetary field goes through
+        `UncertainValue.from_json`, so a contract may state either an exact number or a min/best_estimate/max
+        band (§3.1) without the parser branching. Almost all keys are optional with neutral
+        defaults — absent blocks mean "no capacity charge", "no feed-in", "no discount" — which
+        keeps a simple flat contract a handful of lines; the exceptions are ``supply``, ``carrier``
+        and ``source_ids``, the last because §3.10 admits no unsourced datapoint.
+
+        Args:
+            raw: The parsed contract JSON.
+            registry: Optional source registry; when given, the cited ids are resolved against it
+                immediately so a dangling citation fails here rather than at report time.
+
+        Returns:
+            The parsed contract.
+
+        Raises:
+            CostDataError: If ``source_ids`` is empty or a cited id is unknown to the registry.
+            KeyError / ValueError: On a structurally invalid document (missing ``supply`` or
+                ``carrier``, unknown enum member).
+        """
+        contract_id = raw.get("id", "<missing id>")
+        source_ids = tuple(raw.get("source_ids", ()))
+        if not source_ids:
+            raise CostDataError(f"Tariff {contract_id}: source_ids are mandatory (§3.10).")
+        if registry is not None:
+            registry.resolve(source_ids, f"tariff {contract_id}")
+        supply_raw = raw["supply"]
+        bands = [
+            TimeOfUseBand(
+                name=band["name"],
+                price_in_euro_per_kwh=UncertainValue.from_json(band["price_in_euro_per_kwh"]),
+                weekdays=band.get("weekdays", list(range(7))),
+                hours=band.get("hours", list(range(24))),
+            )
+            for band in supply_raw.get("bands", [])
+        ]
+        formula = supply_raw.get("formula", {})
+        supply = TariffSupply(
+            kind=SupplyKind(supply_raw["kind"]),
+            working_price_in_euro_per_kwh=UncertainValue.from_json(
+                supply_raw.get("working_price_in_euro_per_kwh", 0.0)
+            ),
+            bands=bands,
+            spot_series=supply_raw.get("spot_series"),
+            spot_factor=float(formula.get("spot_factor", 1.0)),
+            markup_in_euro_per_kwh=UncertainValue.from_json(formula.get("markup_in_euro_per_kwh", 0.0)),
+            grid_fee_in_euro_per_kwh=UncertainValue.from_json(supply_raw.get("grid_fee_in_euro_per_kwh", 0.0)),
+            taxes_and_levies_in_euro_per_kwh=UncertainValue.from_json(
+                supply_raw.get("taxes_and_levies_in_euro_per_kwh", 0.0)
+            ),
+            vat_rate=float(supply_raw.get("vat_rate", 0.0)),
+        )
+        capacity_raw = raw.get("capacity_charge", {"kind": "NONE"})
+        capacity = CapacityCharge(
+            kind=CapacityChargeKind(capacity_raw.get("kind", "NONE")),
+            price_in_euro_per_kw=UncertainValue.from_json(capacity_raw.get("price_in_euro_per_kw", 0.0)),
+            billing_interval_in_minutes=int(capacity_raw.get("billing_interval_in_minutes", 15)),
+            window_hours=capacity_raw.get("window_hours", []),
+            window_weekdays=capacity_raw.get("window_weekdays", []),
+        )
+        feed_in_raw = raw.get("feed_in", {"kind": "NONE"})
+        feed_in = FeedIn(
+            kind=FeedInKind(feed_in_raw.get("kind", "NONE")),
+            rate_in_euro_per_kwh=UncertainValue.from_json(feed_in_raw.get("rate_in_euro_per_kwh", 0.0)),
+            duration_in_years=int(feed_in_raw.get("duration_in_years", 20)),
+            spot_factor=float(feed_in_raw.get("spot_factor", 1.0)),
+            markup_in_euro_per_kwh=UncertainValue.from_json(feed_in_raw.get("markup_in_euro_per_kwh", 0.0)),
+        )
+        discount_raw = raw.get("controllability_discount", {"kind": "NONE"})
+        discount = ControllabilityDiscount(
+            kind=discount_raw.get("kind", "NONE"),
+            annual_amount_in_euro=UncertainValue.from_json(discount_raw.get("annual_amount_in_euro", 0.0)),
+            grid_fee_reduction_share=float(discount_raw.get("grid_fee_reduction_share", 0.0)),
+        )
+        jurisdiction = raw.get("jurisdiction", {})
+        return cls(
+            id=contract_id,
+            carrier=EnergyCarrier(raw["carrier"]),
+            country=jurisdiction.get("country", "DE"),
+            region=jurisdiction.get("region"),
+            valid_from_year=int(raw.get("valid_from_year", 0)),
+            supply=supply,
+            standing_charge_in_euro_per_year=UncertainValue.from_json(raw.get("standing_charge_in_euro_per_year", 0.0)),
+            capacity_charge=capacity,
+            feed_in=feed_in,
+            controllability_discount=discount,
+            source_ids=source_ids,
+            is_default_contract=bool(raw.get("is_default_contract", False)),
+        )
+
+    def marginal_purchase_price_components(self) -> UncertainValue:
+        """Additive non-spot per-kWh components (markup + grid fee + taxes), §8.4.
+
+        In euro per kWh: everything that is charged on each purchased kWh regardless of *when* it
+        was purchased, with a ``GRID_FEE_SHARE`` controllability discount already applied to the
+        grid-fee part (and only to it, per §14a). Isolating these is what lets an uncertainty band
+        on a tariff component shift a whole bill by ``E × Δcomponent`` without re-integrating the
+        spot series per slot — the §8.4 rule that keeps three-slot billing cheap and exact.
+
+        It lives on the contract, on the data side of the module, because it is a derived property
+        of the contract's own fields; both the in-simulation price provider and
+        :func:`apply_tariff` add it to the time-varying energy price.
+        """
+        grid_fee = self.supply.grid_fee_in_euro_per_kwh
+        if self.controllability_discount.kind == "GRID_FEE_SHARE":
+            grid_fee = grid_fee.scale(1.0 - self.controllability_discount.grid_fee_reduction_share)
+        return self.supply.markup_in_euro_per_kwh + grid_fee + self.supply.taxes_and_levies_in_euro_per_kwh
+
+
+def contract_to_json(contract: TariffContract) -> dict:
+    """Serializes a contract in the §8.2 catalog schema — the exact inverse of `from_json`.
+
+    Used to embed contracts in `economic_inputs.json` (cost-spec-v2 §2.1, W1.4) so re-pricing a
+    stored result needs no catalog lookup and in-memory contracts survive the round trip. One
+    schema, one parser: the output is a valid `cost_database/tariffs/*.json` file.
+    """
+    supply = contract.supply
+    raw: Dict[str, Any] = {
+        "id": contract.id,
+        "carrier": contract.carrier.value,
+        "jurisdiction": {"country": contract.country, "region": contract.region},
+        "valid_from_year": contract.valid_from_year,
+        "supply": {
+            "kind": supply.kind.value,
+            "working_price_in_euro_per_kwh": supply.working_price_in_euro_per_kwh.to_json(),
+            "bands": [
+                {
+                    "name": band.name,
+                    "price_in_euro_per_kwh": band.price_in_euro_per_kwh.to_json(),
+                    "weekdays": list(band.weekdays),
+                    "hours": list(band.hours),
+                }
+                for band in supply.bands
+            ],
+            "spot_series": supply.spot_series,
+            "formula": {
+                "spot_factor": supply.spot_factor,
+                "markup_in_euro_per_kwh": supply.markup_in_euro_per_kwh.to_json(),
+            },
+            "grid_fee_in_euro_per_kwh": supply.grid_fee_in_euro_per_kwh.to_json(),
+            "taxes_and_levies_in_euro_per_kwh": supply.taxes_and_levies_in_euro_per_kwh.to_json(),
+            "vat_rate": supply.vat_rate,
+        },
+        "standing_charge_in_euro_per_year": contract.standing_charge_in_euro_per_year.to_json(),
+        "capacity_charge": {
+            "kind": contract.capacity_charge.kind.value,
+            "price_in_euro_per_kw": contract.capacity_charge.price_in_euro_per_kw.to_json(),
+            "billing_interval_in_minutes": contract.capacity_charge.billing_interval_in_minutes,
+            "window_hours": list(contract.capacity_charge.window_hours),
+            "window_weekdays": list(contract.capacity_charge.window_weekdays),
+        },
+        "feed_in": {
+            "kind": contract.feed_in.kind.value,
+            "rate_in_euro_per_kwh": contract.feed_in.rate_in_euro_per_kwh.to_json(),
+            "duration_in_years": contract.feed_in.duration_in_years,
+            "spot_factor": contract.feed_in.spot_factor,
+            "markup_in_euro_per_kwh": contract.feed_in.markup_in_euro_per_kwh.to_json(),
+        },
+        "controllability_discount": {
+            "kind": contract.controllability_discount.kind,
+            "annual_amount_in_euro": contract.controllability_discount.annual_amount_in_euro.to_json(),
+            "grid_fee_reduction_share": contract.controllability_discount.grid_fee_reduction_share,
+        },
+        "source_ids": list(contract.source_ids),
+    }
+    if contract.is_default_contract:
+        raw["is_default_contract"] = True
+    return raw
+
+
+def load_tariff_contract(contract_id: str, base_path: Optional[str] = None) -> TariffContract:
+    """Loads one contract JSON by id from the tariffs directory.
+
+    Contracts are resolved by file name, so the id in the document and the name of the file that
+    holds it must agree — the data-file CI checks exactly that, because a mismatch would make a
+    contract referenced by a scenario silently unfindable. Note that no source registry is passed
+    here, so citations are not resolved on this path; ``validation.validate_tariff_contracts`` is
+    where the shipped catalog's sources are checked.
+
+    Args:
+        contract_id: The contract id, equal to the file's base name.
+        base_path: Directory to load from; defaults to the shipped ``cost_database/tariffs``.
+
+    Returns:
+        The parsed contract.
+
+    Raises:
+        CostDataError: If no file of that name exists, or the document fails the schema checks.
+    """
+    base = base_path or TariffContract.DEFAULT_PATH
+    path = os.path.join(base, f"{contract_id}.json")
+    if not os.path.isfile(path):
+        raise CostDataError(f"No tariff contract {contract_id!r} at {path}.")
+    with open(path, encoding="utf-8") as file:
+        return TariffContract.from_json(json.load(file))
+
+
+def load_spot_series(series_id: str, base_path: Optional[str] = None) -> List[float]:
+    """Loads a spot price series (EUR/kWh, hourly) from the cost database.
+
+    Series are versioned CSVs under ``cost_database/spot_series/<id>.csv`` with one price per
+    line (header allowed). A documented loader for user-supplied CSVs (spec Q16).
+
+    A DYNAMIC contract names its series by id and the simulation-side price provider reads it to
+    publish a per-timestep price; the billing engine never opens a series itself, it consumes the
+    integral the meter produced. Real EPEX series are not shipped for licensing reasons, so this
+    exists mainly so that a user can drop their own hourly file in place — hence the tolerant
+    shape handling: it takes the last comma-separated token of each line, so a plain one-column
+    file and a ``timestamp,price`` file both work, and it skips blank lines and a non-numeric
+    first line (the column header). Prices are in EUR/kWh (not EUR/MWh) and the series is expected
+    to be hourly, i.e. 8760 values for a full year.
+
+    What it does *not* do any more is skip whatever else fails to parse (issue #25a). A corrupt
+    value in the middle of a user's file used to vanish, shortening the series by one hour and
+    silently shifting every later price to the wrong hour of the year — a dynamic-tariff bill
+    computed against a shifted price series is wrong in a way nothing downstream can detect. Such
+    a line now fails the load, with the line number to go and look at.
+
+    Args:
+        series_id: The series id, equal to the CSV's base name.
+        base_path: Directory to load from; defaults to ``cost_database/spot_series``.
+
+    Returns:
+        The prices in file order, in EUR/kWh.
+
+    Raises:
+        CostDataError: If the file is missing, contains no parsable value, or holds a non-empty
+            line past the header that is not a price (message names file and line number).
+    """
+    base = base_path or os.path.join(os.path.dirname(TariffContract.DEFAULT_PATH), "spot_series")
+    path = os.path.join(base, f"{series_id}.csv")
+    if not os.path.isfile(path):
+        raise CostDataError(f"No spot price series {series_id!r} at {path}.")
+    prices: List[float] = []
+    with open(path, encoding="utf-8") as file:
+        for line_number, line in enumerate(file, start=1):
+            token = line.strip().split(",")[-1]
+            if not token:
+                continue
+            try:
+                prices.append(float(token))
+            except ValueError as err:
+                if line_number == 1:
+                    continue  # the column header, the one non-numeric line a series may have
+                raise CostDataError(
+                    f"Spot price series {path}, line {line_number}: {token!r} is not a price "
+                    "(only blank lines and a header on line 1 are skipped)."
+                ) from err
+    if not prices:
+        raise CostDataError(f"Spot price series {series_id!r} is empty.")
+    return prices
+
+
+def synthetic_reference_spot_series(mean_price: float = 0.08, amplitude: float = 0.04) -> List[float]:
+    """A synthetic hourly reference profile for tests (spec Q16 fallback).
+
+    A daily sine with morning/evening structure; deterministic, mean ≈ `mean_price`.
+
+    Real day-ahead series cannot be shipped for licensing reasons, so this stands in wherever a
+    DYNAMIC contract must be exercised without user data: the shipped ``DE_DYNAMIC_SYNTHETIC_2024``
+    contract, the price provider's ``SYNTHETIC_TEST`` contract (whose ``spot_series`` is the
+    sentinel ``"__synthetic__"``), and the dynamic-tariff tests. Being a closed formula rather than
+    a stored file makes it reproducible bit for bit across machines, which is what lets tests
+    assert exact bills; it is a *fixture*, not data, and must never back a published result.
+
+    Args:
+        mean_price: Mean level of the profile in EUR/kWh.
+        amplitude: Half-swing of the daily shape in EUR/kWh; a seasonal term of 20 % of it is
+            superimposed, and prices are floored at zero (so a large amplitude biases the mean up).
+
+    Returns:
+        8760 hourly prices in EUR/kWh, starting at hour 0 of January 1.
+    """
+    import math
+
+    prices = []
+    for hour in range(8760):
+        hour_of_day = hour % 24
+        daily = math.sin((hour_of_day - 4) / 24.0 * 2.0 * math.pi)
+        seasonal = 0.2 * math.cos(hour / 8760.0 * 2.0 * math.pi)
+        prices.append(max(0.0, mean_price + amplitude * (daily + seasonal)))
+    return prices
+
+
+def validate_billing_interval(seconds_per_timestep: int, contract: TariffContract) -> None:
+    """`seconds_per_timestep` must divide the billing interval, else pre-check fails (§8.4).
+
+    A contract-data pre-check, not billing: it confronts the contract's declared billing
+    interval with a *simulation* parameter before a run starts, which is why it sits on the data
+    side of the §2.5 cut with the schema and the loaders. Its caller is the simulation-side
+    price provider.
+    """
+    if contract.capacity_charge.kind == CapacityChargeKind.NONE:
+        return
+    interval_seconds = contract.capacity_charge.billing_interval_in_minutes * 60
+    if interval_seconds % seconds_per_timestep != 0:
+        raise CostDataError(
+            f"Tariff {contract.id}: seconds_per_timestep={seconds_per_timestep} does not divide the "
+            f"billing interval of {contract.capacity_charge.billing_interval_in_minutes} min (§8.4)."
+        )
+
+
+# =========================================================================== engine
+# The pure year-1 billing engine and the price selection it defines. This half moves to
+# `economics/engine/` in the §2.5 package split. Default-contract *construction* from a §3.5
+# price entry used to live here as `TariffContract.default_from_price_entry`; it is engine
+# behavior and now lives with its only caller, `calculators/energy.default_contract`.
+
+
+@dataclass
+class Year1Bill:
+    """apply_tariff output: year-1 costs by category, each a slot band (§8.4).
+
+    One carrier's bill for one year, in euro, split into the categories the timeline books
+    separately — working (energy) cost, standing charge, capacity charge and feed-in revenue —
+    because each escalates at its own rate over the horizon. Absent categories mean "this contract
+    does not have that component" rather than zero, so a reader can tell a contract without a
+    capacity charge from one whose peaks happened to be zero.
+
+    The three scalar fields are the §8.5 decomposition, all on the BEST_ESTIMATE slot and all
+    informational except ``flexibility_value_in_euro``: the projection in ``calculators/energy.py``
+    escalates the volume part with the carrier rate and the flexibility part with the (separately
+    configurable) spread rate, because the value of load shifting is expected to grow with spot
+    spreads rather than with the price level. Sign convention: costs positive, feed-in revenue
+    negative and revenue-mirrored (``as_revenue``), while ``flexibility_value_in_euro`` is a
+    positive *saving* that the projection subtracts.
+    """
+
+    by_category: Dict[CostCategory, UncertainValue] = field(default_factory=dict)
+    # Decomposition for the horizon projection (§8.5), BEST_ESTIMATE-slot figures:
+    volume_effect_in_euro: float = 0.0  # E_bought x mean price
+    flexibility_value_in_euro: float = 0.0  # savings of load shifting vs the mean price
+    mean_energy_price_in_euro_per_kwh: float = 0.0
+
+    def total(self) -> UncertainValue:
+        """Signed sum of all categories.
+
+        The whole year-1 bill as one band: costs positive, feed-in revenue negative, so a
+        self-consuming PV building can legitimately total below zero. Used mainly for the tariff
+        counterfactual and for reporting; the timeline itself always books the categories
+        separately, since it is their different escalation that the projection depends on.
+        """
+        return UncertainValue.sum(self.by_category.values())
+
+
+def time_of_use_band_for(
+    supply: TariffSupply, weekday: Optional[int] = None, hour: Optional[int] = None
+) -> Optional[TimeOfUseBand]:
+    """The ToU band that prices one moment — the single band-selection rule (§8.4).
+
+    First declared match wins. When nothing matches, or when the moment is unknown, the **first**
+    band applies: that is the rule `apply_tariff` bills unbanded energy with, so the price a
+    controller reacts to and the price the bill charges cannot disagree. `None` only when the
+    contract declares no bands at all (a data error the billing engine reports).
+    """
+    if not supply.bands:
+        return None
+    if weekday is not None and hour is not None:
+        for band in supply.bands:
+            if weekday in band.weekdays and hour in band.hours:
+                return band
+    return supply.bands[0]
+
+
+def energy_price_in_euro_per_kwh(
+    contract: TariffContract,
+    weekday: Optional[int] = None,
+    hour: Optional[int] = None,
+    spot_price_in_euro_per_kwh: Optional[float] = None,
+) -> UncertainValue:
+    """The energy-only price of one kWh at one moment, before the additive components (§8.4).
+
+    FLAT reads the working price, TIME_OF_USE the band covering the moment, DYNAMIC the passed
+    spot price times the contract's `spot_factor` (the caller supplies the series value; this
+    module does not read series).
+
+    Keeping the *energy-only* price separate from the full marginal price is what makes the
+    macroeconomic view and the flexibility decomposition possible at all — only this part varies
+    with the moment, and only this part is what a controller can shift its consumption into.
+
+    Args:
+        contract: The contract to price from.
+        weekday: 0 = Monday; together with `hour` it selects the ToU band. Both may be None, in
+            which case the first band applies (the same fallback the price provider uses).
+        hour: Clock hour of the day, 0..23.
+        spot_price_in_euro_per_kwh: The series value of this moment, required for DYNAMIC supply.
+
+    Returns:
+        EUR/kWh as a band. DYNAMIC returns an exact value: the spot series is simulation input and
+        stays exact per §3.9, so a dynamic contract's uncertainty lives entirely in its additive
+        components.
+
+    Raises:
+        CostDataError: If a DYNAMIC contract is priced without a spot price.
+    """
+    supply = contract.supply
+    if supply.kind == SupplyKind.FLAT:
+        return supply.working_price_in_euro_per_kwh
+    if supply.kind == SupplyKind.TIME_OF_USE:
+        band = time_of_use_band_for(supply, weekday, hour)
+        return band.price_in_euro_per_kwh if band is not None else UncertainValue.exact(0.0)
+    if spot_price_in_euro_per_kwh is None:
+        raise CostDataError(
+            f"Tariff {contract.id}: a DYNAMIC contract needs the spot price of the moment to "
+            "price a kWh (§8.4)."
+        )
+    return UncertainValue.exact(spot_price_in_euro_per_kwh * supply.spot_factor)
+
+
+def marginal_purchase_price_in_euro_per_kwh(
+    contract: TariffContract,
+    weekday: Optional[int] = None,
+    hour: Optional[int] = None,
+    spot_price_in_euro_per_kwh: Optional[float] = None,
+) -> UncertainValue:
+    """What one more kWh costs at one moment: energy price plus the additive components (§8.4).
+
+    **One price-selection rule for both sides of the module boundary.** The in-simulation
+    provider (`components/tariff_provider.py`) publishes this figure per timestep and controllers
+    optimize against it; `apply_tariff` prices the resulting aggregates with the same function.
+    They used to be two implementations of FLAT/ToU/DYNAMIC selection, which is exactly the kind
+    of duplication that lets a control decision and its bill drift apart (cost-spec-v2 §2.2).
+    """
+    return energy_price_in_euro_per_kwh(
+        contract, weekday, hour, spot_price_in_euro_per_kwh
+    ) + contract.marginal_purchase_price_components()
+
+
+def apply_tariff(determinants: BillingDeterminants, contract: TariffContract) -> Year1Bill:
+    """The billing engine: one pure function (§8.4).
+
+    Property-tested invariants: a flat contract reproduces kWh x price exactly; the capacity
+    charge is monotone in every peak. Uncertain additive components shift each slot's bill by
+    ``E x delta`` without re-integrating the spot series (§8.4).
+
+    This is where measured consumption becomes money, and it is deliberately the *only* such
+    place: every carrier of every perspective is billed through this one function, so a pricing
+    rule cannot exist in two versions. Being pure — no database, no ledger, no clock, no state —
+    is what makes it property-testable and what lets the same call re-price a stored result years
+    later or bill a load profile under a hypothetical contract (:func:`tariff_counterfactual`).
+
+    Units of the inputs. ``determinants`` describes **one full year of one carrier**: energy in
+    kWh (bought, sold, and per ToU band name), the natively integrated ``cost_integrated_in_euro``
+    and ``revenue_integrated_in_euro`` in euro for dynamic supply, peaks in **kW** as
+    billing-interval mean power (never instantaneous), and the unweighted mean spot price in
+    EUR/kWh. A shorter simulation must be annualized *before* this call — the function has no
+    notion of a period. The contract supplies EUR/kWh, EUR/kW and EUR/year figures as bands.
+
+    What the returned :class:`Year1Bill` contains, per uncertainty slot:
+    ``ENERGY_WORKING`` (energy plus the additive per-kWh components, positive),
+    ``ENERGY_STANDING`` (the annual standing charge, reduced by a FIXED_ANNUAL controllability
+    credit), ``ENERGY_CAPACITY_CHARGE`` (price per kW times the summed relevant peaks — present
+    only if the contract has one) and ``FEED_IN_REVENUE`` (negative, revenue-mirrored, present only
+    if something was sold) — plus the §8.5 decomposition scalars on the BEST_ESTIMATE slot. Prices are
+    taken as stated: VAT is never added or removed here, and ``supply.vat_rate`` currently has no
+    consumer at all — the macroeconomic view strips taxes using the price entry's
+    ``tax_and_levy_share`` instead (``calculators/energy.py``).
+
+    Three billing paths, one per supply kind. FLAT multiplies the marginal price by annual energy.
+    TIME_OF_USE prices each band's energy with its own price and bills whatever the meter did not
+    attribute to a band at the fallback band's price — the same fallback the price provider uses,
+    so a band-name mismatch produces a consistent (if wrong-looking) bill instead of free energy.
+    DYNAMIC refuses to work from annual totals at all: it requires the integral the meter computed
+    at native resolution, because kWh times average price is precisely the error a dynamic tariff
+    exists to exploit. Only DYNAMIC can report a non-zero flexibility value, and only when the
+    meter also supplied the unweighted mean spot price.
+
+    Args:
+        determinants: One carrier's annual billing determinants (§8.4), already annualized.
+        contract: The tariff contract to bill under.
+
+    Returns:
+        The year-1 bill by category, with the §8.5 decomposition attached.
+
+    Raises:
+        CostDataError: For a TIME_OF_USE contract without bands, or a DYNAMIC contract whose
+            determinants carry no integrated cost.
+    """
+    bill = Year1Bill()
+    energy_bought = determinants.energy_bought_in_kwh
+    supply = contract.supply
+
+    if supply.kind == SupplyKind.FLAT:
+        working = marginal_purchase_price_in_euro_per_kwh(contract)
+        bill.by_category[CostCategory.ENERGY_WORKING] = working.scale(energy_bought)
+        bill.mean_energy_price_in_euro_per_kwh = working.best_estimate
+        bill.volume_effect_in_euro = energy_bought * working.best_estimate
+        bill.flexibility_value_in_euro = 0.0
+    elif supply.kind == SupplyKind.TIME_OF_USE:
+        if not supply.bands:
+            raise CostDataError(f"Tariff {contract.id}: TIME_OF_USE without bands.")
+        total = UncertainValue.exact(0.0)
+        banded_energy = 0.0
+        for band in supply.bands:
+            band_energy = determinants.energy_bought_per_band_in_kwh.get(band.name, 0.0)
+            banded_energy += band_energy
+            total = total + band.price_in_euro_per_kwh.scale(band_energy)
+        unbanded = energy_bought - banded_energy
+        if unbanded > 1e-6:
+            # Bill unbanded energy at the fallback band and let the meter warn upstream — the
+            # same fallback the price provider applies to an unmatched moment.
+            fallback = time_of_use_band_for(supply)
+            assert fallback is not None  # bands were checked above
+            total = total + fallback.price_in_euro_per_kwh.scale(unbanded)
+        additive = contract.marginal_purchase_price_components().scale(energy_bought)
+        working = total + additive
+        bill.by_category[CostCategory.ENERGY_WORKING] = working
+        bill.mean_energy_price_in_euro_per_kwh = working.best_estimate / energy_bought if energy_bought else 0.0
+        bill.volume_effect_in_euro = working.best_estimate
+        bill.flexibility_value_in_euro = 0.0
+    else:  # DYNAMIC
+        if determinants.cost_integrated_in_euro is None:
+            raise CostDataError(
+                f"Tariff {contract.id}: DYNAMIC supply needs the natively integrated cost "
+                "(load x price series) in the billing determinants (§8.4)."
+            )
+        # Energy-only integral (spot x factor), exact (§3.9); additive components per slot.
+        spot_cost = determinants.cost_integrated_in_euro
+        additive = contract.marginal_purchase_price_components().scale(energy_bought)
+        bill.by_category[CostCategory.ENERGY_WORKING] = UncertainValue.exact(spot_cost) + additive
+        mean_spot = spot_cost / energy_bought if energy_bought else 0.0
+        bill.mean_energy_price_in_euro_per_kwh = mean_spot + contract.marginal_purchase_price_components().best_estimate
+        # Decomposition (§8.5): volume effect at the year's average price; the difference
+        # between paying the average and the integral is the flexibility value.
+        # Additive components are volume-proportional and carry no flexibility.
+        if determinants.mean_spot_price_in_euro_per_kwh is not None:
+            # The meter passed the year's unweighted mean spot price, so the flexibility value
+            # (what load shifting saved vs. paying the average price) is separable (§8.5).
+            mean_spot_unweighted = determinants.mean_spot_price_in_euro_per_kwh
+            bill.volume_effect_in_euro = energy_bought * (
+                mean_spot_unweighted + contract.marginal_purchase_price_components().best_estimate
+            )
+            bill.flexibility_value_in_euro = energy_bought * mean_spot_unweighted - spot_cost
+        else:
+            mean_price_for_volume = spot_cost / energy_bought if energy_bought else 0.0
+            bill.volume_effect_in_euro = energy_bought * mean_price_for_volume
+            bill.flexibility_value_in_euro = 0.0
+
+    # Standing charge and controllability discount. The discount is a credit stated positively, so
+    # its band is mirrored (`as_revenue`) before being added to a cost — otherwise the LOW slot of
+    # the standing charge would combine a cheap charge with a stingy credit (§3.9).
+    standing = contract.standing_charge_in_euro_per_year
+    if contract.controllability_discount.kind == "FIXED_ANNUAL":
+        standing = standing + contract.controllability_discount.annual_amount_in_euro.as_revenue()
+    bill.by_category[CostCategory.ENERGY_STANDING] = standing
+
+    # Capacity charge: monotone in every peak (§8.4).
+    capacity = contract.capacity_charge
+    if capacity.kind != CapacityChargeKind.NONE:
+        if capacity.kind == CapacityChargeKind.ANNUAL_PEAK:
+            peak_sum = determinants.annual_peak_in_kw
+        else:  # MONTHLY_PEAK and PEAK_WINDOW: the meter supplies the relevant period peaks
+            peak_sum = sum(determinants.peak_per_billing_period_in_kw)
+        bill.by_category[CostCategory.ENERGY_CAPACITY_CHARGE] = capacity.price_in_euro_per_kw.scale(peak_sum)
+
+    # Feed-in revenue (negative).
+    if contract.feed_in.kind != FeedInKind.NONE and determinants.energy_sold_in_kwh > 0:
+        if contract.feed_in.kind == FeedInKind.FIXED_TARIFF:
+            revenue = contract.feed_in.rate_in_euro_per_kwh.scale(determinants.energy_sold_in_kwh)
+        else:  # SPOT_REFERENCED
+            if determinants.revenue_integrated_in_euro is not None:
+                # The marketer's share of the spot proceeds (`spot_factor`) applies to the
+                # integrated spot term only; the markup is an agreed per-kWh amount beside it.
+                revenue = UncertainValue.exact(
+                    determinants.revenue_integrated_in_euro * contract.feed_in.spot_factor
+                ) + (contract.feed_in.markup_in_euro_per_kwh.scale(determinants.energy_sold_in_kwh))
+            else:
+                # No natively integrated revenue available (e.g. a meter that only reported
+                # annual totals): fall back to the flat rate rather than dropping the revenue.
+                revenue = contract.feed_in.rate_in_euro_per_kwh.scale(determinants.energy_sold_in_kwh)
+        bill.by_category[CostCategory.FEED_IN_REVENUE] = revenue.as_revenue()
+
+    return bill
+
+
+def tariff_counterfactual(
+    determinants: BillingDeterminants, active: TariffContract, flat: TariffContract
+) -> Dict[str, UncertainValue]:
+    """Bills the *same* load profile under a flat contract (§8.5 counterfactual 1).
+
+    Answers "what did the tariff choice earn, given unchanged behavior": the simulated load profile
+    is re-billed under `flat`, and the difference to the active contract's bill is attributed to
+    the tariff. The counterfactual is therefore *to a different contract, not to a different
+    building or controller* — the load profile, the control strategy and every physical quantity
+    are held fixed, which is what makes it free (no second simulation) and also what limits it.
+
+    The complementary question — what the tariff *and* a price-reactive controller earn together —
+    is §8.5's behavioral counterfactual and needs a second simulation with a flat tariff and a
+    price-blind EMS, compared as an ordinary `VariantComparison`. Re-pricing carries that caveat
+    generally — it is why a *scenario* that overlays energy prices consumed by the simulation must
+    opt in via ``EconomicParameters.allow_counterfactual_billing`` (§4.6); this function is an
+    explicit request and is not gated, so the honest reading of its output is "the tariff
+    difference on this fixed behavior", not "the savings a household would realize".
+
+    Args:
+        determinants: The measured annual determinants, billed unchanged under both contracts.
+        active: The contract actually in force.
+        flat: The flat comparison contract.
+
+    Returns:
+        The two totals and their difference, all as bands; ``tariff_advantage_in_euro`` is positive
+        when the active contract is cheaper than the flat one.
+    """
+    active_bill = apply_tariff(determinants, active)
+    flat_bill = apply_tariff(determinants, flat)
+    return {
+        "active_total_in_euro": active_bill.total(),
+        "flat_total_in_euro": flat_bill.total(),
+        "tariff_advantage_in_euro": flat_bill.total() - active_bill.total(),
+    }

--- a/hisim/economics/validation.py
+++ b/hisim/economics/validation.py
@@ -1,0 +1,386 @@
+"""Data-file CI checks (cost_spec.md §9.6).
+
+Since prices and schemes are data, the data gets the CI treatment code used to get
+implicitly. These functions are called from tests (`tests/test_economics_data_and_integration.py`)
+and can be run standalone via ``python -m hisim.economics validate``.
+
+**The design question it answers.** Moving every number out of Python into `hisim/cost_database/`
+and `hisim/subsidy_catalog/` bought versioning, sourcing and country-specificity — but it also
+moved a large part of the engine's correctness out of the reach of the type checker, the linter and
+code review. This module is the compensation: the checks that would have been compile errors if the
+numbers were still code. An unsourced datapoint, an asset class with no price in one shipped
+country, a subsidy scheme conditioning on a question nobody asks, a tariff contract whose id does
+not match its file name — each of these produces a perfectly loadable data file and a wrong or
+crashing run, and each is caught here instead.
+
+**Errors versus warnings** is the module's central distinction and is deliberate. An *error* means
+the shipped data is internally inconsistent: it fails CI and must be fixed before merge. A
+*warning* means the data may be out of date or untidy — a source retrieved more than twelve months
+ago, a catalog snapshot older than a year, a registry entry or question referenced by nothing.
+Those are judgement calls for a data reviewer, not gates, because time passing is not a defect.
+
+Its place in the pipeline: this runs *beside* the engine, never inside it. It is invoked from
+the data-file test module in CI (today `tests/test_economics_data_and_integration.py`) and by the
+`validate` CLI subcommand after a data edit; no simulation, no evaluation and no result depends on
+it. The checks it performs are
+those of §9.6: schema validation (by loading through the real loaders), source completeness,
+coverage matrices, tariff-contract integrity, question coverage and staleness.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Dict, List, Optional, Set
+
+from hisim.economics.database import CostDatabase, SourceRegistry
+from hisim.economics.subsidies import (
+    SubsidyCatalog,
+    SubsidyScheme,
+    TaxCreditBenefit,
+    question_targets,
+    scheme_context_fields,
+)
+from hisim.economics.tariffs import TariffContract
+
+
+class ValidationConstants:
+    """Requirements the shipped data files are validated against.
+
+    Only the language requirement so far. It lives here rather than inline because it is a policy
+    decision (spec Q31: German and English in v1) that a future country addition will revisit — the
+    §5.7 questionnaire has to be answerable by the people the subsidy applies to, so adding a
+    country with another official language means extending this tuple and the question catalogs
+    together.
+    """
+
+    #: Languages the question catalogs must cover (spec Q31: de + en in v1).
+    REQUIRED_QUESTION_LANGUAGES = ("de", "en")
+
+
+@dataclass
+class ValidationReport:
+    """Errors fail CI; warnings are advisory (staleness).
+
+    The accumulating result of a validation run, and the reason the checks collect rather than
+    raise: a data reviewer wants *every* problem in the file they just edited, not the first one.
+    Messages are plain strings because their only consumers are a test assertion and the CLI's
+    stdout — nothing branches on their content.
+    """
+
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def merge(self, other: "ValidationReport") -> None:
+        """In-place union.
+
+        How the composite checks assemble their sub-reports (`validate_all` over the catalogs,
+        `validate_cost_database` over the tariff contracts) while keeping the error/warning
+        distinction of each.
+        """
+        self.errors.extend(other.errors)
+        self.warnings.extend(other.warnings)
+
+    @property
+    def ok(self) -> bool:
+        """No errors. Warnings do not affect it — this is exactly the CI gate and the CLI exit."""
+        return not self.errors
+
+
+def validate_cost_database(
+    base_path: Optional[str] = None,
+    declared_asset_classes: Optional[Set] = None,
+    used_carriers: Optional[Set] = None,
+    reference_date: Optional[date] = None,
+) -> ValidationReport:
+    """Schema + source completeness + coverage matrix + staleness for the cost database.
+
+    Runs the §9.6 checks over `hisim/cost_database/`. Schema validation is not re-implemented here:
+    the database is simply *loaded* through `CostDatabase`, whose loaders already reject an
+    unsourced datapoint, an inverted uncertainty band or an unknown enum — so a load failure is
+    reported as a single CI error and the run stops there. On top of that come the checks that need
+    a whole-corpus view: the tariff contracts (which used never to be walked at all, W2.5/B9),
+    orphaned and stale source registry entries as warnings, and the two coverage matrices.
+
+    **The coverage matrix is the counterpart of the legacy "new component must implement
+    get_cost_capex" rule** (§9.6): every asset class any component declares must have a device entry
+    in *every* shipped country, and every carrier any meter bills must have a price entry — so
+    adding a `ComponentType` without cost data fails CI instead of failing a user's run in a country
+    nobody tested. The checks are skipped when the caller passes no declared classes/carriers, which
+    is what lets the CLI run without importing the component zoo.
+
+    Ordering note: the tariff contracts are validated *before* the orphan check, so contract sources
+    count as referenced and do not get reported as orphans.
+
+    Args:
+        base_path: Cost database directory; the shipped one by default.
+        declared_asset_classes: `ComponentType`s to demand device entries for. Omit to skip.
+        used_carriers: `EnergyCarrier`s to demand price entries for. Omit to skip.
+        reference_date: "Today" for the 12-month staleness comparison; makes the check testable.
+
+    Returns:
+        The report; `ok` is False if anything structural is wrong.
+    """
+    report = ValidationReport()
+    path = base_path or CostDatabase.DEFAULT_PATH
+    try:
+        database = CostDatabase(path)
+    except Exception as err:  # pylint: disable=broad-except — every load error is a CI error
+        report.errors.append(f"Cost database failed to load: {err}")
+        return report
+
+    # Resolve auxiliary files' sources so their registry entries don't count as orphans.
+    allocation_path = os.path.join(path, "allocation_DE_2024.json")
+    if os.path.isfile(allocation_path):
+        with open(allocation_path, encoding="utf-8") as file:
+            allocation = json.load(file)
+        try:
+            database.sources.resolve(tuple(allocation.get("source_ids", ())), "allocation_DE_2024.json")
+        except Exception as err:  # pylint: disable=broad-except
+            report.errors.append(str(err))
+
+    # W2.5 / §7 B9: the tariff contracts ship inside the cost database but were never validated.
+    # Run before the orphan check so contract sources count as referenced.
+    report.merge(validate_tariff_contracts(os.path.join(path, "tariffs"), database.sources))
+
+    orphans = database.sources.orphaned_ids()
+    if orphans:
+        report.warnings.append(f"Orphaned source registry entries (referenced by no data entry): {orphans}")
+    stale = database.sources.stale_ids(reference_date=reference_date)
+    if stale:
+        report.warnings.append(f"Sources with retrieved date older than 12 months: {stale}")
+
+    # Coverage matrix (§9.6): every declared asset class x supported country has an entry.
+    if declared_asset_classes:
+        for country in database.devices:
+            for asset_class in sorted(declared_asset_classes, key=lambda item: item.value):
+                if not database.has_device_entry(asset_class, country):
+                    report.errors.append(
+                        f"Coverage matrix: no device entry for {asset_class.value!r} in {country}."
+                    )
+    if used_carriers:
+        for country in database.energy_prices:
+            for carrier in sorted(used_carriers, key=lambda item: item.value):
+                if not database.has_energy_price(carrier, country):
+                    report.errors.append(f"Coverage matrix: no energy price for {carrier.value!r} in {country}.")
+    return report
+
+
+def validate_tariff_contracts(
+    base_path: Optional[str] = None, registry: Optional[SourceRegistry] = None
+) -> ValidationReport:
+    """Every shipped tariff contract parses, is addressable by its file name and cites sources.
+
+    W2.5 / §7 B9: `validate_all` never walked ``cost_database/tariffs/*.json``, so a malformed
+    contract shipped silently and only failed when a simulation happened to reference it.
+
+    Checks per file: the JSON parses through the §8.2 schema (`TariffContract.from_json`, which
+    also enforces mandatory source ids), the contract id matches the file name (contracts are
+    looked up by file name in `load_tariff_contract`), a DYNAMIC contract's `spot_series` exists,
+    and every source id resolves against the cost database's registry.
+
+    **W2.4b: inline sources are an error in catalog files.** ``inline:<citation>`` used to be
+    accepted here with a warning; a shipped data file that cites its source in prose cannot be
+    reviewed, deduplicated or checked for staleness, so a tariff *file* must name registry
+    entries. The convention survives only for contracts built in memory (worked examples, test
+    fixtures, the provider's SYNTHETIC_TEST contract), which no registry can back — see the
+    `tariffs.py` module docstring.
+    """
+    report = ValidationReport()
+    path = base_path or TariffContract.DEFAULT_PATH
+    if not os.path.isdir(path):
+        report.errors.append(f"Tariff directory {path} does not exist.")
+        return report
+    series_path = os.path.join(os.path.dirname(path), "spot_series")
+    for file_name in sorted(name for name in os.listdir(path) if name.endswith(".json")):
+        contract_id = file_name[: -len(".json")]
+        full_path = os.path.join(path, file_name)
+        try:
+            with open(full_path, encoding="utf-8") as file:
+                raw = json.load(file)
+            contract = TariffContract.from_json(raw)
+        except Exception as err:  # pylint: disable=broad-except — every load error is a CI error
+            report.errors.append(f"Tariff contract {file_name}: failed to parse: {err}")
+            continue
+        if contract.id != contract_id:
+            report.errors.append(
+                f"Tariff contract {file_name}: declares id {contract.id!r} but is loaded by file "
+                f"name, so it can never be resolved by its own id."
+            )
+        if contract.supply.spot_series and not os.path.isfile(
+            os.path.join(series_path, f"{contract.supply.spot_series}.csv")
+        ):
+            report.errors.append(
+                f"Tariff contract {contract.id}: references spot series "
+                f"{contract.supply.spot_series!r}, which does not exist in {series_path}."
+            )
+        inline = [source_id for source_id in contract.source_ids if source_id.startswith("inline:")]
+        registry_ids = tuple(
+            source_id for source_id in contract.source_ids if not source_id.startswith("inline:")
+        )
+        if registry is not None and registry_ids:
+            try:
+                registry.resolve(registry_ids, f"tariff contract {contract.id}")
+            except Exception as err:  # pylint: disable=broad-except
+                report.errors.append(str(err))
+        if inline:
+            report.errors.append(
+                f"Tariff contract {contract.id}: cites inline source(s) {inline} instead of "
+                f"registry entries in {file_name} — a shipped catalog file must reference "
+                "sources.json entries (§3.10, W2.4). Inline sources are only admissible for "
+                "contracts built in memory."
+            )
+    return report
+
+
+def validate_subsidy_catalog(country: str, base_path: Optional[str] = None) -> ValidationReport:
+    """Schema, condition grammar, question coverage and staleness for one country catalog.
+
+    Validates one `subsidy_catalog/<COUNTRY>.json` and its question file. As with the cost database,
+    schema and benefit typing are enforced by *loading* the catalog (W2.2), so what remains here are
+    the checks that need the catalog as a whole: snapshot-date staleness, scheme-id uniqueness,
+    `excludes` pointing at schemes that actually exist (an exclusion naming a typo can never fire,
+    which silently over-grants), tax-credit instalment shares summing to 1, and cumulation groups
+    whose members agree on their combined rate cap — they must, because the solver applies the
+    minimum cap declared in a group to every member.
+
+    **Question coverage (§5.7) is the check that makes the questionnaire complete by construction.**
+    Every context field a shipped scheme's conditions reference must have a question-catalog entry
+    in every required language, or eligibility could depend on something the user was never asked;
+    the reverse direction, a question no scheme reads, is only a warning. Which fields a scheme
+    depends on comes from the single field-vocabulary registry in `subsidies.py` (W2.3), so this
+    module cannot drift from the condition language it validates.
+
+    Args:
+        country: Catalog country code, i.e. the file stem (`DE`, `AT`).
+        base_path: Catalog directory; the shipped one by default.
+
+    Returns:
+        The report. A catalog that fails to load yields exactly one error and no further checks.
+    """
+    report = ValidationReport()
+    base = base_path or SubsidyCatalog.DEFAULT_PATH
+    try:
+        catalog = SubsidyCatalog.load(country, base)
+    except Exception as err:  # pylint: disable=broad-except
+        report.errors.append(f"Subsidy catalog {country} failed to load: {err}")
+        return report
+
+    # Staleness (§9.6): catalog_snapshot_date older than 12 months.
+    if catalog.snapshot_date:
+        try:
+            snapshot = datetime.strptime(catalog.snapshot_date, "%Y-%m-%d").date()
+            if (date.today() - snapshot).days > 365:
+                report.warnings.append(
+                    f"Subsidy catalog {country}: snapshot date {catalog.snapshot_date} is older than 12 months."
+                )
+        except ValueError:
+            report.errors.append(f"Subsidy catalog {country}: invalid catalog_snapshot_date.")
+    else:
+        report.errors.append(f"Subsidy catalog {country}: catalog_snapshot_date missing.")
+
+    # Cross-scheme coherence (W2.5). Benefit *typing* is enforced at load (W2.2) — a malformed
+    # benefit makes the load above fail — so what is left here are the checks that need the whole
+    # catalog: id uniqueness, `excludes` pointing at real schemes, and cumulation groups whose
+    # members agree on their combined rate cap. (`cumulation_group` is a group *label*, not a
+    # scheme id, so there is nothing to resolve it against; its catalog-level invariant is the
+    # cap coherence below, because the solver applies the minimum cap declared in the group to
+    # all of its members.)
+    seen: Set[str] = set()
+    for scheme in catalog.schemes:
+        if scheme.id in seen:
+            report.errors.append(f"Subsidy catalog {country}: duplicate scheme id {scheme.id!r}.")
+        seen.add(scheme.id)
+    for scheme in catalog.schemes:
+        for excluded in scheme.excludes:
+            if excluded not in seen:
+                report.errors.append(
+                    f"Subsidy catalog {country}: scheme {scheme.id!r} excludes unknown scheme id "
+                    f"{excluded!r} — the exclusion can never fire."
+                )
+        benefit = scheme.benefit
+        if isinstance(benefit, TaxCreditBenefit) and benefit.annual_shares:
+            total_share = sum(benefit.annual_shares)
+            if abs(total_share - 1.0) > 1e-9:
+                report.errors.append(
+                    f"Subsidy catalog {country}: scheme {scheme.id!r} has annual_shares summing "
+                    f"to {total_share} instead of 1."
+                )
+    groups: Dict[str, List[SubsidyScheme]] = {}
+    for scheme in catalog.schemes:
+        if scheme.cumulation_group:
+            groups.setdefault(scheme.cumulation_group, []).append(scheme)
+    for group, members in sorted(groups.items()):
+        caps = {scheme.combined_rate_cap for scheme in members}
+        if len(caps) > 1:
+            report.errors.append(
+                f"Subsidy catalog {country}: cumulation group {group!r} declares inconsistent "
+                f"combined_rate_cap values {sorted(cap for cap in caps if cap is not None)}"
+                f"{' plus null' if None in caps else ''} across "
+                f"{sorted(scheme.id for scheme in members)} — the solver applies the minimum cap "
+                "of the group to every member, so the members must agree."
+            )
+
+    # Question coverage (§5.7, §9.6): every referenced user-answerable field has a question
+    # in every required language; orphaned questions are flagged. Which fields a scheme depends
+    # on, and which question a derived field is asked through, come from the one field-vocabulary
+    # registry in `subsidies.py` (W2.3) — this module no longer keeps its own copy.
+    asked: Set[str] = set()
+    for scheme in catalog.schemes:
+        for fieldname in scheme_context_fields(scheme):
+            if fieldname and not fieldname.startswith("measure."):
+                asked.update(question_targets(fieldname))
+    for fieldname in sorted(asked):
+        entry = catalog.questions.get(fieldname)
+        if entry is None:
+            report.errors.append(
+                f"Subsidy catalog {country}: field {fieldname!r} referenced by scheme conditions has "
+                "no question catalog entry (§5.7)."
+            )
+            continue
+        for language in ValidationConstants.REQUIRED_QUESTION_LANGUAGES:
+            if language not in entry.question:
+                report.errors.append(
+                    f"Subsidy catalog {country}: question for {fieldname!r} misses language {language!r}."
+                )
+    for fieldname in catalog.questions:
+        if fieldname not in asked:
+            report.warnings.append(
+                f"Subsidy catalog {country}: orphaned question entry {fieldname!r} (referenced by no scheme)."
+            )
+    return report
+
+
+def validate_all(cost_database_path: Optional[str] = None, subsidy_base_path: Optional[str] = None) -> ValidationReport:
+    """Everything: cost database plus all shipped subsidy catalogs.
+
+    The single entry point behind ``python -m hisim.economics validate`` and behind the data-file CI
+    test: it validates the cost database and then discovers the shipped country catalogs from the
+    directory listing — every `*.json` that is not a `questions_*` file and not `sources.json` — so
+    adding a country adds its checks automatically, with no code change (§10.1 Phase 4).
+
+    Note the deliberate gap: no `declared_asset_classes` or `used_carriers` are passed on, so the
+    coverage matrices are *not* checked here. Those need the set of classes and carriers components
+    actually declare, which the CI test supplies explicitly; a green `validate` run therefore means
+    "the shipped data is internally consistent", not "every component can be priced".
+
+    Args:
+        cost_database_path: Cost database directory; the shipped one by default.
+        subsidy_base_path: Subsidy catalog directory; the shipped one by default.
+
+    Returns:
+        The merged report over everything checked.
+    """
+    report = validate_cost_database(cost_database_path)
+    base = subsidy_base_path or SubsidyCatalog.DEFAULT_PATH
+    if os.path.isdir(base):
+        for file_name in sorted(os.listdir(base)):
+            if (
+                file_name.endswith(".json")
+                and not file_name.startswith("questions_")
+                and file_name != "sources.json"
+            ):
+                report.merge(validate_subsidy_catalog(file_name[:-len(".json")], base))
+    return report

--- a/hisim/subsidy_catalog/AT.json
+++ b/hisim/subsidy_catalog/AT.json
@@ -12,7 +12,7 @@
       "source_ids": ["src_at_raus_aus_oel"],
       "applies_to": {"asset_classes": ["HEAT_PUMP"], "measure_kinds": ["REPLACE"]},
       "eligibility": {"all": [
-        {"field": "applicant.actor", "op": "in", "value": ["OWNER_OCCUPIER", "LANDLORD", "WEG"]},
+        {"field": "applicant.actor", "op": "in", "value": ["OWNER_OCCUPIER", "LANDLORD", "CONDOMINIUM_ASSOCIATION"]},
         {"field": "building.existing_heating.energy_carrier", "op": "in", "value": ["NATURAL_GAS", "HEATING_OIL"]}
       ]},
       "benefit": {"kind": "LUMP_SUM", "amount": 7500},

--- a/hisim/subsidy_catalog/DE.json
+++ b/hisim/subsidy_catalog/DE.json
@@ -32,7 +32,7 @@
             "value": [
               "OWNER_OCCUPIER",
               "LANDLORD",
-              "WEG"
+              "CONDOMINIUM_ASSOCIATION"
             ]
           },
           {
@@ -363,7 +363,7 @@
             "value": [
               "OWNER_OCCUPIER",
               "LANDLORD",
-              "WEG"
+              "CONDOMINIUM_ASSOCIATION"
             ]
           },
           {
@@ -538,7 +538,7 @@
             "value": [
               "OWNER_OCCUPIER",
               "LANDLORD",
-              "WEG"
+              "CONDOMINIUM_ASSOCIATION"
             ]
           },
           {
@@ -619,7 +619,7 @@
             "value": [
               "OWNER_OCCUPIER",
               "LANDLORD",
-              "WEG"
+              "CONDOMINIUM_ASSOCIATION"
             ]
           },
           {
@@ -816,11 +816,11 @@
             "value": [
               "OWNER_OCCUPIER",
               "LANDLORD",
-              "WEG"
+              "CONDOMINIUM_ASSOCIATION"
             ]
           },
           {
-            "field": "building.has_isfp",
+            "field": "building.has_renovation_roadmap",
             "op": "==",
             "value": true
           }

--- a/hisim/subsidy_catalog/questions_AT.json
+++ b/hisim/subsidy_catalog/questions_AT.json
@@ -7,7 +7,7 @@
       "options": [
         "OWNER_OCCUPIER",
         "LANDLORD",
-        "WEG",
+        "CONDOMINIUM_ASSOCIATION",
         "TENANT"
       ],
       "question": {
@@ -18,13 +18,13 @@
         "de": {
           "OWNER_OCCUPIER": "Selbstnutzende:r Eigentuemer:in",
           "LANDLORD": "Vermieter:in",
-          "WEG": "Wohnungseigentuemergemeinschaft",
+          "CONDOMINIUM_ASSOCIATION": "Wohnungseigentuemergemeinschaft",
           "TENANT": "Mieter:in"
         },
         "en": {
           "OWNER_OCCUPIER": "Owner-occupier",
           "LANDLORD": "Landlord",
-          "WEG": "Homeowners' association",
+          "CONDOMINIUM_ASSOCIATION": "Homeowners' association",
           "TENANT": "Tenant"
         }
       },

--- a/hisim/subsidy_catalog/questions_DE.json
+++ b/hisim/subsidy_catalog/questions_DE.json
@@ -7,7 +7,7 @@
       "options": [
         "OWNER_OCCUPIER",
         "LANDLORD",
-        "WEG",
+        "CONDOMINIUM_ASSOCIATION",
         "TENANT"
       ],
       "question": {
@@ -18,13 +18,13 @@
         "de": {
           "OWNER_OCCUPIER": "Selbstnutzende:r Eigentuemer:in",
           "LANDLORD": "Vermieter:in",
-          "WEG": "Wohnungseigentuemergemeinschaft",
+          "CONDOMINIUM_ASSOCIATION": "Wohnungseigentuemergemeinschaft",
           "TENANT": "Mieter:in"
         },
         "en": {
           "OWNER_OCCUPIER": "Owner-occupier",
           "LANDLORD": "Landlord",
-          "WEG": "Homeowners' association",
+          "CONDOMINIUM_ASSOCIATION": "Homeowners' association",
           "TENANT": "Tenant"
         }
       },
@@ -208,7 +208,7 @@
       }
     },
     {
-      "field": "building.has_isfp",
+      "field": "building.has_renovation_roadmap",
       "answer_kind": "BOOLEAN",
       "question": {
         "de": "Liegt fuer das Gebaeude ein individueller Sanierungsfahrplan (iSFP) vor?",

--- a/tests/test_economics_subsidies.py
+++ b/tests/test_economics_subsidies.py
@@ -1,0 +1,550 @@
+"""Unit tests for the subsidy catalog, conditions and benefits (§5.1-§5.3).
+
+First of the two subsidy unit-test files (split per the PR-3 review's 500-line rule): typed
+benefit payloads and catalog parsing errors, the condition AST with its field vocabulary
+(W2.3), D25's named ineligibility reasons, catalog/scheme provenance, the deleted dead
+surface, and the §4.6 scenario data overlays. The solver-side tests — cumulation, caps,
+subsidy modes and the shipped BEG/§35c behavior — are in
+`test_economics_subsidy_solver.py`; everything that needs the evaluator is in
+`test_economics_subsidy_integration.py`. The placement rule is unchanged: a test importing
+any module above the rule engines belongs in the integration file.
+"""
+
+import dataclasses
+import json
+import os
+import pytest
+from hisim.economics import subsidies
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.database import CostDatabase
+from hisim.economics.facts import ComponentCostFacts, ExistingAsset
+from hisim.economics.parameters import EconomicParameters
+from hisim.economics.subsidies import (
+    ApplicantActor,
+    ApplicantProfile,
+    BenefitKind,
+    Condition,
+    EligibleCostSpec,
+    LoanTermsBenefit,
+    LumpSumBenefit,
+    MeasureForSubsidy,
+    PayoutKind,
+    ShareBenefit,
+    SubsidyBuildingContext,
+    SubsidyCatalog,
+    SubsidyContext,
+    SubsidyContextFields,
+    SubsidyDataError,
+    SubsidyScheme,
+    TaxCreditBenefit,
+    evaluate_condition,
+    failed_condition_descriptions,
+    ineligibility_reason,
+    parse_condition,
+    question_targets,
+    scheme_context_fields,
+    solve_cumulation,
+)
+from hisim.economics.timeline import CostCategory
+from hisim.economics.uncertainty import UncertainValue
+from hisim.loadtypes import ComponentType, Units
+
+pytestmark = pytest.mark.base
+
+DISCOUNT = EconomicParameters(price_basis_year=2024).discount_factor
+
+@pytest.fixture(name="catalog", scope="module")
+def fixture_catalog() -> SubsidyCatalog:
+    """The shipped DE subsidy catalog.
+
+    Used wherever the *real* scheme definitions are the subject — BEG stacking and its 70 % cap,
+    the §35c exclusion, the speed and income bonuses, the questionnaire derived from their
+    conditions. Tests about solver *mechanics* build synthetic catalogs instead, so a change to
+    German subsidy law moves only the tests that are about German subsidy law. Module-scoped
+    because loading resolves and validates the whole catalog including its source registry.
+    """
+    return SubsidyCatalog.load("DE")
+
+def make_measure(cost: float = 30000.0, scop: float = 4.0, refrigerant: str = "R290") -> MeasureForSubsidy:
+    """A heat pump measure for subsidy tests.
+
+    The cost is stated rather than resolved from the database, so awards read as percentages of a
+    round number; `measure_kind="REPLACE"` is what the BEG schemes require. SCOP and refrigerant
+    are the two technical attributes the DE efficiency conditions read: the defaults (4.0, R290)
+    satisfy them, and passing 2.8 / R32 is how a test makes the base scheme fail its technical
+    minimum.
+    """
+    facts = ComponentCostFacts(
+        asset_class=ComponentType.HEAT_PUMP,
+        size=10.0,
+        size_unit=Units.KILOWATT,
+        technical_attributes={"scop": scop, "refrigerant": refrigerant},
+    )
+    return MeasureForSubsidy(
+        subject="HeatPump",
+        facts=facts,
+        measure_kind="REPLACE",
+        cost_by_category={CostCategory.INVESTMENT: UncertainValue.exact(cost)},
+    )
+
+def full_context(income: float = 35000.0) -> SubsidyContext:
+    """Owner-occupier with a functioning gas boiler, everything answered.
+
+    "Everything answered" is the point: no field is None, so no scheme can come back UNDETERMINED
+    and every decision below is a definite yes or no. Tests that want the tri-state path
+    deliberately blank one field afterwards. The functioning gas boiler is what makes the BEG
+    speed bonus eligible, and 35 000 EUR of taxable household income sits below the income-bonus
+    threshold — pass a higher figure to drop that bonus. One dwelling unit and no commercial area
+    keep the residential-share proration at 1.0.
+    """
+    return SubsidyContext(
+        applicant=ApplicantProfile(
+            actor=ApplicantActor.OWNER_OCCUPIER, taxable_household_income_in_euro=income, main_residence=True
+        ),
+        building=SubsidyBuildingContext(
+            construction_year=1985,
+            dwelling_units=1,
+            residential_floor_area_in_m2=150.0,
+            commercial_floor_area_in_m2=0.0,
+            existing_heating=ExistingAsset(
+                asset_class=ComponentType.GAS_HEATER,
+                size=15.0,
+                size_unit=Units.KILOWATT,
+                installation_year=2005,
+                is_functional=True,
+                energy_carrier=EnergyCarrier.NATURAL_GAS,
+            ),
+        ),
+    )
+
+def make_scheme(
+    scheme_id: str,
+    eligibility: Condition,
+    benefit_kind: BenefitKind = BenefitKind.SHARE_OF_ELIGIBLE_COST,
+    benefit=None,
+    eligible_cost: EligibleCostSpec = None,
+) -> SubsidyScheme:
+    """A minimal heat pump scheme whose eligibility is spelled out by the caller.
+
+    Everything a scheme needs to be *valid* is filled in with an inert default — no cumulation
+    group, no rate cap, no exclusions, no eligible-cost restriction, an upfront grant — so a test
+    varies only the dimension it is about and the rest cannot interfere. The default benefit is a
+    deliberately tiny 1 % share: schemes built for the solver's *guard* tests must be eligible and
+    stackable without their amounts mattering.
+    """
+    return SubsidyScheme(
+        id=scheme_id,
+        country="DE",
+        region=None,
+        valid_from="1900-01-01",
+        valid_to=None,
+        legal_basis="synthetic test scheme",
+        url="https://example.invalid/scheme",
+        asset_classes=[ComponentType.HEAT_PUMP],
+        measure_kinds=["INSTALL", "REPLACE"],
+        eligibility=eligibility,
+        benefit_kind=benefit_kind,
+        benefit=benefit if benefit is not None else ShareBenefit(rate=0.01),
+        eligible_cost=eligible_cost if eligible_cost is not None else EligibleCostSpec(),
+        cumulation_group=None,
+        combined_rate_cap=None,
+        excludes=[],
+        payout_kind=PayoutKind.UPFRONT_GRANT,
+    )
+
+def make_catalog(schemes, overall_cap_share: float = None) -> SubsidyCatalog:
+    """An in-memory catalog around the given schemes.
+
+    No file, no country data, no questions — the solver only needs the scheme list and the
+    optional EU state-aid `overall_cap_share`, which is exactly the knob the per-slot cap tests
+    turn. Schemes constructed this way record `IN_MEMORY_DEFINITION` provenance rather than
+    citing a registry entry (W2.4), which is itself asserted in `TestSubsidyProvenance`.
+    """
+    return SubsidyCatalog(
+        schemes=list(schemes),
+        questions={},
+        snapshot_date=None,
+        overall_cap_share=overall_cap_share,
+        base_path="",
+        country="DE",
+    )
+
+ALWAYS_ELIGIBLE = Condition(kind="all")
+
+def write_catalog(tmp_path, benefit: dict, scheme_id: str = "TEST_SCHEME") -> str:
+    """Writes a one-scheme catalog with the given benefit object and returns its base path.
+
+    The benefit is the only variable part; everything else is a valid minimal scheme, so a load
+    error can only come from the benefit under test and the assertion on the message is
+    meaningful. This exercises the *file* path deliberately — W2.2 moved benefit typing to load
+    time, so these malformed payloads must be rejected while parsing the catalog, not later
+    inside the solver where the scheme id is no longer at hand.
+    """
+    catalog = {
+        "catalog_snapshot_date": "2026-01-01",
+        "overall_cap_share": None,
+        "schemes": [
+            {
+                "id": scheme_id,
+                "jurisdiction": {"country": "XX", "region": None},
+                "valid_from": "2024-01-01",
+                "valid_to": None,
+                "legal_basis": "synthetic test catalog",
+                "url": "https://example.invalid/catalog",
+                "applies_to": {"asset_classes": ["HEAT_PUMP"], "measure_kinds": ["INSTALL"]},
+                "eligibility": {"all": []},
+                "benefit": benefit,
+                "eligible_cost": {"categories": ["INVESTMENT"]},
+                "cumulation": {"group": None, "combined_rate_cap": None, "excludes": []},
+                "payout": {"kind": "UPFRONT_GRANT"},
+            }
+        ],
+    }
+    base = str(tmp_path)
+    with open(os.path.join(base, "XX.json"), "w", encoding="utf-8") as file:
+        json.dump(catalog, file)
+    return base
+
+
+class TestTypedBenefits:
+    """W2.2: the catalog JSON is unchanged, but benefits are parsed into typed payloads."""
+
+    def test_shipped_catalog_carries_typed_benefits(self, catalog):
+        """Every shipped DE scheme holds the payload type its kind declares."""
+        by_id = {scheme.id: scheme for scheme in catalog.schemes}
+        assert isinstance(by_id["DE_BEG_EM_HP_BASE_2024"].benefit, ShareBenefit)
+        assert by_id["DE_BEG_EM_HP_BASE_2024"].benefit.rate == pytest.approx(0.3)
+        tax = by_id["DE_TAX_35C_2024"].benefit
+        assert isinstance(tax, TaxCreditBenefit)
+        assert tax.years == 3
+        assert tax.annual_shares == (0.35, 0.35, 0.3)
+        assert tax.schedule_shares() == (0.35, 0.35, 0.3)
+        loan = by_id["DE_KFW_358_LOAN_2024"].benefit
+        assert isinstance(loan, LoanTermsBenefit)
+        assert (loan.interest_rate, loan.term, loan.repayment_grant_rate) == (0.02, 20, 0.0)
+
+    def test_at_catalog_lump_sum_is_typed(self):
+        """The shipped AT catalog parses too (LUMP_SUM)."""
+        at_catalog = SubsidyCatalog.load("AT")
+        benefit = at_catalog.schemes[0].benefit
+        assert isinstance(benefit, LumpSumBenefit) and benefit.amount == pytest.approx(7500.0)
+
+    def test_unknown_benefit_kind_is_rejected_at_load(self, tmp_path):
+        """A typo in the kind names the scheme."""
+        base = write_catalog(tmp_path, {"kind": "SHARE_OF_ELIGABLE_COST", "rate": 0.3})
+        with pytest.raises(SubsidyDataError, match="TEST_SCHEME: unknown benefit kind"):
+            SubsidyCatalog.load("XX", base)
+
+    def test_missing_benefit_key_is_rejected_at_load(self, tmp_path):
+        """A missing mandatory parameter names the scheme and the key."""
+        base = write_catalog(tmp_path, {"kind": "SHARE_OF_ELIGIBLE_COST"})
+        with pytest.raises(SubsidyDataError, match=r"TEST_SCHEME: .*misses the mandatory key 'rate'"):
+            SubsidyCatalog.load("XX", base)
+
+    def test_unknown_benefit_key_is_rejected_at_load(self, tmp_path):
+        """A misspelled parameter is caught at load instead of being silently ignored."""
+        base = write_catalog(tmp_path, {"kind": "SHARE_OF_ELIGIBLE_COST", "rate": 0.3, "raet": 0.1})
+        with pytest.raises(SubsidyDataError, match=r"TEST_SCHEME: .*unknown key\(s\) \['raet'\]"):
+            SubsidyCatalog.load("XX", base)
+
+    def test_unparsable_benefit_value_is_rejected_at_load(self, tmp_path):
+        """A non-numeric rate fails at load, not as a TypeError inside the solver."""
+        base = write_catalog(tmp_path, {"kind": "SHARE_OF_ELIGIBLE_COST", "rate": "thirty percent"})
+        with pytest.raises(SubsidyDataError, match="TEST_SCHEME: benefit key 'rate'"):
+            SubsidyCatalog.load("XX", base)
+
+    def test_annual_shares_must_sum_to_one(self, tmp_path):
+        """The schedule check moved from solve time to load time."""
+        base = write_catalog(
+            tmp_path, {"kind": "TAX_CREDIT", "rate": 0.2, "years": 3, "annual_shares": [0.5, 0.4, 0.4]}
+        )
+        with pytest.raises(SubsidyDataError, match="annual_shares must sum to 1"):
+            SubsidyCatalog.load("XX", base)
+
+    def test_annual_shares_must_match_the_year_count(self, tmp_path):
+        """Shares and years must agree."""
+        base = write_catalog(
+            tmp_path, {"kind": "TAX_CREDIT", "rate": 0.2, "years": 3, "annual_shares": [0.5, 0.5]}
+        )
+        with pytest.raises(SubsidyDataError, match="annual_shares for 3 years"):
+            SubsidyCatalog.load("XX", base)
+
+    def test_benefit_payload_must_match_the_kind(self):
+        """An in-memory scheme cannot pair a kind with a foreign payload."""
+        with pytest.raises(SubsidyDataError, match="needs a LumpSumBenefit"):
+            SubsidyScheme(
+                id="MISMATCH",
+                country="DE",
+                region=None,
+                valid_from="1900-01-01",
+                valid_to=None,
+                legal_basis="synthetic",
+                url="https://example.invalid/scheme",
+                asset_classes=[ComponentType.HEAT_PUMP],
+                measure_kinds=["INSTALL"],
+                eligibility=Condition(kind="all"),
+                benefit_kind=BenefitKind.LUMP_SUM,
+                benefit=ShareBenefit(rate=0.3),
+                eligible_cost=EligibleCostSpec(),
+                cumulation_group=None,
+                combined_rate_cap=None,
+                excludes=[],
+                payout_kind=PayoutKind.UPFRONT_GRANT,
+            )
+
+    def test_value_estimate_is_the_one_simplified_valuation(self):
+        """`required_questions` and the typed payloads agree by construction (§5.7)."""
+        assert ShareBenefit(rate=0.3).value_estimate(20000.0, 10.0) == pytest.approx(6000.0)
+        assert LumpSumBenefit(amount=7500.0).value_estimate(20000.0, 10.0) == pytest.approx(7500.0)
+        assert TaxCreditBenefit(rate=0.2, years=3).value_estimate(20000.0, 10.0) == pytest.approx(4000.0)
+        assert LoanTermsBenefit(interest_rate=0.02, term=20).value_estimate(20000.0, 10.0) == 0.0
+
+
+class TestConditionAstAndFieldVocabulary:
+    """W2.3: the condition is inert data, the evaluator is engine, the vocabulary is derived."""
+
+    def test_condition_is_an_inert_frozen_ast(self):
+        """The catalog payload carries no behavior and cannot be mutated after parsing."""
+        condition = parse_condition({"field": "building.dwelling_units", "op": ">=", "value": 1}, "TEST")
+        assert not hasattr(condition, "evaluate") and not hasattr(condition, "parse")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            condition.value = 2
+
+    def test_parse_rejects_unknown_fields_and_ops(self):
+        """Both grammar errors name the scheme."""
+        with pytest.raises(SubsidyDataError, match="TEST references unknown field"):
+            parse_condition({"field": "building.dwelling_unitz", "op": "==", "value": 1}, "TEST")
+        with pytest.raises(SubsidyDataError, match="TEST: unknown op"):
+            parse_condition({"field": "building.dwelling_units", "op": "=~", "value": 1}, "TEST")
+
+    def test_evaluation_semantics_are_tri_state(self):
+        """Leaf/all/any/not semantics, unchanged by the split (§5.7)."""
+        context = SubsidyContext(
+            applicant=ApplicantProfile(actor=ApplicantActor.LANDLORD, taxable_household_income_in_euro=None),
+            building=SubsidyBuildingContext(construction_year=1985),
+        )
+        landlord = parse_condition({"field": "applicant.actor", "op": "==", "value": "LANDLORD"}, "T")
+        income = parse_condition({"field": "applicant.taxable_household_income_in_euro", "op": "<=", "value": 1}, "T")
+        assert evaluate_condition(landlord, context, None) == (True, [])
+        assert evaluate_condition(income, context, None) == (None, ["applicant.taxable_household_income_in_euro"])
+        assert evaluate_condition(Condition(kind="not", children=(landlord,)), context, None)[0] is False
+        assert evaluate_condition(Condition(kind="all", children=(landlord, income)), context, None)[0] is None
+        assert evaluate_condition(Condition(kind="any", children=(landlord, income)), context, None)[0] is True
+        old = parse_condition({"field": "building.construction_year", "op": "<=", "value": 1900}, "T")
+        assert evaluate_condition(Condition(kind="all", children=(old, income)), context, None) == (False, [])
+
+    def test_vocabulary_is_derived_from_the_context_dataclasses(self):
+        """Every context dataclass field is addressable — no hand-maintained whitelist."""
+        for context_field in dataclasses.fields(ApplicantProfile):
+            assert f"applicant.{context_field.name}" in SubsidyContextFields.KNOWN_CONTEXT_FIELDS
+        for context_field in dataclasses.fields(SubsidyBuildingContext):
+            assert f"building.{context_field.name}" in SubsidyContextFields.KNOWN_CONTEXT_FIELDS
+        # one nested level (the existing heating asset) and the derived property:
+        assert "building.existing_heating.energy_carrier" in SubsidyContextFields.KNOWN_CONTEXT_FIELDS
+        assert "building.residential_share" in SubsidyContextFields.KNOWN_CONTEXT_FIELDS
+
+    def test_a_new_context_field_cannot_be_forgotten(self, monkeypatch):
+        """Adding a field to a context dataclass adds it to the vocabulary automatically."""
+
+        @dataclasses.dataclass
+        class ExtendedProfile(ApplicantProfile):
+            """A context dataclass that grew a field after the whitelist was written."""
+
+            newly_added_flag: bool = False
+
+        monkeypatch.setitem(subsidies.SubsidyContextFields.CONTEXT_ROOTS, "applicant", ExtendedProfile)
+        assert "applicant.newly_added_flag" in subsidies._enumerate_context_fields()
+
+    def test_derived_fields_map_to_their_questions(self):
+        """The derived-field registry replaces the special cases in engine and validation."""
+        assert question_targets("building.residential_share") == (
+            "building.residential_floor_area_in_m2",
+            "building.commercial_floor_area_in_m2",
+        )
+        assert question_targets("building.dwelling_units") == ("building.dwelling_units",)
+
+    def test_scheme_context_fields_include_the_implied_ones(self, catalog):
+        """Proration and per-unit caps imply context fields no condition mentions."""
+        scheme = next(item for item in catalog.schemes if item.id == "DE_BEG_EM_HP_BASE_2024")
+        fields = scheme_context_fields(scheme)
+        assert "building.residential_share" in fields  # from proration
+        assert "building.dwelling_units" in fields  # from the per-dwelling-unit cap
+        assert "applicant.actor" in fields  # from the eligibility condition
+
+
+class TestIneligibilityReasonsNameTheFailingCondition:
+    """Issue #22: an INELIGIBLE scheme says *which* condition it failed, not merely that it did."""
+
+    @staticmethod
+    def _context() -> SubsidyContext:
+        """A 2010 single-family building owned by its occupier — young enough to fail an age test."""
+        return SubsidyContext(
+            applicant=ApplicantProfile(actor=ApplicantActor.OWNER_OCCUPIER, main_residence=True),
+            building=SubsidyBuildingContext(construction_year=2010, dwelling_units=1),
+        )
+
+    def test_a_single_failing_leaf_is_named_with_its_actual_value(self):
+        """The reason quotes the comparison and the answer that failed it."""
+        condition = parse_condition({"field": "building.construction_year", "op": "<=", "value": 2004}, "T")
+        reason = ineligibility_reason(condition, self._context(), None)
+        assert "building.construction_year <= 2004" in reason
+        assert "actual: 2010" in reason
+        assert reason.startswith("condition not met:")
+
+    def test_every_failing_leaf_of_an_and_is_named(self):
+        """Two unmet criteria are two lines of explanation: fixing one would not help."""
+        condition = Condition(
+            kind="all",
+            children=(
+                parse_condition({"field": "building.construction_year", "op": "<=", "value": 2004}, "T"),
+                parse_condition({"field": "building.dwelling_units", "op": ">=", "value": 3}, "T"),
+                parse_condition({"field": "applicant.main_residence", "op": "==", "value": True}, "T"),
+            ),
+        )
+        descriptions = failed_condition_descriptions(condition, self._context(), None)
+        assert len(descriptions) == 2  # the satisfied main-residence leaf explains nothing
+        assert any("construction_year" in text and "actual: 2010" in text for text in descriptions)
+        assert any("dwelling_units" in text and "actual: 1" in text for text in descriptions)
+
+    def test_an_or_is_reported_as_a_group_and_a_not_honestly(self):
+        """`any` fails as "none of", `not` fails because its child does hold (§5.3 shapes)."""
+        alternatives = Condition(
+            kind="any",
+            children=(
+                parse_condition({"field": "building.dwelling_units", "op": ">=", "value": 3}, "T"),
+                parse_condition({"field": "building.construction_year", "op": "<=", "value": 2004}, "T"),
+            ),
+        )
+        [description] = failed_condition_descriptions(alternatives, self._context(), None)
+        assert description.startswith("none of:")
+        assert "dwelling_units" in description and "construction_year" in description
+        negated = Condition(
+            kind="not",
+            children=(parse_condition({"field": "applicant.main_residence", "op": "==", "value": True}, "T"),),
+        )
+        [negated_description] = failed_condition_descriptions(negated, self._context(), None)
+        assert negated_description.startswith("must not hold, but does:")
+        assert "applicant.main_residence" in negated_description
+
+    def test_the_shipped_catalog_rejects_with_a_named_condition(self, catalog):
+        """End to end: a real rejection in a real decision record explains itself."""
+        measure = make_measure(scop=2.8, refrigerant="R32")  # below the technical minimum
+        decision = solve_cumulation(catalog, measure, full_context(), 2024, DISCOUNT)
+        reason = next(
+            reject["reason"]
+            for reject in decision.rejected
+            if reject["scheme_id"] == "DE_BEG_EM_HP_BASE_2024"
+        )
+        assert reason != "failed eligibility condition"
+        assert "measure.technical_attributes.scop" in reason
+        assert "actual: 2.8" in reason
+
+    def test_an_undetermined_scheme_still_carries_no_reason(self):
+        """Only definite failures explain themselves; an unanswered field is not a failure (§5.7)."""
+        context = self._context()
+        context.applicant.taxable_household_income_in_euro = None
+        condition = parse_condition(
+            {"field": "applicant.taxable_household_income_in_euro", "op": "<=", "value": 40000}, "T"
+        )
+        assert failed_condition_descriptions(condition, context, None) == []
+
+
+class TestSubsidyProvenance:
+    """W2.4: subsidy-derived cash flows carry real provenance, never `inline:` pseudo-sources."""
+
+    def test_catalog_keeps_its_resolved_sources(self, catalog):
+        """`load` used to throw the registry resolution away; now the catalog holds it."""
+        assert "src_beg_em_2023" in catalog.sources
+        scheme = catalog.scheme_by_id("DE_BEG_EM_HP_BASE_2024")
+        assert [entry.source_id for entry in catalog.resolved_sources(scheme)] == ["src_beg_em_2023"]
+        assert catalog.source_resolver()["src_beg_em_2023"].citation
+
+    def test_catalog_scheme_records_registry_ids(self, catalog):
+        """A scheme loaded from a catalog file cites its registry entries, plus its legal basis."""
+        from hisim.economics.provenance import ParameterOrigin, ProvenanceLedger
+
+        ledger = ProvenanceLedger()
+        scheme = catalog.scheme_by_id("DE_BEG_EM_HP_BASE_2024")
+        record = ledger.get(catalog.provenance_for_scheme(scheme, ledger, UncertainValue.exact(1000.0)))
+        assert record.origin == ParameterOrigin.DATABASE_ENTRY
+        assert record.source_ids == ("src_beg_em_2023",)
+        assert not any(source_id.startswith("inline:") for source_id in record.source_ids)
+        assert scheme.legal_basis in (record.detail or "") and scheme.url in (record.detail or "")
+
+    def test_in_memory_scheme_gets_an_honest_origin(self):
+        """Test/worked-example schemes have no registry — they say so instead of faking an id."""
+        from hisim.economics.provenance import ParameterOrigin, ProvenanceLedger
+
+        ledger = ProvenanceLedger()
+        catalog = make_catalog([make_scheme("TEST_IN_MEMORY", ALWAYS_ELIGIBLE)])
+        scheme = catalog.scheme_by_id("TEST_IN_MEMORY")
+        record = ledger.get(catalog.provenance_for_scheme(scheme, ledger, UncertainValue.exact(5.0)))
+        assert record.origin == ParameterOrigin.IN_MEMORY_DEFINITION
+        assert record.source_ids == ()
+
+    def test_catalog_schemes_must_cite_sources(self, tmp_path):
+        """An unsourced scheme in a catalog *file* is a load error (§3.10)."""
+        payload = {
+            "catalog_snapshot_date": "2026-01-01",
+            "schemes": [
+                {
+                    "id": "XX_NO_SOURCE",
+                    "jurisdiction": {"country": "XX", "region": None},
+                    "legal_basis": "test",
+                    "url": "https://example.invalid/x",
+                    "applies_to": {"asset_classes": ["HEAT_PUMP"]},
+                    "benefit": {"kind": "SHARE_OF_ELIGIBLE_COST", "rate": 0.1},
+                }
+            ],
+        }
+        with open(os.path.join(str(tmp_path), "XX.json"), "w", encoding="utf-8") as file:
+            json.dump(payload, file)
+        with pytest.raises(SubsidyDataError, match="source_ids are mandatory"):
+            SubsidyCatalog.load("XX", str(tmp_path))
+
+
+class TestDeletedDeadSurface:
+    """Parsed-but-ignored knobs are gone rather than kept as promises (§8 D23).
+
+    `ApplicantActor.from_actor` was a constructor nothing called. Keeping it alive is worse than
+    deleting it — a name that looks like a supported mapping and has no consumer misleads the next
+    reader. This assertion keeps it from being reintroduced silently. The other half of D23,
+    `FinancingPlan.refinance_replacements`, is pinned in
+    `test_economics_subsidy_integration.py`, because naming that dataclass means importing
+    `financing`.
+    """
+
+    def test_applicant_actor_has_no_from_actor_constructor(self):
+        """The unused timeline-actor mapping is deleted; applicants come from the profile."""
+        assert not hasattr(ApplicantActor, "from_actor")
+
+
+class TestScenarioDataOverlays:
+    """§4.6 data overlays: changing one shipped datapoint without touching the shipped files.
+
+    The two scenario tests that need nothing but the cost database. Set expansion, the evaluation
+    cube and the break-even search all run through the evaluator and live in
+    `test_economics_subsidy_integration.py` instead.
+    """
+
+    def test_data_overlay_changes_device_price(self):
+        """Overlaying a datapoint answers 'what if heat pumps get cheaper' (§4.6)."""
+        database = CostDatabase()
+        overlaid = database.with_overlays(
+            {"devices_DE.HEAT_PUMP.specific_investment": {"min": 900, "best_estimate": 1100, "max": 1400}}, "cheap_hp"
+        )
+        entry = overlaid.get_device_entry(ComponentType.HEAT_PUMP, 2024, "DE")
+        assert entry.specific_investment.best_estimate == pytest.approx(1100.0)
+        # The shipped database is untouched.
+        assert database.get_device_entry(ComponentType.HEAT_PUMP, 2024, "DE").specific_investment.best_estimate == 1600.0
+        assert overlaid.overlay_records and overlaid.overlay_records[0].detail == "cheap_hp"
+
+    def test_legacy_flat_subsidy_share_is_not_overlayable(self):
+        """W2.6: the §10.1 shim is subsidy data and left the device overlay surface."""
+        from hisim.economics.database import CostDataError
+
+        database = CostDatabase()
+        with pytest.raises(CostDataError, match="is not overlayable"):
+            database.with_overlays({"devices_DE.HEAT_PUMP.legacy_flat_subsidy_share": 0.0}, "no_subsidy")
+
+

--- a/tests/test_economics_subsidy_solver.py
+++ b/tests/test_economics_subsidy_solver.py
@@ -1,0 +1,464 @@
+"""Unit tests for the cumulation solver and its caps (§5.4-§5.5).
+
+Second of the two subsidy unit-test files (split per the PR-3 review's 500-line rule): the
+exponential-guard on subset enumeration (B6), the shipped BEG/§35c stacking, caps and
+exclusions, the per-slot EU state-aid overall cap (B12 — wide synthetic bands, hand
+derivations in the docstrings), and subsidy-mode filtering before the solve (B5). Catalog,
+condition and provenance tests are in `test_economics_subsidies.py`; evaluator-driven cases
+are in `test_economics_subsidy_integration.py`.
+"""
+
+import pytest
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.facts import ComponentCostFacts, ExistingAsset
+from hisim.economics.parameters import EconomicParameters
+from hisim.economics.subsidies import (
+    ApplicantActor,
+    ApplicantProfile,
+    BenefitKind,
+    Condition,
+    CumulationLimits,
+    EligibleCostSpec,
+    HeritageStatus,
+    LumpSumBenefit,
+    MeasureForSubsidy,
+    PayoutKind,
+    ShareBenefit,
+    SubsidyBuildingContext,
+    SubsidyCatalog,
+    SubsidyContext,
+    SubsidyDataError,
+    SubsidyScheme,
+    required_questions,
+    solve_cumulation,
+)
+from hisim.economics.timeline import CostCategory
+from hisim.economics.uncertainty import UncertainValue
+from hisim.loadtypes import ComponentType, Units
+
+pytestmark = pytest.mark.base
+
+DISCOUNT = EconomicParameters(price_basis_year=2024).discount_factor
+
+@pytest.fixture(name="catalog", scope="module")
+def fixture_catalog() -> SubsidyCatalog:
+    """The shipped DE subsidy catalog.
+
+    Used wherever the *real* scheme definitions are the subject — BEG stacking and its 70 % cap,
+    the §35c exclusion, the speed and income bonuses, the questionnaire derived from their
+    conditions. Tests about solver *mechanics* build synthetic catalogs instead, so a change to
+    German subsidy law moves only the tests that are about German subsidy law. Module-scoped
+    because loading resolves and validates the whole catalog including its source registry.
+    """
+    return SubsidyCatalog.load("DE")
+
+def make_measure(cost: float = 30000.0, scop: float = 4.0, refrigerant: str = "R290") -> MeasureForSubsidy:
+    """A heat pump measure for subsidy tests.
+
+    The cost is stated rather than resolved from the database, so awards read as percentages of a
+    round number; `measure_kind="REPLACE"` is what the BEG schemes require. SCOP and refrigerant
+    are the two technical attributes the DE efficiency conditions read: the defaults (4.0, R290)
+    satisfy them, and passing 2.8 / R32 is how a test makes the base scheme fail its technical
+    minimum.
+    """
+    facts = ComponentCostFacts(
+        asset_class=ComponentType.HEAT_PUMP,
+        size=10.0,
+        size_unit=Units.KILOWATT,
+        technical_attributes={"scop": scop, "refrigerant": refrigerant},
+    )
+    return MeasureForSubsidy(
+        subject="HeatPump",
+        facts=facts,
+        measure_kind="REPLACE",
+        cost_by_category={CostCategory.INVESTMENT: UncertainValue.exact(cost)},
+    )
+
+def full_context(income: float = 35000.0) -> SubsidyContext:
+    """Owner-occupier with a functioning gas boiler, everything answered.
+
+    "Everything answered" is the point: no field is None, so no scheme can come back UNDETERMINED
+    and every decision below is a definite yes or no. Tests that want the tri-state path
+    deliberately blank one field afterwards. The functioning gas boiler is what makes the BEG
+    speed bonus eligible, and 35 000 EUR of taxable household income sits below the income-bonus
+    threshold — pass a higher figure to drop that bonus. One dwelling unit and no commercial area
+    keep the residential-share proration at 1.0.
+    """
+    return SubsidyContext(
+        applicant=ApplicantProfile(
+            actor=ApplicantActor.OWNER_OCCUPIER, taxable_household_income_in_euro=income, main_residence=True
+        ),
+        building=SubsidyBuildingContext(
+            construction_year=1985,
+            dwelling_units=1,
+            residential_floor_area_in_m2=150.0,
+            commercial_floor_area_in_m2=0.0,
+            existing_heating=ExistingAsset(
+                asset_class=ComponentType.GAS_HEATER,
+                size=15.0,
+                size_unit=Units.KILOWATT,
+                installation_year=2005,
+                is_functional=True,
+                energy_carrier=EnergyCarrier.NATURAL_GAS,
+            ),
+        ),
+    )
+
+def make_scheme(
+    scheme_id: str,
+    eligibility: Condition,
+    benefit_kind: BenefitKind = BenefitKind.SHARE_OF_ELIGIBLE_COST,
+    benefit=None,
+    eligible_cost: EligibleCostSpec = None,
+) -> SubsidyScheme:
+    """A minimal heat pump scheme whose eligibility is spelled out by the caller.
+
+    Everything a scheme needs to be *valid* is filled in with an inert default — no cumulation
+    group, no rate cap, no exclusions, no eligible-cost restriction, an upfront grant — so a test
+    varies only the dimension it is about and the rest cannot interfere. The default benefit is a
+    deliberately tiny 1 % share: schemes built for the solver's *guard* tests must be eligible and
+    stackable without their amounts mattering.
+    """
+    return SubsidyScheme(
+        id=scheme_id,
+        country="DE",
+        region=None,
+        valid_from="1900-01-01",
+        valid_to=None,
+        legal_basis="synthetic test scheme",
+        url="https://example.invalid/scheme",
+        asset_classes=[ComponentType.HEAT_PUMP],
+        measure_kinds=["INSTALL", "REPLACE"],
+        eligibility=eligibility,
+        benefit_kind=benefit_kind,
+        benefit=benefit if benefit is not None else ShareBenefit(rate=0.01),
+        eligible_cost=eligible_cost if eligible_cost is not None else EligibleCostSpec(),
+        cumulation_group=None,
+        combined_rate_cap=None,
+        excludes=[],
+        payout_kind=PayoutKind.UPFRONT_GRANT,
+    )
+
+def make_catalog(schemes, overall_cap_share: float = None) -> SubsidyCatalog:
+    """An in-memory catalog around the given schemes.
+
+    No file, no country data, no questions — the solver only needs the scheme list and the
+    optional EU state-aid `overall_cap_share`, which is exactly the knob the per-slot cap tests
+    turn. Schemes constructed this way record `IN_MEMORY_DEFINITION` provenance rather than
+    citing a registry entry (W2.4), which is itself asserted in `TestSubsidyProvenance`.
+    """
+    return SubsidyCatalog(
+        schemes=list(schemes),
+        questions={},
+        snapshot_date=None,
+        overall_cap_share=overall_cap_share,
+        base_path="",
+        country="DE",
+    )
+
+ALWAYS_ELIGIBLE = Condition(kind="all")
+
+NEEDS_HOUSEHOLD_SIZE = Condition(kind="leaf", fieldname="applicant.household_size", op=">=", value=1)
+
+def banded_measure(investment: UncertainValue, planning: float = 0.0) -> MeasureForSubsidy:
+    """A heat pump measure with a genuinely banded cost basis (§3.9).
+
+    The counterpart to `make_measure`, and the reason it exists separately: every shipped catalog
+    and every worked example uses degenerate bands, under which a per-slot bug is invisible. The
+    optional exact planning cost sits in a *second* cost category, so two schemes can disagree
+    about which categories are eligible — that difference is what makes the per-slot cap ratios
+    non-monotone and exposes the B12 ordering problem.
+    """
+    facts = ComponentCostFacts(asset_class=ComponentType.HEAT_PUMP, size=10.0, size_unit=Units.KILOWATT)
+    return MeasureForSubsidy(
+        subject="HeatPump",
+        facts=facts,
+        measure_kind="INSTALL",
+        cost_by_category={
+            CostCategory.INVESTMENT: investment,
+            CostCategory.PLANNING: UncertainValue.exact(planning),
+        },
+    )
+
+BEG_HP_SCHEMES = {
+    "DE_BEG_EM_HP_BASE_2024",
+    "DE_BEG_EM_HP_SPEED_2024",
+    "DE_BEG_EM_HP_INCOME_2024",
+    "DE_BEG_EM_HP_EFFICIENCY_2024",
+}
+
+
+class TestCumulationSolverGuard:
+    """§5.4: the subset enumeration is exponential and must refuse to run away."""
+
+    def test_too_many_eligible_schemes_is_a_data_error(self):
+        """More eligible schemes than the limit raises instead of enumerating 2^n subsets."""
+        count = CumulationLimits.MAX_CUMULATION_SCHEMES + 1
+        catalog = make_catalog(make_scheme(f"TEST_ELIGIBLE_{index:02d}", ALWAYS_ELIGIBLE) for index in range(count))
+        limit_message = f"cumulation solver limit of {CumulationLimits.MAX_CUMULATION_SCHEMES}"
+        with pytest.raises(SubsidyDataError, match=limit_message):
+            solve_cumulation(catalog, make_measure(), full_context(), 2024, DISCOUNT)
+
+    def test_too_many_optimistic_schemes_is_a_data_error(self):
+        """The optimistic-bound enumeration is capped by the same limit."""
+        schemes = [make_scheme("TEST_ELIGIBLE_00", ALWAYS_ELIGIBLE)]
+        schemes += [
+            make_scheme(f"TEST_UNDETERMINED_{index:02d}", NEEDS_HOUSEHOLD_SIZE)
+            for index in range(CumulationLimits.MAX_CUMULATION_SCHEMES)
+        ]
+        limit_message = f"cumulation solver limit of {CumulationLimits.MAX_CUMULATION_SCHEMES}"
+        with pytest.raises(SubsidyDataError, match=limit_message):
+            solve_cumulation(make_catalog(schemes), make_measure(), full_context(), 2024, DISCOUNT)
+
+    def test_small_scheme_sets_still_solve(self):
+        """A catalog inside the limit is unaffected by the guard."""
+        catalog = make_catalog(make_scheme(f"TEST_ELIGIBLE_{index:02d}", ALWAYS_ELIGIBLE) for index in range(4))
+        decision = solve_cumulation(catalog, make_measure(cost=20000.0), full_context(), 2024, DISCOUNT)
+        assert {award.scheme_id for award in decision.applied} == {f"TEST_ELIGIBLE_{index:02d}" for index in range(4)}
+
+
+class TestSubsidyEngine:
+    """§5 scheme mechanics."""
+
+    def test_beg_stacking_capped_at_70_percent(self, catalog):
+        """Base 30 + speed 20 + income 30 caps at 70 % of the eligible cost."""
+        decision = solve_cumulation(catalog, make_measure(cost=20000.0), full_context(), 2024, DISCOUNT)
+        upfront = sum(award.upfront_amount.best_estimate for award in decision.applied)
+        assert upfront == pytest.approx(0.70 * 20000.0)
+
+    def test_eligible_cost_cap_binds(self, catalog):
+        """40 kEUR cost, cap 30 kEUR first unit: support = 70 % of 30 kEUR."""
+        decision = solve_cumulation(catalog, make_measure(cost=40000.0), full_context(), 2024, DISCOUNT)
+        upfront = sum(award.upfront_amount.best_estimate for award in decision.applied)
+        assert upfront == pytest.approx(0.70 * 30000.0)
+        assert any(award.caps_binding_per_slot.get("best_estimate") for award in decision.applied)
+
+    def test_35c_excluded_by_beg(self, catalog):
+        """§35c EStG never stacks with BEG grants."""
+        decision = solve_cumulation(catalog, make_measure(), full_context(), 2024, DISCOUNT)
+        applied_ids = {award.scheme_id for award in decision.applied}
+        assert "DE_TAX_35C_2024" not in applied_ids or not applied_ids & {
+            "DE_BEG_EM_HP_BASE_2024",
+            "DE_BEG_EM_HP_SPEED_2024",
+        }
+
+    def test_income_bonus_needs_low_income(self, catalog):
+        """High income drops the income bonus."""
+        decision = solve_cumulation(catalog, make_measure(cost=20000.0), full_context(income=80000.0), 2024, DISCOUNT)
+        applied_ids = {award.scheme_id for award in decision.applied}
+        assert "DE_BEG_EM_HP_INCOME_2024" not in applied_ids
+        upfront = sum(award.upfront_amount.best_estimate for award in decision.applied)
+        # What is left without the income bonus: base 30 % + speed 20 % + efficiency 5 % = 55 %,
+        # comfortably under the 70 % group cap, so nothing else binds.
+        assert upfront == pytest.approx((0.30 + 0.20 + 0.05) * 20000.0)
+
+    def test_residential_share_proration(self, catalog):
+        """Mixed use: only the residential share of the cost basis is eligible (§5.2)."""
+        context = full_context()
+        context.building.commercial_floor_area_in_m2 = 50.0  # share 0.75
+        decision = solve_cumulation(catalog, make_measure(cost=20000.0), context, 2024, DISCOUNT)
+        upfront = sum(award.upfront_amount.best_estimate for award in decision.applied)
+        assert upfront == pytest.approx(0.70 * 20000.0 * 0.75)
+
+    def test_heritage_relaxes_scop_threshold(self, catalog):
+        """SCOP 2.8 fails normally but passes for a protected building (§5.2 example)."""
+        measure = make_measure(scop=2.8, refrigerant="R32")
+        context = full_context()
+        decision = solve_cumulation(catalog, measure, context, 2024, DISCOUNT)
+        assert "DE_BEG_EM_HP_BASE_2024" in {reject["scheme_id"] for reject in decision.rejected}
+        context.building.heritage_status = HeritageStatus.LISTED_MONUMENT
+        decision = solve_cumulation(catalog, measure, context, 2024, DISCOUNT)
+        assert "DE_BEG_EM_HP_BASE_2024" in {award.scheme_id for award in decision.applied}
+
+    def test_tristate_reports_undetermined_upper_bound(self, catalog):
+        """Unknown income makes schemes UNDETERMINED, with an optimistic upper bound (§5.7)."""
+        context = full_context()
+        context.applicant.taxable_household_income_in_euro = None
+        decision = solve_cumulation(catalog, make_measure(cost=20000.0), context, 2024, DISCOUNT)
+        undetermined_ids = {item["scheme_id"] for item in decision.undetermined}
+        assert "DE_BEG_EM_HP_INCOME_2024" in undetermined_ids
+        assert decision.undetermined_upper_bound_in_euro > 0
+
+    def test_questionnaire_is_minimal_and_ordered(self, catalog):
+        """Only unanswered fields are asked, ordered by pruning power, with asked-because."""
+        context = SubsidyContext(
+            applicant=ApplicantProfile(actor=ApplicantActor.OWNER_OCCUPIER, main_residence=True),
+            building=SubsidyBuildingContext(construction_year=1985, dwelling_units=1),
+        )
+        questions = required_questions(catalog, [make_measure()], context, 2024)
+        fields = [question.entry.fieldname for question in questions]
+        assert "building.construction_year" not in fields  # already known
+        assert "applicant.taxable_household_income_in_euro" in fields
+        powers = [question.pruning_power_in_euro for question in questions]
+        assert powers == sorted(powers, reverse=True)
+        for question in questions:
+            assert question.asked_because
+
+    def test_tax_credit_schedule_shares(self, catalog):
+        """§35c pays 35/35/30 over three years when BEG is not taken."""
+        from hisim.economics.subsidies import _combination_awards  # noqa: PLC2701 — targeted unit test
+
+        scheme = next(scheme for scheme in catalog.schemes if scheme.id == "DE_TAX_35C_2024")
+        awards = _combination_awards([scheme], make_measure(cost=10000.0), full_context(), None)
+        schedule = awards[0].schedule_amounts
+        # 20 % of 10,000 EUR = 2,000 EUR, paid out 35 % / 35 % / 30 % over three tax years.
+        assert [amount.best_estimate for amount in schedule] == pytest.approx([700.0, 700.0, 600.0])
+
+
+class TestOverallCapIsAppliedPerSlot:
+    """§7 B12: the EU state-aid overall cap binds in every slot, not only in the best-estimate slot."""
+
+    def test_cap_binds_in_every_slot_with_a_wide_cost_band(self):
+        """Wide band, share + lump sum: the BEST_ESTIMATE-ratio scale-down overran LOW badly.
+
+        Gross (2 000 / 20 000 / 30 000), cap share 0.8, a 50 % grant and an 8 000 EUR lump sum:
+        the old single ratio (16 000/18 000) left 2 667 EUR of support in the LOW world — more
+        than that world's entire 2 000 EUR gross cost.
+        """
+        investment = UncertainValue(best_estimate=20000.0, minimum=2000.0, maximum=30000.0)
+        measure = banded_measure(investment)
+        catalog = make_catalog(
+            [
+                make_scheme("CAP_SHARE", ALWAYS_ELIGIBLE, benefit=ShareBenefit(rate=0.5)),
+                make_scheme(
+                    "CAP_LUMP",
+                    ALWAYS_ELIGIBLE,
+                    benefit_kind=BenefitKind.LUMP_SUM,
+                    benefit=LumpSumBenefit(amount=8000.0),
+                ),
+            ],
+            overall_cap_share=0.8,
+        )
+        decision = solve_cumulation(catalog, measure, SubsidyContext(), 2024, DISCOUNT)
+        total = UncertainValue.sum(award.upfront_amount for award in decision.applied)
+        for slot, gross in (("minimum", 2000.0), ("best_estimate", 20000.0), ("maximum", 30000.0)):
+            assert getattr(total, slot) <= 0.8 * gross + 1e-6
+        assert total.minimum == pytest.approx(0.8 * 2000.0)  # the cap binds exactly in LOW
+
+    def test_non_monotone_cap_ratios_keep_the_award_bands_ordered(self):
+        """A statutory lump sum plus a wide-band grant makes the per-slot ratio *fall*.
+
+        Gross (700 / 1 600 / 1 800) with an exact 600 EUR planning cost, a 100 % grant on the
+        investment only and a 500 EUR lump sum: the raw per-slot ratios are 0.933 / 0.853 /
+        0.847, so a plain slot-wise product would give the lump sum (466.7, 426.7, 423.5) — a
+        band with minimum > best_estimate, which is not a representable `UncertainValue` at all.
+        """
+        investment = UncertainValue(best_estimate=1000.0, minimum=100.0, maximum=1200.0)
+        measure = banded_measure(investment, planning=600.0)
+        catalog = make_catalog(
+            [
+                make_scheme(
+                    "CAP_SHARE",
+                    ALWAYS_ELIGIBLE,
+                    benefit=ShareBenefit(rate=1.0),
+                    eligible_cost=EligibleCostSpec(categories=[CostCategory.INVESTMENT]),
+                ),
+                make_scheme(
+                    "CAP_LUMP",
+                    ALWAYS_ELIGIBLE,
+                    benefit_kind=BenefitKind.LUMP_SUM,
+                    benefit=LumpSumBenefit(amount=500.0),
+                    eligible_cost=EligibleCostSpec(categories=[CostCategory.INVESTMENT, CostCategory.PLANNING]),
+                ),
+            ],
+            overall_cap_share=0.8,
+        )
+        decision = solve_cumulation(catalog, measure, SubsidyContext(), 2024, DISCOUNT)
+        awards = {award.scheme_id: award.upfront_amount for award in decision.applied}
+        assert set(awards) == {"CAP_SHARE", "CAP_LUMP"}
+        for amount in awards.values():  # UncertainValue enforces this, state it anyway
+            assert amount.minimum <= amount.best_estimate <= amount.maximum
+        # The lump sum is cut to the tightest (HIGH-slot) ratio in all three worlds:
+        assert awards["CAP_LUMP"].minimum == pytest.approx(awards["CAP_LUMP"].maximum)
+        total = UncertainValue.sum(awards.values())
+        for slot, gross in (("minimum", 700.0), ("best_estimate", 1600.0), ("maximum", 1800.0)):
+            assert getattr(total, slot) <= 0.8 * gross + 1e-6
+        assert total.maximum == pytest.approx(0.8 * 1800.0)  # the HIGH slot uses the cap fully
+
+    def test_degenerate_bands_are_unchanged_by_the_per_slot_cap(self):
+        """Every shipped catalog is degenerate: the fix must be a no-op there."""
+        measure = banded_measure(UncertainValue.exact(20000.0))
+        catalog = make_catalog(
+            [make_scheme("CAP_SHARE", ALWAYS_ELIGIBLE, benefit=ShareBenefit(rate=0.9))],
+            overall_cap_share=0.5,
+        )
+        decision = solve_cumulation(catalog, measure, SubsidyContext(), 2024, DISCOUNT)
+        award = decision.applied[0].upfront_amount
+        assert award.is_exact() and award.best_estimate == pytest.approx(0.5 * 20000.0)
+
+
+class TestSubsidyModeFiltersBeforeTheSolve:
+    """§7 B5: the admitted-scheme filter is part of the optimization, not a post-filter."""
+
+    def test_exclude_mode_gets_the_best_admissible_combination(self, catalog):
+        """Excluding the BEG grants must yield the §35c tax credit, not the BEG leftovers.
+
+        Filtering after the solve produced nothing here: the solver picked the BEG stack (best
+        without a filter), which excludes §35c, and the post-filter then dropped every BEG award.
+        """
+        decision = solve_cumulation(
+            catalog,
+            make_measure(cost=20000.0),
+            full_context(),
+            2024,
+            DISCOUNT,
+            admits=lambda scheme_id: scheme_id not in BEG_HP_SCHEMES,
+        )
+        assert "DE_TAX_35C_2024" in {award.scheme_id for award in decision.applied}
+        assert sum(
+            amount.best_estimate for award in decision.applied for amount in award.schedule_amounts
+        ) == pytest.approx(0.2 * 20000.0)
+
+    def test_only_mode_awards_the_named_scheme(self, catalog):
+        """ONLY(speed bonus) awards the speed bonus alone, uncapped by its group partners."""
+        decision = solve_cumulation(
+            catalog,
+            make_measure(cost=20000.0),
+            full_context(),
+            2024,
+            DISCOUNT,
+            admits=lambda scheme_id: scheme_id == "DE_BEG_EM_HP_SPEED_2024",
+        )
+        assert {award.scheme_id for award in decision.applied} == {"DE_BEG_EM_HP_SPEED_2024"}
+        assert sum(award.upfront_amount.best_estimate for award in decision.applied) == pytest.approx(0.2 * 20000.0)
+
+    def test_non_admitted_schemes_are_not_reported_at_all(self, catalog):
+        """Rejections, undetermined schemes and the bound follow the same filter."""
+        context = full_context()
+        context.applicant.taxable_household_income_in_euro = None  # income bonus undetermined
+        decision = solve_cumulation(
+            catalog,
+            make_measure(cost=20000.0),
+            context,
+            2024,
+            DISCOUNT,
+            admits=lambda scheme_id: scheme_id not in BEG_HP_SCHEMES,
+        )
+        reported = (
+            {award.scheme_id for award in decision.applied}
+            | {item["scheme_id"] for item in decision.rejected}
+            | {item["scheme_id"] for item in decision.undetermined}
+        )
+        assert not reported & BEG_HP_SCHEMES
+
+    def test_none_mode_solves_to_nothing(self, catalog):
+        """A perspective without subsidies sees no scheme, not a filtered award list."""
+        decision = solve_cumulation(
+            catalog, make_measure(), full_context(), 2024, DISCOUNT, admits=lambda scheme_id: False
+        )
+        assert decision.applied == [] and decision.rejected == [] and decision.undetermined == []
+        assert decision.undetermined_upper_bound_in_euro == 0.0
+
+    def test_questions_follow_the_same_filter(self, catalog):
+        """No question is asked for a scheme the perspective would never award (§5.7)."""
+        context = SubsidyContext(
+            applicant=ApplicantProfile(actor=ApplicantActor.OWNER_OCCUPIER, main_residence=True),
+            building=SubsidyBuildingContext(construction_year=1985, dwelling_units=1),
+        )
+        unfiltered = required_questions(catalog, [make_measure()], context, 2024)
+        filtered = required_questions(
+            catalog, [make_measure()], context, 2024, admits=lambda scheme_id: False
+        )
+        assert unfiltered and filtered == []
+
+

--- a/tests/test_economics_tariffs.py
+++ b/tests/test_economics_tariffs.py
@@ -1,0 +1,211 @@
+"""Unit tests for the tariff engine (§8).
+
+**Scope.** The pure year-1 billing function `apply_tariff` and its surroundings, needing
+nothing above the rule engines: supply kinds (flat, time-of-use, dynamic on the synthetic
+reference profile), capacity charges, feed-in and the §8.5 decomposition, and
+`validate_billing_interval`. This file and `test_economics_subsidies.py` were one file until
+the PR-3 review asked for the split; the placement rule is unchanged — a test that imports any
+module above the rule engines (`evaluator`, `perspectives`, `scenarios`, `financing`,
+`results`, `views`) belongs in `test_economics_subsidy_integration.py` instead.
+
+**How it covers it.** Against synthetic contracts built by `make_flat_contract` and variants,
+with round numbers, so every expected bill is a product a reviewer can check by eye
+(0.8 x 1 800). The dynamic-tariff cases run on the deterministic synthetic reference profile,
+which is what makes exact-bill assertions possible at all.
+
+**Error class.** A failure here is a billing *formula* failure — the engine turned metered
+determinants into the wrong year-1 bill — isolated from pricing data by the synthetic
+contracts.
+"""
+
+# clean
+
+
+import pytest
+
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.facts import BillingDeterminants
+from hisim.economics.tariffs import (
+    CapacityCharge,
+    CapacityChargeKind,
+    FeedIn,
+    FeedInKind,
+    SupplyKind,
+    TariffContract,
+    TariffSupply,
+    apply_tariff,
+    synthetic_reference_spot_series,
+    tariff_counterfactual,
+    validate_billing_interval,
+)
+from hisim.economics.timeline import CostCategory
+from hisim.economics.uncertainty import UncertainValue
+
+pytestmark = pytest.mark.base
+
+def make_flat_contract(price: float = 0.30, standing: float = 0.0) -> TariffContract:
+    """A flat contract for billing tests.
+
+    Everything optional is left at its neutral default — no markup, no grid fee, no taxes, no
+    capacity charge, no feed-in — so a bill is `kWh x price` and nothing else until a test
+    explicitly attaches the component it wants to examine. Several tests below do exactly that:
+    they take this contract and replace its `supply` or set its `capacity_charge`/`feed_in`, so
+    the mutable dataclass is used on purpose rather than by accident.
+    """
+    return TariffContract(
+        id="TEST_FLAT",
+        carrier=EnergyCarrier.ELECTRICITY,
+        country="DE",
+        region=None,
+        valid_from_year=2024,
+        supply=TariffSupply(kind=SupplyKind.FLAT, working_price_in_euro_per_kwh=UncertainValue.exact(price)),
+        standing_charge_in_euro_per_year=UncertainValue.exact(standing),
+    )
+
+
+class TestTariffEngine:
+    """§8.4 billing engine properties."""
+
+    def test_flat_contract_reproduces_kwh_times_price(self):
+        """The central property test of §8.4."""
+        determinants = BillingDeterminants(carrier=EnergyCarrier.ELECTRICITY, energy_bought_in_kwh=4321.0)
+        bill = apply_tariff(determinants, make_flat_contract(price=0.25))
+        assert bill.by_category[CostCategory.ENERGY_WORKING].best_estimate == pytest.approx(4321.0 * 0.25)
+
+    def test_capacity_charge_monotone_in_every_peak(self):
+        """Raising any period peak never lowers the bill."""
+        contract = make_flat_contract()
+        contract.capacity_charge = CapacityCharge(
+            kind=CapacityChargeKind.MONTHLY_PEAK, price_in_euro_per_kw=UncertainValue.exact(8.0)
+        )
+        base_peaks = [4.0] * 12
+        base = apply_tariff(
+            BillingDeterminants(
+                carrier=EnergyCarrier.ELECTRICITY, energy_bought_in_kwh=1000.0,
+                peak_per_billing_period_in_kw=base_peaks, annual_peak_in_kw=4.0,
+            ),
+            contract,
+        )
+        for month in range(12):
+            raised = list(base_peaks)
+            raised[month] += 2.0
+            higher = apply_tariff(
+                BillingDeterminants(
+                    carrier=EnergyCarrier.ELECTRICITY, energy_bought_in_kwh=1000.0,
+                    peak_per_billing_period_in_kw=raised, annual_peak_in_kw=6.0,
+                ),
+                contract,
+            )
+            assert higher.total().best_estimate > base.total().best_estimate
+
+    def test_dynamic_supply_uses_integrated_cost_and_decomposes(self):
+        """DYNAMIC bills the native integral; flexibility value separates from volume (§8.5)."""
+        contract = make_flat_contract()
+        contract.supply = TariffSupply(
+            kind=SupplyKind.DYNAMIC,
+            spot_series="test",
+            markup_in_euro_per_kwh=UncertainValue.exact(0.02),
+        )
+        determinants = BillingDeterminants(
+            carrier=EnergyCarrier.ELECTRICITY,
+            energy_bought_in_kwh=1000.0,
+            cost_integrated_in_euro=70.0,  # load shifted into cheap hours
+            mean_spot_price_in_euro_per_kwh=0.08,
+        )
+        bill = apply_tariff(determinants, contract)
+        assert bill.by_category[CostCategory.ENERGY_WORKING].best_estimate == pytest.approx(70.0 + 1000.0 * 0.02)
+        assert bill.flexibility_value_in_euro == pytest.approx(1000.0 * 0.08 - 70.0)
+
+    def test_uncertain_additive_components_shift_slots(self):
+        """Additive per-kWh bands shift each slot by E x delta without re-integration (§8.4)."""
+        contract = make_flat_contract()
+        contract.supply = TariffSupply(
+            kind=SupplyKind.DYNAMIC,
+            spot_series="test",
+            markup_in_euro_per_kwh=UncertainValue(best_estimate=0.02, minimum=0.01, maximum=0.04),
+        )
+        determinants = BillingDeterminants(
+            carrier=EnergyCarrier.ELECTRICITY, energy_bought_in_kwh=1000.0, cost_integrated_in_euro=80.0
+        )
+        working = apply_tariff(determinants, contract).by_category[CostCategory.ENERGY_WORKING]
+        # The integrated spot cost (80 EUR) is a measured quantity and stays exact; only the
+        # markup band moves the slots: 1000 kWh x 0.01 and x 0.04 EUR/kWh.
+        assert working.minimum == pytest.approx(80.0 + 10.0)
+        assert working.maximum == pytest.approx(80.0 + 40.0)
+
+    def test_feed_in_revenue_negative(self):
+        """Fixed tariff feed-in enters as negative cost."""
+        contract = make_flat_contract()
+        contract.feed_in = FeedIn(kind=FeedInKind.FIXED_TARIFF, rate_in_euro_per_kwh=UncertainValue.exact(0.08))
+        bill = apply_tariff(
+            BillingDeterminants(carrier=EnergyCarrier.ELECTRICITY, energy_bought_in_kwh=0.0, energy_sold_in_kwh=500.0),
+            contract,
+        )
+        # 500 kWh x 0.08 EUR/kWh = 40 EUR, entered negative: money arriving is negative cost.
+        assert bill.by_category[CostCategory.FEED_IN_REVENUE].best_estimate == pytest.approx(-40.0)
+
+    def test_spot_referenced_feed_in_applies_the_spot_factor(self):
+        """A direct-marketing share below 1.0 scales the spot term, not the markup (§8.4).
+
+        SPOT_REFERENCED feed-in pays the marketer's share of the spot proceeds plus a flat
+        markup; `FeedIn.spot_factor` is that share, and it was parsed but never applied, so a
+        contract paying 80 % of spot was billed as if it paid all of it. The markup is a
+        per-kWh amount agreed independently of the spot price and stays untouched, which is what
+        the second assertion separates: only the integrated term moves with the factor.
+        """
+        contract = make_flat_contract()
+        contract.feed_in = FeedIn(
+            kind=FeedInKind.SPOT_REFERENCED,
+            spot_factor=0.8,
+            markup_in_euro_per_kwh=UncertainValue.exact(0.01),
+        )
+        determinants = BillingDeterminants(
+            carrier=EnergyCarrier.ELECTRICITY,
+            energy_bought_in_kwh=0.0,
+            energy_sold_in_kwh=500.0,
+            revenue_integrated_in_euro=100.0,
+        )
+        revenue = apply_tariff(determinants, contract).by_category[CostCategory.FEED_IN_REVENUE]
+        assert revenue.best_estimate == pytest.approx(-(100.0 * 0.8 + 500.0 * 0.01))
+        contract.feed_in.spot_factor = 1.0
+        unscaled = apply_tariff(determinants, contract).by_category[CostCategory.FEED_IN_REVENUE]
+        assert unscaled.best_estimate == pytest.approx(-(100.0 + 500.0 * 0.01))
+
+    def test_billing_interval_must_divide(self):
+        """seconds_per_timestep must divide the billing interval (§8.4).
+
+        The rejection is pinned to `CostDataError` and to the message naming the interval: a bare
+        `Exception` would also be satisfied by a `TypeError` or an `AttributeError` from a
+        refactor that broke the check outright, which is the failure this test exists to catch.
+        """
+        from hisim.economics.database import CostDataError
+
+        contract = make_flat_contract()
+        contract.capacity_charge = CapacityCharge(
+            kind=CapacityChargeKind.MONTHLY_PEAK,
+            price_in_euro_per_kw=UncertainValue.exact(8.0),
+            billing_interval_in_minutes=15,
+        )
+        validate_billing_interval(900, contract)
+        validate_billing_interval(60, contract)
+        with pytest.raises(CostDataError, match="does not divide the billing interval"):
+            validate_billing_interval(7 * 60, contract)
+
+    def test_tariff_counterfactual(self):
+        """Billing the same profile under a flat contract isolates the tariff choice (§8.5)."""
+        dynamic = make_flat_contract()
+        dynamic.supply = TariffSupply(kind=SupplyKind.DYNAMIC, spot_series="test")
+        determinants = BillingDeterminants(
+            carrier=EnergyCarrier.ELECTRICITY, energy_bought_in_kwh=1000.0, cost_integrated_in_euro=200.0
+        )
+        outcome = tariff_counterfactual(determinants, dynamic, make_flat_contract(price=0.30))
+        assert outcome["tariff_advantage_in_euro"].best_estimate == pytest.approx(300.0 - 200.0)
+
+    def test_synthetic_series_is_deterministic_and_hourly(self):
+        """The Q16 fallback profile."""
+        series = synthetic_reference_spot_series()
+        assert len(series) == 8760
+        assert series == synthetic_reference_spot_series()
+        assert min(series) >= 0.0
+
+


### PR DESCRIPTION
# PR 3/8 — Cost module stack: subsidy engine, tariff engine, data validation

- **Branch:** `cost/03-subsidies-tariffs` (`8714f975`)
- **Base:** `cost/02-data` (`8b1a1ae0`)
- **Files:** 4 · **Tests:** 156 passed (58 new in `tests/test_economics_subsidies_tariffs.py`)

## What this is

Three modules, ~all of the rule complexity in the cost engine. They turn the catalogs shipped in
PR 2 into cash flows. Both engines import only the kernel (PR 1) and the database (PR 2);
neither reaches into the evaluator.

- **`subsidies.py`** (§5) — the subsidy scheme model and its solver: eligibility conditions,
  rate / lump-sum / tiered awards, caps and basis clamping, combination rules, the cumulation
  solver that picks the best legal combination, and the decision audit trail (§5.6).
- **`tariffs.py`** (§4.4) — the tariff contract model: flat, time-of-use, dynamic-spot and
  capacity-charge components, feed-in netting, controllability discounts.
- **`validation.py`** — schema and consistency validation of the shipped cost database, tariff
  contracts and subsidy catalogs.

## Review guide

This is the highest-risk diff in the stack per line. The rules encode real subsidy programmes and
real tariff structures, and a wrong rule produces a plausible-looking number that no invariant
test will catch.

**Start with the cumulation solver in `subsidies.py`.** It answers "which combination of schemes
wins", and it is the one place where a bug changes the headline result without changing anything
that looks wrong. Check it against §5: is it really choosing the best *legal* combination, and
does it reject combinations the programme rules forbid rather than silently down-weighting them?

**Then the clamping order.** Basis clamping, rate application, absolute cap and tiered cap
compose, and the order matters — a lump sum clamped to the basis before or after a cap gives
different money. §5 fixes the order; confirm the code follows it.

**Then `tariffs.py` feed-in netting.** Netting decides whether exported energy offsets imported
energy before or after the tariff is applied, which is the difference between two quite different
bills.

**Verified on this branch:** `validation.validate_all()` reports **0 errors, 0 warnings** against
all shipped data, and both catalogs load (DE: 9 schemes).

## Test coverage — 51 tests, shipped with the code they test

`tests/test_economics_subsidies_tariffs.py` — **58 tests, all passing on this branch**:

- `TestSubsidyEngine` — eligibility, award shapes, caps
- `TestTypedBenefits` — grants, tax credits, and how they differ
- `TestConditionAstAndFieldVocabulary` — the eligibility condition language
- `TestOverallCapIsAppliedPerSlot` — capping in all three worlds
- `TestSubsidyModeFiltersBeforeTheSolve` — which schemes reach the solver
- `TestCumulationSolverGuard` — the solver and the combination rules
- `TestSubsidyProvenance` — a catalog and its schemes cite their registry entries
- `TestTariffEngine` — contract evaluation, netting, capacity charges
- `TestScenarioDataOverlays` — the §4.6 overlay surface of the cost database
- `TestDeletedDeadSurface` — D23: a deleted knob stays deleted

Review round 2 adds the **D25 fail-fast** cases here: an INELIGIBLE scheme now names the
condition leaves that failed and the answers that failed them (`any` reports as "none of", `not`
says the child holds), instead of returning a bare verdict a user cannot act on. Read those
messages as a user would — they are the diagnostic surface of the whole subsidy engine.

This file previously shipped with PR 4, because nine of its tests drove the same rules *through*
the evaluator and so could not pass before that layer existed. Those nine were split out into
`tests/test_economics_subsidy_integration.py`, which ships with **PR 4**; everything that needs
nothing above the rule engines now ships here. The split was pure code motion — the nine bodies
are byte-identical and the set of test names across the two files is unchanged (69 = 58 + 11).

Reviewers who want the end-to-end picture should read the integration file in PR 4 as well: it
covers subsidy provenance reaching `explain()`, scenario-set expansion, the evaluation cube and
the break-even search.

**PR 6** is the stronger check on this diff: the `subsidies/` and `tariffs/` worked examples are
five hand-computed Excel workbooks each, covering exactly the cases above (share with absolute
cap, combined rate/cap pro-rata, lump sum clamped to basis, per-dwelling-unit tiered cap, grant
versus tax credit; flat bill, two-band ToU, dynamic spot integral, capacity charge,
controllability discount, feed-in netting).

### Spec sections
§5 and §5.6 (subsidies), §4.4 (tariffs), §9.6 (data-file CI checks) of `cost_spec.md`.

## Push

```bash
git push origin cost/03-subsidies-tariffs

gh pr create --base cost/02-data --head cost/03-subsidies-tariffs \
  --title "Cost module stack 3/8: subsidy engine, tariff engine, data validation" \
  --body-file roadmap/pr_descriptions/03-subsidies-tariffs.md
```

Retarget as the PRs below it merge.
