### PR TITLE
fix main quality

### DIFF
--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -6,10 +6,10 @@ import datetime
 import math
 import os
 from dataclasses import dataclass
-from dataclasses_json import dataclass_json
 from enum import Enum, unique
 from typing import Any, List, Optional, Union
 
+from dataclasses_json import dataclass_json
 import numpy as np
 import pandas as pd
 import pvlib

--- a/hisim/economics/database.py
+++ b/hisim/economics/database.py
@@ -469,7 +469,7 @@ class CostDatabase:
     CONVERTED_PRICE_FIELDS = ("working_price_in_euro_per_kwh", "emission_factor_in_kg_per_kwh")
 
     def energy_content_of(self, entry: EnergyPriceEntry) -> Optional[EnergyContent]:
-        """kWh per native billing unit of a fuel-quoted row; None for a row already quoted per kWh.
+        """Give the kWh per native billing unit of a fuel-quoted row, or None if already per kWh.
 
         The lookup behind decision D26. Heating values come from exactly one place —
         `components.configuration.PhysicsConfig`, the same lower heating values the boilers and
@@ -508,8 +508,8 @@ class CostDatabase:
             )
         # Deferred, both of them: see the docstring — §10.0 rule 1 keeps `hisim.economics`
         # importable without `hisim.components`.
-        from hisim import loadtypes as lt
-        from hisim.components.configuration import PhysicsConfig
+        from hisim import loadtypes as lt  # pylint: disable=import-outside-toplevel
+        from hisim.components.configuration import PhysicsConfig  # pylint: disable=import-outside-toplevel
 
         load_types_by_carrier = {
             EnergyCarrier.HEATING_OIL: lt.LoadTypes.OIL,
@@ -667,11 +667,11 @@ class CostDatabase:
         ledger: ProvenanceLedger,
         fields: Sequence[str],
     ) -> ResolvedPriceEntry:
-        """The §3.5 energy price entry and its provenance in one step — see
-        :meth:`resolve_device_entry`.
+        """Return the §3.5 energy price entry and its provenance in one step.
 
