### PR TITLE
Cost module stack 5/8: serialization, component adapter, CLI

### DIFF
--- a/cost_spec.md
+++ b/cost_spec.md
@@ -1569,8 +1569,12 @@ implementation silently drops a component from every cost result. Countermeasure
   (must provide `EnergyFlowFacts`). The base class default is `UNDECLARED`.
 - **Completeness check at simulation start, not end.** During component registration, any `UNDECLARED`
   component, or a `PRICED` component whose facts don't build, aborts with a message naming the class
-  and file. Strictness is configurable (`strict_cost_completeness`): hard error in CI and tests,
-  downgradeable to a warning for legacy system setups during migration.
+  and file. There is no lenient mode and no `strict_cost_completeness` flag: an undeclared component
+  is always a hard error, because the alternative is a cost result that is quietly incomplete. The
+  same rule applies to the compatibility adapter (§10.0): relevance is read off the class
+  declaration only — never inferred from the adapter's own tables — and every way of producing no
+  facts other than "this class is unknown and claims nothing" carries a reason that fails the
+  evaluation.
 
 Forgetting the cost model on a new component thus fails the very first test run — today, forgetting
 `get_cost_opex` merely produces a silent `NotImplementedError` swallowed by the None-filtering in
@@ -1689,8 +1693,9 @@ explicit final phase. Concretely, the following rules bind every phase except Ph
    CSV re-parse — is neither edited nor refactored.
 2. **Changes to existing files are purely additive**: a new `PostProcessingOptions` flag
    (`COMPUTE_LIFECYCLE_COSTS`), new optional methods on `Component` with a no-op default