-        The energy half of the W2.1 resolved-entry contract. `calculators/energy.py` calls it once
-        per carrier, naming the fields it is about to bill from (working price, standing charge,
+        The counterpart of :meth:`resolve_device_entry`, and the energy half of the W2.1
+        resolved-entry contract. `calculators/energy.py` calls it once per carrier,
+        naming the fields it is about to bill from (working price, standing charge,
         emission factor, …), so every component of an energy bill can later be traced back to the
         row and the citation it came from (§3.10).
 
@@ -832,7 +832,9 @@ class CostDatabase:
         for path, value in overlays.items():
             if value is None:
                 continue
-            clone._apply_overlay(path, value, scenario_id)
+            # `clone` is a copy of `self`, i.e. the very class this method belongs to, so the
+            # protected call is internal; pylint only sees an access on a foreign name.
+            clone._apply_overlay(path, value, scenario_id)  # pylint: disable=protected-access
         return clone
 
     def _apply_overlay(self, path: str, value: Any, scenario_id: str) -> None:

--- a/hisim/json_generator.py
+++ b/hisim/json_generator.py
@@ -62,6 +62,29 @@ class Scenario(BaseModel):
     connections: dict[str, Any] | list[Any] | None = None
 
 
+def count_outputs_created_by_constructor(component: L2GenericEnergyManagementSystem) -> int:
+    """Count the outputs the EMS builds for itself, before any system setup adds more.
+
+    The EMS creates dynamic outputs from inside its own ``__init__``, one per
+    ``get_default_connections_from_*`` helper. Those must not be written to the scenario
+    JSON, because the JSON executor instantiates the component the same way and would end
+    up with each of them twice. Outputs a system setup appended afterwards must be written,
+    and they are exactly the ones whose ``OutputN`` index runs past this count.
+
+    The count is measured rather than assumed: a pristine instance of the same class is
+    built from the same config and its outputs are counted. ``Component.__init__`` only
+    populates the instance -- it registers nothing globally -- so the throwaway instance is
+    free of side effects. Hard-coding the number instead silently rotted once already, when
+    retiring the modular DHW heat pump removed one of the EMS helpers and shifted every
+    setup-added output down by one index.
+    """
+    pristine_instance = type(component)(
+        my_simulation_parameters=component.my_simulation_parameters,
+        config=component.ems_config,
+    )
+    return len(pristine_instance.outputs)
+
+
 # Adapted from old json_generator.py
 def convert_component_to_json(config: ConfigBase, component: cp.Component) -> Tuple[Component, list[Any], list[Any]]:
     """Converts a component to a JSON-compatible dictionary."""
@@ -85,6 +108,12 @@ def convert_component_to_json(config: ConfigBase, component: cp.Component) -> Tu
 
     outs = []
     ins = []
+    # Used by the EMS special case inside the output loop below; see the comment there.
+    number_of_outputs_built_by_constructor = (
+        count_outputs_created_by_constructor(component)
+        if isinstance(component, L2GenericEnergyManagementSystem)
+        else 0
+    )
     for out in component.outputs:
         if isinstance(component, DynamicComponent):
             output_matches = [
@@ -100,10 +129,15 @@ def convert_component_to_json(config: ConfigBase, component: cp.Component) -> Tu
                 match = re.search(r"Output(\d+)$", out.field_name)
                 number = int(match.group(1)) if match else 100
 
-                # Handle special case for EMS
-                # For both cases, exactly 15 outputs are added during construction of the component
+                # Handle special case for EMS: its constructor already builds a batch of
+                # dynamic outputs (one per `get_default_connections_from_*` helper), and the
+                # JSON executor gets those back for free when it instantiates the component.
+                # Re-declaring them here would duplicate them, so only the outputs a system
+                # setup added on top of the constructor's belong in the file. The cut-off is
+                # read off a pristine instance instead of hard-coded, because it shifts
+                # whenever a default-connection helper is added or retired.
                 if isinstance(component, L2GenericEnergyManagementSystem):
-                    if number < 16:
+                    if number <= number_of_outputs_built_by_constructor:
                         continue
 
                 # add_component_output has been used

--- a/system_setups/automatic_default_connections.scenario.json
+++ b/system_setups/automatic_default_connections.scenario.json
@@ -192,7 +192,7 @@
                 "set_cooling_threshold_outside_temperature_in_celsius": 20.0,
                 "upper_temperature_offset_for_state_conditions_in_celsius": 5.0,
                 "lower_temperature_offset_for_state_conditions_in_celsius": 5.0,
-                "heat_distribution_system_type": 2
+                "heat_distribution_system_type": "FLOORHEATING"
             },
             "config_full_classname": "hisim.components.more_advanced_heat_pump_hplib.MoreAdvancedHeatPumpHPLibControllerSpaceHeatingConfig",
             "inputs": [],

--- a/system_setups/dynamic_components.scenario.json
+++ b/system_setups/dynamic_components.scenario.json
@@ -336,7 +336,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "ElectricityTargetOutput16"
+                "field_name": "ElectricityTargetOutput15"
             },
             "target": {
                 "component_name": "Battery1",
@@ -346,7 +346,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "ElectricityTargetOutput17"
+                "field_name": "ElectricityTargetOutput16"
             },
             "target": {
                 "component_name": "Battery2",
@@ -356,7 +356,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "ElectricityTargetOutput18"
+                "field_name": "ElectricityTargetOutput17"
             },
             "target": {
                 "component_name": "CHP1",
@@ -366,7 +366,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "ElectricityTargetOutput19"
+                "field_name": "ElectricityTargetOutput18"
             },
             "target": {
                 "component_name": "CHP2",

--- a/system_setups/household_district_heating_building_sizer.scenario.json
+++ b/system_setups/household_district_heating_building_sizer.scenario.json
@@ -250,7 +250,7 @@
                     "dynamic": true,
                     "source_component_output": "ThermalOutputDhwEnergy",
                     "source_object_name": "DistrictHeating",
-                    "source_load_type": "Heating",
+                    "source_load_type": "WarmWater",
                     "source_unit": "Wh",
                     "source_tags": [
                         "HEAT_CONSUMPTION"
@@ -419,7 +419,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "LoadingPowerInputForBattery_Output16"
+                "field_name": "LoadingPowerInputForBattery_Output15"
             },
             "target": {
                 "component_name": "Battery",

--- a/system_setups/household_electric_heating_building_sizer.scenario.json
+++ b/system_setups/household_electric_heating_building_sizer.scenario.json
@@ -350,7 +350,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "LoadingPowerInputForBattery_Output16"
+                "field_name": "LoadingPowerInputForBattery_Output15"
             },
             "target": {
                 "component_name": "Battery",

--- a/system_setups/household_gas_building_sizer.scenario.json
+++ b/system_setups/household_gas_building_sizer.scenario.json
@@ -455,7 +455,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "LoadingPowerInputForBattery_Output16"
+                "field_name": "LoadingPowerInputForBattery_Output15"
             },
             "target": {
                 "component_name": "Battery",

--- a/system_setups/household_gas_solar_thermal_building_sizer.scenario.json
+++ b/system_setups/household_gas_solar_thermal_building_sizer.scenario.json
@@ -558,7 +558,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "LoadingPowerInputForBattery_Output16"
+                "field_name": "LoadingPowerInputForBattery_Output15"
             },
             "target": {
                 "component_name": "Battery",

--- a/system_setups/household_heatpump_building_sizer.scenario.json
+++ b/system_setups/household_heatpump_building_sizer.scenario.json
@@ -163,7 +163,7 @@
                 "set_cooling_threshold_outside_temperature_in_celsius": 20.0,
                 "upper_temperature_offset_for_state_conditions_in_celsius": 5.0,
                 "lower_temperature_offset_for_state_conditions_in_celsius": 5.0,
-                "heat_distribution_system_type": 2
+                "heat_distribution_system_type": "FLOORHEATING"
             },
             "config_full_classname": "hisim.components.more_advanced_heat_pump_hplib.MoreAdvancedHeatPumpHPLibControllerSpaceHeatingConfig",
             "inputs": [],
@@ -447,7 +447,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "LoadingPowerInputForBattery_Output16"
+                "field_name": "LoadingPowerInputForBattery_Output15"
             },
             "target": {
                 "component_name": "Battery",

--- a/system_setups/household_heatpump_car_building_sizer.scenario.json
+++ b/system_setups/household_heatpump_car_building_sizer.scenario.json
@@ -165,7 +165,7 @@
                 "set_cooling_threshold_outside_temperature_in_celsius": 20.0,
                 "upper_temperature_offset_for_state_conditions_in_celsius": 5.0,
                 "lower_temperature_offset_for_state_conditions_in_celsius": 5.0,
-                "heat_distribution_system_type": 2
+                "heat_distribution_system_type": "FLOORHEATING"
             },
             "config_full_classname": "hisim.components.more_advanced_heat_pump_hplib.MoreAdvancedHeatPumpHPLibControllerSpaceHeatingConfig",
             "inputs": [],
@@ -526,7 +526,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "ElectricityToOrFromGridOfL1Controller_Output16"
+                "field_name": "ElectricityToOrFromGridOfL1Controller_Output15"
             },
             "target": {
                 "component_name": "L1EVChargeControl_1",
@@ -546,7 +546,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "ChargingPowerForBattery_Output17"
+                "field_name": "ChargingPowerForBattery_Output16"
             },
             "target": {
                 "component_name": "Battery",

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.scenario.json
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.scenario.json
@@ -453,7 +453,7 @@
                 "set_cooling_threshold_outside_temperature_in_celsius": 20.0,
                 "upper_temperature_offset_for_state_conditions_in_celsius": 5.0,
                 "lower_temperature_offset_for_state_conditions_in_celsius": 5.0,
-                "heat_distribution_system_type": 2
+                "heat_distribution_system_type": "FLOORHEATING"
             },
             "config_full_classname": "hisim.components.more_advanced_heat_pump_hplib.MoreAdvancedHeatPumpHPLibControllerSpaceHeatingConfig",
             "inputs": [],
@@ -550,7 +550,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "LoadingPowerInputForBattery_Output16"
+                "field_name": "LoadingPowerInputForBattery_Output15"
             },
             "target": {
                 "component_name": "Battery",

--- a/system_setups/household_hydrogen_boiler_building_sizer.scenario.json
+++ b/system_setups/household_hydrogen_boiler_building_sizer.scenario.json
@@ -455,7 +455,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "LoadingPowerInputForBattery_Output16"
+                "field_name": "LoadingPowerInputForBattery_Output15"
             },
             "target": {
                 "component_name": "Battery",

--- a/system_setups/household_oil_building_sizer.scenario.json
+++ b/system_setups/household_oil_building_sizer.scenario.json
@@ -271,7 +271,7 @@
                     "dynamic": true,
                     "source_component_output": "EnergyDemandSh",
                     "source_object_name": "ConventionalOilBoiler",
-                    "source_load_type": "Heating",
+                    "source_load_type": "Any",
                     "source_unit": "Wh",
                     "source_tags": [
                         "HEAT_CONSUMPTION"
@@ -282,7 +282,7 @@
                     "dynamic": true,
                     "source_component_output": "EnergyDemandDhw",
                     "source_object_name": "ConventionalOilBoiler",
-                    "source_load_type": "Heating",
+                    "source_load_type": "Any",
                     "source_unit": "Wh",
                     "source_tags": [
                         "HEAT_CONSUMPTION"
@@ -451,7 +451,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "LoadingPowerInputForBattery_Output16"
+                "field_name": "LoadingPowerInputForBattery_Output15"
             },
             "target": {
                 "component_name": "Battery",

--- a/system_setups/household_pellets_building_sizer.scenario.json
+++ b/system_setups/household_pellets_building_sizer.scenario.json
@@ -271,7 +271,7 @@
                     "dynamic": true,
                     "source_component_output": "EnergyDemandSh",
                     "source_object_name": "ConventionalPelletBoiler",
-                    "source_load_type": "Heating",
+                    "source_load_type": "Any",
                     "source_unit": "Wh",
                     "source_tags": [
                         "HEAT_CONSUMPTION"
@@ -282,7 +282,7 @@
                     "dynamic": true,
                     "source_component_output": "EnergyDemandDhw",
                     "source_object_name": "ConventionalPelletBoiler",
-                    "source_load_type": "Heating",
+                    "source_load_type": "Any",
                     "source_unit": "Wh",
                     "source_tags": [
                         "HEAT_CONSUMPTION"
@@ -451,7 +451,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "LoadingPowerInputForBattery_Output16"
+                "field_name": "LoadingPowerInputForBattery_Output15"
             },
             "target": {
                 "component_name": "Battery",

--- a/system_setups/household_wood_chips_building_sizer.scenario.json
+++ b/system_setups/household_wood_chips_building_sizer.scenario.json
@@ -271,7 +271,7 @@
                     "dynamic": true,
                     "source_component_output": "EnergyDemandSh",
                     "source_object_name": "ConventionalWoodChipBoiler",
-                    "source_load_type": "Heating",
+                    "source_load_type": "Any",
                     "source_unit": "Wh",
                     "source_tags": [
                         "HEAT_CONSUMPTION"
@@ -282,7 +282,7 @@
                     "dynamic": true,
                     "source_component_output": "EnergyDemandDhw",
                     "source_object_name": "ConventionalWoodChipBoiler",
-                    "source_load_type": "Heating",
+                    "source_load_type": "Any",
                     "source_unit": "Wh",
                     "source_tags": [
                         "HEAT_CONSUMPTION"
@@ -451,7 +451,7 @@
         {
             "source": {
                 "component_name": "L2EMSElectricityController",
-                "field_name": "LoadingPowerInputForBattery_Output16"
+                "field_name": "LoadingPowerInputForBattery_Output15"
             },
             "target": {
                 "component_name": "Battery",

--- a/system_setups/simple_air_conditioner_household_building_sizer.scenario.json
+++ b/system_setups/simple_air_conditioner_household_building_sizer.scenario.json
@@ -1,6 +1,6 @@
 {
-    "name": "Simple Air Conditioner Household Building Sizer",
-    "description": "Household with a simple Carnot-efficiency air conditioner for cooling.",
+    "name": "Simple air conditioner household building sizer",
+    "description": "Simple air-conditioner household building-sizer system setup.",
     "multiple_buildings": false,
     "components": [
         {
@@ -47,7 +47,7 @@
                 "building_name": "BUI1",
                 "name": "Weather",
                 "location": "Aachen",
-                "source_path": "<<utils.get_input_directory()>>\\weather\\test-reference-years_1995-2012_1-location\\data_processed\\aachen_center",
+                "source_path": "<<utils.get_input_directory()>>/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center",
                 "data_source": "DWD_TRY",
                 "predictive_control": false
             },

--- a/tests/test_config_enum_serialization.py
+++ b/tests/test_config_enum_serialization.py
@@ -275,9 +275,11 @@ def test_no_config_field_is_annotated_with_an_int_valued_enum() -> None:
             return [annotation]
         return []
 
+    # No ``is_dataclass`` guard here: ``ConfigBase`` is itself a dataclass, so every
+    # subclass inherits ``__dataclass_fields__`` and passes such a check whether or not
+    # it carries its own ``@dataclass`` decorator. The guard would never fire, and mypy
+    # (which knows the same thing) rejects its dead fall-through as unreachable.
     for config_class in seen:
-        if not dataclasses.is_dataclass(config_class):
-            continue
         try:
             hints = typing.get_type_hints(config_class)
         except Exception:  # noqa: BLE001  # unresolvable forward refs are not this test's concern

--- a/tests/test_economics_kernel.py
+++ b/tests/test_economics_kernel.py
@@ -41,7 +41,7 @@ class TestUncertainValue:
     """§3.9 semantics."""
 
     def test_band_order_enforced(self):
-        """min <= best_estimate <= max is an invariant."""
+        """Ordering min <= best_estimate <= max is an invariant."""
         with pytest.raises(ValueError):
             UncertainValue(best_estimate=1.0, minimum=2.0, maximum=3.0)
 

--- a/tests/test_economics_kernel.py
+++ b/tests/test_economics_kernel.py
@@ -7,6 +7,8 @@ components declare. Everything here is verifiable by hand.
 
 # clean
 
+from typing import Any, Dict
+
 import pytest
 
 from hisim.economics.carriers import EnergyCarrier
@@ -414,8 +416,11 @@ class TestProvenanceLedger:
 class TestFactValidation:
     """§9.3: components fail fast on their own declarations."""
 
-    def _facts(self, **overrides) -> ComponentCostFacts:
-        arguments = {
+    def _facts(self, **overrides: Any) -> ComponentCostFacts:
+        # Annotated rather than inferred: the literal's values have no common type
+        # beyond ``object``, and ``**`` of a ``dict[str, object]`` matches none of the
+        # constructor's typed parameters.
+        arguments: Dict[str, Any] = {
             "asset_class": ComponentType.HEAT_PUMP,
             "size": 10.0,
             "size_unit": Units.KILOWATT,


### PR DESCRIPTION
- **Fix mypy errors in tests/ that broke the quality gate**
  `mypy --config-file mypy_moderate.ini tests/` reported 10 errors on main.
  
  test_economics_kernel.py: the `_facts` helper built its constructor keywords
  in a dict literal whose values (ComponentType, float, Units) join to `object`,
  so `ComponentCostFacts(**arguments)` matched none of the typed parameters
  (9 x arg-type). Annotated the forwarding dict as `Dict[str, Any]`, which is
  what a **kwargs relay is, and typed `**overrides` to match.
  
  test_config_enum_serialization.py: the `is_dataclass` guard in the int-valued
  enum sweep is dead. `ConfigBase` is itself a dataclass, so every subclass
  inherits `__dataclass_fields__` and passes the check with or without its own
  decorator; mypy knows this and flagged the `continue` as unreachable. Removed
  the guard and recorded why, rather than silencing the warning.
  
  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
  

- **Fix pylint and prospector findings that broke the quality gate**
  pylint (`--rcfile pylintrc-critical-only`) exited 20 on three messages, all in
  the cost database added by the cost stack:
  
    economics/database.py:511,512  C0415 import-outside-toplevel
    economics/database.py:835      W0212 protected-access
  
  Both are deliberate. The two imports are deferred so `hisim.economics` stays
  importable without `hisim.components` (spec rule 10.0), which the surrounding
  comment already says; the repo's convention for that is an inline disable, used
  in 24 other places. The protected call is on `clone`, a copy of `self` and hence
  of the same class -- pylint only sees an access on a foreign name, the same
  false positive already waived in result_path_provider.py. Both get a scoped
  disable, not a file- or config-wide one.
  
  prospector flagged six more, in `hisim/` and `tests/`:
  
    components/weather.py:10,11    wrong-import-order (from #565 / #566: a
                                   third-party import landed in the middle of
                                   the stdlib block) -- imports regrouped.
    economics/database.py:472      D403 -- summary reworded so it no longer opens
                                   on the lowercase-by-nature word "kWh".
    economics/database.py:670      D205/D400/D415 -- two-line summary ending in
                                   "see" split into a one-line summary and body.
    tests/test_economics_kernel.py:44  D403 -- same, for "min".
  
  All five prospector targets (setup.py, system_setups, tests, hisim, docs) now
  report 0 messages.
  
  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
  

- **Stop the scenario-JSON converter hard-coding the EMS output count, regenerate**
  `scripts/regenerate_scenario_jsons.py --all-py` rebuilt 14 of the committed
  `system_setups/*.scenario.json` files differently, so the scenario-json-freshness
  gate failed and, downstream of it, all eight golden-json pairs.
  
  Root cause of the largest class of drift is the converter, not the data. When
  serializing the EMS, `json_generator` skipped every dynamic output whose index
  was below a hard-coded 16, on the assumption that the EMS constructor always
  builds exactly 15 outputs of its own and everything past that came from a system
  setup. That assumption broke in #544, which moved the modular DHW heat pump to
  obsolete and with it one `get_default_connections_from_*` helper: the EMS has
  built 14 outputs ever since. Two things followed. The committed JSONs, last
  regenerated before #544, still name the battery target `..._Output16` while the
  setups now create `..._Output15`; and a fresh regeneration would have dropped the
  setup-added output from the file altogether, because index 15 fell below the
  hard-coded threshold.
  
  That is also the mechanism behind golden-json: `json_executor` logs a warning and
  carries on when a connection cannot be resolved, so the JSON runs silently lost
  the EMS -> Battery link that the Python runs had. The Python-route golden-check
  stayed green throughout, which is why the divergence looked like a JSON-only
  problem -- it was.
  
  The threshold is now measured instead of assumed: a pristine EMS is built from
  the same config and its outputs counted, so retiring or adding a default-
  connection helper can no longer silently shift the cut-off. `Component.__init__`
  only populates the instance, so the throwaway costs nothing but a few objects.
  
  Regenerating on top of that fix also picks up three older, unrelated staleness
  classes that no one had regenerated away:
  
    - `heat_distribution_system_type: 2` -> `"FLOORHEATING"` in 4 files (#566
      hand-edited the string-enum cutover into the JSONs and missed these);
    - `source_load_type` on the fuel/district-heating meter inputs, `"Heating"`
      -> `"Any"` / `"WarmWater"` in 4 files (from #565 / #567);
    - `simple_air_conditioner_household_building_sizer`, whose committed file had
      a hand-written name/description and Windows-style backslashes in the weather
      `source_path`.
  
  All 22 convertible setups build (0 failed), and a second full regeneration
  produces no further drift.
  
  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
  