-   (`get_cost_facts()` returning `None`), the `cost_relevance` class attribute (§9.2, metadata only,
-   warning-mode during the parallel phase). No existing line of calculation logic changes.
+   (`get_cost_facts()` returning `None`), the `cost_relevance` class attribute (§9.2 — metadata for
+   everything except the cost engine, which requires it). No existing line of calculation logic
+   changes.
 3. **Activation is opt-in and side-effect-free.** With the flag off, behavior is bit-identical to
    today. With the flag on, the new engine runs *in addition* and writes only new files
    (`lifecycle_costs.json`, `component_costs.*`, `cash_flow_timeline.csv`, `cost_audit.csv`,
@@ -1731,7 +1736,8 @@ data source as data-only PRs, whose effect is visible in the audit diff (§9.5).
 `observation_period = simulated period`, all rates 0, the engine reproduces today's
 "per simulated period" numbers exactly — verified via the shadow-mode parity report, not by modifying
 the old path. Unit tests against hand-calculated VDI 2067 / EN 15459 examples. This phase also ships
-the maintenance infrastructure of §9: `cost_relevance` declarations (additive, warning-mode), the
+the maintenance infrastructure of §9: `cost_relevance` declarations (additive, but mandatory once
+the bridge runs — an undeclared component aborts the evaluation), the
 pre-run resolution check, the auto-discovered contract test, the cost audit report, and the data-file
 CI (schema + coverage matrix) — so the safety net exists *before* any component adopts the new API.
 
@@ -1911,9 +1917,11 @@ revertable by turning the flag off.
     re-running scheme selection per scenario.
 
 **Cross-cutting (maintainability, §9)**
-14. Enforcement strictness rollout: when does `strict_cost_completeness` flip from warning to hard
-    error — per system setup, or globally at cutover (Phase 7)? Proposal: error in CI from Phase 1,
-    error everywhere at cutover.
+14. ~~Enforcement strictness rollout: when does `strict_cost_completeness` flip from warning to hard
+    error — per system setup, or globally at cutover (Phase 7)?~~ **Decided: no rollout and no
+    flag.** Declaration is mandatory from the start and an undeclared component aborts the
+    evaluation everywhere (§9.2). The flag was never implemented; the leniency it promised is what
+    would have let a component disappear from a cost result.
 15. Capacity-field convention for the contract test's scaling check: dataclass field metadata
     (`field(metadata={"capacity": True})`, proposal) vs. a `get_capacity_field_name()` classmethod on
     `ConfigBase`.

--- a/hisim/economics/README.md
+++ b/hisim/economics/README.md
@@ -113,6 +113,13 @@ python -m hisim.economics validate
 python -m hisim.economics report <results_dir> [--compare <reference_results_dir>]
 ```
 
+`evaluate`, `explain` and `report` all accept `--parameters <file>` (an `EconomicParameters`
+JSON document) and `--subsidy-catalog <dir>`, and all three mean the same thing: price under
+*these* assumptions rather than the stored ones, the flag winning over the
+`subsidy_catalog_path` inside the parameters file. `report` renders the stored evaluation when
+neither flag is given — that is what keeps it a rendering step rather than a second
+evaluation — and re-evaluates, saying so on stdout, when one of them is.
+
 The report layer follows the money along the calculation chain — every spec feature has at
 least one visualization plus a result table: **0** automated plausibility panel (thresholds:
 `cost_database/plausibility_checks.json` — range checks WARN, structural invariants FAIL),

--- a/hisim/economics/__main__.py
+++ b/hisim/economics/__main__.py
@@ -150,8 +150,13 @@ def _cmd_evaluate(args: argparse.Namespace) -> int:
     first = next(iter(matrix.results.values()), None)
     if first is not None:
         # The audit belongs to the stored evaluation: without it a later `report` could not
-        # render section 1 without reopening the cost database (W4.5).
-        from hisim.economics.audit import build_input_audit, write_cost_audit
+        # render section 1 without reopening the cost database (W4.5). The audit module itself
+        # arrives with the presentation part of this stack, so until then this subcommand fails
+        # on the import rather than on a half-written report.
+        from hisim.economics.audit import (  # pylint: disable=no-name-in-module,import-error
+            build_input_audit,
+            write_cost_audit,
+        )
 
         audit = build_input_audit(inputs, database, parameters, first)
         write_cost_audit(audit, args.results_dir)
@@ -221,8 +226,8 @@ def _evaluate_directory(
     Returns:
         The evaluated matrix and its input audit (None only when no perspective was evaluated).
     """
-    from hisim.economics.audit import build_input_audit
-    from hisim.economics.results import EvaluationMatrix
+    # See the note above: `audit` is part of the presentation layer of this stack.
+    from hisim.economics.audit import build_input_audit  # pylint: disable=no-name-in-module,import-error
 
     inputs = read_inputs(results_dir)
     parameters = _load_parameters(args)
@@ -291,8 +296,16 @@ def _cmd_report(args: argparse.Namespace) -> int:
         two compared directories share no perspective.
     """
     from hisim.economics.plausibility import run_plausibility_checks
-    from hisim.economics.report_plots import plot_payback_curve, write_report_plots
-    from hisim.economics.reporting import write_cost_summary, write_lifecycle_report
+
+    # Both renderers are the presentation layer of this stack, as `audit` above.
+    from hisim.economics.report_plots import (  # pylint: disable=no-name-in-module,import-error
+        plot_payback_curve,
+        write_report_plots,
+    )
+    from hisim.economics.reporting import (  # pylint: disable=no-name-in-module,import-error
+        write_cost_summary,
+        write_lifecycle_report,
+    )
     from hisim.economics.results import compare
 
     matrix, audit = _load_or_evaluate(args.results_dir, args, args.results_dir)
@@ -318,8 +331,6 @@ def _cmd_report(args: argparse.Namespace) -> int:
     if getattr(args, "scenarios", None):
         # The scenario cube is a fresh cube of evaluations by definition (§4.6), so this branch
         # needs the engine whether or not stored results exist.
-        from hisim.economics.scenarios import ScenarioSet, evaluate_cube, export_cube_csv, export_cube_json
-
         inputs = read_inputs(args.results_dir)
         parameters = _load_parameters(args)
         database = CostDatabase(parameters.cost_database_path)

--- a/hisim/economics/__main__.py
+++ b/hisim/economics/__main__.py
@@ -1,0 +1,441 @@
+"""CLI of the lifecycle cost engine (cost_spec.md §3.10, §4.6).
+
+Usage::
+
+    python -m hisim.economics evaluate <results_dir> [--scenarios scenarios.json]
+    python -m hisim.economics explain <results_dir> --value "<perspective>/<field-path>"
+    python -m hisim.economics validate
+
+**Why a CLI exists at all.** Three of these four commands are only possible because the evaluator
+is a pure function of `economic_inputs.json` (the seam-1 contract, §4.6): a result directory can be
+re-priced, explained or reported on years after the simulation ran, without HiSim's simulation
+stack, the original system setup or the weather data. The fourth, `validate`, is the data-file CI
+of §9.6 made runnable by hand after a price or catalog edit. None of them can run a simulation, and
+none of them touches legacy cost outputs.
+
+**The four subcommands and their contracts:**
+
+- ``evaluate <results_dir> [--scenarios F] [--parameters F] [--subsidy-catalog DIR]`` — re-prices
+  the stored inputs. Without ``--scenarios`` it evaluates the applicable perspectives and
+  *overwrites* the directory's `lifecycle_costs.json`, `component_costs.*`,
+  `cash_flow_timeline.csv`, `cost_provenance.json`, `cost_audit.csv` and `cost_audit.json`, then
+  prints how many perspectives it wrote. With ``--scenarios`` it instead evaluates the §4.6 cube
+  and writes `scenario_cube.csv`/`.json`, printing the number of cells. Exit 0 on success.
+- ``explain <results_dir> --value "<perspective>/<field-path>"`` — re-evaluates one perspective and
+  traces one result value back through the provenance ledger to the data entries and sources behind
+  it (§3.10), as text or, with ``--json``, as the machine-readable report. Exit 2 with a message on
+  stderr when the ``--value`` argument has no ``/`` or names an unknown perspective.
+- ``report <results_dir> [--compare DIR] [--scenarios F]`` — writes the human-readable outputs
+  (`cost_summary.md`, `lifecycle_report.html`, the PNG charts) for stored results, adding a variant
+  comparison and/or a scenario section on request. Exit 2 when there is nothing to report or the
+  two directories share no perspective.
+- ``validate`` — runs `validation.validate_all` over the shipped data files, printing every warning
+  and every error followed by a count. **Exit 1 when any error was found, 0 otherwise**; warnings
+  never affect the exit code, which is what makes it usable as a CI gate. A failing check means the
+  shipped data is internally inconsistent — an unsourced datapoint, a coverage or question-coverage
+  hole, a malformed tariff contract — and the run that would have used it is not to be trusted.
+
+Across all commands, an `UnresolvableSubjectsError` — the fail-fast of decision D7 — is caught in
+`main` and turned into exit code 2 with the same message the postprocessing bridge logs. There are
+no partial cost results and no ``--allow-drops`` escape. Every other `CostDataError` — a cost
+database that will not load, a `--parameters` file that is not there (issue #23) — is caught in
+the same place and reported the same way, so a data or invocation problem is a message and an
+exit code rather than a traceback, and never a silently substituted default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Optional, Tuple
+
+from hisim.economics.database import CostDatabase, CostDataError
+from hisim.economics.evaluator import (
+    EconomicEvaluator,
+    UnresolvableSubjectsError,
+    require_resolvable_subjects,
+)
+from hisim.economics.exports import (
+    write_cash_flow_timeline,
+    write_component_costs,
+    write_lifecycle_costs_json,
+    write_provenance_ledger,
+)
+from hisim.economics.input_audit import InputAuditReport, read_input_audit, write_input_audit
+from hisim.economics.parameters import EconomicParameters
+from hisim.economics.perspectives import load_default_bundle, select_applicable
+from hisim.economics.results import EvaluationMatrix
+from hisim.economics.scenarios import ScenarioSet, evaluate_cube, export_cube_csv, export_cube_json
+from hisim.economics.serialization import read_inputs, read_results
+from hisim.economics.subsidies import SubsidyCatalog
+from hisim.economics.validation import validate_all
+
+
+def _load_parameters(args: argparse.Namespace) -> EconomicParameters:
+    """The economic assumptions for this invocation: a `--parameters` file, or the defaults.
+
+    Shared by every subcommand so they all price identically. Note that the parameters come from the
+    *caller*, never from the result directory — that is the point of re-pricing: the stored file
+    carries the physical facts, the assumptions are supplied fresh (§4.6).
+
+    Omitting `--parameters` means "use the defaults" and is a legitimate invocation. *Passing* a
+    path that does not exist is not: it used to fall back to the defaults silently, so a typo in
+    the file name produced a full, plausible-looking result priced under assumptions the caller
+    never chose (issue #23). The two cases are therefore separated here, and only the second one
+    fails.
+
+    Returns:
+        The parsed parameters, or the defaults when the flag was omitted.
+
+    Raises:
+        CostDataError: If `--parameters` names a path that is not a readable file. `main` turns it
+            into exit code 2 with the message on stderr.
+    """
+    if not args.parameters:
+        return EconomicParameters()
+    if not os.path.isfile(args.parameters):
+        raise CostDataError(
+            f"--parameters file not found: {args.parameters!r}. Omit the flag to price with the "
+            "default economic parameters; the defaults are never used as a fallback for a path "
+            "that was given explicitly."
+        )
+    with open(args.parameters, encoding="utf-8") as file:
+        parameters: EconomicParameters = EconomicParameters.from_dict(json.load(file))
+    return parameters
+
+
+def _cmd_evaluate(args: argparse.Namespace) -> int:
+    """``evaluate``: re-price a stored result directory, or sweep it (§4.6).
+
+    Reads `economic_inputs.json`, applies the caller's parameters and catalog, runs the D7
+    resolution check and then either evaluates the applicable perspectives — overwriting the
+    directory's export set in place, audit included so a later `report` needs no cost database
+    (W4.5) — or, with ``--scenarios``, evaluates the scenario cube instead and writes only
+    `scenario_cube.csv`/`.json`. The two are exclusive: a scenario run does not refresh the base
+    exports.
+
+    This is the command that makes "new interest-rate assumptions" or "an updated subsidy catalog"
+    a second-long operation on an archived study rather than a re-simulation.
+
+    Returns:
+        0. Failure surfaces as an exception — `UnresolvableSubjectsError` becomes exit 2 in `main`,
+        an unreadable directory or malformed scenario file propagates.
+    """
+    inputs = read_inputs(args.results_dir)
+    parameters = _load_parameters(args)
+    database = CostDatabase(parameters.cost_database_path)
+    catalog = None
+    if parameters.subsidy_catalog_path or args.subsidy_catalog:
+        catalog = SubsidyCatalog.load(parameters.country, args.subsidy_catalog or parameters.subsidy_catalog_path)
+    evaluator = EconomicEvaluator(database, parameters, catalog)
+    require_resolvable_subjects(inputs, evaluator)
+    perspectives = select_applicable(load_default_bundle(), has_register=inputs.existing_assets is not None)
+    if args.scenarios:
+        with open(args.scenarios, encoding="utf-8") as file:
+            scenario_set = ScenarioSet.from_json(json.load(file))
+        cube = evaluate_cube(inputs, parameters, perspectives, scenario_set, database, catalog)
+        export_cube_csv(cube, os.path.join(args.results_dir, "scenario_cube.csv"))
+        export_cube_json(cube, os.path.join(args.results_dir, "scenario_cube.json"))
+        print(f"Wrote scenario_cube.csv/.json for {sum(len(v) for v in cube.results.values())} cells.")
+        return 0
+    matrix = EvaluationMatrix()
+    for perspective in perspectives:
+        matrix.results[perspective.id] = evaluator.evaluate(inputs, perspective)
+    write_lifecycle_costs_json(matrix, args.results_dir)
+    write_component_costs(matrix, args.results_dir)
+    write_cash_flow_timeline(matrix, args.results_dir)
+    write_provenance_ledger(matrix, args.results_dir)
+    first = next(iter(matrix.results.values()), None)
+    if first is not None:
+        # The audit belongs to the stored evaluation: without it a later `report` could not
+        # render section 1 without reopening the cost database (W4.5).
+        from hisim.economics.audit import build_input_audit, write_cost_audit
+
+        audit = build_input_audit(inputs, database, parameters, first)
+        write_cost_audit(audit, args.results_dir)
+        write_input_audit(audit, args.results_dir)
+    print(f"Re-evaluated {len(matrix.results)} perspectives into {args.results_dir}.")
+    return 0
+
+
+def _cmd_explain(args: argparse.Namespace) -> int:
+    """``explain``: trace one result value back to the data entries and sources behind it (§3.10).
+
+    Takes ``--value "<perspective>/<field-path>"``, re-evaluates that single perspective from the
+    stored inputs and asks the result to explain the named field: which parameters entered it, where
+    each came from (database entry with its `valid_from_year`, config override with its
+    `override_source`, scenario overlay, engine default, legacy shim) and which registry sources
+    back them. This is the on-demand counterpart of the eager `cost_audit.csv`, and the answer to
+    "is this number defensible" for any single number.
+
+    It re-evaluates rather than reading stored results because the provenance ledger is what is being
+    queried, and it is built during evaluation. No subsidy catalog is loaded here, so subsidy-derived
+    values are explained through the flat shim path.
+
+    Returns:
+        0 on success; 2 with a message on stderr when ``--value`` is malformed (no ``/``) or names a
+        perspective that is not applicable to this directory.
+    """
+    inputs = read_inputs(args.results_dir)
+    parameters = _load_parameters(args)
+    database = CostDatabase(parameters.cost_database_path)
+    if "/" not in args.value:
+        print("--value must have the form '<perspective>/<field-path>'", file=sys.stderr)
+        return 2
+    perspective_id, value_path = args.value.split("/", 1)
+    perspectives = [
+        perspective
+        for perspective in select_applicable(load_default_bundle(), inputs.existing_assets is not None)
+        if perspective.id == perspective_id
+    ]
+    if not perspectives:
+        print(f"Unknown perspective {perspective_id!r}.", file=sys.stderr)
+        return 2
+    evaluator = EconomicEvaluator(database, parameters)
+    require_resolvable_subjects(inputs, evaluator)
+    result = evaluator.evaluate(inputs, perspectives[0])
+    report = result.explain(value_path)
+    if args.json:
+        print(json.dumps(report.to_json(), indent=2))
+    else:
+        print(report.render_text())
+    return 0
+
+
+def _evaluate_directory(
+    results_dir: str, args: argparse.Namespace
+) -> "Tuple[EvaluationMatrix, Optional[InputAuditReport]]":
+    """The fallback path: re-price a directory's `economic_inputs.json` from scratch.
+
+    Used by `report` when a directory holds inputs but no stored evaluation. It does the full
+    engine run — database, catalog, resolution check, every applicable perspective — plus the input
+    audit, so the caller gets exactly what `read_results` + `read_input_audit` would have returned
+    for a directory that had them.
+
+    Args:
+        results_dir: Directory holding `economic_inputs.json`.
+        args: The parsed CLI namespace, for `--parameters`.
+
+    Returns:
+        The evaluated matrix and its input audit (None only when no perspective was evaluated).
+    """
+    from hisim.economics.audit import build_input_audit
+    from hisim.economics.results import EvaluationMatrix
+
+    inputs = read_inputs(results_dir)
+    parameters = _load_parameters(args)
+    database = CostDatabase(parameters.cost_database_path)
+    catalog = None
+    if parameters.subsidy_catalog_path:
+        catalog = SubsidyCatalog.load(parameters.country, parameters.subsidy_catalog_path)
+    evaluator = EconomicEvaluator(database, parameters, catalog)
+    require_resolvable_subjects(inputs, evaluator)
+    perspectives = select_applicable(load_default_bundle(), has_register=inputs.existing_assets is not None)
+    matrix = EvaluationMatrix()
+    for perspective in perspectives:
+        matrix.results[perspective.id] = evaluator.evaluate(inputs, perspective)
+    first = next(iter(matrix.results.values()), None)
+    audit = build_input_audit(inputs, database, parameters, first) if first is not None else None
+    return matrix, audit
+
+
+def _load_or_evaluate(
+    results_dir: str, args: argparse.Namespace, label: str
+) -> "Tuple[EvaluationMatrix, Optional[InputAuditReport]]":
+    """Stored results if the directory has them, otherwise a fresh evaluation (W4.5).
+
+    Reporting is supposed to *render* an evaluation, not perform one — the docstring said so
+    long before the code did. A directory written by `evaluate`, by the postprocessing bridge or
+    by an earlier `report` carries everything the reports need; only a directory holding nothing
+    but `economic_inputs.json` still has to be priced, and then it says so.
+
+    The distinction matters to a reader of the output: rendered stored results show the numbers the
+    original run published, while a re-priced directory shows what *today's* data and parameters
+    say about the same physical facts. The printed line is the only signal of which happened.
+
+    Args:
+        results_dir: Directory to load or evaluate.
+        args: The parsed CLI namespace, for `--parameters`.
+        label: How to name the directory in the fallback message (the caller passes the path).
+
+    Returns:
+        The matrix and the input audit, from storage or from a fresh evaluation.
+    """
+    stored = read_results(results_dir)
+    if stored is not None and stored.results:
+        return stored, read_input_audit(results_dir)
+    print(f"No stored results in {label}: re-evaluating from economic_inputs.json.")
+    return _evaluate_directory(results_dir, args)
+
+
+def _cmd_report(args: argparse.Namespace) -> int:
+    """Writes cost_summary.md, lifecycle_report.html and the PNG charts for stored results.
+
+    ``report`` is the human-facing command: it renders the plausibility panel and the report
+    sections that follow the money along the calculation chain, from the input audit through the
+    year-0 investment build-up to the perspective and per-component views. It prefers *stored*
+    results and only re-prices when the directory has none (`_load_or_evaluate`), which is what
+    keeps reporting a rendering step rather than a second evaluation (W4.5).
+
+    Two optional additions. ``--compare <reference_dir>`` loads a second directory, picks a shared
+    perspective (preferring `brownfield_net`, then `greenfield_net`) and adds the variant-comparison
+    section — delta waterfall, discounted payback band, warm-rent change — plus the payback PNG.
+    ``--scenarios`` evaluates a §4.6 cube for the scenario section; that branch always needs the
+    engine, since a cube is a set of fresh evaluations by definition, and it also writes
+    `scenario_cube.csv`/`.json`.
+
+    Returns:
+        0 on success; 2 with a message on stderr when the directory yields no results, or when the
+        two compared directories share no perspective.
+    """
+    from hisim.economics.plausibility import run_plausibility_checks
+    from hisim.economics.report_plots import plot_payback_curve, write_report_plots
+    from hisim.economics.reporting import write_cost_summary, write_lifecycle_report
+    from hisim.economics.results import compare
+
+    matrix, audit = _load_or_evaluate(args.results_dir, args, args.results_dir)
+    if not matrix.results:
+        print(f"No results to report in {args.results_dir}.", file=sys.stderr)
+        return 2
+
+    comparison = None
+    reference_result = None
+    if args.compare:
+        reference_matrix, _reference_audit = _load_or_evaluate(args.compare, args, args.compare)
+        shared = [pid for pid in matrix.results if pid in reference_matrix.results]
+        if not shared:
+            print("No shared perspective between the two result directories.", file=sys.stderr)
+            return 2
+        chosen = next((pid for pid in ("brownfield_net", "greenfield_net") if pid in shared), shared[0])
+        reference_result = reference_matrix.results[chosen]
+        comparison = compare(
+            reference_result, matrix.results[chosen], reference_id=args.compare, variant_id=args.results_dir
+        )
+
+    scenario_cube = None
+    if getattr(args, "scenarios", None):
+        # The scenario cube is a fresh cube of evaluations by definition (§4.6), so this branch
+        # needs the engine whether or not stored results exist.
+        from hisim.economics.scenarios import ScenarioSet, evaluate_cube, export_cube_csv, export_cube_json
+
+        inputs = read_inputs(args.results_dir)
+        parameters = _load_parameters(args)
+        database = CostDatabase(parameters.cost_database_path)
+        catalog = None
+        if parameters.subsidy_catalog_path:
+            catalog = SubsidyCatalog.load(parameters.country, parameters.subsidy_catalog_path)
+        evaluator = EconomicEvaluator(database, parameters, catalog)
+        require_resolvable_subjects(inputs, evaluator)
+        perspectives = select_applicable(load_default_bundle(), has_register=inputs.existing_assets is not None)
+        with open(args.scenarios, encoding="utf-8") as file:
+            scenario_set = ScenarioSet.from_json(json.load(file))
+        scenario_cube = evaluate_cube(inputs, parameters, perspectives, scenario_set, database, catalog)
+        export_cube_csv(scenario_cube, os.path.join(args.results_dir, "scenario_cube.csv"))
+        export_cube_json(scenario_cube, os.path.join(args.results_dir, "scenario_cube.json"))
+
+    plausibility = run_plausibility_checks(matrix)
+    write_cost_summary(matrix, plausibility, args.results_dir, comparison)
+    write_lifecycle_report(
+        matrix, plausibility, args.results_dir, audit, comparison, scenario_cube=scenario_cube,
+    )
+    write_report_plots(matrix, args.results_dir)
+    if comparison is not None and reference_result is not None:
+        plot_payback_curve(
+            reference_result,
+            matrix.results[comparison.perspective_id],
+            os.path.join(args.results_dir, "lifecycle_payback_curve.png"),
+        )
+    print(
+        f"Wrote cost_summary.md, lifecycle_report.html and PNG charts to {args.results_dir} "
+        f"({len(plausibility)} plausibility checks, {len(plausibility.flagged())} flagged)."
+    )
+    return 0
+
+
+def _cmd_validate(_args: argparse.Namespace) -> int:
+    """``validate``: run the §9.6 data-file CI checks over the shipped data, as a CI gate.
+
+    Takes no arguments and always checks the shipped `hisim/cost_database/` and
+    `hisim/subsidy_catalog/`. Prints every warning, then every error, then a count line; the same
+    checks run in CI, so this is what to execute after editing a price, adding a source or writing a
+    subsidy scheme, before opening the PR.
+
+    Returns:
+        0 when there are no errors (warnings alone do not fail it), 1 otherwise. A non-zero exit
+        means the shipped data is internally inconsistent — an unsourced datapoint, a coverage or
+        question-coverage hole, a malformed tariff contract, an exclusion naming a scheme that does
+        not exist — and any run using it would be untrustworthy rather than merely imperfect.
+    """
+    report = validate_all()
+    for warning in report.warnings:
+        print(f"WARNING: {warning}")
+    for error in report.errors:
+        print(f"ERROR: {error}")
+    print(f"{len(report.errors)} errors, {len(report.warnings)} warnings.")
+    return 0 if report.ok else 1
+
+
+def main(argv=None) -> int:
+    """Entry point.
+
+    Builds the four subparsers (each documented in the module docstring), dispatches to the matching
+    `_cmd_*` handler and returns its exit code. The one piece of behaviour that lives here rather
+    than in a handler is the D7 contract: `UnresolvableSubjectsError` is caught for *every*
+    subcommand and turned into exit code 2 with the error on stderr — the same message the
+    postprocessing bridge logs — so no entry point can ever emit a partial cost result.
+
+    Args:
+        argv: Argument list, defaulting to `sys.argv[1:]`; passed explicitly by the CLI tests.
+
+    Returns:
+        The subcommand's exit code, or 2 for an unresolvable subject.
+    """
+    parser = argparse.ArgumentParser(prog="python -m hisim.economics")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    evaluate_parser = subparsers.add_parser("evaluate", help="re-price stored results (§4.6)")
+    evaluate_parser.add_argument("results_dir")
+    evaluate_parser.add_argument("--scenarios", help="scenario-set JSON file")
+    evaluate_parser.add_argument("--parameters", help="EconomicParameters JSON file")
+    evaluate_parser.add_argument("--subsidy-catalog", dest="subsidy_catalog", help="subsidy catalog directory")
+    evaluate_parser.set_defaults(func=_cmd_evaluate)
+
+    explain_parser = subparsers.add_parser("explain", help="trace a result value to its sources (§3.10)")
+    explain_parser.add_argument("results_dir")
+    explain_parser.add_argument("--value", required=True, help="e.g. brownfield_net/equivalent_annual_cost_in_euro")
+    explain_parser.add_argument("--parameters", help="EconomicParameters JSON file")
+    explain_parser.add_argument("--json", action="store_true")
+    explain_parser.set_defaults(func=_cmd_explain)
+
+    report_parser = subparsers.add_parser(
+        "report", help="human-readable report + plausibility panel for stored results"
+    )
+    report_parser.add_argument("results_dir")
+    report_parser.add_argument("--compare", help="reference result directory for a variant comparison")
+    report_parser.add_argument("--parameters", help="EconomicParameters JSON file")
+    report_parser.add_argument("--scenarios", help="scenario-set JSON file for the report's scenario section")
+    report_parser.set_defaults(func=_cmd_report)
+
+    validate_parser = subparsers.add_parser("validate", help="data-file CI checks (§9.6)")
+    validate_parser.set_defaults(func=_cmd_validate)
+
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except UnresolvableSubjectsError as err:
+        # D7 (cost-spec-v2 §8): evaluate/explain/report all refuse to produce partial cost
+        # results; the same message the bridge logs goes to stderr with a non-zero exit code.
+        print(str(err), file=sys.stderr)
+        return 2
+    except CostDataError as err:
+        # Everything else the data layer refuses to do — an unloadable database, a missing
+        # `--parameters` file (issue #23). Same channel, same exit code: the caller asked for a
+        # priced result and is told why there is none instead of getting one built on defaults.
+        print(str(err), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hisim/economics/__main__.py
+++ b/hisim/economics/__main__.py
@@ -13,6 +13,14 @@ stack, the original system setup or the weather data. The fourth, `validate`, is
 of §9.6 made runnable by hand after a price or catalog edit. None of them can run a simulation, and
 none of them touches legacy cost outputs.
 
+**One setup block, three commands.** `evaluate`, `explain` and `report` all need the same
+assembly — stored inputs, the caller's `--parameters`, the cost database, the subsidy catalog, the
+D7 resolution check, the applicable perspectives — and it lives exactly once, in
+`_build_context`. That matters for more than tidiness: while each command assembled its own, they
+drifted, and a directory could be explained under different assumptions than the ones it was
+evaluated with. `--parameters` and `--subsidy-catalog` are therefore accepted by all three and mean
+the same thing in each, the flag taking precedence over the path stored in the parameters file.
+
 **The four subcommands and their contracts:**
 
 - ``evaluate <results_dir> [--scenarios F] [--parameters F] [--subsidy-catalog DIR]`` — re-prices
@@ -21,14 +29,17 @@ none of them touches legacy cost outputs.
   `cash_flow_timeline.csv`, `cost_provenance.json`, `cost_audit.csv` and `cost_audit.json`, then
   prints how many perspectives it wrote. With ``--scenarios`` it instead evaluates the §4.6 cube
   and writes `scenario_cube.csv`/`.json`, printing the number of cells. Exit 0 on success.
-- ``explain <results_dir> --value "<perspective>/<field-path>"`` — re-evaluates one perspective and
-  traces one result value back through the provenance ledger to the data entries and sources behind
-  it (§3.10), as text or, with ``--json``, as the machine-readable report. Exit 2 with a message on
-  stderr when the ``--value`` argument has no ``/`` or names an unknown perspective.
-- ``report <results_dir> [--compare DIR] [--scenarios F]`` — writes the human-readable outputs
-  (`cost_summary.md`, `lifecycle_report.html`, the PNG charts) for stored results, adding a variant
-  comparison and/or a scenario section on request. Exit 2 when there is nothing to report or the
-  two directories share no perspective.
+- ``explain <results_dir> --value "<perspective>/<field-path>" [--parameters F]
+  [--subsidy-catalog DIR]`` — re-evaluates one perspective and traces one result value back
+  through the provenance ledger to the data entries and sources behind it (§3.10), as text or,
+  with ``--json``, as the machine-readable report. Exit 2 with a message on stderr when the
+  ``--value`` argument has no ``/`` or names an unknown perspective.
+- ``report <results_dir> [--compare DIR] [--scenarios F] [--parameters F]
+  [--subsidy-catalog DIR]`` — writes the human-readable outputs (`cost_summary.md`,
+  `lifecycle_report.html`, the PNG charts) for stored results, adding a variant comparison and/or
+  a scenario section on request. Given a re-pricing flag it re-evaluates instead of rendering the
+  stored numbers, and says so on stdout. Exit 2 when there is nothing to report or the two
+  directories share no perspective.
 - ``validate`` — runs `validation.validate_all` over the shipped data files, printing every warning
   and every error followed by a count. **Exit 1 when any error was found, 0 otherwise**; warnings
   never affect the exit code, which is what makes it usable as a CI gate. A failing check means the
@@ -39,21 +50,26 @@ Across all commands, an `UnresolvableSubjectsError` — the fail-fast of decisio
 `main` and turned into exit code 2 with the same message the postprocessing bridge logs. There are
 no partial cost results and no ``--allow-drops`` escape. Every other `CostDataError` — a cost
 database that will not load, a `--parameters` file that is not there (issue #23) — is caught in
-the same place and reported the same way, so a data or invocation problem is a message and an
-exit code rather than a traceback, and never a silently substituted default.
+the same place, and so is the ordinary shape of a bad invocation: an unreadable path, malformed
+JSON, a rejected parameter value. A data or invocation problem is therefore a one-line message and
+an exit code rather than a traceback, and never a silently substituted default. Anything else — a
+genuine programming error — still propagates, because a traceback is the right report for it.
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import sys
-from typing import Optional, Tuple
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
 
 from hisim.economics.database import CostDatabase, CostDataError
 from hisim.economics.evaluator import (
     EconomicEvaluator,
+    EvaluationInputs,
     UnresolvableSubjectsError,
     require_resolvable_subjects,
 )
@@ -65,12 +81,94 @@ from hisim.economics.exports import (
 )
 from hisim.economics.input_audit import InputAuditReport, read_input_audit, write_input_audit
 from hisim.economics.parameters import EconomicParameters
-from hisim.economics.perspectives import load_default_bundle, select_applicable
+from hisim.economics.perspectives import Perspective, load_default_bundle, select_applicable
 from hisim.economics.results import EvaluationMatrix
-from hisim.economics.scenarios import ScenarioSet, evaluate_cube, export_cube_csv, export_cube_json
+from hisim.economics.scenarios import (
+    ScenarioCube,
+    ScenarioSet,
+    evaluate_cube,
+    export_cube_csv,
+    export_cube_json,
+)
 from hisim.economics.serialization import read_inputs, read_results
 from hisim.economics.subsidies import SubsidyCatalog
 from hisim.economics.validation import validate_all
+
+
+class CliFileNames:
+    """Names of the files the CLI itself writes, as opposed to the export modules.
+
+    Only the scenario cube is written here — every other output is named by `exports`,
+    `input_audit` or the reporting layer — but it is written by two subcommands, so the two names
+    live in one place rather than as literals in both.
+    """
+
+    SCENARIO_CUBE_CSV = "scenario_cube.csv"
+    SCENARIO_CUBE_JSON = "scenario_cube.json"
+
+
+class AuditLayerProbe:
+    """Whether the audit layer this stack's later part adds is importable yet.
+
+    `evaluate` writes `cost_audit.csv`/`.json` alongside the numeric exports, using
+    `hisim.economics.audit` — a module that arrives with the presentation part of this stack. Until
+    then the lazy import fails, and it used to fail *after* four export files had been written,
+    leaving a half-written directory that a later `report` would happily render as complete. The
+    probe answers the same question before anything is written, so the subcommand refuses instead
+    of half-succeeding. Once the presentation part is merged the probe always passes and the lazy
+    imports below simply work.
+    """
+
+    #: Module that must be importable for `evaluate` to write a complete export set.
+    MODULE_NAME = "hisim.economics.audit"
+
+    @classmethod
+    def require(cls) -> None:
+        """Raises unless the audit layer is importable.
+
+        Uses `importlib.util.find_spec`, so the check costs a path lookup and does not import
+        anything — the lazy imports at the use sites stay where they are.
+
+        Raises:
+            CostDataError: If the module is absent. `main` turns it into exit code 2 with the
+                message on stderr, before any output file exists.
+        """
+        if importlib.util.find_spec(cls.MODULE_NAME) is not None:
+            return
+        raise CostDataError(
+            f"{cls.MODULE_NAME} is not importable: the audit/reporting layer arrives with a later "
+            "PR of this stack, and `evaluate` cannot run yet because it would leave a "
+            "half-written export set behind. Nothing was written."
+        )
+
+
+@dataclass(frozen=True)
+class EvaluationContext:
+    """Everything one re-pricing invocation needs, assembled once (§4.6).
+
+    `evaluate`, `explain` and `report` all begin the same way — read the stored inputs, load the
+    caller's assumptions and the data files behind them, refuse the run if any subject cannot be
+    priced (D7), work out which perspectives apply — and that block used to be pasted into each of
+    them. The copies had already drifted: one honored `--subsidy-catalog`, one read only the
+    parameters file's path, and `explain` loaded no catalog at all and therefore traced different
+    numbers than the run had published. Holding the assembled state in one record is what makes
+    the three commands agree by construction.
+
+    Attributes:
+        inputs: The stored physical facts of one simulated variant (`economic_inputs.json`).
+        parameters: The caller's assumptions, from `--parameters` or the documented defaults.
+        database: The cost database the parameters point at.
+        catalog: The subsidy catalog, or None when neither the flag nor the parameters name one.
+        evaluator: The engine bound to database, parameters and catalog.
+        perspectives: The applicable rows of the default bundle, in bundle order.
+    """
+
+    inputs: EvaluationInputs
+    parameters: EconomicParameters
+    database: CostDatabase
+    catalog: Optional[SubsidyCatalog]
+    evaluator: EconomicEvaluator
+    perspectives: List[Perspective]
 
 
 def _load_parameters(args: argparse.Namespace) -> EconomicParameters:
@@ -106,6 +204,92 @@ def _load_parameters(args: argparse.Namespace) -> EconomicParameters:
     return parameters
 
 
+def _build_context(results_dir: str, args: argparse.Namespace) -> EvaluationContext:
+    """The one setup block behind `evaluate`, `explain` and `report` (§4.6).
+
+    Reads the directory's stored inputs, resolves the assumptions and the two data sources, binds
+    an evaluator to them, runs the D7 resolution check and selects the applicable perspectives —
+    in that order, because the resolution check has to see the same database and catalog the
+    evaluation will use.
+
+    The catalog precedence is the one policy decided here: `--subsidy-catalog` wins over
+    `parameters.subsidy_catalog_path`, so an archived assumption set can be re-priced against a
+    different catalog without editing it, and a run configured through the parameters file still
+    loads its catalog when no flag is given.
+
+    Args:
+        results_dir: Directory holding `economic_inputs.json`.
+        args: The parsed CLI namespace; `--parameters` and `--subsidy-catalog` are read from it.
+
+    Returns:
+        The assembled context, ready for `_evaluate_perspectives` or a single `evaluate` call.
+
+    Raises:
+        UnresolvableSubjectsError: If any cost subject cannot be priced (D7) — no partial results.
+        CostDataError: If the parameters file, the database or the catalog cannot be loaded.
+    """
+    inputs = read_inputs(results_dir)
+    parameters = _load_parameters(args)
+    database = CostDatabase(parameters.cost_database_path)
+    catalog_path = getattr(args, "subsidy_catalog", None) or parameters.subsidy_catalog_path
+    catalog = SubsidyCatalog.load(parameters.country, catalog_path) if catalog_path else None
+    evaluator = EconomicEvaluator(database, parameters, catalog)
+    require_resolvable_subjects(inputs, evaluator)
+    return EvaluationContext(
+        inputs=inputs,
+        parameters=parameters,
+        database=database,
+        catalog=catalog,
+        evaluator=evaluator,
+        perspectives=select_applicable(load_default_bundle(), has_register=inputs.existing_assets is not None),
+    )
+
+
+def _evaluate_perspectives(context: EvaluationContext) -> EvaluationMatrix:
+    """Evaluates every applicable perspective of the context into one matrix (§7.1).
+
+    The evaluate-all loop, in one place for the same reason as `_build_context`: `evaluate` and the
+    `report` fallback path must produce identical matrices for identical inputs, and a matrix
+    missing a perspective is not visible in any output.
+
+    Args:
+        context: The assembled evaluation context.
+
+    Returns:
+        The matrix, keyed by perspective id in bundle order.
+    """
+    matrix = EvaluationMatrix()
+    for perspective in context.perspectives:
+        matrix.results[perspective.id] = context.evaluator.evaluate(context.inputs, perspective)
+    return matrix
+
+
+def _write_scenario_cube(context: EvaluationContext, scenarios_path: str, results_dir: str) -> ScenarioCube:
+    """Evaluates the §4.6 scenario cube and writes `scenario_cube.csv`/`.json`.
+
+    Shared by `evaluate --scenarios` and `report --scenarios`, which differ only in what they do
+    with the returned cube: the first prints a cell count, the second renders a report section
+    from it. A cube is a set of fresh evaluations by definition, so this path always runs the
+    engine whether or not the directory holds stored results.
+
+    Args:
+        context: The assembled evaluation context.
+        scenarios_path: The scenario-set JSON file to read.
+        results_dir: Directory the two cube files are written to.
+
+    Returns:
+        The evaluated cube.
+    """
+    with open(scenarios_path, encoding="utf-8") as file:
+        scenario_set = ScenarioSet.from_json(json.load(file))
+    cube = evaluate_cube(
+        context.inputs, context.parameters, context.perspectives, scenario_set, context.database, context.catalog
+    )
+    export_cube_csv(cube, os.path.join(results_dir, CliFileNames.SCENARIO_CUBE_CSV))
+    export_cube_json(cube, os.path.join(results_dir, CliFileNames.SCENARIO_CUBE_JSON))
+    return cube
+
+
 def _cmd_evaluate(args: argparse.Namespace) -> int:
     """``evaluate``: re-price a stored result directory, or sweep it (§4.6).
 
@@ -116,33 +300,24 @@ def _cmd_evaluate(args: argparse.Namespace) -> int:
     `scenario_cube.csv`/`.json`. The two are exclusive: a scenario run does not refresh the base
     exports.
 
+    The audit-layer probe runs first, before any file is opened for writing, so a stack state in
+    which `hisim.economics.audit` is not merged yet fails with a message instead of leaving a
+    partly refreshed export set behind.
+
     This is the command that makes "new interest-rate assumptions" or "an updated subsidy catalog"
     a second-long operation on an archived study rather than a re-simulation.
 
     Returns:
-        0. Failure surfaces as an exception — `UnresolvableSubjectsError` becomes exit 2 in `main`,
-        an unreadable directory or malformed scenario file propagates.
+        0. Failure surfaces as an exception — `UnresolvableSubjectsError` and every other
+        `CostDataError` become exit 2 in `main`, and so does a malformed scenario file.
     """
-    inputs = read_inputs(args.results_dir)
-    parameters = _load_parameters(args)
-    database = CostDatabase(parameters.cost_database_path)
-    catalog = None
-    if parameters.subsidy_catalog_path or args.subsidy_catalog:
-        catalog = SubsidyCatalog.load(parameters.country, args.subsidy_catalog or parameters.subsidy_catalog_path)
-    evaluator = EconomicEvaluator(database, parameters, catalog)
-    require_resolvable_subjects(inputs, evaluator)
-    perspectives = select_applicable(load_default_bundle(), has_register=inputs.existing_assets is not None)
+    AuditLayerProbe.require()
+    context = _build_context(args.results_dir, args)
     if args.scenarios:
-        with open(args.scenarios, encoding="utf-8") as file:
-            scenario_set = ScenarioSet.from_json(json.load(file))
-        cube = evaluate_cube(inputs, parameters, perspectives, scenario_set, database, catalog)
-        export_cube_csv(cube, os.path.join(args.results_dir, "scenario_cube.csv"))
-        export_cube_json(cube, os.path.join(args.results_dir, "scenario_cube.json"))
+        cube = _write_scenario_cube(context, args.scenarios, args.results_dir)
         print(f"Wrote scenario_cube.csv/.json for {sum(len(v) for v in cube.results.values())} cells.")
         return 0
-    matrix = EvaluationMatrix()
-    for perspective in perspectives:
-        matrix.results[perspective.id] = evaluator.evaluate(inputs, perspective)
+    matrix = _evaluate_perspectives(context)
     write_lifecycle_costs_json(matrix, args.results_dir)
     write_component_costs(matrix, args.results_dir)
     write_cash_flow_timeline(matrix, args.results_dir)
@@ -150,15 +325,14 @@ def _cmd_evaluate(args: argparse.Namespace) -> int:
     first = next(iter(matrix.results.values()), None)
     if first is not None:
         # The audit belongs to the stored evaluation: without it a later `report` could not
-        # render section 1 without reopening the cost database (W4.5). The audit module itself
-        # arrives with the presentation part of this stack, so until then this subcommand fails
-        # on the import rather than on a half-written report.
+        # render section 1 without reopening the cost database (W4.5). The probe above has
+        # already established that this import will succeed.
         from hisim.economics.audit import (  # pylint: disable=no-name-in-module,import-error
             build_input_audit,
             write_cost_audit,
         )
 
-        audit = build_input_audit(inputs, database, parameters, first)
+        audit = build_input_audit(context.inputs, context.database, context.parameters, first)
         write_cost_audit(audit, args.results_dir)
         write_input_audit(audit, args.results_dir)
     print(f"Re-evaluated {len(matrix.results)} perspectives into {args.results_dir}.")
@@ -176,31 +350,24 @@ def _cmd_explain(args: argparse.Namespace) -> int:
     "is this number defensible" for any single number.
 
     It re-evaluates rather than reading stored results because the provenance ledger is what is being
-    queried, and it is built during evaluation. No subsidy catalog is loaded here, so subsidy-derived
-    values are explained through the flat shim path.
+    queried, and it is built during evaluation. It builds its context exactly like `evaluate`,
+    subsidy catalog included: while it did not, a catalog-configured run was explained through the
+    flat shim path, so the trace described numbers the run had never published.
 
     Returns:
         0 on success; 2 with a message on stderr when ``--value`` is malformed (no ``/``) or names a
         perspective that is not applicable to this directory.
     """
-    inputs = read_inputs(args.results_dir)
-    parameters = _load_parameters(args)
-    database = CostDatabase(parameters.cost_database_path)
     if "/" not in args.value:
         print("--value must have the form '<perspective>/<field-path>'", file=sys.stderr)
         return 2
     perspective_id, value_path = args.value.split("/", 1)
-    perspectives = [
-        perspective
-        for perspective in select_applicable(load_default_bundle(), inputs.existing_assets is not None)
-        if perspective.id == perspective_id
-    ]
-    if not perspectives:
+    context = _build_context(args.results_dir, args)
+    matching = [perspective for perspective in context.perspectives if perspective.id == perspective_id]
+    if not matching:
         print(f"Unknown perspective {perspective_id!r}.", file=sys.stderr)
         return 2
-    evaluator = EconomicEvaluator(database, parameters)
-    require_resolvable_subjects(inputs, evaluator)
-    result = evaluator.evaluate(inputs, perspectives[0])
+    result = context.evaluator.evaluate(context.inputs, matching[0])
     report = result.explain(value_path)
     if args.json:
         print(json.dumps(report.to_json(), indent=2))
@@ -214,60 +381,90 @@ def _evaluate_directory(
 ) -> "Tuple[EvaluationMatrix, Optional[InputAuditReport]]":
     """The fallback path: re-price a directory's `economic_inputs.json` from scratch.
 
-    Used by `report` when a directory holds inputs but no stored evaluation. It does the full
-    engine run — database, catalog, resolution check, every applicable perspective — plus the input
-    audit, so the caller gets exactly what `read_results` + `read_input_audit` would have returned
-    for a directory that had them.
+    Used by `report` when a directory holds inputs but no stored evaluation, and when a re-pricing
+    flag makes the stored evaluation the wrong thing to render. It does the full engine run —
+    database, catalog, resolution check, every applicable perspective — plus the input audit, so
+    the caller gets exactly what `read_results` + `read_input_audit` would have returned for a
+    directory that had them.
 
     Args:
         results_dir: Directory holding `economic_inputs.json`.
-        args: The parsed CLI namespace, for `--parameters`.
+        args: The parsed CLI namespace, for `--parameters` and `--subsidy-catalog`.
 
     Returns:
         The evaluated matrix and its input audit (None only when no perspective was evaluated).
+
+    Raises:
+        CostDataError: If the audit layer is not importable yet, or the data will not load.
     """
-    # See the note above: `audit` is part of the presentation layer of this stack.
+    AuditLayerProbe.require()
+    # See `AuditLayerProbe`: `audit` is part of the presentation layer of this stack.
     from hisim.economics.audit import build_input_audit  # pylint: disable=no-name-in-module,import-error
 
-    inputs = read_inputs(results_dir)
-    parameters = _load_parameters(args)
-    database = CostDatabase(parameters.cost_database_path)
-    catalog = None
-    if parameters.subsidy_catalog_path:
-        catalog = SubsidyCatalog.load(parameters.country, parameters.subsidy_catalog_path)
-    evaluator = EconomicEvaluator(database, parameters, catalog)
-    require_resolvable_subjects(inputs, evaluator)
-    perspectives = select_applicable(load_default_bundle(), has_register=inputs.existing_assets is not None)
-    matrix = EvaluationMatrix()
-    for perspective in perspectives:
-        matrix.results[perspective.id] = evaluator.evaluate(inputs, perspective)
+    context = _build_context(results_dir, args)
+    matrix = _evaluate_perspectives(context)
     first = next(iter(matrix.results.values()), None)
-    audit = build_input_audit(inputs, database, parameters, first) if first is not None else None
+    audit = (
+        build_input_audit(context.inputs, context.database, context.parameters, first) if first is not None else None
+    )
     return matrix, audit
+
+
+def _repricing_flags(args: argparse.Namespace) -> List[str]:
+    """The flags on this invocation that change the assumptions a result is priced under.
+
+    `report` renders stored results by default, which is what keeps it a rendering step (W4.5). A
+    caller who passes `--parameters` or `--subsidy-catalog` is asking for something else, and those
+    flags used to be accepted and then ignored: the report came out under the *original*
+    assumptions, and with `--scenarios` it mixed a freshly evaluated cube into a stored base — an
+    internally inconsistent document with nothing in it to say so.
+
+    Args:
+        args: The parsed CLI namespace.
+
+    Returns:
+        The names of the re-pricing flags that were given, in flag order; empty when none were.
+    """
+    given = (
+        (getattr(args, "parameters", None), "--parameters"),
+        (getattr(args, "subsidy_catalog", None), "--subsidy-catalog"),
+    )
+    return [name for value, name in given if value]
 
 
 def _load_or_evaluate(
     results_dir: str, args: argparse.Namespace, label: str
 ) -> "Tuple[EvaluationMatrix, Optional[InputAuditReport]]":
-    """Stored results if the directory has them, otherwise a fresh evaluation (W4.5).
+    """Stored results if the directory has them and nothing re-prices them, else a fresh run (W4.5).
 
     Reporting is supposed to *render* an evaluation, not perform one — the docstring said so
     long before the code did. A directory written by `evaluate`, by the postprocessing bridge or
-    by an earlier `report` carries everything the reports need; only a directory holding nothing
-    but `economic_inputs.json` still has to be priced, and then it says so.
+    by an earlier `report` carries everything the reports need, so it is rendered as it stands.
+
+    Two things send this to the engine instead: a directory holding nothing but
+    `economic_inputs.json`, and a re-pricing flag (`_repricing_flags`), which is a request to
+    render *these* assumptions rather than the stored ones.
 
     The distinction matters to a reader of the output: rendered stored results show the numbers the
-    original run published, while a re-priced directory shows what *today's* data and parameters
-    say about the same physical facts. The printed line is the only signal of which happened.
+    original run published, while a re-priced directory shows what today's data and the given
+    parameters say about the same physical facts. The printed line is the only signal of which
+    happened, so both re-pricing paths print one.
 
     Args:
         results_dir: Directory to load or evaluate.
-        args: The parsed CLI namespace, for `--parameters`.
-        label: How to name the directory in the fallback message (the caller passes the path).
+        args: The parsed CLI namespace, for `--parameters` and `--subsidy-catalog`.
+        label: How to name the directory in the printed message (the caller passes the path).
 
     Returns:
         The matrix and the input audit, from storage or from a fresh evaluation.
     """
+    flags = _repricing_flags(args)
+    if flags:
+        print(
+            f"{' and '.join(flags)} given: re-evaluating {label} under those assumptions instead "
+            "of rendering its stored results."
+        )
+        return _evaluate_directory(results_dir, args)
     stored = read_results(results_dir)
     if stored is not None and stored.results:
         return stored, read_input_audit(results_dir)
@@ -281,15 +478,17 @@ def _cmd_report(args: argparse.Namespace) -> int:
     ``report`` is the human-facing command: it renders the plausibility panel and the report
     sections that follow the money along the calculation chain, from the input audit through the
     year-0 investment build-up to the perspective and per-component views. It prefers *stored*
-    results and only re-prices when the directory has none (`_load_or_evaluate`), which is what
-    keeps reporting a rendering step rather than a second evaluation (W4.5).
+    results and re-prices only when the directory has none or when a re-pricing flag asks it to
+    (`_load_or_evaluate`), which is what keeps reporting a rendering step rather than a second
+    evaluation (W4.5).
 
     Two optional additions. ``--compare <reference_dir>`` loads a second directory, picks a shared
     perspective (preferring `brownfield_net`, then `greenfield_net`) and adds the variant-comparison
-    section — delta waterfall, discounted payback band, warm-rent change — plus the payback PNG.
-    ``--scenarios`` evaluates a §4.6 cube for the scenario section; that branch always needs the
-    engine, since a cube is a set of fresh evaluations by definition, and it also writes
-    `scenario_cube.csv`/`.json`.
+    section — delta waterfall, discounted payback band, warm-rent change — plus the payback PNG;
+    it goes through the same load-or-evaluate path, so both sides of a comparison are always priced
+    under the same assumptions. ``--scenarios`` evaluates a §4.6 cube for the scenario section;
+    that branch always needs the engine, since a cube is a set of fresh evaluations by definition,
+    and it also writes `scenario_cube.csv`/`.json`.
 
     Returns:
         0 on success; 2 with a message on stderr when the directory yields no results, or when the
@@ -329,22 +528,9 @@ def _cmd_report(args: argparse.Namespace) -> int:
 
     scenario_cube = None
     if getattr(args, "scenarios", None):
-        # The scenario cube is a fresh cube of evaluations by definition (§4.6), so this branch
-        # needs the engine whether or not stored results exist.
-        inputs = read_inputs(args.results_dir)
-        parameters = _load_parameters(args)
-        database = CostDatabase(parameters.cost_database_path)
-        catalog = None
-        if parameters.subsidy_catalog_path:
-            catalog = SubsidyCatalog.load(parameters.country, parameters.subsidy_catalog_path)
-        evaluator = EconomicEvaluator(database, parameters, catalog)
-        require_resolvable_subjects(inputs, evaluator)
-        perspectives = select_applicable(load_default_bundle(), has_register=inputs.existing_assets is not None)
-        with open(args.scenarios, encoding="utf-8") as file:
-            scenario_set = ScenarioSet.from_json(json.load(file))
-        scenario_cube = evaluate_cube(inputs, parameters, perspectives, scenario_set, database, catalog)
-        export_cube_csv(scenario_cube, os.path.join(args.results_dir, "scenario_cube.csv"))
-        export_cube_json(scenario_cube, os.path.join(args.results_dir, "scenario_cube.json"))
+        scenario_cube = _write_scenario_cube(
+            _build_context(args.results_dir, args), args.scenarios, args.results_dir
+        )
 
     plausibility = run_plausibility_checks(matrix)
     write_cost_summary(matrix, plausibility, args.results_dir, comparison)
@@ -393,15 +579,20 @@ def main(argv=None) -> int:
 
     Builds the four subparsers (each documented in the module docstring), dispatches to the matching
     `_cmd_*` handler and returns its exit code. The one piece of behaviour that lives here rather
-    than in a handler is the D7 contract: `UnresolvableSubjectsError` is caught for *every*
+    than in a handler is the error contract. `UnresolvableSubjectsError` is caught for *every*
     subcommand and turned into exit code 2 with the error on stderr — the same message the
-    postprocessing bridge logs — so no entry point can ever emit a partial cost result.
+    postprocessing bridge logs — so no entry point can ever emit a partial cost result. Every other
+    `CostDataError` and the ordinary shapes of a bad invocation (`OSError` for an unreadable path,
+    `json.JSONDecodeError` for a malformed file, `ValueError` for a rejected value) are reported the
+    same way, because the module docstring promises a message rather than a traceback for a data or
+    invocation problem. Any other exception type propagates: that is a defect, and a traceback is
+    the right report for it.
 
     Args:
         argv: Argument list, defaulting to `sys.argv[1:]`; passed explicitly by the CLI tests.
 
     Returns:
-        The subcommand's exit code, or 2 for an unresolvable subject.
+        The subcommand's exit code, or 2 for an unresolvable subject or a data/invocation problem.
     """
     parser = argparse.ArgumentParser(prog="python -m hisim.economics")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -417,6 +608,7 @@ def main(argv=None) -> int:
     explain_parser.add_argument("results_dir")
     explain_parser.add_argument("--value", required=True, help="e.g. brownfield_net/equivalent_annual_cost_in_euro")
     explain_parser.add_argument("--parameters", help="EconomicParameters JSON file")
+    explain_parser.add_argument("--subsidy-catalog", dest="subsidy_catalog", help="subsidy catalog directory")
     explain_parser.add_argument("--json", action="store_true")
     explain_parser.set_defaults(func=_cmd_explain)
 
@@ -425,7 +617,12 @@ def main(argv=None) -> int:
     )
     report_parser.add_argument("results_dir")
     report_parser.add_argument("--compare", help="reference result directory for a variant comparison")
-    report_parser.add_argument("--parameters", help="EconomicParameters JSON file")
+    report_parser.add_argument("--parameters", help="EconomicParameters JSON file (re-prices instead of rendering)")
+    report_parser.add_argument(
+        "--subsidy-catalog",
+        dest="subsidy_catalog",
+        help="subsidy catalog directory (re-prices instead of rendering)",
+    )
     report_parser.add_argument("--scenarios", help="scenario-set JSON file for the report's scenario section")
     report_parser.set_defaults(func=_cmd_report)
 
@@ -445,6 +642,12 @@ def main(argv=None) -> int:
         # `--parameters` file (issue #23). Same channel, same exit code: the caller asked for a
         # priced result and is told why there is none instead of getting one built on defaults.
         print(str(err), file=sys.stderr)
+        return 2
+    except (OSError, json.JSONDecodeError, ValueError) as err:
+        # The ordinary shapes of a bad invocation: a directory that is not there, a JSON file that
+        # will not parse, a parameter value the record rejects. A traceback would be the wrong
+        # report for any of them — the caller mistyped something, they did not hit a bug.
+        print(f"{type(err).__name__}: {err}", file=sys.stderr)
         return 2
 
 

--- a/hisim/economics/adapter.py
+++ b/hisim/economics/adapter.py
@@ -1,0 +1,530 @@
+"""Compatibility adapter: legacy components -> ComponentCostFacts (cost_spec.md §10.0 rule 4).
+
+The new engine never calls the legacy `get_cost_capex`/`get_cost_opex` methods (they mutate
+configs as a side effect). Facts come from `get_cost_facts()` where a component has adopted
+the new API, and otherwise from this adapter, which maps known component classes and their
+configs to facts directly. The adapter shrinks as adoption grows (§10.1 Phase 6).
+
+**Why this file exists at all.** §10.0 rule 4 is a hard constraint of the parallel-implementation
+phase: calling `get_cost_capex` a second time from the new path would corrupt the very legacy
+calculation the new engine must leave bit-identical, because that method writes back into the
+component's config. So the new engine reads *configs*, never legacy cost methods — and this
+module is the one place that knows how to read them. Nothing here imports a component module
+either; the tables are keyed by class *name* (§10.0 rule 1), which keeps `hisim.economics` free
+of any dependency on `hisim.components`.
+
+**Its place in the pipeline.** It sits on the extraction side of the cost-spec-v2 seam-1 cut,
+used only by `bridge.py` while it walks a finished simulation's wrapped components: for each one
+it asks `effective_cost_relevance` whether the component is priced, free of cost or a meter,
+`extract_cost_facts` for its `ComponentCostFacts`, `get_energy_flow_facts` for a declared carrier
+flow, and `get_meter_spec` for how to read that flow out of the results frame when the component
+has not adopted the hook. Everything it produces lands in `EvaluationInputs` and hence in
+`economic_inputs.json`; nothing downstream of that file knows this module exists.
+
+**What it does and does not fail on.** The adapter is also used exploratorily, so a component it
+cannot describe comes back as a `FactsExtraction` carrying a *reason* rather than as an exception
+— the bridge owns the decision to fail (decision D7, issue #2). The one exception is a
+configuration that names something the engine has no mapping for, above all a fuel meter whose
+`fuel_loadtype` is unset or unknown: that raises `CostDataError` instead of billing the fuel at
+oil prices (issue #3), and the bridge catches it per component so it too lands on the D7 path.
+
+**It is temporary and should shrink.** Every entry below is a component that has not yet
+implemented `get_cost_facts()` in its own module, where the declaration belongs next to the
+config it reads (§9.1). When a component adopts the hook, its entry here becomes dead and should
+be deleted; when all of them have, the file goes (§10.1 Phase 6). A reviewer comparing an entry
+against the component is doing exactly the right thing — the asset class, the config field and
+the unit conversion are the whole reviewable surface.
+
+**Known unit quirks, documented rather than papered over.** Sizes are converted with hand-written
+factors here (`* 1e-3` for W→kW) instead of the typed `units.Quantity` helpers, mirroring what
+the components do today, and `Battery` deliberately declares the physically correct capacity where
+the legacy path has a latent unit bug (issue #20a). Energy quantities are *not* on that list any
+more: a meter's kWh stay kWh all the way into `BillingDeterminants.energy_bought_in_kwh`, for
+every carrier. Fuels quoted per ton or per liter in the literature are handled on the price side
+instead — `database.get_energy_price` divides the quote by the carrier's lower heating value and
+bills in EUR/kWh (decision D26, cost-spec-v2 §8) — so the field name and the number in it finally
+agree (this is what closed issue #11 / §2.1 issue #21).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from hisim import log
+from hisim import loadtypes as lt
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.catalog_entries import CostDataError
+from hisim.economics.facts import ComponentCostFacts, CostRelevance, EnergyFlowFacts
+from hisim.loadtypes import ComponentType, Units
+from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass
+
+
+@dataclass
+class MeterSpec:
+    """How to read a meter's carrier flows from the postprocessing results.
+
+    A declarative description of one meter — which carrier it measures and which of its output
+    columns hold the bought/sold energy and the instantaneous power — so `bridge.py` can extract
+    billing determinants generically instead of special-casing each meter class. It is the
+    §3.4/§8.4 "what the meter must measure" contract seen from the extraction side; the pricing
+    side never sees a `MeterSpec`, only the resulting `BillingDeterminants`.
+
+    Units: the named output columns are per-timestep energy in Wh (summed and scaled to kWh by
+    `bridge._sum_output_column`) and instantaneous power in W, from which the 15-minute billing
+    peaks are derived. There is no unit conversion beyond that and deliberately so — every carrier
+    is measured, carried and billed in kWh, and a fuel quoted per ton or per liter is converted on
+    the *price* side at resolution time (D26).
+    """
+
+    carrier: EnergyCarrier
+    bought_field: str  # output field name holding bought energy per timestep (Wh)
+    sold_field: Optional[str] = None
+    power_field: Optional[str] = None  # instantaneous power series (W) for peak computation
+
+
+def _quantity_value(value: Any) -> float:
+    """Unwraps hisim.units Quantity objects.
+
+    Config fields are typed `Quantity` in some components and bare floats in others; this accepts
+    both so an extractor need not know which. It does *not* convert units — the caller still
+    applies the factor the field's own unit requires, which is why every call site is followed by
+    an explicit `* 1e-3`.
+    """
+    return float(getattr(value, "value", value))
+
+
+def _heat_pump_facts(config: Any) -> ComponentCostFacts:
+    """Facts for `HeatPumpHplib` from its configured thermal output power.
+
+    Named rather than inlined into the table below because the config field arrives as a typed
+    `Quantity` and needs unwrapping. Sized in kW thermal, which is what the `HEAT_PUMP` device
+    entries are priced per (§3.5); the KPI tag marks it as the space-heating heat pump.
+    """
+    return ComponentCostFacts(
+        asset_class=ComponentType.HEAT_PUMP,
+        size=_quantity_value(config.set_thermal_output_power_in_watt) * 1e-3,
+        size_unit=Units.KILOWATT,
+        kpi_tag=KpiTagEnumClass.HEATPUMP_SPACE_HEATING,
+    )
+
+
+def _boiler_facts(config: Any) -> Optional[ComponentCostFacts]:
+    """Facts for `GenericBoiler`, whose asset class depends on the fuel it burns.
+
+    One component class covers five priced asset classes — gas, oil, hydrogen, pellet and wood
+    chip boilers have different prices, service lives and subsidy treatment — so the fuel carrier
+    in the config, not the class name, decides both the `ComponentType` and the KPI tag. Sized in
+    kW of maximal thermal power.
+
+    Returns:
+        None for a carrier that has no boiler asset class, rather than guessing one. Since the
+        class *is* in the extractor table, that None is not an "undeclared component" but an
+        unresolved subject: `extract_cost_facts` turns it into a reason and `bridge.py` fails the
+        evaluation through the D7 path rather than dropping the boiler silently (issue #2).
+    """
+    carrier_map = {
+        lt.LoadTypes.GAS: (ComponentType.GAS_HEATER, KpiTagEnumClass.GAS_BOILER),
+        lt.LoadTypes.OIL: (ComponentType.OIL_HEATER, KpiTagEnumClass.OIL_BOILER),
+        lt.LoadTypes.GREEN_HYDROGEN: (ComponentType.HYDROGEN_HEATER, KpiTagEnumClass.HYDROGEN_BOILER),
+        lt.LoadTypes.PELLETS: (ComponentType.PELLET_HEATER, KpiTagEnumClass.PELLET_BOILER),
+        lt.LoadTypes.WOOD_CHIPS: (ComponentType.WOOD_CHIP_HEATER, KpiTagEnumClass.WOOD_CHIP_BOILER),
+    }
+    mapping = carrier_map.get(config.energy_carrier)
+    if mapping is None:
+        return None
+    asset_class, kpi_tag = mapping
+    return ComponentCostFacts(
+        asset_class=asset_class,
+        size=config.maximal_thermal_power_in_watt * 1e-3,
+        size_unit=Units.KILOWATT,
+        kpi_tag=kpi_tag,
+    )
+
+
+def _hds_facts(config: Any) -> Optional[ComponentCostFacts]:
+    """Facts for the heat distribution system, whose asset class depends on the emitter type.
+
+    Floor heating and radiators are separately priced classes, sized in m² of conditioned floor
+    area. The emitter type is matched against *both* its numeric enum value and its name, so the
+    extractor works whether the config holds an enum member or a plain string — it is shared by
+    two component classes (`HeatDistribution`, `HeatDistributionSystem`) and reads their configs
+    as they are, without importing either.
+
+    Returns:
+        None for low-temperature radiators, which have no cost database entry yet; see
+        `_boiler_facts` for what an unpriced-but-registered component means — it surfaces as an
+        unresolved subject, not as a silent omission.
+    """
+    heating_system = getattr(config, "heating_system", None)
+    heating_value = getattr(heating_system, "value", heating_system)
+    if heating_value in (2, "FloorHeating"):
+        asset_class = ComponentType.HEAT_DISTRIBUTION_SYSTEM_FLOORHEATING
+    elif heating_value in (1, "Radiator"):
+        asset_class = ComponentType.HEAT_DISTRIBUTION_SYSTEM_RADIATOR
+    else:
+        return None  # low-temperature radiators have no cost database entry yet
+    return ComponentCostFacts(
+        asset_class=asset_class,
+        size=config.absolute_conditioned_floor_area_in_m2,
+        size_unit=Units.SQUARE_METER,
+        kpi_tag=KpiTagEnumClass.HEAT_DISTRIBUTION_SYSTEM,
+    )
+
+
+class FactsExtractors:
+    """Class-name keyed extraction table (avoids importing component modules; §10.0).
+
+    The whole compatibility layer in one place: component class name -> a function that turns that
+    component's config into `ComponentCostFacts`. Keying by name rather than by type is what keeps
+    `hisim.economics` importable without pulling in `hisim.components` (§10.0 rule 1), at the
+    price of no static checking — a renamed component class silently drops out of the cost model,
+    which is what the §9.2 completeness check and the auto-discovered contract test exist to
+    catch.
+
+    Each entry is a ~4-line declaration of exactly what §9.1 says a reviewer should have to
+    verify: the asset class, the config field the size comes from, the unit conversion, and the
+    KPI tag. Entries disappear as components implement `get_cost_facts()` themselves; the table is
+    expected to end up empty (§10.1 Phase 6).
+    """
+
+    BY_CLASS_NAME: Dict[str, Callable[[Any], Optional[ComponentCostFacts]]] = {
+        "HeatPumpHplib": _heat_pump_facts,
+        "MoreAdvancedHeatPumpHPLib": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.HEAT_PUMP,
+            size=_quantity_value(config.set_thermal_output_power_in_watt) * 1e-3,
+            size_unit=Units.KILOWATT,
+            kpi_tag=KpiTagEnumClass.HEATPUMP_SPACE_HEATING_AND_DOMESTIC_HOT_WATER,
+        ),
+        "ModularHeatPump": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.HEAT_PUMP,
+            size=config.power_th * 1e-3,
+            size_unit=Units.KILOWATT,
+            kpi_tag=KpiTagEnumClass.HEATPUMP_SPACE_HEATING,
+        ),
+        # Note: the legacy battery capex multiplies the kWh capacity by 1e-3 — a latent unit bug
+        # surfaced by the parity harness (cost_module_issues.md #20a). The adapter declares the
+        # physically correct size.
+        "Battery": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.BATTERY,
+            size=config.custom_battery_capacity_generic_in_kilowatt_hour,
+            size_unit=Units.KWH,
+            kpi_tag=KpiTagEnumClass.BATTERY,
+        ),
+        "PVSystem": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.PV,
+            size=config.power_in_watt * 1e-3,
+            size_unit=Units.KILOWATT,
+            kpi_tag=KpiTagEnumClass.ROOFTOP_PV,
+        ),
+        "GenericBoiler": _boiler_facts,
+        "GenericDistrictHeating": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.DISTRICT_HEATING,
+            size=config.connected_load_w * 1e-3,
+            size_unit=Units.KILOWATT,
+            kpi_tag=KpiTagEnumClass.DISTRICT_HEATING,
+        ),
+        "GenericElectricHeating": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.ELECTRIC_HEATER,
+            size=config.maximum_electric_power_w * 1e-3,
+            size_unit=Units.KILOWATT,
+            kpi_tag=KpiTagEnumClass.ELECTRIC_HEATING,
+        ),
+        "HeatDistribution": _hds_facts,
+        "HeatDistributionSystem": _hds_facts,
+        "SimpleHotWaterStorage": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.THERMAL_ENERGY_STORAGE,
+            size=config.volume_heating_water_storage_in_liter,
+            size_unit=Units.LITER,
+            kpi_tag=KpiTagEnumClass.STORAGE_HOT_WATER_SPACE_HEATING,
+        ),
+        "SimpleDHWStorage": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.THERMAL_ENERGY_STORAGE,
+            size=config.volume_heating_water_storage_in_liter,
+            size_unit=Units.LITER,
+            kpi_tag=KpiTagEnumClass.STORAGE_DOMESTIC_HOT_WATER,
+        ),
+        "SolarThermalSystem": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.SOLAR_THERMAL_SYSTEM,
+            size=config.area_m2,
+            size_unit=Units.SQUARE_METER,
+            kpi_tag=KpiTagEnumClass.SOLAR_THERMAL,
+        ),
+        "ElectricityMeter": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.ELECTRICITY_METER,
+            size=1.0,
+            size_unit=Units.ANY,
+            kpi_tag=KpiTagEnumClass.ELECTRICITY_METER,
+        ),
+        "GasMeter": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.GAS_METER,
+            size=1.0,
+            size_unit=Units.ANY,
+            kpi_tag=KpiTagEnumClass.GAS_METER,
+        ),
+        "L2GenericEnergyManagementSystem": lambda config: ComponentCostFacts(
+            asset_class=ComponentType.ENERGY_MANAGEMENT_SYSTEM,
+            size=1.0,
+            size_unit=Units.ANY,
+            kpi_tag=KpiTagEnumClass.ENERGY_MANAGEMENT_SYSTEM,
+        ),
+    }
+
+
+def _gas_meter_carrier(config: Any) -> EnergyCarrier:
+    """The pricing carrier a `GasMeter` bills against, natural gas unless it meters hydrogen.
+
+    `EnergyCarrier` is the *pricing* vocabulary and is deliberately distinct from `LoadTypes`,
+    the simulation's physical vocabulary; this is one of the few places the two are mapped onto
+    each other. Natural gas is the default because a gas meter without an explicit load type is a
+    natural-gas meter in every shipped setup.
+    """
+    if getattr(config, "gas_loadtype", None) == lt.LoadTypes.GREEN_HYDROGEN:
+        return EnergyCarrier.HYDROGEN
+    return EnergyCarrier.NATURAL_GAS
+
+
+def _fuel_meter_carrier(config: Any, component_name: str) -> EnergyCarrier:
+    """The pricing carrier a `FuelMeter` bills against, from its configured fuel load type.
+
+    The `LoadTypes` -> `EnergyCarrier` mapping for the solid and liquid fuels, plus district
+    heating, which HiSim also routes through the fuel meter. There is deliberately no fallback:
+    an unmapped or missing `fuel_loadtype` used to be billed as heating oil, so a mis-configured
+    meter published oil prices for whatever it actually metered (issue #3). A carrier the engine
+    cannot derive is a configuration error, and configuration errors fail (§10.0 rule 3 covers
+    *extraction* accidents, not a meter that does not say what it meters).
+
+    Args:
+        config: The meter's config; only `fuel_loadtype` is read.
+        component_name: The meter's instance name, so the raised message names the component a
+            user has to go and fix rather than just its class.
+
+    Returns:
+        The pricing carrier for one of the four mapped load types.
+
+    Raises:
+        CostDataError: If `fuel_loadtype` is missing or is a load type with no carrier mapping.
+            `bridge.py` catches it per component and reports it as an unresolved subject, so it
+            aborts the evaluation through the same D7 path as an unpriceable device.
+    """
+    fuel = getattr(config, "fuel_loadtype", None)
+    mapping = {
+        lt.LoadTypes.OIL: EnergyCarrier.HEATING_OIL,
+        lt.LoadTypes.PELLETS: EnergyCarrier.PELLETS,
+        lt.LoadTypes.WOOD_CHIPS: EnergyCarrier.WOOD_CHIPS,
+        lt.LoadTypes.DISTRICTHEATING: EnergyCarrier.DISTRICT_HEATING,
+    }
+    if fuel in mapping:
+        return mapping[fuel]
+    known = ", ".join(sorted(load_type.value for load_type in mapping))
+    raise CostDataError(
+        f"Fuel meter {component_name}: fuel_loadtype "
+        f"{getattr(fuel, 'value', fuel)!r} has no energy carrier mapping (known: {known}), so the "
+        "metered fuel cannot be billed."
+    )
+
+
+def get_meter_spec(component: Any) -> Optional[MeterSpec]:
+    """Meter descriptor for known meter classes; None for non-meters.
+
+    The energy half of the adapter, and the reason the engine can claim no double counting by
+    construction (§3.1): energy is billed only where a *meter* recorded a flow across the system
+    boundary, so a component's internal consumption can never turn into a second bill. `bridge.py`
+    calls this for every component; a non-None result makes it read the named output columns out
+    of the results frame into `BillingDeterminants`.
+
+    Only the electricity meter declares a `power_field`, because it is the only carrier with a
+    capacity-charge tariff to compute peaks for (§8.4).
+
+    Raises:
+        CostDataError: For a fuel meter whose `fuel_loadtype` maps to no pricing carrier — the
+            meter exists but cannot say what it meters (issue #3). Callers that classify
+            components exploratorily (`effective_cost_relevance`) propagate it too; `bridge.py`
+            turns it into an unresolved subject for the component.
+    """
+    class_name = type(component).__name__
+    if class_name == "ElectricityMeter":
+        return MeterSpec(
+            carrier=EnergyCarrier.ELECTRICITY,
+            bought_field="ElectricityFromGrid",
+            sold_field="ElectricityToGrid",
+            power_field="ElectricityFromGridInWatt",
+        )
+    if class_name == "GasMeter":
+        return MeterSpec(carrier=_gas_meter_carrier(component.config), bought_field="GasFromGrid")
+    if class_name == "FuelMeter":
+        return MeterSpec(
+            carrier=_fuel_meter_carrier(
+                component.config, getattr(component, "component_name", class_name)
+            ),
+            bought_field="HeatConsumption",
+        )
+    if class_name == "HeatingMeter":
+        # District-heating style heat delivery (cost_module_issues.md #18).
+        return MeterSpec(carrier=EnergyCarrier.DISTRICT_HEATING, bought_field="HeatConsumption")
+    return None
+
+
+@dataclass
+class FactsExtraction:
+    """The outcome of asking one component for its cost facts, with a reason when there are none.
+
+    The seam issue #2 needed: the adapter is also used *exploratorily* — by
+    `effective_cost_relevance`, by tests, by anyone inspecting a component — so it must not raise
+    when a component it knows yields nothing. It returns this record instead, which lets the one
+    caller that owns the policy (`bridge.py`) distinguish the two kinds of "no facts": a class the
+    adapter has never heard of (`unresolved_reason` None — that is the §9.2 undeclared-components
+    path) from a class it *does* know that produced nothing anyway (`unresolved_reason` set — an
+    unresolved subject under decision D7).
+
+    Exactly one of the two fields is meaningful at a time: facts present means resolved,
+    `unresolved_reason` present means the component should have had facts and does not.
+    """
+
+    facts: Optional[ComponentCostFacts] = None
+    #: Why a component the adapter recognizes produced no facts; None when there is nothing to
+    #: report (unknown class, or facts extracted successfully).
+    unresolved_reason: Optional[str] = None
+
+
+def extract_cost_facts(component: Any) -> FactsExtraction:
+    """Facts for one component: the adopted `get_cost_facts()` API first, adapter table second.
+
+    The full-information entry point `bridge.py` uses, and the place the migration order is
+    enforced: a component that has adopted the §9.1 declaration wins, and the compatibility table
+    is consulted only when it has not. That precedence is what lets adoption happen component by
+    component without any coordinating change, and what makes an adapter entry become dead the
+    moment the component implements the hook.
+
+    Three subtleties. A `get_cost_facts()` that returns None on a class declared `FREE_OF_COST`
+    (§9.2) means "genuinely no cost", so the table is deliberately *not* consulted afterwards; any
+    other None falls through to the table. A registered class whose extractor returns None — an
+    unmapped boiler fuel, an unpriced emitter type — is *not* silently dropped any more (issue
+    #2): it comes back with an `unresolved_reason` naming the class, which the bridge turns into a
+    D7 failure. And an extractor that trips over a config field that moved is still only warned
+    about, per §10.0 rule 3, because that is a parallel-phase accident rather than a statement
+    about the modelled system — with one exception: a `CostDataError` is the adapter's own way of
+    saying "this configuration cannot be priced" (see `_fuel_meter_carrier`) and is reported as
+    unresolved instead of swallowed.
+
+    Args:
+        component: The finished simulation's component object; only its class name, its
+            `cost_relevance`, its `config` and the optional hook are read.
+
+    Returns:
+        A `FactsExtraction` — facts when the component could be described, a reason when a
+        recognized component could not, and neither when the adapter simply does not know it.
+    """
+    getter = getattr(component, "get_cost_facts", None)
+    if getter is not None:
+        facts: Optional[ComponentCostFacts]
+        try:
+            facts = getter()
+        except NotImplementedError:
+            facts = None
+        if facts is not None:
+            return FactsExtraction(facts=facts)
+        relevance = getattr(type(component), "cost_relevance", CostRelevance.UNDECLARED)
+        if relevance == CostRelevance.FREE_OF_COST:
+            return FactsExtraction()
+    class_name = type(component).__name__
+    extractor = FactsExtractors.BY_CLASS_NAME.get(class_name)
+    if extractor is None:
+        return FactsExtraction()
+    try:
+        extracted: Optional[ComponentCostFacts] = extractor(component.config)
+    except CostDataError as err:
+        return FactsExtraction(unresolved_reason=str(err))
+    except (AttributeError, TypeError, ValueError) as err:
+        log.warning(f"Cost adapter could not extract facts from {class_name}: {err}")
+        return FactsExtraction()
+    if extracted is None:
+        return FactsExtraction(
+            unresolved_reason=(
+                f"the registered cost extractor for class {class_name} returned no facts "
+                "(unmapped fuel or unpriced variant?), so the component would be dropped from "
+                "the cost model while counting as priced"
+            )
+        )
+    return FactsExtraction(facts=extracted)
+
+
+def get_cost_facts(component: Any) -> Optional[ComponentCostFacts]:
+    """Just the facts of `extract_cost_facts`, for callers that only want to look.
+
+    The exploratory form: it answers "what would this component contribute" without the
+    resolution policy attached, which is what parity tooling and interactive inspection want. The
+    bridge deliberately does not use it — dropping the reason is exactly the silent omission issue
+    #2 was about — so anything that must not lose a subject calls `extract_cost_facts` instead.
+    """
+    return extract_cost_facts(component).facts
+
+
+def get_energy_flow_facts(
+    component: Any, all_outputs: Any, postprocessing_results: Any
+) -> Optional[EnergyFlowFacts]:
+    """The component's adopted §3.4 flow declaration, or None (mirrors `get_cost_facts`, issue #18).
+
+    The billing counterpart of the precedence in `extract_cost_facts`, and the reason
+    `component.get_energy_flow_facts` is no longer dead code: `bridge.py` asks this first and only
+    falls back to the class-name table of `get_meter_spec` when a component has not adopted the
+    hook. There is deliberately no fallback *table* here — the adapter's compatibility knowledge
+    about flows is the `MeterSpec`, which the bridge holds separately because reading a series out
+    of the results frame is the bridge's job, not the adapter's.
+
+    What the hook cannot express is documented at the bridge's call site: an `EnergyFlowFacts`
+    carries carrier and integrated kWh, but no capacity peaks, so those keep coming from the
+    `MeterSpec` when one exists.
+
+    Args:
+        component: The component to ask; one without the hook (or with the base implementation)
+            yields None.
+        all_outputs: The run's output declarations, passed through to the hook.
+        postprocessing_results: The results frame, passed through to the hook.
+
+    Returns:
+        The declared flows, or None when the component did not declare any. A hook that raises
+        `NotImplementedError` counts as "not adopted"; every other exception propagates, since a
+        meter that fails while reporting its own flows must not be billed as if it measured zero.
+    """
+    getter = getattr(component, "get_energy_flow_facts", None)
+    if getter is None:
+        return None
+    try:
+        flows: Optional[EnergyFlowFacts] = getter(all_outputs, postprocessing_results)
+    except NotImplementedError:
+        return None
+    return flows
+
+
+def effective_cost_relevance(component: Any) -> CostRelevance:
+    """Declared relevance, or the adapter's best guess for legacy components (§9.2).
+
+    §9.2 exists because the naive default — "no `get_cost_facts()` means no costs" — has a failure
+    mode locality never had: a forgotten implementation silently drops a component from every cost
+    result. The class-level `cost_relevance` declaration makes that omission visible, and this
+    function is the bridge during migration: an explicit declaration always wins, and only an
+    `UNDECLARED` component is classified from what the adapter happens to know about it.
+
+    The inferred order matters — METER before PRICED — because meters can be both (an electricity
+    meter measures flows *and* is itself a priced device); `bridge.py` handles that by reading the
+    meter flows and then still asking for cost facts. Everything the adapter recognizes in neither
+    way stays `UNDECLARED` and is reported as such: not priced, but not silently forgotten either.
+
+    Note that a component which meters a carrier through the `get_energy_flow_facts` hook but has
+    no entry in the meter table must declare `cost_relevance = METER` itself — the inference here
+    cannot call the hook, which needs the results frame this function does not have.
+
+    Raises:
+        CostDataError: From the `get_meter_spec` inference for a meter whose configuration names
+            no priceable carrier (issue #3); classification of such a component is impossible
+            rather than merely uncertain.
+    """
+    declared = getattr(type(component), "cost_relevance", CostRelevance.UNDECLARED)
+    if declared != CostRelevance.UNDECLARED:
+        return declared
+    if get_meter_spec(component) is not None:
+        return CostRelevance.METER
+    if type(component).__name__ in FactsExtractors.BY_CLASS_NAME:
+        return CostRelevance.PRICED
+    return CostRelevance.UNDECLARED

--- a/hisim/economics/adapter.py
+++ b/hisim/economics/adapter.py
@@ -387,7 +387,10 @@ class FactsExtraction:
     unresolved_reason: Optional[str] = None
 
 
-def extract_cost_facts(component: Any) -> FactsExtraction:
+# The seven returns are the precedence rule this function exists to state -- hook, declared
+# free of cost, unknown class, unpriceable configuration, extractor accident, no facts, facts --
+# and folding them into fewer branches would hide the order rather than simplify it.
+def extract_cost_facts(component: Any) -> FactsExtraction:  # pylint: disable=too-many-return-statements
     """Facts for one component: the adopted `get_cost_facts()` API first, adapter table second.
 
     The full-information entry point `bridge.py` uses, and the place the migration order is

--- a/hisim/economics/adapter.py
+++ b/hisim/economics/adapter.py
@@ -99,21 +99,6 @@ def _quantity_value(value: Any) -> float:
     return float(getattr(value, "value", value))
 
 
-def _heat_pump_facts(config: Any) -> ComponentCostFacts:
-    """Facts for `HeatPumpHplib` from its configured thermal output power.
-
-    Named rather than inlined into the table below because the config field arrives as a typed
-    `Quantity` and needs unwrapping. Sized in kW thermal, which is what the `HEAT_PUMP` device
-    entries are priced per (§3.5); the KPI tag marks it as the space-heating heat pump.
-    """
-    return ComponentCostFacts(
-        asset_class=ComponentType.HEAT_PUMP,
-        size=_quantity_value(config.set_thermal_output_power_in_watt) * 1e-3,
-        size_unit=Units.KILOWATT,
-        kpi_tag=KpiTagEnumClass.HEATPUMP_SPACE_HEATING,
-    )
-
-
 def _boiler_facts(config: Any) -> Optional[ComponentCostFacts]:
     """Facts for `GenericBoiler`, whose asset class depends on the fuel it burns.
 
@@ -196,7 +181,9 @@ class FactsExtractors:
     """
 
     BY_CLASS_NAME: Dict[str, Callable[[Any], Optional[ComponentCostFacts]]] = {
-        "HeatPumpHplib": _heat_pump_facts,
+        # HeatPumpHplib has no entry: main retired it into the obsolete staging area (#604), and
+        # the contract test rightly refuses a key that names no class in hisim.components. The
+        # fleet's hplib heat pump is MoreAdvancedHeatPumpHPLib below.
         "MoreAdvancedHeatPumpHPLib": lambda config: ComponentCostFacts(
             asset_class=ComponentType.HEAT_PUMP,
             size=_quantity_value(config.set_thermal_output_power_in_watt) * 1e-3,

--- a/hisim/economics/adapter.py
+++ b/hisim/economics/adapter.py
@@ -15,18 +15,23 @@ of any dependency on `hisim.components`.
 
 **Its place in the pipeline.** It sits on the extraction side of the cost-spec-v2 seam-1 cut,
 used only by `bridge.py` while it walks a finished simulation's wrapped components: for each one
-it asks `effective_cost_relevance` whether the component is priced, free of cost or a meter,
-`extract_cost_facts` for its `ComponentCostFacts`, `get_energy_flow_facts` for a declared carrier
-flow, and `get_meter_spec` for how to read that flow out of the results frame when the component
-has not adopted the hook. Everything it produces lands in `EvaluationInputs` and hence in
+it asks `effective_cost_relevance` for the class's *declared* cost role, `extract_cost_facts` for
+its `ComponentCostFacts`, `get_energy_flow_facts` for a declared carrier flow, and
+`get_meter_spec` for how to read that flow out of the results frame when the component has not
+adopted the hook. Everything it produces lands in `EvaluationInputs` and hence in
 `economic_inputs.json`; nothing downstream of that file knows this module exists.
 
-**What it does and does not fail on.** The adapter is also used exploratorily, so a component it
-cannot describe comes back as a `FactsExtraction` carrying a *reason* rather than as an exception
-— the bridge owns the decision to fail (decision D7, issue #2). The one exception is a
-configuration that names something the engine has no mapping for, above all a fuel meter whose
-`fuel_loadtype` is unset or unknown: that raises `CostDataError` instead of billing the fuel at
-oil prices (issue #3), and the bridge catches it per component so it too lands on the D7 path.
+**What it does and does not fail on.** Nothing here guesses and nothing here shrugs. Relevance is
+read off the class declaration only — there is no inference from these tables, so a component that
+forgot to declare stays `UNDECLARED` and the bridge aborts the evaluation on it (decision D7,
+§9.2). Extraction likewise never returns "no facts" without saying why: an extractor that returns
+None, one that trips over a config field that has moved, and a class declared `PRICED` with
+neither hook nor table entry all come back as a `FactsExtraction` carrying an `unresolved_reason`.
+The adapter is also used exploratorily, so those are records rather than exceptions and the bridge
+owns the decision to fail. The one thing that does raise is a configuration naming something the
+engine has no mapping for, above all a fuel meter whose `fuel_loadtype` is unset or unknown: that
+raises `CostDataError` instead of billing the fuel at oil prices (issue #3), and the bridge catches
+it per component so it too lands on the D7 path.
 
 **It is temporary and should shrink.** Every entry below is a component that has not yet
 implemented `get_cost_facts()` in its own module, where the declaration belongs next to the
@@ -143,24 +148,24 @@ def _boiler_facts(config: Any) -> Optional[ComponentCostFacts]:
 
 
 def _hds_facts(config: Any) -> Optional[ComponentCostFacts]:
-    """Facts for the heat distribution system, whose asset class depends on the emitter type.
+    """Facts for `HeatDistribution`, whose asset class depends on the emitter type.
 
     Floor heating and radiators are separately priced classes, sized in m² of conditioned floor
-    area. The emitter type is matched against *both* its numeric enum value and its name, so the
-    extractor works whether the config holds an enum member or a plain string — it is shared by
-    two component classes (`HeatDistribution`, `HeatDistributionSystem`) and reads their configs
-    as they are, without importing either.
+    area. The emitter type is matched against the *name* of the `HeatDistributionSystemType`
+    member, which is also what a serialized config spells it as, so the extractor works whether
+    the config holds an enum member or a plain string and reads the config as it is without
+    importing the component module.
 
     Returns:
-        None for low-temperature radiators, which have no cost database entry yet; see
-        `_boiler_facts` for what an unpriced-but-registered component means — it surfaces as an
-        unresolved subject, not as a silent omission.
+        None for low-temperature radiators (and any emitter type added later), which have no cost
+        database entry yet; see `_boiler_facts` for what an unpriced-but-registered component
+        means — it surfaces as an unresolved subject, not as a silent omission.
     """
     heating_system = getattr(config, "heating_system", None)
-    heating_value = getattr(heating_system, "value", heating_system)
-    if heating_value in (2, "FloorHeating"):
+    heating_name = getattr(heating_system, "name", heating_system)
+    if heating_name == "FLOORHEATING":
         asset_class = ComponentType.HEAT_DISTRIBUTION_SYSTEM_FLOORHEATING
-    elif heating_value in (1, "Radiator"):
+    elif heating_name == "RADIATOR":
         asset_class = ComponentType.HEAT_DISTRIBUTION_SYSTEM_RADIATOR
     else:
         return None  # low-temperature radiators have no cost database entry yet
@@ -178,9 +183,11 @@ class FactsExtractors:
     The whole compatibility layer in one place: component class name -> a function that turns that
     component's config into `ComponentCostFacts`. Keying by name rather than by type is what keeps
     `hisim.economics` importable without pulling in `hisim.components` (§10.0 rule 1), at the
-    price of no static checking — a renamed component class silently drops out of the cost model,
-    which is what the §9.2 completeness check and the auto-discovered contract test exist to
-    catch.
+    price of no static checking — a renamed component class or a renamed config field would drop
+    out of the cost model unnoticed. `tests/test_economics_adapter_contract.py` is what makes that
+    impossible: it resolves every key below against the classes actually defined in
+    `hisim.components` and runs every extractor against the real default configs, so a rename
+    fails a test instead of quietly shrinking a cost result.
 
     Each entry is a ~4-line declaration of exactly what §9.1 says a reviewer should have to
     verify: the asset class, the config field the size comes from, the unit conversion, and the
@@ -195,12 +202,6 @@ class FactsExtractors:
             size=_quantity_value(config.set_thermal_output_power_in_watt) * 1e-3,
             size_unit=Units.KILOWATT,
             kpi_tag=KpiTagEnumClass.HEATPUMP_SPACE_HEATING_AND_DOMESTIC_HOT_WATER,
-        ),
-        "ModularHeatPump": lambda config: ComponentCostFacts(
-            asset_class=ComponentType.HEAT_PUMP,
-            size=config.power_th * 1e-3,
-            size_unit=Units.KILOWATT,
-            kpi_tag=KpiTagEnumClass.HEATPUMP_SPACE_HEATING,
         ),
         # Note: the legacy battery capex multiplies the kWh capacity by 1e-3 — a latent unit bug
         # surfaced by the parity harness (cost_module_issues.md #20a). The adapter declares the
@@ -218,20 +219,19 @@ class FactsExtractors:
             kpi_tag=KpiTagEnumClass.ROOFTOP_PV,
         ),
         "GenericBoiler": _boiler_facts,
-        "GenericDistrictHeating": lambda config: ComponentCostFacts(
+        "DistrictHeating": lambda config: ComponentCostFacts(
             asset_class=ComponentType.DISTRICT_HEATING,
-            size=config.connected_load_w * 1e-3,
+            size=config.connected_load_in_w * 1e-3,
             size_unit=Units.KILOWATT,
             kpi_tag=KpiTagEnumClass.DISTRICT_HEATING,
         ),
-        "GenericElectricHeating": lambda config: ComponentCostFacts(
+        "ElectricHeating": lambda config: ComponentCostFacts(
             asset_class=ComponentType.ELECTRIC_HEATER,
             size=config.maximum_electric_power_w * 1e-3,
             size_unit=Units.KILOWATT,
             kpi_tag=KpiTagEnumClass.ELECTRIC_HEATING,
         ),
         "HeatDistribution": _hds_facts,
-        "HeatDistributionSystem": _hds_facts,
         "SimpleHotWaterStorage": lambda config: ComponentCostFacts(
             asset_class=ComponentType.THERMAL_ENERGY_STORAGE,
             size=config.volume_heating_water_storage_in_liter,
@@ -291,8 +291,9 @@ def _fuel_meter_carrier(config: Any, component_name: str) -> EnergyCarrier:
     heating, which HiSim also routes through the fuel meter. There is deliberately no fallback:
     an unmapped or missing `fuel_loadtype` used to be billed as heating oil, so a mis-configured
     meter published oil prices for whatever it actually metered (issue #3). A carrier the engine
-    cannot derive is a configuration error, and configuration errors fail (§10.0 rule 3 covers
-    *extraction* accidents, not a meter that does not say what it meters).
+    cannot derive is a configuration error, and configuration errors fail. This one raises rather
+    than returning a reason because it is reached from `get_meter_spec` too, which has no
+    `FactsExtraction` to put a reason in.
 
     Args:
         config: The meter's config; only `fuel_loadtype` is read.
@@ -338,9 +339,8 @@ def get_meter_spec(component: Any) -> Optional[MeterSpec]:
 
     Raises:
         CostDataError: For a fuel meter whose `fuel_loadtype` maps to no pricing carrier — the
-            meter exists but cannot say what it meters (issue #3). Callers that classify
-            components exploratorily (`effective_cost_relevance`) propagate it too; `bridge.py`
-            turns it into an unresolved subject for the component.
+            meter exists but cannot say what it meters (issue #3). `bridge.py` catches it per
+            component and turns it into an unresolved subject.
     """
     class_name = type(component).__name__
     if class_name == "ElectricityMeter":
@@ -373,23 +373,25 @@ class FactsExtraction:
     `effective_cost_relevance`, by tests, by anyone inspecting a component — so it must not raise
     when a component it knows yields nothing. It returns this record instead, which lets the one
     caller that owns the policy (`bridge.py`) distinguish the two kinds of "no facts": a class the
-    adapter has never heard of (`unresolved_reason` None — that is the §9.2 undeclared-components
-    path) from a class it *does* know that produced nothing anyway (`unresolved_reason` set — an
-    unresolved subject under decision D7).
+    adapter has never heard of *and* which declares no cost role (`unresolved_reason` None — that
+    is the §9.2 undeclared-components path, and the bridge rejects it on the declaration before it
+    ever gets here) from a class that should have produced facts and did not
+    (`unresolved_reason` set — an unresolved subject under decision D7).
 
     Exactly one of the two fields is meaningful at a time: facts present means resolved,
     `unresolved_reason` present means the component should have had facts and does not.
     """
 
     facts: Optional[ComponentCostFacts] = None
-    #: Why a component the adapter recognizes produced no facts; None when there is nothing to
-    #: report (unknown class, or facts extracted successfully).
+    #: Why a component that should have had facts produced none; None when there is nothing to
+    #: report (an unknown, undeclared class, or facts extracted successfully).
     unresolved_reason: Optional[str] = None
 
 
-# The seven returns are the precedence rule this function exists to state -- hook, declared
-# free of cost, unknown class, unpriceable configuration, extractor accident, no facts, facts --
-# and folding them into fewer branches would hide the order rather than simplify it.
+# The eight returns are the precedence rule this function exists to state -- hook, declared
+# free of cost, declared priced but undescribable, unknown class, unpriceable configuration,
+# extractor accident, no facts, facts -- and folding them into fewer branches would hide the
+# order rather than simplify it.
 def extract_cost_facts(component: Any) -> FactsExtraction:  # pylint: disable=too-many-return-statements
     """Facts for one component: the adopted `get_cost_facts()` API first, adapter table second.
 
@@ -399,16 +401,21 @@ def extract_cost_facts(component: Any) -> FactsExtraction:  # pylint: disable=to
     component without any coordinating change, and what makes an adapter entry become dead the
     moment the component implements the hook.
 
-    Three subtleties. A `get_cost_facts()` that returns None on a class declared `FREE_OF_COST`
+    The rule for the "no facts" cases is that only a genuinely unknown class may come back
+    without a reason. A `get_cost_facts()` that returns None on a class declared `FREE_OF_COST`
     (§9.2) means "genuinely no cost", so the table is deliberately *not* consulted afterwards; any
     other None falls through to the table. A registered class whose extractor returns None — an
-    unmapped boiler fuel, an unpriced emitter type — is *not* silently dropped any more (issue
-    #2): it comes back with an `unresolved_reason` naming the class, which the bridge turns into a
-    D7 failure. And an extractor that trips over a config field that moved is still only warned
-    about, per §10.0 rule 3, because that is a parallel-phase accident rather than a statement
-    about the modelled system — with one exception: a `CostDataError` is the adapter's own way of
-    saying "this configuration cannot be priced" (see `_fuel_meter_carrier`) and is reported as
-    unresolved instead of swallowed.
+    unmapped boiler fuel, an unpriced emitter type — gets an `unresolved_reason` naming the class,
+    which the bridge turns into a D7 failure (issue #2). So does a class declared `PRICED` that
+    has neither the hook nor a table entry, and so does an extractor that trips over a config
+    field that has moved: both used to pass silently (the latter as nothing but a log warning), and
+    both meant a component vanished from every cost result because of a rename. A parallel-phase
+    accident is still an accident that unprices a device, so it fails like one. A
+    `CostDataError` — the adapter's own way of saying "this configuration cannot be priced", see
+    `_fuel_meter_carrier` — is reported the same way.
+
+    The only silent outcome left is a class the adapter has never heard of and that declared
+    nothing, which the bridge rejects on its `UNDECLARED` relevance before it ever asks for facts.
 
     Args:
         component: The finished simulation's component object; only its class name, its
@@ -416,7 +423,8 @@ def extract_cost_facts(component: Any) -> FactsExtraction:  # pylint: disable=to
 
     Returns:
         A `FactsExtraction` — facts when the component could be described, a reason when a
-        recognized component could not, and neither when the adapter simply does not know it.
+        recognized or declared-priced component could not be, and neither when the adapter simply
+        does not know the class and the class claims nothing.
     """
     getter = getattr(component, "get_cost_facts", None)
     if getter is not None:
@@ -433,6 +441,14 @@ def extract_cost_facts(component: Any) -> FactsExtraction:  # pylint: disable=to
     class_name = type(component).__name__
     extractor = FactsExtractors.BY_CLASS_NAME.get(class_name)
     if extractor is None:
+        if getattr(type(component), "cost_relevance", CostRelevance.UNDECLARED) == CostRelevance.PRICED:
+            return FactsExtraction(
+                unresolved_reason=(
+                    f"class {class_name} declares cost_relevance PRICED, but neither "
+                    "get_cost_facts() nor the adapter table FactsExtractors.BY_CLASS_NAME "
+                    "yields facts for it, so nothing can describe it to the cost model"
+                )
+            )
         return FactsExtraction()
     try:
         extracted: Optional[ComponentCostFacts] = extractor(component.config)
@@ -440,7 +456,13 @@ def extract_cost_facts(component: Any) -> FactsExtraction:  # pylint: disable=to
         return FactsExtraction(unresolved_reason=str(err))
     except (AttributeError, TypeError, ValueError) as err:
         log.warning(f"Cost adapter could not extract facts from {class_name}: {err}")
-        return FactsExtraction()
+        return FactsExtraction(
+            unresolved_reason=(
+                f"the registered cost extractor for class {class_name} failed with "
+                f"{type(err).__name__}: {err} — most likely a config field it reads has been "
+                "renamed, which would drop the component from the cost model"
+            )
+        )
     if extracted is None:
         return FactsExtraction(
             unresolved_reason=(
@@ -501,33 +523,28 @@ def get_energy_flow_facts(
 
 
 def effective_cost_relevance(component: Any) -> CostRelevance:
-    """Declared relevance, or the adapter's best guess for legacy components (§9.2).
+    """The component class's declared cost role, and nothing else (§9.2).
 
     §9.2 exists because the naive default — "no `get_cost_facts()` means no costs" — has a failure
     mode locality never had: a forgotten implementation silently drops a component from every cost
-    result. The class-level `cost_relevance` declaration makes that omission visible, and this
-    function is the bridge during migration: an explicit declaration always wins, and only an
-    `UNDECLARED` component is classified from what the adapter happens to know about it.
+    result. Declaring `cost_relevance` on the class is therefore mandatory, and this function only
+    reports the declaration: a class that declares nothing is `UNDECLARED`, which `bridge.py`
+    treats as fatal (D7) rather than as something to be guessed at.
 
-    The inferred order matters — METER before PRICED — because meters can be both (an electricity
-    meter measures flows *and* is itself a priced device); `bridge.py` handles that by reading the
-    meter flows and then still asking for cost facts. Everything the adapter recognizes in neither
-    way stays `UNDECLARED` and is reported as such: not priced, but not silently forgotten either.
+    Earlier revisions inferred `METER` from `get_meter_spec` and `PRICED` from
+    `FactsExtractors.BY_CLASS_NAME` for undeclared classes, as a migration aid. That inference is
+    gone: it turned the two things that must be visible — a component nobody has classified, and a
+    component whose adapter entry no longer matches its class name — into a plausible-looking
+    answer. A meter still needs `get_meter_spec` to say *how* to read its flows, and `bridge.py`
+    calls that separately; a meter that is also a priced device (an electricity meter measures
+    flows and costs money) declares `METER` and is still asked for cost facts.
 
-    Note that a component which meters a carrier through the `get_energy_flow_facts` hook but has
-    no entry in the meter table must declare `cost_relevance = METER` itself — the inference here
-    cannot call the hook, which needs the results frame this function does not have.
+    Args:
+        component: The component to classify; only its class's `cost_relevance` attribute is read,
+            so this never touches a config and never raises.
 
-    Raises:
-        CostDataError: From the `get_meter_spec` inference for a meter whose configuration names
-            no priceable carrier (issue #3); classification of such a component is impossible
-            rather than merely uncertain.
+    Returns:
+        The declared `CostRelevance`, or `CostRelevance.UNDECLARED` when the class declares none.
     """
-    declared = getattr(type(component), "cost_relevance", CostRelevance.UNDECLARED)
-    if declared != CostRelevance.UNDECLARED:
-        return declared
-    if get_meter_spec(component) is not None:
-        return CostRelevance.METER
-    if type(component).__name__ in FactsExtractors.BY_CLASS_NAME:
-        return CostRelevance.PRICED
-    return CostRelevance.UNDECLARED
+    declared: CostRelevance = getattr(type(component), "cost_relevance", CostRelevance.UNDECLARED)
+    return declared

--- a/hisim/economics/adapter.py
+++ b/hisim/economics/adapter.py
@@ -325,6 +325,97 @@ def _fuel_meter_carrier(config: Any, component_name: str) -> EnergyCarrier:
     )
 
 
+@dataclass(frozen=True)
+class MeterOutputContract:
+    """Which of a meter class's own constants name the columns the billing engine reads.
+
+    A `MeterSpec` needs three column names, and a meter class already publishes them as class
+    constants (`ElectricityMeter.ElectricityFromGrid` and friends) because its own `add_output`
+    calls use them. This record therefore stores the *constant names*, not the column strings: the
+    strings are read off the class at resolution time, so the class stays the single source of the
+    column it writes. While they were duplicated here as literals, renaming a meter output moved
+    the column and left the adapter reading a name nothing wrote any more — an empty series, a
+    carrier billed at zero, and no complaint anywhere.
+
+    `carrier_of` takes the whole component rather than its config because the two fuel-ish meters
+    derive their pricing carrier from configured load types and want their instance name for the
+    error message, while the other two are fixed.
+    """
+
+    carrier_of: Callable[[Any], EnergyCarrier]
+    bought_constant: str
+    sold_constant: Optional[str] = None
+    power_constant: Optional[str] = None
+
+
+class MeterOutputContracts:
+    """Class-name keyed meter table, the energy twin of `FactsExtractors` (§3.4/§8.4).
+
+    The four meter classes the engine can bill from, each with the carrier it meters and the
+    constants naming its billable outputs. Keyed by class name for the same reason as the facts
+    table — `hisim.economics` imports no component module (§10.0 rule 1) — and pinned by the same
+    test file, which resolves every key against the real classes and compares every resolved
+    column name against the class constant it claims to read.
+    """
+
+    BY_CLASS_NAME: Dict[str, MeterOutputContract] = {
+        "ElectricityMeter": MeterOutputContract(
+            carrier_of=lambda _component: EnergyCarrier.ELECTRICITY,
+            bought_constant="ElectricityFromGrid",
+            sold_constant="ElectricityToGrid",
+            # The only carrier with a capacity-charge tariff, so the only one needing peaks (§8.4).
+            power_constant="ElectricityFromGridInWatt",
+        ),
+        "GasMeter": MeterOutputContract(
+            carrier_of=lambda component: _gas_meter_carrier(component.config),
+            bought_constant="GasFromGrid",
+        ),
+        "FuelMeter": MeterOutputContract(
+            carrier_of=lambda component: _fuel_meter_carrier(
+                component.config, getattr(component, "component_name", type(component).__name__)
+            ),
+            bought_constant="HeatConsumption",
+        ),
+        # District-heating style heat delivery (cost_module_issues.md #18).
+        "HeatingMeter": MeterOutputContract(
+            carrier_of=lambda _component: EnergyCarrier.DISTRICT_HEATING,
+            bought_constant="HeatConsumption",
+        ),
+    }
+
+
+def _meter_output_name(component: Any, constant_name: str) -> str:
+    """The output column a meter class publishes under the given constant.
+
+    Reads the constant off `type(component)` instead of repeating its value here, so the meter
+    class owns the name of the column it writes and the adapter can only ever ask for a column
+    that class actually declares.
+
+    Args:
+        component: The meter instance; only its class is read.
+        constant_name: Name of the class constant holding the output field name.
+
+    Returns:
+        The output field name as the class states it.
+
+    Raises:
+        CostDataError: If the class has no such constant. That is a renamed or deleted meter
+            output, and the alternative is billing a carrier from a column nothing writes;
+            `bridge.py` catches it per component and reports it as an unresolved subject, so the
+            run aborts through the D7 path instead of publishing a zero bill.
+    """
+    meter_class = type(component)
+    field_name = getattr(meter_class, constant_name, None)
+    if not isinstance(field_name, str):
+        raise CostDataError(
+            f"Meter class {meter_class.__name__} declares no output-name constant "
+            f"{constant_name!r}, so the cost engine cannot tell which results column carries its "
+            "metered energy. The constant was renamed or removed; update "
+            "adapter.MeterOutputContracts to match."
+        )
+    return field_name
+
+
 def get_meter_spec(component: Any) -> Optional[MeterSpec]:
     """Meter descriptor for known meter classes; None for non-meters.
 
@@ -334,35 +425,28 @@ def get_meter_spec(component: Any) -> Optional[MeterSpec]:
     calls this for every component; a non-None result makes it read the named output columns out
     of the results frame into `BillingDeterminants`.
 
-    Only the electricity meter declares a `power_field`, because it is the only carrier with a
-    capacity-charge tariff to compute peaks for (§8.4).
+    The column names come from the meter class itself (`_meter_output_name`), which is what makes a
+    renamed meter output a loud failure rather than a carrier quietly billed from an empty series.
 
     Raises:
         CostDataError: For a fuel meter whose `fuel_loadtype` maps to no pricing carrier — the
-            meter exists but cannot say what it meters (issue #3). `bridge.py` catches it per
-            component and turns it into an unresolved subject.
+            meter exists but cannot say what it meters (issue #3) — and for a meter class that no
+            longer declares one of the output constants the table names. `bridge.py` catches both
+            per component and turns them into unresolved subjects.
     """
-    class_name = type(component).__name__
-    if class_name == "ElectricityMeter":
-        return MeterSpec(
-            carrier=EnergyCarrier.ELECTRICITY,
-            bought_field="ElectricityFromGrid",
-            sold_field="ElectricityToGrid",
-            power_field="ElectricityFromGridInWatt",
-        )
-    if class_name == "GasMeter":
-        return MeterSpec(carrier=_gas_meter_carrier(component.config), bought_field="GasFromGrid")
-    if class_name == "FuelMeter":
-        return MeterSpec(
-            carrier=_fuel_meter_carrier(
-                component.config, getattr(component, "component_name", class_name)
-            ),
-            bought_field="HeatConsumption",
-        )
-    if class_name == "HeatingMeter":
-        # District-heating style heat delivery (cost_module_issues.md #18).
-        return MeterSpec(carrier=EnergyCarrier.DISTRICT_HEATING, bought_field="HeatConsumption")
-    return None
+    contract = MeterOutputContracts.BY_CLASS_NAME.get(type(component).__name__)
+    if contract is None:
+        return None
+    return MeterSpec(
+        carrier=contract.carrier_of(component),
+        bought_field=_meter_output_name(component, contract.bought_constant),
+        sold_field=(
+            _meter_output_name(component, contract.sold_constant) if contract.sold_constant else None
+        ),
+        power_field=(
+            _meter_output_name(component, contract.power_constant) if contract.power_constant else None
+        ),
+    )
 
 
 @dataclass

--- a/hisim/economics/calculators/energy.py
+++ b/hisim/economics/calculators/energy.py
@@ -106,7 +106,7 @@ def contract_from_price_entry(entry: EnergyPriceEntry, country: str) -> TariffCo
     engine; the whole default-contract construction lives here, in one place.
     """
     return TariffContract(
-        id=f"{country}_DEFAULT_{entry.carrier.value}_{entry.year}",
+        id=TariffContract.default_contract_id(country, entry.carrier, entry.year),
         carrier=entry.carrier,
         country=country,
         region=None,

--- a/hisim/economics/exports.py
+++ b/hisim/economics/exports.py
@@ -1,0 +1,444 @@
+"""Exports and lifecycle KPIs (cost_spec.md §7.2, §7.3, §7.4).
+
+All monetary figures are exported as min/best_estimate/max: triplet objects in JSON, *_min/*_best_estimate/*_max
+column groups in CSV. New KPIs are namespaced per perspective and written to
+`lifecycle_kpis.json` during the parallel phase (legacy KPI files stay byte-identical;
+cost_module_issues.md #6).
+
+**What this module owns**: turning an in-memory `EvaluationMatrix` into the machine-readable files
+a webtool, the RenoVisor uploader, a spreadsheet or an archived-result reader consumes. It is
+result *serialization*, not presentation — the human-facing renderings live in `reporting.py` and
+`report_plots.py`, and the seam-4 import lint treats this module as one of their few permitted
+imports precisely so the report's KPI table and `lifecycle_kpis.json` cannot disagree (they call
+the same `build_lifecycle_kpi_entries`).
+
+**What it deliberately does not own**: any derivation. Every number written here is read off the
+result object or off `views.py`; an export never applies an annuity factor, never re-clamps a
+subsidy, never sums what a view already totals (cost-spec-v2 W4.1 — "exports render, they do not
+derive"). The one arithmetic left in the file is the discount factor applied per timeline row, and
+that is a restatement of the entry's year, not a decision.
+
+**The KPI naming scheme** (§7.3). New KPIs are namespaced by appending the perspective id in
+parentheses to a name that already carries its unit in brackets, e.g.
+``"Equivalent annual cost [EUR/a] (brownfield_net)"``, ``"Net present cost over 20 years [EUR]
+(greenfield_gross)"``, ``"Subsidy DE_BEG_EM_HP_2024 [EUR] (brownfield_net)"``. The namespace is
+what makes nine perspectives coexist in one flat KPI namespace without collision, and what lets a
+consumer pick "the owner's monthly cost" rather than "a monthly cost". Every monetary KPI carries
+its uncertainty band in the additive `KpiEntry.value_min` / `value_max` fields, with `value` itself
+being the BEST_ESTIMATE slot.
+
+**These are NEW files only.** During the parallel phase the legacy KPI names, the legacy CSVs and
+their values are untouched and remain the source of all published numbers; the lifecycle engine
+writes `lifecycle_kpis.json` beside `all_kpis.json` rather than into it, and legacy KPIs stay plain
+scalars. Both merge at the Phase-7 cutover (§10), after the parity evidence supports it — not
+before.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+from hisim.economics import views
+from hisim.economics.results import EvaluationMatrix, VariantComparison
+from hisim.economics.timeline import Actor, discount_factor
+from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiTagEnumClass
+
+
+class ExportFileNames:
+    """Names of the result files the engine writes next to a simulation's results.
+
+    All five are new files that no legacy code reads or writes (§10.0 rule 3), which is what keeps
+    the parallel phase side-effect free. They are named constants because both the writers here and
+    the readers in `serialization.py` and the CLI address them; the input-side names live in
+    `serialization.SerializationFileNames`.
+    """
+
+    LIFECYCLE_COSTS_FILE_NAME = "lifecycle_costs.json"
+    COMPONENT_COSTS_JSON_FILE_NAME = "component_costs.json"
+    COMPONENT_COSTS_CSV_FILE_NAME = "component_costs.csv"
+    CASH_FLOW_TIMELINE_FILE_NAME = "cash_flow_timeline.csv"
+    LIFECYCLE_KPIS_FILE_NAME = "lifecycle_kpis.json"
+
+
+def write_lifecycle_costs_json(matrix: EvaluationMatrix, result_directory: str) -> str:
+    """`lifecycle_costs.json`: the full typed EvaluationMatrix incl. subsidy audit trails.
+
+    The primary machine-readable result of a run and the richest of the exports: one entry per
+    perspective with the headline KPIs, every pivot, the per-component breakdowns, the CO2 result
+    and the §5 subsidy decisions, all monetary figures as min/best_estimate/max triplets. It is what the
+    webtool and the RenoVisor uploader consume, and — together with `cash_flow_timeline.csv` — what
+    `serialization.read_results` reads back so a report can be rendered from an archived directory
+    without a cost database (§7.2, W4.5).
+
+    Returns:
+        The path written.
+    """
+    path = os.path.join(result_directory, ExportFileNames.LIFECYCLE_COSTS_FILE_NAME)
+    with open(path, "w", encoding="utf-8") as file:
+        json.dump(matrix.to_json(), file, indent=2)
+    return path
+
+
+def write_component_costs(matrix: EvaluationMatrix, result_directory: str) -> List[str]:
+    """`component_costs.json` / `.csv`: per-component breakdowns for the frontend (§7.4).
+
+    Answers "what does each component contribute to the total, in this perspective" — the data
+    behind stacked bars per variant and component-level diffs between variants. The JSON is the
+    typed `{perspective: {subject: ComponentCostBreakdown}}` map the webtool and the uploader
+    consume; the CSV is the long format for ad-hoc analysis, one row per
+    (perspective, subject, subject_kind, asset_class, category) with NPV, equivalent annual cost and
+    year-1 nominal cost as min/best_estimate/max column groups, plus lifecycle CO2.
+
+    Two properties a reviewer should rely on: subjects cover components *and* energy carriers (the
+    electricity bill is its own subject rather than smeared over consuming devices, §3.1), and the
+    subject NPVs sum exactly to the perspective total per uncertainty slot — so a stacked chart
+    always reconciles with the headline KPI.
+
+    Returns:
+        The two paths written, JSON first.
+    """
+    json_path = os.path.join(result_directory, ExportFileNames.COMPONENT_COSTS_JSON_FILE_NAME)
+    payload = {
+        perspective: {subject: breakdown.to_json() for subject, breakdown in result.component_breakdowns.items()}
+        for perspective, result in matrix.results.items()
+    }
+    with open(json_path, "w", encoding="utf-8") as file:
+        json.dump(payload, file, indent=2)
+
+    csv_path = os.path.join(result_directory, ExportFileNames.COMPONENT_COSTS_CSV_FILE_NAME)
+    with open(csv_path, "w", newline="", encoding="utf-8") as file:
+        writer = csv.writer(file, delimiter=";")
+        writer.writerow(
+            [
+                "perspective",
+                "subject",
+                "subject_kind",
+                "asset_class",
+                "category",
+                "npv_min",
+                "npv_best_estimate",
+                "npv_max",
+                "eac_min",
+                "eac_best_estimate",
+                "eac_max",
+                "year1_nominal_min",
+                "year1_nominal_best_estimate",
+                "year1_nominal_max",
+                "lifecycle_co2_kg",
+            ]
+        )
+        for perspective, result in matrix.results.items():
+            # The annuitized figures come from the view-model, not from an annuity factor
+            # applied here (cost-spec-v2 W4.1: exports render, they do not derive).
+            equivalent_annual_costs = views.subject_equivalent_annual_cost_by_category(result)
+            for subject, breakdown in result.component_breakdowns.items():
+                year1 = (
+                    breakdown.annual_cost_series_nominal_in_euro[1]
+                    if len(breakdown.annual_cost_series_nominal_in_euro) > 1
+                    else None
+                )
+                for category, npv in breakdown.npv_by_category.items():
+                    eac = equivalent_annual_costs[subject][category]
+                    writer.writerow(
+                        [
+                            perspective,
+                            subject,
+                            breakdown.subject_kind.value,
+                            breakdown.asset_class.value if breakdown.asset_class else "",
+                            category.value,
+                            npv.minimum,
+                            npv.best_estimate,
+                            npv.maximum,
+                            eac.minimum,
+                            eac.best_estimate,
+                            eac.maximum,
+                            year1.minimum if year1 else "",
+                            year1.best_estimate if year1 else "",
+                            year1.maximum if year1 else "",
+                            breakdown.lifecycle_co2_in_kg,
+                        ]
+                    )
+    return [json_path, csv_path]
+
+
+def write_cash_flow_timeline(matrix: EvaluationMatrix, result_directory: str) -> str:
+    """`cash_flow_timeline.csv` in long format with timeline-entry ids for offline explain.
+
+    The canonical timeline itself, unaggregated: one row per cash-flow entry with its year,
+    category, subject, payer and optional subsidy scheme, in nominal *and* discounted form, each as
+    a min/best_estimate/max triple. Every published figure of a perspective is a filter or pivot of these
+    rows, so this file is where a reviewer goes to check an aggregate by hand, and it is what
+    `serialization.read_cash_flow_timelines` reads back to restore a full result.
+
+    Each row carries `provenance_ids` — the ledger records behind the amount — which is what keeps
+    an exported number explainable offline, from the archived directory alone, with no database and
+    no rerun (§3.10, §7.2). The stored timeline is always the fully allocated one (all payers); a
+    perspective's own scope is restored from its `scope_payer`.
+
+    Returns:
+        The path written.
+    """
+    path = os.path.join(result_directory, ExportFileNames.CASH_FLOW_TIMELINE_FILE_NAME)
+    with open(path, "w", newline="", encoding="utf-8") as file:
+        writer = csv.writer(file, delimiter=";")
+        writer.writerow(
+            [
+                "perspective",
+                "entry_id",
+                "year",
+                "category",
+                "subject",
+                "payer",
+                "subsidy_scheme_id",
+                "nominal_min",
+                "nominal_best_estimate",
+                "nominal_max",
+                "discounted_min",
+                "discounted_best_estimate",
+                "discounted_max",
+                "provenance_ids",
+                # Appended by W4.5 so the stored timeline reloads faithfully; last column, so
+                # anything reading this file positionally is unaffected.
+                "subject_kind",
+            ]
+        )
+        for perspective, result in matrix.results.items():
+            interest = result.parameters.interest_rate
+            for entry_id, entry in enumerate(result.timeline.entries):
+                discounted = entry.amount_in_euro.scale(discount_factor(interest, entry.year))
+                writer.writerow(
+                    [
+                        perspective,
+                        entry_id,
+                        entry.year,
+                        entry.category.value,
+                        entry.subject,
+                        entry.payer.value,
+                        entry.subsidy_scheme_id or "",
+                        entry.amount_in_euro.minimum,
+                        entry.amount_in_euro.best_estimate,
+                        entry.amount_in_euro.maximum,
+                        discounted.minimum,
+                        discounted.best_estimate,
+                        discounted.maximum,
+                        " ".join(str(record_id) for record_id in entry.provenance_ids),
+                        entry.subject_kind.value,
+                    ]
+                )
+    return path
+
+
+def write_provenance_ledger(matrix: EvaluationMatrix, result_directory: str) -> Optional[str]:
+    """`cost_provenance.json` (§3.10): one ledger per perspective (they share most records).
+
+    The record of where every number came from: for each parameter the engine used, its origin
+    (database entry, config override, scenario overlay, engine default, legacy shim), its value per
+    slot and its source ids. Together with the `provenance_ids` on the timeline rows this is what
+    makes any exported figure traceable back to a citation without re-running anything — the eager
+    counterpart of the on-demand `explain` API.
+
+    Returns:
+        The path written, or None when no perspective carried a ledger (in which case no file is
+        created at all, so a reader can tell "no provenance recorded" from "empty provenance").
+    """
+    payload = {}
+    for perspective, result in matrix.results.items():
+        if result.ledger is not None:
+            payload[perspective] = result.ledger.to_json()
+    if not payload:
+        return None
+    path = os.path.join(result_directory, "cost_provenance.json")
+    with open(path, "w", encoding="utf-8") as file:
+        json.dump(payload, file, indent=2)
+    return path
+
+
+# ---------------------------------------------------------------------- KPIs (§7.3)
+
+def build_lifecycle_kpi_entries(
+    matrix: EvaluationMatrix, comparison: Optional[VariantComparison] = None
+) -> List[KpiEntry]:
+    """The new namespaced KPI set; every monetary KPI carries its uncertainty band.
+
+    Builds the §7.3 KPI list from an evaluated matrix: per perspective the equivalent annual cost,
+    the net present cost over the horizon, the year-1 monthly cost and the levelized cost of heat,
+    plus one KPI per applied subsidy scheme and the perspective's total support; then the §6.5
+    per-actor net present costs of `actor_kpi_entries` for whichever perspectives allocated flows
+    to a payer; and, when a variant comparison is supplied, the NPV delta, the discounted payback
+    and the warm-rent figures. Each
+    name is suffixed with the perspective id in parentheses — that namespacing is what lets all nine
+    perspectives coexist in one flat KPI space (see the module docstring).
+
+    It exists as a separate function from `write_lifecycle_kpis` so the HTML report's KPI table and
+    `lifecycle_kpis.json` are literally the same list; a KPI can therefore not appear in one and
+    not the other. A KPI whose band is None is omitted entirely rather than published as zero.
+
+    Two entries are deliberately *not* bands and are constructed by hand instead of via `add`: the
+    discounted payback (whose low/high crossings are a bracket, carried in the description) and the
+    warm-rent-neutral flag (a boolean rendered as a string, with the per-slot verdicts in the
+    description).
+
+    Args:
+        matrix: The evaluated perspectives.
+        comparison: Optional variant comparison against a reference run; adds the delta KPIs.
+
+    Returns:
+        The KPI entries, in perspective order.
+    """
+    entries: List[KpiEntry] = []
+
+    def add(name: str, unit: str, band, description: Optional[str] = None) -> None:
+        """Appends one banded KPI, or nothing at all when the figure does not exist.
+
+        `value` is the BEST_ESTIMATE slot and `value_min`/`value_max` the envelope (§3.9, §7.3). Skipping
+        a None band is the deliberate contract: an absent KPI (no heat demand, hence no LCOH) must
+        not be published as a zero.
+        """
+        if band is None:
+            return
+        entries.append(
+            KpiEntry(
+                name=name,
+                unit=unit,
+                value=band.best_estimate,
+                value_min=band.minimum,
+                value_max=band.maximum,
+                tag=KpiTagEnumClass.COSTS,
+                description=description,
+            )
+        )
+
+    for perspective, result in matrix.results.items():
+        horizon = result.parameters.observation_period_in_years
+        add(f"Equivalent annual cost [EUR/a] ({perspective})", "EUR/a", result.equivalent_annual_cost_in_euro)
+        add(
+            f"Net present cost over {horizon} years [EUR] ({perspective})",
+            "EUR",
+            result.total_npv_in_euro,
+        )
+        add(f"Monthly cost year 1 [EUR/month] ({perspective})", "EUR/month", result.monthly_cost_year1_in_euro)
+        add(
+            f"Levelized cost of heat [EUR/kWh] ({perspective})",
+            "EUR/kWh",
+            result.levelized_cost_of_heat_in_euro_per_kwh,
+        )
+        for decision in result.subsidy_decisions:
+            for award in decision.applied:
+                if award.upfront_amount.maximum > 0:
+                    add(
+                        f"Subsidy {award.scheme_id} [EUR] ({perspective})",
+                        "EUR",
+                        award.upfront_amount,
+                        description=decision.measure_subject,
+                    )
+        # The total is a view of the result, not a running sum kept while emitting KPIs (W4.1),
+        # and since D2 it is the timeline-based nominal figure — so it is *not* the sum of the
+        # per-scheme "Subsidy <id>" KPIs above wherever support reaches the timeline without an
+        # upfront catalog award (flat shim, operational support, scheduled payouts).
+        add(
+            f"Total subsidies received [EUR] ({perspective})",
+            "EUR",
+            views.total_subsidies_received(result),
+            description="nominal support on the perspective's timeline (cost-spec-v2 §8, D2)",
+        )
+    entries.extend(actor_kpi_entries(matrix))
+    if comparison is not None:
+        add(
+            f"Net present cost delta vs reference [EUR] ({comparison.perspective_id})",
+            "EUR",
+            comparison.npv_delta_in_euro,
+        )
+        payback = comparison.discounted_payback_years.get("best_estimate")
+        entries.append(
+            KpiEntry(
+                name=f"Discounted payback vs reference [a] ({comparison.perspective_id})",
+                unit="a",
+                value=payback,
+                tag=KpiTagEnumClass.COSTS,
+                description=f"band: low={comparison.discounted_payback_years.get('low')}, "
+                f"high={comparison.discounted_payback_years.get('high')}",
+            )
+        )
+        if comparison.warm_rent_change_per_month_in_euro is not None:
+            add(
+                f"Warm rent change [EUR/month] ({comparison.perspective_id})",
+                "EUR/month",
+                comparison.warm_rent_change_per_month_in_euro,
+            )
+            entries.append(
+                KpiEntry(
+                    name=f"Warm-rent neutral ({comparison.perspective_id})",
+                    unit="-",
+                    value=str(comparison.warm_rent_neutral_per_slot.get("best_estimate", False)),
+                    tag=KpiTagEnumClass.COSTS,
+                    description=f"per slot: {comparison.warm_rent_neutral_per_slot}",
+                )
+            )
+    return entries
+
+
+def write_lifecycle_kpis(
+    matrix: EvaluationMatrix,
+    result_directory: str,
+    comparison: Optional[VariantComparison] = None,
+) -> str:
+    """Writes `lifecycle_kpis.json` (separate from all_kpis.json during the parallel phase).
+
+    Serializes `build_lifecycle_kpi_entries` under a single "Lifecycle costs" group, keyed by KPI
+    name. The separate file is the whole point of the parallel phase: legacy KPI names and values
+    stay byte-identical in `all_kpis.json` whether or not this engine runs (§10.0 rule 3), and the
+    two merge only at the Phase-7 cutover, when legacy KPIs also start carrying bands (§7.3).
+
+    Args:
+        matrix: The evaluated perspectives.
+        result_directory: Where to write, normally next to the simulation's other results.
+        comparison: Optional variant comparison, which adds the delta/payback/warm-rent KPIs.
+
+    Returns:
+        The path written.
+    """
+    entries = build_lifecycle_kpi_entries(matrix, comparison)
+    path = os.path.join(result_directory, ExportFileNames.LIFECYCLE_KPIS_FILE_NAME)
+    payload: Dict[str, Any] = {
+        "Lifecycle costs": {entry.name: entry.to_dict() for entry in entries},
+    }
+    with open(path, "w", encoding="utf-8") as file:
+        json.dump(payload, file, indent=2)
+    return path
+
+
+def actor_kpi_entries(matrix: EvaluationMatrix) -> List[KpiEntry]:
+    """Actor-level KPI entries (§6.5) for perspectives with payer allocations.
+
+    One banded "Net present cost of <actor> [EUR] (<perspective>)" KPI per landlord / tenant /
+    owner-occupier that the perspective's allocation ruleset actually produced, read straight off
+    `npv_by_payer`; an actor with no allocation is skipped rather than reported as zero. The
+    landlord and tenant figures sum with the owner's to the system NPV per slot (the §6 zero-sum
+    invariant), so they can be published side by side without double counting — and because the
+    KPI values are the payer bands verbatim, that invariant survives into the exported numbers.
+
+    Part of `build_lifecycle_kpi_entries`, hence of both `lifecycle_kpis.json` and the report's
+    KPI table. The entries are purely additive: they carry names no other KPI uses (no existing
+    name, value or band changes), and a run whose perspectives allocate nothing to a payer adds
+    none of them.
+    """
+    entries: List[KpiEntry] = []
+    for perspective, result in matrix.results.items():
+        for actor in (Actor.LANDLORD, Actor.TENANT, Actor.OWNER_OCCUPIER):
+            band = result.npv_by_payer.get(actor)
+            if band is None:
+                continue
+            entries.append(
+                KpiEntry(
+                    name=f"Net present cost of {actor.value} [EUR] ({perspective})",
+                    unit="EUR",
+                    value=band.best_estimate,
+                    value_min=band.minimum,
+                    value_max=band.maximum,
+                    tag=KpiTagEnumClass.COSTS,
+                )
+            )
+    return entries

--- a/hisim/economics/facts.py
+++ b/hisim/economics/facts.py
@@ -49,9 +49,13 @@ class CostRelevance(str, enum.Enum):
     registration — an `UNDECLARED` component, or a `PRICED` one whose facts do not build, aborts the
     run before the timestep loop starts rather than producing a quietly incomplete cost report.
 
-    `UNDECLARED` is the base-class default and exists only so that not-yet-migrated components stay
-    loadable during the parallel phase; strictness is configurable so CI can treat it as an error
-    while legacy system setups get a warning.
+    `UNDECLARED` exists only as the base-class default, so that a component class is loadable
+    before anyone has classified it. It is not a tolerated state and there is no lenient mode: a
+    component that reaches the cost engine still carrying `UNDECLARED` aborts the evaluation
+    (decision D7), and every component in this repository must name its role explicitly. The
+    fleet-wide test that enforces that on all `Component` subclasses arrives with the bridge
+    wiring; `adapter.effective_cost_relevance` already reports the declaration verbatim and
+    infers nothing.
     """
 
     UNDECLARED = "UNDECLARED"

--- a/hisim/economics/input_audit.py
+++ b/hisim/economics/input_audit.py
@@ -1,0 +1,275 @@
+"""The resolved-input audit, as data (cost-spec-v2 §2.4, W4.6).
+
+"Which price did each declared fact actually resolve to, from where, and what looks wrong about
+it" is one question with two renderings: `cost_audit.csv` (written by `audit.py`) and section 1
+of the HTML report (rendered by `reporting.py`). Before W4.6 each of them answered it for
+itself, and the two override-precedence implementations disagreed — the report dropped an
+override's unit price whenever the asset class had no database entry, which the CSV did not.
+
+The types live here, apart from the function that fills them (`audit.build_input_audit`),
+because the renderers sit on opposite sides of the seam-4 lint: `audit.py` is verification and
+may reach into the cost database, `reporting.py` is presentation and may not. A module that
+holds only the answer — no evaluator, no database, no pandas — is importable from both.
+
+Why the audit matters to a reviewer: it is the fastest way to catch the errors that actually happen.
+Everything downstream of a wrong unit price is arithmetically correct and completely wrong, so a
+table of "this component, this asset class, this size, priced at this unit price from this entry,
+citing these sources, with these subsidies and these caps binding" is where a mis-sized component, a
+kW/m² mix-up or an uncited override is spotted — long before anyone questions an NPV. It is also
+persisted (`cost_audit.json`, alongside the human-facing `cost_audit.csv`), so a report can be
+rebuilt from an archived result directory with no cost database present at all (W4.5).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Dict, List, Optional
+
+from hisim.economics.provenance import ResolvedSource
+from hisim.economics.uncertainty import UncertainValue
+
+
+class OriginKind:
+    """How a row's unit price was resolved. The vocabulary is shared by both renderers; each
+    spells it its own way, which is formatting and therefore theirs to decide.
+
+    Three outcomes are possible and the distinction is the audit's central question: the price came
+    from a per-field config override (OVERRIDE, which wins over the database whether or not a
+    database entry exists), from a cost-database entry (DATABASE), or from nowhere at all
+    (UNRESOLVED — a component the engine could not price, which must be visible rather than silently
+    contributing zero). Deciding this once here is what fixed the pre-W4.6 disagreement in which the
+    HTML report dropped an override's unit price whenever the asset class had no database entry.
+    """
+
+    ORIGIN_OVERRIDE = "OVERRIDE"
+    ORIGIN_DATABASE = "DATABASE"
+    ORIGIN_UNRESOLVED = "UNRESOLVED"
+
+
+@dataclass(frozen=True)
+class ResolvedInputRow:
+    """One declared fact with everything resolving it produced (§9.5).
+
+    Pure data: no string only one of the two renderers could want, no formatting. `origin_kind`
+    settles the precedence once — a config override wins over the database entry whether or not
+    that entry exists — so neither renderer decides it again.
+
+    One row per declared cost subject, carrying the whole chain from declaration to money: what was
+    declared (subject, asset class, size and its unit), how it was priced (origin kind, override
+    source, database entry key, source ids, unit price and lifetime), and what that produced (gross
+    investment, nominal subsidies, the scheme ids and which caps bound in which slots). `entry_key`
+    and `source_ids` are filled whenever a database entry was found — including when an override
+    won — so a reader can see what the declared price is being compared against.
+
+    Units, since several of these fields are easy to misread: `unit_price_in_euro` is the price as
+    the winning origin states it — the database entry's `specific_investment`, i.e. euro per size
+    unit, or the declared `investment_cost_override_in_euro` when an override won;
+    `investment_gross_in_euro` is the absolute year-0 figure before support; and
+    `subsidies_nominal_in_euro` is nominal, undiscounted, positive support — not the negative
+    timeline amount and not its NPV.
+    """
+
+    subject: str
+    asset_class: str
+    size: float
+    size_unit: str
+    origin_kind: str
+    #: The `override_source` the facts declared, when `origin_kind` is OVERRIDE. Empty means the
+    #: override cites nothing — a flagged condition, not a formatting question.
+    override_source: Optional[str] = None
+    #: Database entry the price came from, when one was found (also when an override won).
+    entry_key: Optional[str] = None
+    source_ids: List[str] = field(default_factory=list)
+    unit_price_in_euro: Optional[UncertainValue] = None
+    lifetime_in_years: Optional[float] = None
+    investment_gross_in_euro: Optional[UncertainValue] = None
+    subsidies_nominal_in_euro: Optional[UncertainValue] = None
+    subsidy_scheme_ids: List[str] = field(default_factory=list)
+    #: scheme id -> the slots whose cap bound, only for awards where at least one did.
+    caps_binding_by_scheme: Dict[str, List[str]] = field(default_factory=dict)
+    #: Review flags, in the order they are raised. Rendered by the HTML report only.
+    flags: List[str] = field(default_factory=list)
+
+    def to_json(self) -> dict:
+        """Serialization for cost_audit.json.
+
+        Writes every field, including the ones only the HTML report renders (`flags`,
+        `caps_binding_by_scheme`), because the stored audit has to be sufficient to rebuild either
+        rendering later. Bands go through `UncertainValue.to_json` and `None` stays `None`, so an
+        unresolved row is distinguishable from a zero-priced one.
+        """
+        return {
+            "subject": self.subject,
+            "asset_class": self.asset_class,
+            "size": self.size,
+            "size_unit": self.size_unit,
+            "origin_kind": self.origin_kind,
+            "override_source": self.override_source,
+            "entry_key": self.entry_key,
+            "source_ids": self.source_ids,
+            "unit_price_in_euro": _band_json(self.unit_price_in_euro),
+            "lifetime_in_years": self.lifetime_in_years,
+            "investment_gross_in_euro": _band_json(self.investment_gross_in_euro),
+            "subsidies_nominal_in_euro": _band_json(self.subsidies_nominal_in_euro),
+            "subsidy_scheme_ids": self.subsidy_scheme_ids,
+            "caps_binding_by_scheme": self.caps_binding_by_scheme,
+            "flags": self.flags,
+        }
+
+    @staticmethod
+    def from_json(raw: dict) -> "ResolvedInputRow":
+        """Inverse of `to_json`.
+
+        Rebuilds a row from a stored `cost_audit.json`, defaulting the collection fields to empty so
+        an audit written by an older version still loads. The mandatory keys are the identity and
+        origin fields; everything a run may legitimately not have produced is optional.
+        """
+        return ResolvedInputRow(
+            subject=raw["subject"],
+            asset_class=raw["asset_class"],
+            size=raw["size"],
+            size_unit=raw["size_unit"],
+            origin_kind=raw["origin_kind"],
+            override_source=raw.get("override_source"),
+            entry_key=raw.get("entry_key"),
+            source_ids=list(raw.get("source_ids", [])),
+            unit_price_in_euro=_band_from(raw.get("unit_price_in_euro")),
+            lifetime_in_years=raw.get("lifetime_in_years"),
+            investment_gross_in_euro=_band_from(raw.get("investment_gross_in_euro")),
+            subsidies_nominal_in_euro=_band_from(raw.get("subsidies_nominal_in_euro")),
+            subsidy_scheme_ids=list(raw.get("subsidy_scheme_ids", [])),
+            caps_binding_by_scheme={
+                scheme: list(slots) for scheme, slots in raw.get("caps_binding_by_scheme", {}).items()
+            },
+            flags=list(raw.get("flags", [])),
+        )
+
+
+@dataclass(frozen=True)
+class InputAuditReport:
+    """The resolved-input audit: its rows, the price basis they resolved at, its sources.
+
+    The complete answer to "what did this evaluation actually read": one row per cost subject, the
+    price basis year everything resolved at, and the §3.10 registry entries the run cited. The basis
+    year is on the report rather than on each row because it is a single decision for the whole
+    evaluation — and a consequential one, since the database falls back to the earliest covered year
+    with a warning when it has no data for the simulated year (see `evaluator.
+    effective_price_basis_year`).
+
+    Built by `audit.build_input_audit` from the inputs, the database and the first result; rendered
+    to `cost_audit.csv` by `audit.py` and to section 1 of the HTML report by `reporting.py`; and
+    persisted as `cost_audit.json` so either rendering can be reproduced offline.
+    """
+
+    #: Name of the JSON file this report is written to.
+    FILE_NAME: ClassVar[str] = "cost_audit.json"
+
+    price_basis_year: int
+    rows: List[ResolvedInputRow] = field(default_factory=list)
+    #: The §3.10 registry entries this evaluation cited, sorted by id — from the cost database's
+    #: registry and, through the result's ledger, the subsidy catalog's.
+    sources: List[ResolvedSource] = field(default_factory=list)
+
+    def to_json(self) -> dict:
+        """Serialization for cost_audit.json — the machine-readable twin of cost_audit.csv.
+
+        The CSV is the review artifact — deliberately diffable, so a price-data PR shows up as a
+        clean textual delta on the golden scenarios (§9.5) — while this JSON is the reload format,
+        carrying the fields the CSV flattens away. Sources are expanded inline rather than left as
+        ids, since a reader of the archived file has no registry to resolve them against.
+        """
+        return {
+            "price_basis_year": self.price_basis_year,
+            "rows": [row.to_json() for row in self.rows],
+            "sources": [
+                {
+                    "source_id": source.source_id,
+                    "citation": source.citation,
+                    "url": source.url,
+                    "publication_year": source.publication_year,
+                    "retrieved": source.retrieved,
+                    "kind": source.kind,
+                    "notes": source.notes,
+                }
+                for source in self.sources
+            ],
+        }
+
+    @staticmethod
+    def from_json(raw: dict) -> "InputAuditReport":
+        """Inverse of `to_json` — reloads the audit without touching the cost database (W4.5).
+
+        That independence is the point: `python -m hisim.economics report <results_dir>` can render
+        the input-audit section of an archived run even if the price files have since moved on, or
+        are not installed at all. Only `price_basis_year` is mandatory; rows and sources default to
+        empty.
+        """
+        return InputAuditReport(
+            price_basis_year=raw["price_basis_year"],
+            rows=[ResolvedInputRow.from_json(item) for item in raw.get("rows", [])],
+            sources=[
+                ResolvedSource(
+                    source_id=item["source_id"],
+                    citation=item["citation"],
+                    url=item.get("url"),
+                    publication_year=item.get("publication_year"),
+                    retrieved=item.get("retrieved"),
+                    kind=item.get("kind"),
+                    notes=item.get("notes"),
+                )
+                for item in raw.get("sources", [])
+            ],
+        )
+
+
+def _band_json(value: Optional[UncertainValue]) -> Any:
+    """Serializes an optional band, keeping `None` distinct from a zero band."""
+    return value.to_json() if value is not None else None
+
+
+def _band_from(value: Any) -> Optional[UncertainValue]:
+    """Parses an optional band; the inverse of `_band_json`, `None` staying `None`."""
+    return UncertainValue.from_json(value) if value is not None else None
+
+
+def write_input_audit(audit: InputAuditReport, result_directory: str) -> str:
+    """Writes cost_audit.json next to the CSV, so a report can be rebuilt without the database.
+
+    Called by `bridge.py` at the end of a `COMPUTE_LIFECYCLE_COSTS` run and by the `evaluate` CLI
+    command, always alongside `audit.write_cost_audit`, which writes the human-facing CSV from the
+    same object — the two files can therefore never disagree.
+
+    Args:
+        audit: The report to store.
+        result_directory: Directory the run's other cost outputs are written to.
+
+    Returns:
+        The path written, for logging.
+    """
+    path = os.path.join(result_directory, InputAuditReport.FILE_NAME)
+    with open(path, "w", encoding="utf-8") as file:
+        json.dump(audit.to_json(), file, indent=2)
+    return path
+
+
+def read_input_audit(result_directory: str) -> Optional[InputAuditReport]:
+    """Reads cost_audit.json, or None when the directory has none.
+
+    The reload path used by the `report` CLI command on a stored result directory. Returning `None`
+    rather than raising for a missing file is deliberate: result directories produced before the
+    audit was persisted, or by a run that only computed KPIs, are still reportable — the caller
+    simply omits the input-audit section.
+
+    Args:
+        result_directory: Directory to look in.
+
+    Returns:
+        The stored audit, or `None` if the file is absent.
+    """
+    path = os.path.join(result_directory, InputAuditReport.FILE_NAME)
+    if not os.path.isfile(path):
+        return None
+    with open(path, encoding="utf-8") as file:
+        return InputAuditReport.from_json(json.load(file))

--- a/hisim/economics/input_audit.py
+++ b/hisim/economics/input_audit.py
@@ -32,8 +32,10 @@ from hisim.economics.uncertainty import UncertainValue
 
 
 class OriginKind:
-    """How a row's unit price was resolved. The vocabulary is shared by both renderers; each
-    spells it its own way, which is formatting and therefore theirs to decide.
+    """How a row's unit price was resolved.
+
+    The vocabulary is shared by both renderers; each spells it its own way, which is formatting
+    and therefore theirs to decide.
 
     Three outcomes are possible and the distinction is the audit's central question: the price came
     from a per-field config override (OVERRIDE, which wins over the database whether or not a

--- a/hisim/economics/input_audit.py
+++ b/hisim/economics/input_audit.py
@@ -25,13 +25,14 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Dict, List, Optional
+from enum import Enum
+from typing import ClassVar, Dict, List, Optional
 
 from hisim.economics.provenance import ResolvedSource
 from hisim.economics.uncertainty import UncertainValue
 
 
-class OriginKind:
+class OriginKind(str, Enum):
     """How a row's unit price was resolved.
 
     The vocabulary is shared by both renderers; each spells it its own way, which is formatting
@@ -43,6 +44,12 @@ class OriginKind:
     (UNRESOLVED — a component the engine could not price, which must be visible rather than silently
     contributing zero). Deciding this once here is what fixed the pre-W4.6 disagreement in which the
     HTML report dropped an override's unit price whenever the asset class had no database entry.
+
+    An enum rather than a bag of string constants, so a `cost_audit.json` carrying a fourth,
+    misspelled kind fails on load instead of falling through every renderer's comparisons and being
+    rendered as a blank cell. The member *values* are the strings the file format has always
+    carried, so the change is invisible to any file already written; deriving from `str` keeps the
+    members usable wherever the old constants were.
     """
 
     ORIGIN_OVERRIDE = "OVERRIDE"
@@ -77,7 +84,7 @@ class ResolvedInputRow:
     asset_class: str
     size: float
     size_unit: str
-    origin_kind: str
+    origin_kind: OriginKind
     #: The `override_source` the facts declared, when `origin_kind` is OVERRIDE. Empty means the
     #: override cites nothing — a flagged condition, not a formatting question.
     override_source: Optional[str] = None
@@ -107,14 +114,14 @@ class ResolvedInputRow:
             "asset_class": self.asset_class,
             "size": self.size,
             "size_unit": self.size_unit,
-            "origin_kind": self.origin_kind,
+            "origin_kind": self.origin_kind.value,
             "override_source": self.override_source,
             "entry_key": self.entry_key,
             "source_ids": self.source_ids,
-            "unit_price_in_euro": _band_json(self.unit_price_in_euro),
+            "unit_price_in_euro": UncertainValue.optional_to_json(self.unit_price_in_euro),
             "lifetime_in_years": self.lifetime_in_years,
-            "investment_gross_in_euro": _band_json(self.investment_gross_in_euro),
-            "subsidies_nominal_in_euro": _band_json(self.subsidies_nominal_in_euro),
+            "investment_gross_in_euro": UncertainValue.optional_to_json(self.investment_gross_in_euro),
+            "subsidies_nominal_in_euro": UncertainValue.optional_to_json(self.subsidies_nominal_in_euro),
             "subsidy_scheme_ids": self.subsidy_scheme_ids,
             "caps_binding_by_scheme": self.caps_binding_by_scheme,
             "flags": self.flags,
@@ -127,20 +134,28 @@ class ResolvedInputRow:
         Rebuilds a row from a stored `cost_audit.json`, defaulting the collection fields to empty so
         an audit written by an older version still loads. The mandatory keys are the identity and
         origin fields; everything a run may legitimately not have produced is optional.
+
+        `origin_kind` goes through `OriginKind`, so a file carrying a spelling no renderer knows
+        fails here instead of reaching the report as a kind that matches none of its comparisons
+        and renders as an empty cell.
+
+        Raises:
+            KeyError: If a mandatory key is missing.
+            ValueError: If `origin_kind` names no `OriginKind` member.
         """
         return ResolvedInputRow(
             subject=raw["subject"],
             asset_class=raw["asset_class"],
             size=raw["size"],
             size_unit=raw["size_unit"],
-            origin_kind=raw["origin_kind"],
+            origin_kind=OriginKind(raw["origin_kind"]),
             override_source=raw.get("override_source"),
             entry_key=raw.get("entry_key"),
             source_ids=list(raw.get("source_ids", [])),
-            unit_price_in_euro=_band_from(raw.get("unit_price_in_euro")),
+            unit_price_in_euro=UncertainValue.optional_from_json(raw.get("unit_price_in_euro")),
             lifetime_in_years=raw.get("lifetime_in_years"),
-            investment_gross_in_euro=_band_from(raw.get("investment_gross_in_euro")),
-            subsidies_nominal_in_euro=_band_from(raw.get("subsidies_nominal_in_euro")),
+            investment_gross_in_euro=UncertainValue.optional_from_json(raw.get("investment_gross_in_euro")),
+            subsidies_nominal_in_euro=UncertainValue.optional_from_json(raw.get("subsidies_nominal_in_euro")),
             subsidy_scheme_ids=list(raw.get("subsidy_scheme_ids", [])),
             caps_binding_by_scheme={
                 scheme: list(slots) for scheme, slots in raw.get("caps_binding_by_scheme", {}).items()
@@ -224,16 +239,6 @@ class InputAuditReport:
                 for item in raw.get("sources", [])
             ],
         )
-
-
-def _band_json(value: Optional[UncertainValue]) -> Any:
-    """Serializes an optional band, keeping `None` distinct from a zero band."""
-    return value.to_json() if value is not None else None
-
-
-def _band_from(value: Any) -> Optional[UncertainValue]:
-    """Parses an optional band; the inverse of `_band_json`, `None` staying `None`."""
-    return UncertainValue.from_json(value) if value is not None else None
 
 
 def write_input_audit(audit: InputAuditReport, result_directory: str) -> str:

--- a/hisim/economics/parameters.py
+++ b/hisim/economics/parameters.py
@@ -16,8 +16,8 @@ what makes a full factorial sweep a matter of milliseconds per cell.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Optional
+from dataclasses import asdict, dataclass, field, fields
+from typing import Any, Dict, Mapping, Optional
 
 from hisim.economics.carriers import EnergyCarrier
 from hisim.economics.timeline import discount_factor
@@ -132,3 +132,45 @@ class EconomicParameters:
         the per-carrier and per-asset-class rate dicts keep JSON-compatible string keys.
         """
         return asdict(self)
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "EconomicParameters":
+        """Rebuilds a parameter record from the mapping :meth:`to_dict` wrote.
+
+        The counterpart of `to_dict`, and the reason a stored evaluation can be re-priced at all:
+        `economic_inputs.json` and a hand-written `--parameters` file both arrive as plain JSON,
+        and the two rate dictionaries key on enums that JSON can only carry as strings. Those keys
+        are converted back here; every other field is a scalar that survives the round trip
+        unchanged, and a field the mapping omits keeps its documented default, so a subset is a
+        legitimate input.
+
+        An unknown key is refused rather than ignored: at this level a key that no field claims is
+        a typo in a hand-written assumption file, and silently dropping it would price the run
+        with a default the author believed they had overridden.
+
+        Args:
+            raw: The mapping to read, as produced by `to_dict` or parsed from JSON.
+
+        Returns:
+            The reconstructed parameter record, validated by `__post_init__`.
+
+        Raises:
+            ValueError: If the mapping carries a key that is not a field of this class.
+        """
+        known = {field_info.name for field_info in fields(cls)}
+        values = dict(raw)
+        unknown = sorted(set(values) - known)
+        if unknown:
+            raise ValueError(
+                f"unknown economic parameter(s) {', '.join(unknown)}; the record accepts "
+                f"{', '.join(sorted(known))}."
+            )
+        for key, enum_class in (
+            ("energy_price_escalation_rates", EnergyCarrier),
+            ("investment_price_escalation_rates", ComponentType),
+        ):
+            if values.get(key):
+                values[key] = {
+                    enum_class(member): float(rate) for member, rate in values[key].items()
+                }
+        return cls(**values)

--- a/hisim/economics/parameters.py
+++ b/hisim/economics/parameters.py
@@ -128,8 +128,11 @@ class EconomicParameters:
         """The parameter record as a JSON-serializable dict, one key per field.
 
         Consumed by `LifecycleCostResult.to_json` so the assumptions travel with every stored
-        result (§4.6). Plain `asdict` is sufficient: every enum in the record is a str-enum, so
-        the per-carrier and per-asset-class rate dicts keep JSON-compatible string keys.
+        result (§4.6). Plain `asdict` is sufficient, but note what it does *not* do: the keys of the
+        two rate dicts stay `EnergyCarrier` and `ComponentType` *members* here, not strings. Both
+        enums derive from `str`, so `json.dump` writes each key as its enum *value* ("HeatPump",
+        not "HEAT_PUMP") — which is the spelling `from_dict` has to read back, and the reason that
+        method accepts the member name as well.
         """
         return asdict(self)
 
@@ -140,13 +143,17 @@ class EconomicParameters:
         The counterpart of `to_dict`, and the reason a stored evaluation can be re-priced at all:
         `economic_inputs.json` and a hand-written `--parameters` file both arrive as plain JSON,
         and the two rate dictionaries key on enums that JSON can only carry as strings. Those keys
-        are converted back here; every other field is a scalar that survives the round trip
-        unchanged, and a field the mapping omits keeps its documented default, so a subset is a
-        legitimate input.
+        are converted back here — by member value *or* member name, see `_enum_key`, since the two
+        kinds of file spell them differently; every other field is a scalar that survives the round
+        trip unchanged, and a field the mapping omits keeps its documented default, so a subset is
+        a legitimate input.
 
         An unknown key is refused rather than ignored: at this level a key that no field claims is
         a typo in a hand-written assumption file, and silently dropping it would price the run
-        with a default the author believed they had overridden.
+        with a default the author believed they had overridden. A rate dict that is present but is
+        not a mapping is refused for the same reason: `"energy_price_escalation_rates": null` used
+        to pass straight through as `None`, and the record then carried `None` where every reader
+        expects a dict.
 
         Args:
             raw: The mapping to read, as produced by `to_dict` or parsed from JSON.
@@ -155,7 +162,8 @@ class EconomicParameters:
             The reconstructed parameter record, validated by `__post_init__`.
 
         Raises:
-            ValueError: If the mapping carries a key that is not a field of this class.
+            ValueError: If the mapping carries a key that is not a field of this class, if a rate
+                dict is present but is not a mapping, or if one of its keys names no enum member.
         """
         known = {field_info.name for field_info in fields(cls)}
         values = dict(raw)
@@ -169,8 +177,53 @@ class EconomicParameters:
             ("energy_price_escalation_rates", EnergyCarrier),
             ("investment_price_escalation_rates", ComponentType),
         ):
-            if values.get(key):
-                values[key] = {
-                    enum_class(member): float(rate) for member, rate in values[key].items()
-                }
+            if key not in values:
+                continue  # absent means "no per-carrier / per-asset-class override", the default
+            rates = values[key]
+            if not isinstance(rates, dict):
+                raise ValueError(
+                    f"economic parameter {key!r} must be a mapping of {enum_class.__name__} to "
+                    f"rate, got {rates!r}. Omit the key to keep the default (an empty mapping, so "
+                    "every carrier or asset class falls back to the general escalation rate); an "
+                    "explicit null is not that statement."
+                )
+            values[key] = {
+                cls._enum_key(enum_class, member, key): float(rate) for member, rate in rates.items()
+            }
         return cls(**values)
+
+    @staticmethod
+    def _enum_key(enum_class: Any, spelling: Any, parameter_name: str) -> Any:
+        """Resolves one rate-dict key onto an enum member, by value or by member name.
+
+        Both spellings have to work. `to_dict` + `json.dump` writes the enum *value* ("HeatPump"),
+        so that is what a stored `economic_inputs.json` carries; a hand-written `--parameters`
+        file, on the other hand, is almost always typed as the member *name* ("HEAT_PUMP"), which
+        is the spelling the enum is referred to by everywhere else in the code and in the spec.
+        Accepting only the value made the natural hand-written spelling raise a bare
+        `ValueError: 'HEAT_PUMP' is not a valid ComponentType` from inside a dict comprehension,
+        with nothing to say which parameter it came from.
+
+        Args:
+            enum_class: `EnergyCarrier` or `ComponentType`.
+            spelling: The key as it was written in the JSON file.
+            parameter_name: Field the dict belongs to, so the error names it.
+
+        Returns:
+            The matching enum member.
+
+        Raises:
+            ValueError: If the spelling matches neither a member value nor a member name.
+        """
+        try:
+            return enum_class(spelling)
+        except ValueError:
+            pass
+        try:
+            return enum_class[spelling]
+        except KeyError:
+            accepted = ", ".join(f"{member.name}/{member.value!r}" for member in enum_class)
+            raise ValueError(
+                f"{spelling!r} in economic parameter {parameter_name!r} is no {enum_class.__name__}; "
+                f"accepted spellings are the member name or its value: {accepted}."
+            ) from None

--- a/hisim/economics/serialization.py
+++ b/hisim/economics/serialization.py
@@ -1,0 +1,730 @@
+"""Serialization of evaluator inputs for post-hoc re-pricing (cost_spec.md §4.6).
+
+All evaluator inputs are serialized into the result directory (`economic_inputs.json`,
+accompanied by `cost_provenance.json`) so new economic assumptions never require re-running
+the building simulation.
+
+**This module implements the seam-1 contract of cost-spec-v2 §2.1.** The engine is required to be
+a pure function of a JSON file: everything the evaluator needs about one simulated variant must
+survive being written to disk and read back, so that re-pricing an archived run under new interest
+rates, an updated subsidy catalog or a reviewer's "what if" never re-runs the building simulation.
+That is also what makes the two error classes separable — "the wrong physical quantities went in"
+is a question about this file, "they were priced wrong" is a question about everything downstream
+of it — and what lets the downstream tests be small hand-written JSON files with exact expected
+results instead of simulation runs.
+
+**Round-trip fidelity is therefore the property under test**, not an implementation detail:
+`tests/test_economics_data_and_integration.py` writes inputs, reads them back and asserts that the
+reloaded record evaluates to the same NPV per slot, that a `SubsidyBuildingContext.existing_heating`
+survives with every attribute (it decides the BEG speed bonus — dropping it used to silently degrade
+that scheme, cost-spec-v2 W1.3), and that a `TariffContract` which exists in no catalog file
+round-trips byte-equal and prices identically (W1.4). A field that does not round-trip is a bug of
+exactly the class this seam exists to prevent: it makes an archived run re-price differently from
+the run that produced it, silently and without any error to catch. The one *deliberate* exception is
+the default tariff contract synthesized from the §3.5 price entries — it is written for the record
+but not restored, because it is derived data the evaluator regenerates at the price basis year, and
+restoring it would freeze the shipped prices and defeat scenario price overlays.
+
+The module owns nothing economic: no defaults, no fallbacks, no validation beyond what the target
+types enforce in their own constructors. It also owns the *inverse* direction (below the "stored
+results" divider, W4.5): reading `lifecycle_costs.json`, `cash_flow_timeline.csv` and
+`cost_provenance.json` back into a full `EvaluationMatrix`, so `python -m hisim.economics report`
+renders a stored evaluation instead of quietly performing a new one.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from typing import Any, Dict, Optional
+
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.evaluator import EvaluationInputs, SubjectCostFacts, UnresolvedSubject
+from hisim.economics.exports import ExportFileNames
+from hisim.economics.facts import (
+    BillingDeterminants,
+    ComponentCostFacts,
+    ExistingAsset,
+    ExistingAssetRegister,
+)
+from hisim.economics.parameters import EconomicParameters
+from hisim.economics.provenance import ProvenanceLedger
+from hisim.economics.results import (
+    AnnualEnergyQuantities,
+    ComponentCostBreakdown,
+    EvaluationMatrix,
+    LifecycleCo2Result,
+    LifecycleCostResult,
+    ReferenceAreas,
+)
+from hisim.economics.subsidies import (
+    ApplicantActor,
+    ApplicantProfile,
+    HeritageStatus,
+    PayoutKind,
+    SubsidyAward,
+    SubsidyBuildingContext,
+    SubsidyContext,
+    SubsidyDecision,
+)
+from hisim.economics.tariffs import contract_to_json
+from hisim.economics.timeline import Actor, CashFlowEntry, CashFlowTimeline, CostCategory, SubjectKind
+from hisim.economics.uncertainty import UncertainValue
+from hisim.loadtypes import ComponentType, Units
+from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass
+
+
+class SerializationFileNames:
+    """Names of the files the input/provenance serialization writes.
+
+    Kept as named constants rather than literals because both directions of the seam and several
+    unrelated readers (the CLI, the parity pass, the report layer, archived-result tooling) address
+    the same two files; the export-side names live in `exports.ExportFileNames`.
+    """
+
+    ECONOMIC_INPUTS_FILE_NAME = "economic_inputs.json"
+    PROVENANCE_FILE_NAME = "cost_provenance.json"
+
+
+def _band_or_none(value: Optional[UncertainValue]) -> Any:
+    """Serializes an optional uncertainty band, preserving the None/zero distinction.
+
+    Every monetary override is optional, and "no override" is a different statement from "an
+    override of zero euro" — so None must survive as JSON null rather than collapsing to a band.
+    """
+    return value.to_json() if value is not None else None
+
+
+def _band_from(value: Any) -> Optional[UncertainValue]:
+    """The inverse of `_band_or_none`: JSON null stays None, anything else becomes a triplet."""
+    return UncertainValue.from_json(value) if value is not None else None
+
+
+def facts_to_json(facts: ComponentCostFacts) -> dict:
+    """Serializes ComponentCostFacts.
+
+    Writes every declared field including the per-field overrides and `override_source`, so a
+    re-priced run applies exactly the same overrides — and stays as traceable — as the original.
+    Enums are stored by `name` (asset class, size unit) and the KPI tag by its value; the free-form
+    `technical_attributes` dict passes through unchanged, which is why `ComponentCostFacts` requires
+    it to be JSON-serializable in the first place.
+    """
+    return {
+        "asset_class": facts.asset_class.name,
+        "size": facts.size,
+        "size_unit": facts.size_unit.name,
+        "kpi_tag": facts.kpi_tag.value if facts.kpi_tag else None,
+        "count": facts.count,
+        "investment_cost_override_in_euro": _band_or_none(facts.investment_cost_override_in_euro),
+        "installation_cost_override_in_euro": _band_or_none(facts.installation_cost_override_in_euro),
+        "lifetime_override_in_years": facts.lifetime_override_in_years,
+        "maintenance_rate_override": _band_or_none(facts.maintenance_rate_override),
+        "fixed_operation_cost_override_in_euro_per_year": _band_or_none(
+            facts.fixed_operation_cost_override_in_euro_per_year
+        ),
+        "embodied_co2_override_in_kg": facts.embodied_co2_override_in_kg,
+        "override_source": facts.override_source,
+        "technical_attributes": facts.technical_attributes,
+    }
+
+
+def facts_from_json(raw: dict) -> ComponentCostFacts:
+    """Deserializes ComponentCostFacts.
+
+    The exact inverse of `facts_to_json`. Optional keys are read with `.get` and their dataclass
+    defaults, so a file written by an older version still loads; note that this reconstruction runs
+    through `ComponentCostFacts.__post_init__`, i.e. the same fail-fast validation a component
+    declaration goes through — a hand-edited inputs file with an implausible size or an unpriceable
+    size unit is rejected here rather than producing nonsense downstream.
+    """
+    from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass
+
+    kpi_tag = None
+    if raw.get("kpi_tag"):
+        kpi_tag = KpiTagEnumClass(raw["kpi_tag"])
+    return ComponentCostFacts(
+        asset_class=ComponentType[raw["asset_class"]],
+        size=raw["size"],
+        size_unit=Units[raw["size_unit"]],
+        kpi_tag=kpi_tag,
+        count=raw.get("count", 1),
+        investment_cost_override_in_euro=_band_from(raw.get("investment_cost_override_in_euro")),
+        installation_cost_override_in_euro=_band_from(raw.get("installation_cost_override_in_euro")),
+        lifetime_override_in_years=raw.get("lifetime_override_in_years"),
+        maintenance_rate_override=_band_from(raw.get("maintenance_rate_override")),
+        fixed_operation_cost_override_in_euro_per_year=_band_from(
+            raw.get("fixed_operation_cost_override_in_euro_per_year")
+        ),
+        embodied_co2_override_in_kg=raw.get("embodied_co2_override_in_kg"),
+        override_source=raw.get("override_source"),
+        technical_attributes=raw.get("technical_attributes", {}),
+    )
+
+
+def billing_to_json(determinants: BillingDeterminants) -> dict:
+    """Serializes BillingDeterminants.
+
+    One record per carrier that crossed the system boundary (§3.4), carrying everything a tariff
+    needs to bill it: annual volumes bought and sold, the time-of-use band split, the billing-period
+    and annual peaks for capacity charges (§8.4), and — for dynamic tariffs — the in-simulation
+    integrated cost/revenue and mean spot price. Every quantity is in kilowatt-hours, for every
+    carrier: the `_in_kwh` field names are literally true since prices, not quantities, carry the
+    conversion out of EUR/t and EUR/l (D26).
+    """
+    return {
+        "carrier": determinants.carrier.value,
+        "energy_bought_in_kwh": determinants.energy_bought_in_kwh,
+        "energy_sold_in_kwh": determinants.energy_sold_in_kwh,
+        "energy_bought_per_band_in_kwh": determinants.energy_bought_per_band_in_kwh,
+        "cost_integrated_in_euro": determinants.cost_integrated_in_euro,
+        "revenue_integrated_in_euro": determinants.revenue_integrated_in_euro,
+        "peak_per_billing_period_in_kw": determinants.peak_per_billing_period_in_kw,
+        "annual_peak_in_kw": determinants.annual_peak_in_kw,
+        "mean_spot_price_in_euro_per_kwh": determinants.mean_spot_price_in_euro_per_kwh,
+    }
+
+
+def billing_from_json(raw: dict) -> BillingDeterminants:
+    """Deserializes BillingDeterminants.
+
+    Only carrier and bought volume are required; every other determinant defaults to its
+    "not measured" value, so a hand-written test input can state a bare annual consumption and be
+    billed against a flat tariff without inventing peaks or band splits.
+    """
+    return BillingDeterminants(
+        carrier=EnergyCarrier(raw["carrier"]),
+        energy_bought_in_kwh=raw["energy_bought_in_kwh"],
+        energy_sold_in_kwh=raw.get("energy_sold_in_kwh", 0.0),
+        energy_bought_per_band_in_kwh=raw.get("energy_bought_per_band_in_kwh", {}),
+        cost_integrated_in_euro=raw.get("cost_integrated_in_euro"),
+        revenue_integrated_in_euro=raw.get("revenue_integrated_in_euro"),
+        peak_per_billing_period_in_kw=raw.get("peak_per_billing_period_in_kw", []),
+        annual_peak_in_kw=raw.get("annual_peak_in_kw", 0.0),
+        mean_spot_price_in_euro_per_kwh=raw.get("mean_spot_price_in_euro_per_kwh"),
+    )
+
+
+def asset_to_json(asset: ExistingAsset) -> dict:
+    """Serializes a single existing asset.
+
+    An `ExistingAsset` is a piece of the building as it was *before* the measure, and the fields
+    below are exactly what the brownfield arithmetic of §4.1 needs: installation year (drives
+    remaining life, first replacement and the anyway-cost credit), functionality, carrier, an
+    optional like-for-like replacement price, and `replaced_by_asset_classes` — the declaration that
+    turns "kept" into "replaced by this measure". Used both for register entries and for the
+    subsidy context's `existing_heating`, which the BEG speed bonus conditions on.
+    """
+    return {
+        "asset_class": asset.asset_class.name,
+        "size": asset.size,
+        "size_unit": asset.size_unit.name,
+        "installation_year": asset.installation_year,
+        "replacement_cost_override_in_euro": _band_or_none(asset.replacement_cost_override_in_euro),
+        "is_functional": asset.is_functional,
+        "energy_carrier": asset.energy_carrier.value if asset.energy_carrier else None,
+        "replaced_by_asset_classes": [asset_class.name for asset_class in asset.replaced_by_asset_classes],
+    }
+
+
+def asset_from_json(item: dict) -> ExistingAsset:
+    """Deserializes a single existing asset.
+
+    Inverse of `asset_to_json`; `is_functional` defaults to True and the replacement declarations to
+    empty, which is the "an old but working device is simply there" reading.
+    """
+    return ExistingAsset(
+        asset_class=ComponentType[item["asset_class"]],
+        size=item["size"],
+        size_unit=Units[item["size_unit"]],
+        installation_year=item["installation_year"],
+        replacement_cost_override_in_euro=_band_from(item.get("replacement_cost_override_in_euro")),
+        is_functional=item.get("is_functional", True),
+        energy_carrier=EnergyCarrier(item["energy_carrier"]) if item.get("energy_carrier") else None,
+        replaced_by_asset_classes=[ComponentType[name] for name in item.get("replaced_by_asset_classes", [])],
+    )
+
+
+def register_to_json(register: Optional[ExistingAssetRegister]) -> Optional[list]:
+    """Serializes the existing-asset register.
+
+    The None/list distinction carries real meaning here and must survive the file: no register at
+    all means greenfield, and an empty list means "a brownfield situation with nothing worth
+    registering" — the former evaluates the greenfield perspectives, the latter the brownfield ones
+    (`perspectives.select_applicable`).
+    """
+    if register is None:
+        return None
+    return [asset_to_json(asset) for asset in register.assets]
+
+
+def register_from_json(raw: Optional[list]) -> Optional[ExistingAssetRegister]:
+    """Deserializes the existing-asset register, keeping null distinct from an empty list."""
+    if raw is None:
+        return None
+    return ExistingAssetRegister(assets=[asset_from_json(item) for item in raw])
+
+
+def subsidy_context_to_json(context: SubsidyContext) -> dict:
+    """Serializes the subsidy context.
+
+    The applicant/building answers the §5.3 eligibility conditions resolve against — everything the
+    §5.7 questionnaire asks. Every field is written even when None, because in the condition language
+    an unanswered field is *undetermined* (reported as such, with an upper bound on what it could
+    have been worth) rather than false, and that tri-state has to survive re-pricing.
+
+    `building.existing_heating` in particular is load-bearing: the shipped DE catalog's BEG speed
+    bonus conditions on it, and it was silently dropped here until cost-spec-v2 W1.3 — re-priced
+    runs used to lose that bonus without a word.
+    """
+    building = context.building
+    return {
+        "applicant": {
+            "actor": context.applicant.actor.value,
+            "taxable_household_income_in_euro": context.applicant.taxable_household_income_in_euro,
+            "household_size": context.applicant.household_size,
+            "main_residence": context.applicant.main_residence,
+            "region": context.applicant.region,
+        },
+        "building": {
+            "construction_year": building.construction_year,
+            "dwelling_units": building.dwelling_units,
+            "heated_floor_area_in_m2": building.heated_floor_area_in_m2,
+            "residential_floor_area_in_m2": building.residential_floor_area_in_m2,
+            "commercial_floor_area_in_m2": building.commercial_floor_area_in_m2,
+            "heritage_status": building.heritage_status.value if building.heritage_status else None,
+            "energy_performance_class": building.energy_performance_class,
+            "existing_heating": asset_to_json(building.existing_heating) if building.existing_heating else None,
+            "has_renovation_roadmap": building.has_renovation_roadmap,
+        },
+    }
+
+
+def subsidy_context_from_json(raw: dict) -> SubsidyContext:
+    """Deserializes the subsidy context.
+
+    Tolerant by construction: an empty dict yields a default owner-occupier context with everything
+    unanswered, which is what a run without an `EconomicContext` produces and what the flat shim
+    path needs. Only `heritage_status` is defaulted to a concrete value (NONE) rather than left
+    None, mirroring `SubsidyBuildingContext`'s own default.
+    """
+    applicant_raw = raw.get("applicant", {})
+    building_raw = raw.get("building", {})
+    # Absent in files written before the field was round-tripped; stays None there.
+    existing_heating_raw = building_raw.get("existing_heating")
+    return SubsidyContext(
+        applicant=ApplicantProfile(
+            actor=ApplicantActor(applicant_raw.get("actor", "OWNER_OCCUPIER")),
+            taxable_household_income_in_euro=applicant_raw.get("taxable_household_income_in_euro"),
+            household_size=applicant_raw.get("household_size"),
+            main_residence=applicant_raw.get("main_residence"),
+            region=applicant_raw.get("region"),
+        ),
+        building=SubsidyBuildingContext(
+            construction_year=building_raw.get("construction_year"),
+            dwelling_units=building_raw.get("dwelling_units", 1),
+            heated_floor_area_in_m2=building_raw.get("heated_floor_area_in_m2"),
+            residential_floor_area_in_m2=building_raw.get("residential_floor_area_in_m2"),
+            commercial_floor_area_in_m2=building_raw.get("commercial_floor_area_in_m2", 0.0),
+            heritage_status=HeritageStatus(building_raw["heritage_status"])
+            if building_raw.get("heritage_status")
+            else HeritageStatus.NONE,
+            energy_performance_class=building_raw.get("energy_performance_class"),
+            existing_heating=asset_from_json(existing_heating_raw) if existing_heating_raw else None,
+            has_renovation_roadmap=building_raw.get("has_renovation_roadmap"),
+        ),
+    )
+
+
+def inputs_to_json(inputs: EvaluationInputs) -> dict:
+    """Serializes EvaluationInputs to the economic_inputs.json structure.
+
+    The seam-1 payload: every field of `EvaluationInputs` appears here, which is the property that
+    makes the evaluator a pure function of this file. Nothing economic is written — no prices, no
+    rates, no perspective, not even the price basis year, which is re-derived downstream from
+    `simulation_year` so the postprocessing bridge and the `evaluate` CLI cannot drift apart
+    (cost-spec-v2 W1.2).
+
+    Adding a field to `EvaluationInputs` without adding it here silently breaks re-pricing, since
+    the reader would fall back to that field's default. The round-trip tests in
+    `tests/test_economics_data_and_integration.py` are what catch it.
+    """
+    return {
+        "simulation_year": inputs.simulation_year,
+        "simulated_period_fraction": inputs.simulated_period_fraction,
+        "cost_facts": [
+            {"subject": subject_facts.subject, "facts": facts_to_json(subject_facts.facts)}
+            for subject_facts in inputs.cost_facts
+        ],
+        "billing": [billing_to_json(determinants) for determinants in inputs.billing],
+        # Extraction failures travel with the extract (issue #2): re-pricing an archived run must
+        # hit the same D7 wall as the original one, not quietly price a smaller system.
+        "unresolved_subjects": [
+            {"subject": unresolved.subject, "reason": unresolved.reason}
+            for unresolved in inputs.unresolved_subjects
+        ],
+        "existing_assets": register_to_json(inputs.existing_assets),
+        "subsidy_context": subsidy_context_to_json(inputs.subsidy_context),
+        # Contracts are embedded in full (W1.4): the file is self-contained, so re-pricing uses
+        # byte-identical contract data instead of whatever the tariffs directory happens to hold.
+        "tariff_contracts": {
+            carrier.value: contract_to_json(contract) for carrier, contract in inputs.tariff_contracts.items()
+        },
+        "consumed_tariff_ids": inputs.consumed_tariff_ids,
+        "annual_heat_demand_in_kwh": inputs.annual_heat_demand_in_kwh,
+        "building_specific_emissions_in_kg_per_m2_a": inputs.building_specific_emissions_in_kg_per_m2_a,
+        "heated_floor_area_in_m2": inputs.heated_floor_area_in_m2,
+        "living_area_in_m2": inputs.living_area_in_m2,
+        "current_cold_rent_in_euro_per_m2_month": inputs.current_cold_rent_in_euro_per_m2_month,
+    }
+
+
+def contracts_from_json(raw: dict, tariffs_base_path: Optional[str] = None) -> Dict[EnergyCarrier, Any]:
+    """Reads the tariff contracts of an inputs file.
+
+    Preferred form (W1.4): ``tariff_contracts`` holds the full contract objects, so no catalog
+    lookup happens and contracts that exist in no file survive the round trip. Files written
+    before that (``tariff_contract_ids``) are still read by resolving the ids against the
+    tariffs directory. In both forms, contracts generated from the §3.5 price entries are
+    skipped: they are derived data that the evaluator regenerates at the price basis year, which
+    keeps scenario price overlays effective.
+    """
+    from hisim.economics.tariffs import TariffContract, load_tariff_contract
+
+    contracts: Dict[EnergyCarrier, Any] = {}
+    embedded = raw.get("tariff_contracts")
+    if embedded:
+        for carrier_name, contract_raw in embedded.items():
+            contract = TariffContract.from_json(contract_raw)
+            if contract.is_default_contract:
+                continue
+            contracts[EnergyCarrier(carrier_name)] = contract
+        return contracts
+    for carrier_name, contract_id in (raw.get("tariff_contract_ids") or {}).items():
+        if contract_id.split("_DEFAULT_")[0] in ("DE", "AT") and "_DEFAULT_" in contract_id:
+            continue  # default contracts are regenerated from the price entries
+        contracts[EnergyCarrier(carrier_name)] = load_tariff_contract(contract_id, tariffs_base_path)
+    return contracts
+
+
+def inputs_from_json(raw: dict, tariffs_base_path: Optional[str] = None) -> EvaluationInputs:
+    """Deserializes EvaluationInputs (`tariffs_base_path` only matters for old id-only files).
+
+    The entry point of every downstream consumer that did not run the simulation itself: the
+    `evaluate` / `explain` / `report` CLI commands, the parity pass, and the downstream half of the
+    seam-1 test strategy (hand-written input files with exact expected results). Only
+    `simulation_year` and `simulated_period_fraction` are mandatory; everything else degrades to the
+    dataclass default, so a minimal file stays a legitimate input.
+
+    Args:
+        raw: The parsed `economic_inputs.json` payload.
+        tariffs_base_path: Directory to resolve contract *ids* against — needed only for files
+            written before contracts were embedded in full (W1.4).
+
+    Returns:
+        The reconstructed record; evaluating it must reproduce the original result exactly.
+    """
+    contracts = contracts_from_json(raw, tariffs_base_path)
+    return EvaluationInputs(
+        simulation_year=raw["simulation_year"],
+        simulated_period_fraction=raw["simulated_period_fraction"],
+        cost_facts=[
+            SubjectCostFacts(subject=item["subject"], facts=facts_from_json(item["facts"]))
+            for item in raw.get("cost_facts", [])
+        ],
+        billing=[billing_from_json(item) for item in raw.get("billing", [])],
+        unresolved_subjects=[
+            UnresolvedSubject(subject=item["subject"], reason=item["reason"])
+            for item in raw.get("unresolved_subjects", [])
+        ],
+        existing_assets=register_from_json(raw.get("existing_assets")),
+        subsidy_context=subsidy_context_from_json(raw.get("subsidy_context", {})),
+        tariff_contracts=contracts,
+        consumed_tariff_ids=raw.get("consumed_tariff_ids", []),
+        annual_heat_demand_in_kwh=raw.get("annual_heat_demand_in_kwh"),
+        building_specific_emissions_in_kg_per_m2_a=raw.get("building_specific_emissions_in_kg_per_m2_a"),
+        heated_floor_area_in_m2=raw.get("heated_floor_area_in_m2"),
+        living_area_in_m2=raw.get("living_area_in_m2"),
+        current_cold_rent_in_euro_per_m2_month=raw.get("current_cold_rent_in_euro_per_m2_month"),
+    )
+
+
+def write_inputs(inputs: EvaluationInputs, result_directory: str) -> str:
+    """Writes economic_inputs.json into the result directory.
+
+    Called by `bridge.py` as the very first thing after extraction — before the cost database is
+    consulted, before the resolution check, before any evaluation — so the file is a faithful
+    extract of the simulation and never depends on cost-database state (cost-spec-v2 W1.1). It is
+    written even for a run where nothing can be priced, which is precisely when someone wants to
+    look at it. Indented JSON on purpose: the file is meant to be read and diffed by humans.
+
+    Returns:
+        The path written, for logging and for tests.
+    """
+    path = os.path.join(result_directory, SerializationFileNames.ECONOMIC_INPUTS_FILE_NAME)
+    with open(path, "w", encoding="utf-8") as file:
+        json.dump(inputs_to_json(inputs), file, indent=2)
+    return path
+
+
+def read_inputs(result_directory: str, tariffs_base_path: Optional[str] = None) -> EvaluationInputs:
+    """Reads economic_inputs.json from a (possibly archived) result directory.
+
+    ``tariffs_base_path`` is only consulted for legacy files that reference contracts by id.
+
+    "Possibly archived" is the point: a study's result directory stays re-priceable years after the
+    simulation ran, against a newer cost database or an updated subsidy catalog, without the
+    original system setup, HiSim version or weather data being available (§4.6).
+
+    Raises:
+        OSError: If the directory holds no `economic_inputs.json` — which the callers treat as
+            "this directory was not produced by a lifecycle-cost run" rather than as a failure.
+    """
+    path = os.path.join(result_directory, SerializationFileNames.ECONOMIC_INPUTS_FILE_NAME)
+    with open(path, encoding="utf-8") as file:
+        return inputs_from_json(json.load(file), tariffs_base_path)
+
+
+# ---------------------------------------------------------------------- stored results (W4.5)
+#
+# The inverse of the export set, so `python -m hisim.economics report` can render a stored
+# evaluation without reconstructing database, catalog and evaluator — which is what it used to
+# do, in contradiction of reporting's own docstring (cost-spec-v2 W4.5).
+#
+# Three files carry a full `EvaluationMatrix`: `lifecycle_costs.json` (everything aggregated),
+# `cash_flow_timeline.csv` (the entries, in long format) and, when present,
+# `cost_provenance.json` (the ledger). Nothing else is needed: since W4.2/W4.6 the result also
+# carries the physical quantities, reference areas, scope and simulation year the reports and
+# the plausibility checks used to fetch from `EvaluationInputs`. The one thing a reload cannot
+# reproduce is `source_resolver`, a cost-database/catalog artifact — the report reads its source
+# list off the stored input audit instead (`input_audit.read_input_audit`).
+
+
+def _breakdown_from_json(raw: dict) -> ComponentCostBreakdown:
+    """Rebuilds one subject's `ComponentCostBreakdown` from `lifecycle_costs.json` (W4.5).
+
+    The per-subject pivot the stacked-bar frontends and the report's section 7 render (§7.4). Every
+    field is required here rather than defaulted: a breakdown with a missing category would still
+    render, but would no longer satisfy the invariant that the subjects sum to the perspective total
+    — so a truncated file must fail loudly instead of producing a chart that does not reconcile.
+    """
+    return ComponentCostBreakdown(
+        subject=raw["subject"],
+        subject_kind=SubjectKind(raw["subject_kind"]),
+        asset_class=ComponentType(raw["asset_class"]) if raw.get("asset_class") else None,
+        kpi_tag=KpiTagEnumClass(raw["kpi_tag"]) if raw.get("kpi_tag") else None,
+        npv_by_category={
+            CostCategory(key): UncertainValue.from_json(value)
+            for key, value in raw["npv_by_category"].items()
+        },
+        total_npv_in_euro=UncertainValue.from_json(raw["total_npv_in_euro"]),
+        equivalent_annual_cost_in_euro=UncertainValue.from_json(raw["equivalent_annual_cost_in_euro"]),
+        investment_gross_in_euro=UncertainValue.from_json(raw["investment_gross_in_euro"]),
+        subsidies_nominal_in_euro=UncertainValue.from_json(raw["subsidies_nominal_in_euro"]),
+        subsidies_npv_in_euro=UncertainValue.from_json(raw["subsidies_npv_in_euro"]),
+        annual_cost_series_nominal_in_euro=[
+            UncertainValue.from_json(value) for value in raw["annual_cost_series_nominal_in_euro"]
+        ],
+        lifecycle_co2_in_kg=raw["lifecycle_co2_in_kg"],
+    )
+
+
+def _decision_from_json(raw: dict) -> SubsidyDecision:
+    """Rebuilds one measure's `SubsidyDecision` — the §5 audit trail — from stored results (W4.5).
+
+    Restores not only what was granted (`applied`, with payout kind, schedule, loan terms and which
+    caps bound in which slot) but also what was *not*: rejected schemes with their reason and
+    undetermined ones with the upper bound of what an unanswered question could still be worth. That
+    negative half is the part a reviewer checks, so it has to survive into an archived directory
+    rather than being recomputed from a catalog that may have changed since.
+    """
+    return SubsidyDecision(
+        measure_subject=raw["measure_subject"],
+        applied=[
+            SubsidyAward(
+                scheme_id=item["scheme_id"],
+                payout_kind=PayoutKind(item["payout_kind"]),
+                upfront_amount=UncertainValue.from_json(item["upfront_amount"]),
+                schedule_amounts=[UncertainValue.from_json(a) for a in item.get("schedule_amounts", [])],
+                operational_rate_per_kwh=item.get("operational_rate_per_kwh", 0.0),
+                operational_carrier=(
+                    EnergyCarrier(item["operational_carrier"]) if item.get("operational_carrier") else None
+                ),
+                operational_duration_years=item.get("operational_duration_years", 0),
+                loan_interest_rate=item.get("loan_interest_rate"),
+                loan_term_in_years=item.get("loan_term_in_years"),
+                # No default: an absent grant share means "not stated by the award" (inherit the
+                # plan's), which is a different instruction than a stated 0.0.
+                loan_repayment_grant_share=item.get("loan_repayment_grant_share"),
+                reduced_vat_rate=item.get("reduced_vat_rate"),
+                caps_binding_per_slot=dict(item.get("caps_binding_per_slot", {})),
+            )
+            for item in raw.get("applied", [])
+        ],
+        rejected=list(raw.get("rejected", [])),
+        undetermined=list(raw.get("undetermined", [])),
+        undetermined_upper_bound_in_euro=raw.get("undetermined_upper_bound_in_euro", 0.0),
+        other_slot_optimal_combination=dict(raw.get("other_slot_optimal_combination", {})),
+    )
+
+
+def read_cash_flow_timelines(result_directory: str) -> Dict[str, CashFlowTimeline]:
+    """Reads `cash_flow_timeline.csv` back into one timeline per perspective.
+
+    The stored timeline is always the **full** allocated one (all payers); the perspective's own
+    scope is restored from `LifecycleCostResult.scope_payer`, exactly as the evaluator set it.
+    """
+    path = os.path.join(result_directory, ExportFileNames.CASH_FLOW_TIMELINE_FILE_NAME)
+    timelines: Dict[str, CashFlowTimeline] = {}
+    if not os.path.isfile(path):
+        return timelines
+    with open(path, newline="", encoding="utf-8") as file:
+        for row in csv.DictReader(file, delimiter=";"):
+            entries = timelines.setdefault(row["perspective"], CashFlowTimeline()).entries
+            provenance = tuple(int(part) for part in (row.get("provenance_ids") or "").split() if part)
+            entries.append(
+                CashFlowEntry(
+                    year=int(row["year"]),
+                    amount_in_euro=UncertainValue(
+                        best_estimate=float(row["nominal_best_estimate"]),
+                        minimum=float(row["nominal_min"]),
+                        maximum=float(row["nominal_max"]),
+                    ),
+                    category=CostCategory(row["category"]),
+                    subject=row["subject"],
+                    subject_kind=SubjectKind(row.get("subject_kind") or SubjectKind.COMPONENT.value),
+                    payer=Actor(row["payer"]),
+                    subsidy_scheme_id=row.get("subsidy_scheme_id") or None,
+                    provenance_ids=provenance,
+                )
+            )
+    return timelines
+
+
+def result_from_json(
+    raw: dict,
+    timeline: Optional[CashFlowTimeline] = None,
+    ledger: Optional[ProvenanceLedger] = None,
+) -> LifecycleCostResult:
+    """Rebuilds one `LifecycleCostResult` from its `lifecycle_costs.json` entry (W4.5).
+
+    Restores one perspective's complete result — headline KPIs, the category/component/payer pivots,
+    the nominal annual series, the CO2 result, the subsidy decisions and the parameters it was
+    evaluated under. The timeline and the ledger come from separate files and are passed in, because
+    they are stored per run rather than per perspective (`cash_flow_timeline.csv`,
+    `cost_provenance.json`); a result without them still renders every aggregate figure, it just
+    cannot explain one.
+
+    Args:
+        raw: One perspective's entry of `lifecycle_costs.json`.
+        timeline: That perspective's reloaded cash-flow timeline, if the CSV was present.
+        ledger: That perspective's provenance ledger, if `cost_provenance.json` was present.
+
+    Returns:
+        The reconstructed result, equivalent to what the evaluator produced for the same run.
+    """
+    co2 = raw.get("lifecycle_co2", {})
+    return LifecycleCostResult(
+        perspective_id=raw["perspective"],
+        parameters=EconomicParameters.from_dict(raw["parameters"]),
+        total_npv_in_euro=UncertainValue.from_json(raw["total_npv_in_euro"]),
+        equivalent_annual_cost_in_euro=UncertainValue.from_json(raw["equivalent_annual_cost_in_euro"]),
+        npv_by_category={
+            CostCategory(key): UncertainValue.from_json(value)
+            for key, value in raw["npv_by_category"].items()
+        },
+        npv_by_component={
+            subject: UncertainValue.from_json(value) for subject, value in raw["npv_by_component"].items()
+        },
+        npv_by_payer={
+            Actor(key): UncertainValue.from_json(value) for key, value in raw["npv_by_payer"].items()
+        },
+        component_breakdowns={
+            subject: _breakdown_from_json(item) for subject, item in raw["component_breakdowns"].items()
+        },
+        annual_cost_series_nominal_in_euro=[
+            UncertainValue.from_json(value) for value in raw["annual_cost_series_nominal_in_euro"]
+        ],
+        monthly_cost_year1_in_euro=_band_from(raw.get("monthly_cost_year1_in_euro")),
+        levelized_cost_of_heat_in_euro_per_kwh=_band_from(raw.get("levelized_cost_of_heat_in_euro_per_kwh")),
+        timeline=timeline if timeline is not None else CashFlowTimeline(),
+        lifecycle_co2_result=LifecycleCo2Result(
+            embodied_co2_in_kg=co2.get("embodied_co2_in_kg", 0.0),
+            operational_co2_by_year_in_kg=list(co2.get("operational_co2_by_year_in_kg", [])),
+            operational_co2_by_carrier_in_kg=dict(co2.get("operational_co2_by_carrier_in_kg", {})),
+            total_co2_in_kg=co2.get("total_co2_in_kg", 0.0),
+            embodied_by_subject_in_kg=dict(co2.get("embodied_by_subject_in_kg", {})),
+        ),
+        subsidy_decisions=[_decision_from_json(item) for item in raw.get("subsidy_decisions", [])],
+        sunk_cost_written_off_in_euro=UncertainValue.from_json(raw["sunk_cost_written_off_in_euro"]),
+        ledger=ledger,
+        scope_payer=Actor(raw.get("scope_payer", Actor.SYSTEM.value)),
+        annual_energy_quantities_by_carrier={
+            carrier: AnnualEnergyQuantities(
+                bought_in_kwh=item.get("bought_in_kwh", 0.0), sold_in_kwh=item.get("sold_in_kwh", 0.0)
+            )
+            for carrier, item in raw.get("annual_energy_quantities_by_carrier", {}).items()
+        },
+        reference_areas=ReferenceAreas(
+            heated_floor_area_in_m2=raw.get("reference_areas", {}).get("heated_floor_area_in_m2"),
+            living_area_in_m2=raw.get("reference_areas", {}).get("living_area_in_m2"),
+        ),
+        simulated_period_fraction=raw.get("simulated_period_fraction", 1.0),
+        simulation_year=raw.get("simulation_year"),
+        raw_flexibility_value_by_carrier=dict(raw.get("raw_flexibility_value_by_carrier", {})),
+    )
+
+
+def matrix_from_json(
+    raw: dict,
+    timelines: Optional[Dict[str, CashFlowTimeline]] = None,
+    ledgers: Optional[Dict[str, ProvenanceLedger]] = None,
+) -> EvaluationMatrix:
+    """Rebuilds a full `EvaluationMatrix` from `lifecycle_costs.json` (W4.5).
+
+    The matrix is just "one result per perspective id", so this loops `result_from_json` and hands
+    each result its own timeline and ledger where they were found. Perspectives with no stored
+    timeline or ledger are kept rather than skipped: an incomplete result directory should still
+    report its numbers.
+
+    Args:
+        raw: The parsed `lifecycle_costs.json` — perspective id -> result payload.
+        timelines: Reloaded timelines by perspective id (from `read_cash_flow_timelines`).
+        ledgers: Reloaded provenance ledgers by perspective id.
+    """
+    timelines = timelines or {}
+    ledgers = ledgers or {}
+    matrix = EvaluationMatrix()
+    for perspective, item in raw.items():
+        matrix.results[perspective] = result_from_json(
+            item, timelines.get(perspective), ledgers.get(perspective)
+        )
+    return matrix
+
+
+def read_results(result_directory: str) -> Optional[EvaluationMatrix]:
+    """Reads a stored evaluation back, or None when the directory holds none (W4.5).
+
+    The one call `python -m hisim.economics report` makes before deciding whether it may render or
+    must re-price: a directory written by the bridge, by `evaluate` or by an earlier `report` has
+    everything the reports need, so reporting stays rendering rather than quietly becoming a second
+    evaluation. Returning None (rather than raising) for a directory holding only
+    `economic_inputs.json` is what makes that fallback a clean branch in the CLI.
+
+    Reads three files, of which only the first is required: `lifecycle_costs.json` (the aggregates),
+    `cash_flow_timeline.csv` (the entries) and `cost_provenance.json` (the ledger).
+    """
+    path = os.path.join(result_directory, ExportFileNames.LIFECYCLE_COSTS_FILE_NAME)
+    if not os.path.isfile(path):
+        return None
+    with open(path, encoding="utf-8") as file:
+        raw = json.load(file)
+    ledgers: Dict[str, ProvenanceLedger] = {}
+    ledger_path = os.path.join(result_directory, SerializationFileNames.PROVENANCE_FILE_NAME)
+    if os.path.isfile(ledger_path):
+        with open(ledger_path, encoding="utf-8") as file:
+            ledgers = {
+                perspective: ProvenanceLedger.from_json(item)
+                for perspective, item in json.load(file).items()
+            }
+    return matrix_from_json(raw, read_cash_flow_timelines(result_directory), ledgers)

--- a/hisim/economics/serialization.py
+++ b/hisim/economics/serialization.py
@@ -138,8 +138,6 @@ def facts_from_json(raw: dict) -> ComponentCostFacts:
     declaration goes through — a hand-edited inputs file with an implausible size or an unpriceable
     size unit is rejected here rather than producing nonsense downstream.
     """
-    from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass
-
     kpi_tag = None
     if raw.get("kpi_tag"):
         kpi_tag = KpiTagEnumClass(raw["kpi_tag"])

--- a/hisim/economics/serialization.py
+++ b/hisim/economics/serialization.py
@@ -68,7 +68,7 @@ from hisim.economics.subsidies import (
     SubsidyContext,
     SubsidyDecision,
 )
-from hisim.economics.tariffs import contract_to_json
+from hisim.economics.tariffs import TariffContract, contract_to_json, load_tariff_contract
 from hisim.economics.timeline import Actor, CashFlowEntry, CashFlowTimeline, CostCategory, SubjectKind
 from hisim.economics.uncertainty import UncertainValue
 from hisim.loadtypes import ComponentType, Units
@@ -87,20 +87,6 @@ class SerializationFileNames:
     PROVENANCE_FILE_NAME = "cost_provenance.json"
 
 
-def _band_or_none(value: Optional[UncertainValue]) -> Any:
-    """Serializes an optional uncertainty band, preserving the None/zero distinction.
-
-    Every monetary override is optional, and "no override" is a different statement from "an
-    override of zero euro" — so None must survive as JSON null rather than collapsing to a band.
-    """
-    return value.to_json() if value is not None else None
-
-
-def _band_from(value: Any) -> Optional[UncertainValue]:
-    """The inverse of `_band_or_none`: JSON null stays None, anything else becomes a triplet."""
-    return UncertainValue.from_json(value) if value is not None else None
-
-
 def facts_to_json(facts: ComponentCostFacts) -> dict:
     """Serializes ComponentCostFacts.
 
@@ -116,11 +102,11 @@ def facts_to_json(facts: ComponentCostFacts) -> dict:
         "size_unit": facts.size_unit.name,
         "kpi_tag": facts.kpi_tag.value if facts.kpi_tag else None,
         "count": facts.count,
-        "investment_cost_override_in_euro": _band_or_none(facts.investment_cost_override_in_euro),
-        "installation_cost_override_in_euro": _band_or_none(facts.installation_cost_override_in_euro),
+        "investment_cost_override_in_euro": UncertainValue.optional_to_json(facts.investment_cost_override_in_euro),
+        "installation_cost_override_in_euro": UncertainValue.optional_to_json(facts.installation_cost_override_in_euro),
         "lifetime_override_in_years": facts.lifetime_override_in_years,
-        "maintenance_rate_override": _band_or_none(facts.maintenance_rate_override),
-        "fixed_operation_cost_override_in_euro_per_year": _band_or_none(
+        "maintenance_rate_override": UncertainValue.optional_to_json(facts.maintenance_rate_override),
+        "fixed_operation_cost_override_in_euro_per_year": UncertainValue.optional_to_json(
             facts.fixed_operation_cost_override_in_euro_per_year
         ),
         "embodied_co2_override_in_kg": facts.embodied_co2_override_in_kg,
@@ -147,11 +133,13 @@ def facts_from_json(raw: dict) -> ComponentCostFacts:
         size_unit=Units[raw["size_unit"]],
         kpi_tag=kpi_tag,
         count=raw.get("count", 1),
-        investment_cost_override_in_euro=_band_from(raw.get("investment_cost_override_in_euro")),
-        installation_cost_override_in_euro=_band_from(raw.get("installation_cost_override_in_euro")),
+        investment_cost_override_in_euro=UncertainValue.optional_from_json(raw.get("investment_cost_override_in_euro")),
+        installation_cost_override_in_euro=UncertainValue.optional_from_json(
+            raw.get("installation_cost_override_in_euro")
+        ),
         lifetime_override_in_years=raw.get("lifetime_override_in_years"),
-        maintenance_rate_override=_band_from(raw.get("maintenance_rate_override")),
-        fixed_operation_cost_override_in_euro_per_year=_band_from(
+        maintenance_rate_override=UncertainValue.optional_from_json(raw.get("maintenance_rate_override")),
+        fixed_operation_cost_override_in_euro_per_year=UncertainValue.optional_from_json(
             raw.get("fixed_operation_cost_override_in_euro_per_year")
         ),
         embodied_co2_override_in_kg=raw.get("embodied_co2_override_in_kg"),
@@ -218,7 +206,7 @@ def asset_to_json(asset: ExistingAsset) -> dict:
         "size": asset.size,
         "size_unit": asset.size_unit.name,
         "installation_year": asset.installation_year,
-        "replacement_cost_override_in_euro": _band_or_none(asset.replacement_cost_override_in_euro),
+        "replacement_cost_override_in_euro": UncertainValue.optional_to_json(asset.replacement_cost_override_in_euro),
         "is_functional": asset.is_functional,
         "energy_carrier": asset.energy_carrier.value if asset.energy_carrier else None,
         "replaced_by_asset_classes": [asset_class.name for asset_class in asset.replaced_by_asset_classes],
@@ -236,7 +224,9 @@ def asset_from_json(item: dict) -> ExistingAsset:
         size=item["size"],
         size_unit=Units[item["size_unit"]],
         installation_year=item["installation_year"],
-        replacement_cost_override_in_euro=_band_from(item.get("replacement_cost_override_in_euro")),
+        replacement_cost_override_in_euro=UncertainValue.optional_from_json(
+            item.get("replacement_cost_override_in_euro")
+        ),
         is_functional=item.get("is_functional", True),
         energy_carrier=EnergyCarrier(item["energy_carrier"]) if item.get("energy_carrier") else None,
         replaced_by_asset_classes=[ComponentType[name] for name in item.get("replaced_by_asset_classes", [])],
@@ -386,9 +376,17 @@ def contracts_from_json(raw: dict, tariffs_base_path: Optional[str] = None) -> D
     tariffs directory. In both forms, contracts generated from the §3.5 price entries are
     skipped: they are derived data that the evaluator regenerates at the price basis year, which
     keeps scenario price overlays effective.
-    """
-    from hisim.economics.tariffs import TariffContract, load_tariff_contract
 
+    How a generated contract is recognized differs between the two forms, and only because it has
+    to: an embedded contract declares itself through the typed ``is_default_contract`` flag, while
+    an id-only file offers nothing but the id — and a generated contract has no catalog file to
+    load and ask. `TariffContract.is_default_contract_id` therefore answers that from the id shape,
+    next to the code that mints it, instead of the substring split against a hardcoded pair of
+    countries this function used to do (which sent a generated contract for any third country to
+    the catalog loader, where it failed). An id that survives that check is loaded and its flag
+    tested too, so a default contract that *was* written to a file is still skipped by its own
+    declaration.
+    """
     contracts: Dict[EnergyCarrier, Any] = {}
     embedded = raw.get("tariff_contracts")
     if embedded:
@@ -399,9 +397,12 @@ def contracts_from_json(raw: dict, tariffs_base_path: Optional[str] = None) -> D
             contracts[EnergyCarrier(carrier_name)] = contract
         return contracts
     for carrier_name, contract_id in (raw.get("tariff_contract_ids") or {}).items():
-        if contract_id.split("_DEFAULT_")[0] in ("DE", "AT") and "_DEFAULT_" in contract_id:
-            continue  # default contracts are regenerated from the price entries
-        contracts[EnergyCarrier(carrier_name)] = load_tariff_contract(contract_id, tariffs_base_path)
+        if TariffContract.is_default_contract_id(contract_id):
+            continue  # never had a file; regenerated from the price entries at the basis year
+        contract = load_tariff_contract(contract_id, tariffs_base_path)
+        if contract.is_default_contract:
+            continue
+        contracts[EnergyCarrier(carrier_name)] = contract
     return contracts
 
 
@@ -643,8 +644,10 @@ def result_from_json(
         annual_cost_series_nominal_in_euro=[
             UncertainValue.from_json(value) for value in raw["annual_cost_series_nominal_in_euro"]
         ],
-        monthly_cost_year1_in_euro=_band_from(raw.get("monthly_cost_year1_in_euro")),
-        levelized_cost_of_heat_in_euro_per_kwh=_band_from(raw.get("levelized_cost_of_heat_in_euro_per_kwh")),
+        monthly_cost_year1_in_euro=UncertainValue.optional_from_json(raw.get("monthly_cost_year1_in_euro")),
+        levelized_cost_of_heat_in_euro_per_kwh=UncertainValue.optional_from_json(
+            raw.get("levelized_cost_of_heat_in_euro_per_kwh")
+        ),
         timeline=timeline if timeline is not None else CashFlowTimeline(),
         lifecycle_co2_result=LifecycleCo2Result(
             embodied_co2_in_kg=co2.get("embodied_co2_in_kg", 0.0),

--- a/hisim/economics/tariffs.py
+++ b/hisim/economics/tariffs.py
@@ -220,6 +220,10 @@ class TariffContract:
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "cost_database", "tariffs"
     )
 
+    #: Infix reserved for the ids of contracts synthesized from the §3.5 price entries. A catalog
+    #: file must not use it, or its contract would be mistaken for a synthesized one.
+    DEFAULT_ID_INFIX: ClassVar[str] = "_DEFAULT_"
+
     id: str  # equals the file name for catalog contracts
     carrier: EnergyCarrier
     country: str
@@ -232,6 +236,48 @@ class TariffContract:
     controllability_discount: ControllabilityDiscount = field(default_factory=ControllabilityDiscount)
     source_ids: Tuple[str, ...] = ()
     is_default_contract: bool = False  # generated from the §3.5 price entries
+
+    @classmethod
+    def default_contract_id(cls, country: str, carrier: EnergyCarrier, year: int) -> str:
+        """The id a contract synthesized from the §3.5 price entries carries.
+
+        The format lives here, next to the flag such a contract sets, because two unrelated places
+        need to agree on it: `calculators/energy.contract_from_price_entry`, which mints it, and
+        `serialization.contracts_from_json`, which has to recognize one in an archived file whose
+        contracts were stored as bare ids. That second reader used to re-derive the format from a
+        substring split and a hardcoded list of countries, so a synthesized contract for any third
+        country was looked up as a catalog file and failed.
+
+        Args:
+            country: Country code the price entries were read for.
+            carrier: The carrier the contract bills.
+            year: The price entry's year.
+
+        Returns:
+            The synthesized contract's id.
+        """
+        return f"{country}{cls.DEFAULT_ID_INFIX}{carrier.value}_{year}"
+
+    @classmethod
+    def is_default_contract_id(cls, contract_id: str) -> bool:
+        """Whether the id is one :meth:`default_contract_id` would mint.
+
+        Needed because a synthesized default contract has no catalog file — it is regenerated from
+        the price entries at the price basis year, which is what keeps scenario price overlays
+        effective — so a reader holding nothing but its id cannot load it and check
+        `is_default_contract`. The match is on the whole shape (country, the reserved infix, a real
+        carrier value, a numeric year) rather than on the infix alone, so a catalog contract that
+        happens to contain the word is not mistaken for a synthesized one.
+
+        Args:
+            contract_id: The id to classify.
+
+        Returns:
+            True if the id has the synthesized-default shape.
+        """
+        country, _, tail = contract_id.partition(cls.DEFAULT_ID_INFIX)
+        carrier_value, _, year = tail.rpartition("_")
+        return bool(country) and year.isdigit() and carrier_value in {member.value for member in EnergyCarrier}
 
     @classmethod
     def from_json(cls, raw: dict, registry: Optional[SourceRegistry] = None) -> "TariffContract":

--- a/hisim/economics/uncertainty.py
+++ b/hisim/economics/uncertainty.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, ClassVar, Iterable, Union
+from typing import Any, ClassVar, Iterable, Optional, Union
 
 
 class Slot(str, Enum):
@@ -159,6 +159,47 @@ class UncertainValue:
         if self.minimum == self.best_estimate == self.maximum:
             return self.best_estimate
         return {"min": self.minimum, "best_estimate": self.best_estimate, "max": self.maximum}
+
+    @staticmethod
+    def optional_to_json(value: Optional["UncertainValue"]) -> Any:
+        """Serializes an optional band, preserving the None/zero distinction.
+
+        Every monetary override and every audited unit price is optional, and "no value" is a
+        different statement from "a value of zero euro": the first means the run never resolved
+        one, the second means it resolved one and it was free. So `None` survives as JSON null
+        rather than collapsing to a zero band, which is what keeps an unresolved audit row
+        distinguishable from a zero-priced one after a round trip.
+
+        Lives on the type rather than as a private helper in each writer because both
+        `serialization.py` and `input_audit.py` need it and each had its own copy — two copies of
+        one rule that only stayed in agreement by luck.
+
+        Args:
+            value: The band to serialize, or None.
+
+        Returns:
+            What `to_json` returns for a band, or None.
+        """
+        return value.to_json() if value is not None else None
+
+    @staticmethod
+    def optional_from_json(value: Any) -> Optional["UncertainValue"]:
+        """The inverse of `optional_to_json`: JSON null stays None, anything else becomes a band.
+
+        Used by every loader of an optional monetary field, so a missing key and an explicit null
+        both come back as None while a number or a `{"min", "best_estimate", "max"}` object goes
+        through the ordinary `from_json` validation.
+
+        Args:
+            value: The parsed JSON value, or None for an absent or null field.
+
+        Returns:
+            The parsed band, or None.
+
+        Raises:
+            ValueError: If a non-null value is neither a number nor a well-formed band object.
+        """
+        return UncertainValue.from_json(value) if value is not None else None
 
     def is_exact(self) -> bool:
         """True when the band is degenerate (min = best_estimate = max).

--- a/tests/test_economics_adapter_contract.py
+++ b/tests/test_economics_adapter_contract.py
@@ -84,6 +84,11 @@ class AdapterContractScan:
     AUTO_SUBSTITUTES: Dict[str, Any] = {
         "GenericBoilerConfig.minimal_thermal_power_in_watt": 3000.0,
         "GenericBoilerConfig.maximal_thermal_power_in_watt": 12000.0,
+        # Only sizable on current main (the PR CI runs on the merge with main); the extractor
+        # never reads it, so any realized identity string exercises the sweep.
+        "PVSystemConfig.weather_identity": (
+            "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
+        ),
         "HeatDistributionConfig.heating_system": HeatDistributionSystemType.RADIATOR,
         "HeatDistributionConfig.water_mass_flow_rate_in_kg_per_second": 0.5,
         "HeatDistributionConfig.absolute_conditioned_floor_area_in_m2": 120.0,
@@ -192,7 +197,7 @@ class AdapterContractScan:
         return dataclasses.replace(config, **substitutes)
 
     @classmethod
-    def uninitialized(cls, component_class: type) -> Any:
+    def uninitialized(cls, component_class: Any) -> Any:
         """A bare instance of the component class carrying a default config, built without ``__init__``.
 
         ``get_meter_spec`` reads a component's class and, for the two meters whose carrier depends
@@ -202,7 +207,8 @@ class AdapterContractScan:
         attached when the class has one.
 
         Args:
-            component_class: The component class to instantiate.
+            component_class: The component class to instantiate. Typed ``Any`` because
+                ``type.__new__`` has no overload accepting an arbitrary class object.
 
         Returns:
             The bare instance, with ``config`` set when a default config could be built.

--- a/tests/test_economics_adapter_contract.py
+++ b/tests/test_economics_adapter_contract.py
@@ -1,0 +1,439 @@
+"""Contract tests over the class-name keyed cost adapter (``hisim/economics/adapter.py``).
+
+The adapter maps component classes to ``ComponentCostFacts`` through a table keyed by class
+*name*, which is what keeps ``hisim.economics`` importable without pulling in ``hisim.components``
+— at the price of no static checking whatsoever. A renamed component class, a renamed config field
+or a reshaped enum therefore used to drop a component out of every cost result without any
+complaint, which is exactly the silent omission §9.2 forbids. These tests are the missing static
+check: they resolve every table key against the classes actually defined in ``hisim.components``
+and run every extractor against the real default configs, so a rename fails here instead of
+quietly shrinking a lifecycle cost.
+
+The second half checks the adapter's failure semantics rather than its table: nothing may report
+"no facts" without a reason except a class that is both unknown to the adapter and undeclared, and
+relevance must be read off the class declaration only. Both are the "fail loudly" rule seen from
+the extraction side.
+
+A single module of ``hisim.components`` failing to import for lack of an optional third-party
+package must not shrink the scan, so those failures are tolerated — but a table key that cannot be
+resolved because its module refused to import fails, since an unresolvable key is precisely the
+defect these tests exist to find.
+"""
+
+# clean
+
+import dataclasses
+import importlib
+import inspect
+import pkgutil
+from types import SimpleNamespace
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import pytest
+
+from hisim.components.heat_distribution_system import HeatDistributionConfig, HeatDistributionSystemType
+from hisim.config import auto_fields, presets_of
+from hisim.economics.adapter import (
+    FactsExtractors,
+    _hds_facts,
+    effective_cost_relevance,
+    extract_cost_facts,
+)
+from hisim.economics.facts import ComponentCostFacts, CostRelevance
+from hisim.loadtypes import ComponentType
+
+
+class AdapterContractScan:
+    """The one scan of ``hisim.components`` these tests share, plus the config plumbing.
+
+    Importing every component module takes a moment and has import-time side effects, so it
+    happens once here and the resulting class-name index is handed to the individual tests. The
+    class also holds the two conventions the sweep needs: how a config class is found from its
+    component class (through ``get_main_classname``, which every ``ConfigBase`` subclass
+    implements) and how a config's still-unresolved ``AUTO`` fields are made concrete so that an
+    extractor's arithmetic can run.
+    """
+
+    #: Third-party packages HiSim does not require: a component module that imports one of them
+    #: may legitimately be missing from the scan on a machine without it. Anything else failing to
+    #: import is a defect, not an environment.
+    OPTIONAL_DEPENDENCIES: Tuple[str, ...] = ("wetterdienst",)
+
+    #: Instance name handed to a preset builder; deliberately unmistakable so a leak is obvious.
+    PROBE_NAME: str = "AdapterContractProbe"
+
+    #: A pre-preset default factory is a classmethod whose name contains this word. The older
+    #: config classes spell it ``get_default_<something>``, a few spell it
+    #: ``get_<something>_default_config``, so the infix is matched rather than a prefix.
+    FACTORY_INFIX: str = "default"
+
+    #: ``get_default_connections*`` is the component wiring API, not a config factory, and lives
+    #: on config classes too; it is excluded by this infix.
+    CONNECTION_INFIX: str = "connection"
+
+    #: Concrete stand-ins for the sizable fields that a preset leaves as ``AUTO``, keyed
+    #: ``"<ConfigClass>.<field>"``. A component can never be constructed from an unresolved
+    #: config, so ``AUTO`` is a pre-simulation state the adapter never sees in production; the
+    #: sweep substitutes real values instead of skipping, because reading the *right field* is
+    #: what is under test. An ``AUTO`` field with no entry here fails the sweep rather than being
+    #: ignored, so a newly sizable field has to be considered rather than silently dropped.
+    AUTO_SUBSTITUTES: Dict[str, Any] = {
+        "GenericBoilerConfig.minimal_thermal_power_in_watt": 3000.0,
+        "GenericBoilerConfig.maximal_thermal_power_in_watt": 12000.0,
+        "HeatDistributionConfig.heating_system": HeatDistributionSystemType.RADIATOR,
+        "HeatDistributionConfig.water_mass_flow_rate_in_kg_per_second": 0.5,
+        "HeatDistributionConfig.absolute_conditioned_floor_area_in_m2": 120.0,
+    }
+
+    @staticmethod
+    def collect() -> Tuple[Dict[str, List[type]], List[Tuple[str, str]]]:
+        """Indexes every class defined in an importable ``hisim.components`` module by its name.
+
+        Only classes whose ``__module__`` is the module being scanned are indexed, so a class
+        merely imported into a second module does not look like a duplicate definition.
+
+        Returns:
+            The class-name index (a name maps to every class defining it, so an ambiguous name is
+            visible) and ``(module, error)`` pairs for the modules that could not be imported.
+        """
+        import hisim.components as components_package  # pylint: disable=import-outside-toplevel
+
+        failures: List[Tuple[str, str]] = []
+        found: Dict[str, List[type]] = {}
+        for info in pkgutil.walk_packages(components_package.__path__, components_package.__name__ + "."):
+            try:
+                module = importlib.import_module(info.name)
+            except Exception as error:  # pylint: disable=broad-except
+                failures.append((info.name, f"{type(error).__name__}: {error}"))
+                continue
+            for _name, candidate in inspect.getmembers(module, inspect.isclass):
+                if candidate.__module__ == module.__name__:
+                    found.setdefault(candidate.__name__, []).append(candidate)
+        return found, failures
+
+    @staticmethod
+    def configs_of(component_class: type) -> List[type]:
+        """The config dataclasses in the component's own module that name it as their main class.
+
+        ``ConfigBase.get_main_classname`` returns the fully qualified name of the component the
+        config configures, which is the only machine-readable link from a component back to its
+        config; matching on its last segment finds the config without a naming convention.
+        """
+        module = importlib.import_module(component_class.__module__)
+        configs = []
+        for _name, candidate in inspect.getmembers(module, inspect.isclass):
+            if not dataclasses.is_dataclass(candidate) or candidate.__module__ != module.__name__:
+                continue
+            getter = getattr(candidate, "get_main_classname", None)
+            if getter is None:
+                continue
+            try:
+                main_class = str(getter())
+            except Exception:  # pylint: disable=broad-except
+                continue
+            if main_class.rsplit(".", 1)[-1] == component_class.__name__:
+                configs.append(candidate)
+        return configs
+
+    @classmethod
+    def factories_of(cls, config_class: type) -> Dict[str, Callable[[], Any]]:
+        """Every way of building a default instance of the config class, as zero-argument calls.
+
+        Two mechanisms coexist in the repository: the declared ``@preset`` builders, which take
+        only the instance name, and the older ``get_..default..`` classmethods. Both are collected
+        so that a class with several defaults — the two solar-thermal variants, the seven boiler
+        fuels — has each of them run through the extractor. A legacy factory that needs arguments
+        beyond its defaults is *not* silently dropped: it is returned as a factory too, and the
+        sweep reports the ``TypeError`` it raises.
+        """
+        factories: Dict[str, Callable[[], Any]] = {}
+        for name, builder in presets_of(config_class).items():
+            factories[f"preset {name}"] = lambda builder=builder: builder.build(cls.PROBE_NAME)
+        for name, member in inspect.getmembers(config_class, callable):
+            if not name.startswith("get_") or cls.FACTORY_INFIX not in name:
+                continue
+            if cls.CONNECTION_INFIX in name:
+                continue
+            factories[name] = lambda member=member: member()
+        return factories
+
+    @classmethod
+    def concrete(cls, config: Any) -> Any:
+        """Returns a copy of the config with its ``AUTO`` fields replaced by real values.
+
+        Args:
+            config: A freshly built config, possibly still carrying ``AUTO`` or a per-preset
+                sizing law in its sizable fields.
+
+        Returns:
+            The config itself when nothing needs sizing, otherwise a copy with substitutes from
+            :attr:`AUTO_SUBSTITUTES`.
+
+        Raises:
+            AssertionError: If a field needs sizing and has no substitute declared — a new
+                sizable field must be considered here rather than quietly leaving the sweep with
+                an unresolved config the extractor cannot read.
+        """
+        unresolved = auto_fields(config)
+        if not unresolved:
+            return config
+        substitutes = {}
+        for field_name in unresolved:
+            key = f"{type(config).__name__}.{field_name}"
+            assert key in cls.AUTO_SUBSTITUTES, (
+                f"{key} needs sizing but AdapterContractScan.AUTO_SUBSTITUTES has no concrete "
+                "value for it, so the cost extractor cannot be exercised against this config"
+            )
+            substitutes[field_name] = cls.AUTO_SUBSTITUTES[key]
+        return dataclasses.replace(config, **substitutes)
+
+
+class FakeComponents:
+    """Throwaway component stand-ins, one per adapter failure branch under test.
+
+    The adapter reads nothing but a component's class name, its ``config`` attribute, its optional
+    ``cost_relevance`` declaration and its optional hooks, so a two-attribute object is a faithful
+    stand-in and lets a test name a class after a real table key without importing (or breaking)
+    the real component.
+    """
+
+    @staticmethod
+    def named(class_name: str, config: Any, relevance: Optional[CostRelevance] = None) -> Any:
+        """Builds one stand-in instance with the given class name, config and declaration.
+
+        Args:
+            class_name: The name the adapter will look up in its table.
+            config: Whatever the extractor should be handed as ``component.config``.
+            relevance: The ``cost_relevance`` to declare on the class, or None to declare none at
+                all — which is what an unmigrated component looks like.
+        """
+        namespace: Dict[str, Any] = {
+            "__doc__": f"Test stand-in for a component class named {class_name!r}.",
+            "config": config,
+        }
+        if relevance is not None:
+            namespace["cost_relevance"] = relevance
+        return type(class_name, (), namespace)()
+
+
+@pytest.fixture(name="scan", scope="module")
+def fixture_scan() -> Tuple[Dict[str, List[type]], List[Tuple[str, str]]]:
+    """Runs the component scan once for the whole module."""
+    return AdapterContractScan.collect()
+
+
+@pytest.mark.base
+def test_every_component_module_imports(scan):
+    """No component module fails to import except for a missing optional dependency.
+
+    Failure mode caught: a module whose import breaks drops its classes out of the scan, so the
+    key-resolution sweep below would pass while covering less. A module needing a third-party
+    package HiSim does not require is tolerated, because its absence is an environment and not a
+    defect — but it is reported here rather than anywhere else.
+    """
+    _found, failures = scan
+    unexpected = [
+        f"{name}: {error}"
+        for name, error in failures
+        if not any(dependency in error for dependency in AdapterContractScan.OPTIONAL_DEPENDENCIES)
+    ]
+    assert unexpected == [], "component modules failed to import: " + "; ".join(unexpected)
+
+
+@pytest.mark.base
+def test_every_table_key_names_exactly_one_real_component_class(scan):
+    """Every key of ``FactsExtractors.BY_CLASS_NAME`` resolves to one class in hisim.components.
+
+    Failure mode caught: the whole point of the file. A key that matches no class — because the
+    component was renamed, moved out of ``hisim.components``, or was never spelled that way —
+    makes that component fall through to ``UNDECLARED`` and vanish from every cost result. A key
+    matching *two* classes is just as bad: whichever of them the simulation holds gets the other
+    one's asset class and size.
+
+    A key whose module failed to import fails here too, deliberately: the tolerance for optional
+    dependencies above cannot extend to a table entry nobody can check.
+    """
+    found, _failures = scan
+    problems = []
+    for key in FactsExtractors.BY_CLASS_NAME:
+        classes = found.get(key, [])
+        if len(classes) != 1:
+            where = ", ".join(f"{cls.__module__}.{cls.__name__}" for cls in classes) or "nothing"
+            problems.append(f"{key} -> {where}")
+    assert not problems, (
+        "cost adapter table keys that do not name exactly one class defined in hisim.components: "
+        + "; ".join(problems)
+    )
+
+
+@pytest.mark.base
+def test_the_scan_finds_the_component_classes_it_is_meant_to_check(scan):
+    """The scan really sees the classes involved, so the sweeps above and below are not vacuous.
+
+    Failure mode caught: a scan that quietly matches nothing — the key-resolution test would then
+    prove nothing, and the extractor sweep would run zero extractors.
+    """
+    found, _failures = scan
+    assert {"Battery", "GenericBoiler", "HeatDistribution", "DistrictHeating", "ElectricHeating"} <= set(found)
+
+
+@pytest.mark.base
+def test_every_extractor_reads_its_real_config_without_raising(scan):
+    """Each table extractor, run against every default config of its component, yields facts or None.
+
+    Failure mode caught: a config field that has been renamed. The extractors read fields by name
+    off an ``Any``-typed config, so ``config.connected_load_w`` against a config that now spells it
+    ``connected_load_in_w`` is invisible to mypy and to every other test; it surfaces only as a
+    component missing from a cost report. Running the real default configs through the real
+    extractors makes that a test failure at the moment of the rename.
+
+    ``None`` is an accepted answer, since it legitimately means "registered but not priceable in
+    this configuration" (an unmapped boiler fuel, a low-temperature radiator); the adapter turns
+    it into an unresolved reason rather than a silent drop, which is checked separately.
+    """
+    found, _failures = scan
+    problems = []
+    for key, extractor in FactsExtractors.BY_CLASS_NAME.items():
+        classes = found.get(key, [])
+        if len(classes) != 1:
+            continue  # already reported by the key-resolution test; nothing to build a config from
+        configs = AdapterContractScan.configs_of(classes[0])
+        if not configs:
+            problems.append(f"{key}: no config class in {classes[0].__module__} names it as its main class")
+            continue
+        for config_class in configs:
+            factories = AdapterContractScan.factories_of(config_class)
+            if not factories:
+                problems.append(f"{key}: {config_class.__name__} offers no default config to test the extractor on")
+                continue
+            for factory_name, factory in factories.items():
+                try:
+                    config = AdapterContractScan.concrete(factory())
+                except AssertionError:
+                    raise
+                except Exception as error:  # pylint: disable=broad-except
+                    problems.append(
+                        f"{key}: {config_class.__name__}.{factory_name} did not build: "
+                        f"{type(error).__name__}: {error}"
+                    )
+                    continue
+                try:
+                    facts = extractor(config)
+                except Exception as error:  # pylint: disable=broad-except
+                    problems.append(
+                        f"{key}: extractor raised on {config_class.__name__}.{factory_name}: "
+                        f"{type(error).__name__}: {error}"
+                    )
+                    continue
+                assert facts is None or isinstance(facts, ComponentCostFacts), (
+                    f"{key}: extractor returned a {type(facts).__name__} for "
+                    f"{config_class.__name__}.{factory_name}"
+                )
+    assert not problems, "cost adapter extractors disagree with their configs: " + "; ".join(problems)
+
+
+@pytest.mark.base
+def test_the_heat_distribution_extractor_matches_the_real_emitter_types():
+    """``_hds_facts`` prices floor heating and radiators and declines low-temperature radiators.
+
+    Failure mode caught: the emitter match drifting away from ``HeatDistributionSystemType``. The
+    enum has been a string enum whose values equal its member names since the string-valued-enum
+    cutover, so a match written against numeric values or title-cased spellings can never succeed
+    and every real heat distribution system becomes unpriceable. Asserting against the real enum
+    members ties the extractor to the type it reads.
+    """
+    base = AdapterContractScan.concrete(HeatDistributionConfig.preset_standard(AdapterContractScan.PROBE_NAME))
+
+    floor_heating = _hds_facts(dataclasses.replace(base, heating_system=HeatDistributionSystemType.FLOORHEATING))
+    assert floor_heating is not None
+    assert floor_heating.asset_class == ComponentType.HEAT_DISTRIBUTION_SYSTEM_FLOORHEATING
+    assert floor_heating.size == base.absolute_conditioned_floor_area_in_m2
+
+    radiator = _hds_facts(dataclasses.replace(base, heating_system=HeatDistributionSystemType.RADIATOR))
+    assert radiator is not None
+    assert radiator.asset_class == ComponentType.HEAT_DISTRIBUTION_SYSTEM_RADIATOR
+    assert radiator.size == base.absolute_conditioned_floor_area_in_m2
+
+    # No cost database entry for this one yet; None is the honest answer and becomes an
+    # unresolved reason one level up rather than a dropped component.
+    low_temperature = dataclasses.replace(
+        base, heating_system=HeatDistributionSystemType.LOW_TEMPERATURE_RADIATOR
+    )
+    assert _hds_facts(low_temperature) is None
+
+
+@pytest.mark.base
+def test_a_broken_extractor_reports_a_reason_instead_of_no_facts():
+    """An extractor that trips over a missing config field comes back unresolved, not empty.
+
+    Failure mode caught: the extraction accident being swallowed. Returning an empty
+    ``FactsExtraction`` made a renamed config field indistinguishable from an unknown component
+    class, so the bridge had no way to tell "nothing to price here" from "this device just lost
+    its price", and a log warning was the only trace.
+    """
+    component = FakeComponents.named("Battery", SimpleNamespace())
+    extraction = extract_cost_facts(component)
+    assert extraction.facts is None
+    assert extraction.unresolved_reason is not None
+    assert "Battery" in extraction.unresolved_reason
+    assert "AttributeError" in extraction.unresolved_reason
+
+
+@pytest.mark.base
+def test_a_declared_priced_class_without_hook_or_table_entry_reports_a_reason():
+    """A class declaring PRICED that nothing can describe is unresolved, not free of cost.
+
+    Failure mode caught: a component author declaring ``cost_relevance = PRICED``, forgetting
+    ``get_cost_facts()`` and getting no complaint — the exact omission §9.2 exists to prevent,
+    reintroduced by the empty extraction the adapter used to return for an unknown class.
+    """
+    component = FakeComponents.named(
+        "ComponentTheAdapterHasNeverHeardOf", SimpleNamespace(), CostRelevance.PRICED
+    )
+    extraction = extract_cost_facts(component)
+    assert extraction.facts is None
+    assert extraction.unresolved_reason is not None
+    assert "ComponentTheAdapterHasNeverHeardOf" in extraction.unresolved_reason
+    assert "PRICED" in extraction.unresolved_reason
+
+
+@pytest.mark.base
+def test_an_unknown_undeclared_class_still_extracts_to_nothing_at_all():
+    """A class the adapter does not know and that declares nothing yields neither facts nor reason.
+
+    Failure mode caught: over-correcting the two tests above into a blanket failure. The bridge
+    rejects an ``UNDECLARED`` component on its declaration *before* asking for facts, so this path
+    must stay quiet — otherwise every controller and every idealized device would produce a reason
+    the bridge would then have to filter out again.
+    """
+    extraction = extract_cost_facts(FakeComponents.named("SomeUnmigratedController", SimpleNamespace()))
+    assert extraction.facts is None
+    assert extraction.unresolved_reason is None
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("class_name", ["Battery", "ElectricityMeter", "FuelMeter"])
+def test_relevance_is_never_inferred_from_the_adapter_tables(class_name):
+    """An undeclared class stays UNDECLARED even when its name is in the adapter's own tables.
+
+    Failure mode caught: the migration-era inference coming back. Reading ``PRICED`` out of
+    ``BY_CLASS_NAME`` and ``METER`` out of ``get_meter_spec`` produced a plausible answer for a
+    component nobody had classified, which hid both the missing declaration and — because the
+    tables are keyed by class name — an entry whose key no longer matches any class. Declaration
+    is now the only source.
+    """
+    component = FakeComponents.named(class_name, SimpleNamespace())
+    assert effective_cost_relevance(component) == CostRelevance.UNDECLARED
+
+
+@pytest.mark.base
+def test_a_declared_relevance_is_reported_verbatim():
+    """``effective_cost_relevance`` hands back exactly what the class declared.
+
+    Failure mode caught: the reporting side of the same function regressing while the inference
+    was removed — a declaration that is read but then overridden would be worse than no
+    declaration at all.
+    """
+    for relevance in CostRelevance:
+        component = FakeComponents.named("SomeDeclaredComponent", SimpleNamespace(), relevance)
+        assert effective_cost_relevance(component) == relevance

--- a/tests/test_economics_adapter_contract.py
+++ b/tests/test_economics_adapter_contract.py
@@ -35,10 +35,14 @@ from hisim.components.heat_distribution_system import HeatDistributionConfig, He
 from hisim.config import auto_fields, presets_of
 from hisim.economics.adapter import (
     FactsExtractors,
+    MeterOutputContracts,
     _hds_facts,
     effective_cost_relevance,
     extract_cost_facts,
+    get_meter_spec,
 )
+from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.database import CostDataError
 from hisim.economics.facts import ComponentCostFacts, CostRelevance
 from hisim.loadtypes import ComponentType
 
@@ -187,6 +191,32 @@ class AdapterContractScan:
             substitutes[field_name] = cls.AUTO_SUBSTITUTES[key]
         return dataclasses.replace(config, **substitutes)
 
+    @classmethod
+    def uninitialized(cls, component_class: type) -> Any:
+        """A bare instance of the component class carrying a default config, built without ``__init__``.
+
+        ``get_meter_spec`` reads a component's class and, for the two meters whose carrier depends
+        on a configured load type, its ``config``. Constructing a real meter would need a
+        simulator, a `SimulationParameters` and wired inputs, so the sweep hands it the least
+        object the function can read: an instance created through ``__new__`` with a default config
+        attached when the class has one.
+
+        Args:
+            component_class: The component class to instantiate.
+
+        Returns:
+            The bare instance, with ``config`` set when a default config could be built.
+        """
+        instance = component_class.__new__(component_class)
+        for config_class in cls.configs_of(component_class):
+            for factory in cls.factories_of(config_class).values():
+                try:
+                    instance.config = cls.concrete(factory())
+                except Exception:  # pylint: disable=broad-except
+                    continue
+                return instance
+        return instance
+
 
 class FakeComponents:
     """Throwaway component stand-ins, one per adapter failure branch under test.
@@ -330,6 +360,103 @@ def test_every_extractor_reads_its_real_config_without_raising(scan):
                     f"{config_class.__name__}.{factory_name}"
                 )
     assert not problems, "cost adapter extractors disagree with their configs: " + "; ".join(problems)
+
+
+class MeterSpecExpectations:
+    """The carrier each mapped meter bills when configured the way its default config configures it.
+
+    Pinned here rather than derived, because "which carrier does this meter's reading get billed
+    at" is the one decision in a `MeterSpec` that no class constant states: it comes from a load
+    type in the config (gas or hydrogen, oil or pellets) or from the meter's identity. A silent
+    change of it would price a metered kWh from the wrong price series.
+    """
+
+    CARRIER_BY_CLASS_NAME: Dict[str, EnergyCarrier] = {
+        "ElectricityMeter": EnergyCarrier.ELECTRICITY,
+        "GasMeter": EnergyCarrier.NATURAL_GAS,
+        "FuelMeter": EnergyCarrier.HEATING_OIL,
+        "HeatingMeter": EnergyCarrier.DISTRICT_HEATING,
+    }
+
+
+@pytest.mark.base
+def test_the_meter_expectations_cover_the_whole_meter_table():
+    """Every mapped meter class has a pinned carrier, so the sweep below cannot skip one.
+
+    Failure mode caught: a meter added to ``MeterOutputContracts`` and not to the expectations,
+    which would make the sweep pass over the very entry that was just added.
+    """
+    assert set(MeterSpecExpectations.CARRIER_BY_CLASS_NAME) == set(MeterOutputContracts.BY_CLASS_NAME)
+
+
+@pytest.mark.base
+def test_every_meter_spec_names_the_columns_its_meter_class_declares(scan):
+    """``get_meter_spec`` resolves each mapped meter's columns off the real class's own constants.
+
+    Failure mode caught: the one this whole file exists for, on the energy side. The billable
+    output columns used to be duplicated into the adapter as string literals, so renaming
+    ``ElectricityMeter.ElectricityFromGrid`` moved the column and left the engine reading a name
+    nothing wrote — an empty series, a carrier billed at zero, and no error anywhere. The adapter
+    now reads the constants off the class, and this test runs that resolution against the real
+    classes: a renamed or deleted constant fails here, and so does a table key that no longer
+    names exactly one class.
+
+    The carrier is checked too, against `MeterSpecExpectations`, because it is derived from config
+    load types rather than from a class constant and nothing else would notice it moving.
+    """
+    found, _failures = scan
+    problems = []
+    for class_name, contract in MeterOutputContracts.BY_CLASS_NAME.items():
+        classes = found.get(class_name, [])
+        if len(classes) != 1:
+            where = ", ".join(f"{cls.__module__}.{cls.__name__}" for cls in classes) or "nothing"
+            problems.append(f"{class_name} -> {where}")
+            continue
+        meter_class = classes[0]
+        try:
+            spec = get_meter_spec(AdapterContractScan.uninitialized(meter_class))
+        except Exception as error:  # pylint: disable=broad-except
+            problems.append(f"{class_name}: get_meter_spec raised {type(error).__name__}: {error}")
+            continue
+        assert spec is not None, f"{class_name} is a key of the meter table but yields no MeterSpec"
+        expected_carrier = MeterSpecExpectations.CARRIER_BY_CLASS_NAME[class_name]
+        if spec.carrier != expected_carrier:
+            problems.append(f"{class_name}: bills {spec.carrier} where {expected_carrier} is expected")
+        for spec_field, constant_name in (
+            ("bought_field", contract.bought_constant),
+            ("sold_field", contract.sold_constant),
+            ("power_field", contract.power_constant),
+        ):
+            resolved = getattr(spec, spec_field)
+            if constant_name is None:
+                if resolved is not None:
+                    problems.append(
+                        f"{class_name}.{spec_field} is {resolved!r} although the table declares no constant"
+                    )
+                continue
+            declared = getattr(meter_class, constant_name, None)
+            if resolved != declared:
+                problems.append(
+                    f"{class_name}.{spec_field} reads {resolved!r}, but "
+                    f"{meter_class.__name__}.{constant_name} is {declared!r}"
+                )
+    assert not problems, "cost adapter meter specs disagree with their meter classes: " + "; ".join(problems)
+
+
+@pytest.mark.base
+def test_a_meter_without_its_output_constant_refuses_instead_of_billing_a_stale_column():
+    """A meter class missing a declared output constant raises, naming the class and the constant.
+
+    Failure mode caught: the runtime lookup degrading back into a silent one. Falling back to a
+    literal, or to None, would bill the carrier from a column nothing writes; the raised
+    ``CostDataError`` is what ``bridge.py`` turns into an unresolved subject and hence into a D7
+    abort of the whole evaluation.
+    """
+    stand_in = FakeComponents.named("ElectricityMeter", SimpleNamespace())
+    with pytest.raises(CostDataError) as raised:
+        get_meter_spec(stand_in)
+    assert "ElectricityMeter" in str(raised.value)
+    assert "ElectricityFromGrid" in str(raised.value)
 
 
 @pytest.mark.base


### PR DESCRIPTION
# PR 5/8 — Cost module stack: serialization, component adapter, CLI

- **Branch:** `cost/05-io-cli` (`aa12239e`)
- **Base:** `cost/04-engine` (`d0bf105f`)
- **Files:** 5 · **Tests:** 307 passed (no *new* test file here — see below)

## What this is

Everything that moves engine results across a process boundary. No new economics behaviour —
this slice is about file formats.

- **`serialization.py`** (§3.8) — the JSON round trip of the evaluator's inputs and results, so a
  run can be re-priced later without re-simulating.
- **`exports.py`** — the result files themselves (`lifecycle_costs.json`,
  `cash_flow_timeline.csv`) and the lifecycle KPI entries, so the KPI table and
  `lifecycle_kpis.json` cannot disagree.
- **`input_audit.py`** (W4.6) — the typed "which input came from where" rows. The module that
  *fills* them from the cost database is `audit.py` in PR 7.
- **`adapter.py`** (§3.4) — maps a HiSim component's config to `ComponentCostFacts`. Read-only
  towards the components; the components themselves are not touched until PR 8.
- **`__main__.py`** — the `python -m hisim.economics` CLI: `evaluate` / `explain` / `report` /
  `validate`.

## Placement note

`exports.py` and `input_audit.py` were originally grouped with the presentation PR, but
`serialization.py` imports `exports` at module level and `__main__.py` imports `input_audit` at
module level — so they sit *below* the presentation layer, not in it. They are byte-identical to
`new_cost_module`; only their PR assignment moved.

## Known gap in this slice

The CLI's `report` and `explain --audit` paths import `reporting` / `report_plots` / `audit`
lazily, inside the subcommand handlers. Those modules arrive in **PR 7**, so on this branch:

- `python -m hisim.economics validate` works — **verified: 0 errors, 0 warnings**
- `python -m hisim.economics evaluate` works
- `python -m hisim.economics report` raises `ImportError`

That is the existing lazy-import structure of the file (the usual pattern for deferring
matplotlib), not something introduced by the split. It closes in PR 7.

## Review guide

**The JSON schemas in `serialization.py` are the compatibility surface of this whole module.**
Once results are stored in the field, changing these shapes breaks the ability to re-price old
runs. Review them as you would a public API: are the field names ones you want to live with, are
optional fields genuinely optional, and does the round trip lose anything (bands, provenance ids,
subsidy decision trails)?

**`exports.py` and the KPI consistency claim.** The reason `build_lifecycle_kpi_entries` lives
here rather than in the report is so the KPI table and `lifecycle_kpis.json` are produced from one
source. Check that PR 7's report really consumes this and does not build a parallel table.

**`adapter.py`** is the seam between HiSim components and the cost engine. Ask whether it fails
loudly on a component it does not understand, or silently returns nothing — the latter would mean
a component silently priced at zero.

### Spec sections
§3.4 (facts), §3.8 (serialization), §3.10 (provenance) of `cost_spec.md`; W4.6 of
`roadmap/cost-spec-v2.md`.

### Test coverage — read it in PR 8

**This PR ships no test file of its own.** `tests/test_economics_data_and_integration.py` covers
serialization, exports and the CLI (49 tests), but it also asserts the cost-fact contract of the
four components adopted in PR 8 and calls the parity harness in `audit.py` from PR 7 — so it can
only pass once both have landed, and is committed with **PR 8**.

The classes covering this diff are `TestSerializationRoundtrip` (round trips, contracts, subsidy
context) and `TestCliAndExports` (the CLI and the export files). The 307 tests of PRs 1–4 still
pass on this branch.

## Push

```bash
git push origin cost/05-io-cli

gh pr create --base cost/04-engine --head cost/05-io-cli \
  --title "Cost module stack 5/8: serialization, component adapter, CLI" \
  --body-file roadmap/pr_descriptions/05-io-cli.md
```
