### PR TITLE
Constructor uniformity: drop the dead name parameters, make both offe…

### DIFF
--- a/hisim/components/advanced_fuel_cell_controller.py
+++ b/hisim/components/advanced_fuel_cell_controller.py
@@ -312,12 +312,11 @@ class ExtendedController(Component):
 
     def __init__(
         self,
-        component_name: str,
         config: ExtendedControllerConfig,
         my_simulation_parameters: SimulationParameters,
         my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
-        """Initialize the class."""
+        """Initialize the class. The component name is derived from the config's identity."""
         self.my_simulation_parameters: SimulationParameters = my_simulation_parameters
         self.config: ExtendedControllerConfig = config
         component_name = self.get_component_name()
@@ -392,24 +391,28 @@ class ExtendedController(Component):
             ExtendedController.ControllerCHP,
             lt.LoadTypes.ANY,
             lt.Units.PERCENT,
+            output_description="CHP modulation signal in percent (0 = off, 100 = full power).",
         )
         self.controller_gas_heater_channel: ComponentOutput = self.add_output(
             self.component_name,
             ExtendedController.ControllerGasHeater,
             lt.LoadTypes.ANY,
             lt.Units.PERCENT,
+            output_description="Gas heater modulation signal in percent (0 = off, 100 = full power).",
         )
         self.power_to_electrolyzer_channel: ComponentOutput = self.add_output(
             self.component_name,
             ExtendedController.PowerToElectrolyzer,
             lt.LoadTypes.ELECTRICITY,
             lt.Units.WATT,
+            output_description="Electric power routed to the electrolyzer in watt.",
         )
         self.power_from_or_to_grid_channel: ComponentOutput = self.add_output(
             self.component_name,
             ExtendedController.PowerFromOrToGrid,
             lt.LoadTypes.ELECTRICITY,
             lt.Units.WATT,
+            output_description="Electric power exchanged with the grid in watt (sign follows the household balance).",
         )
 
         self.runtime_counter_chp_channel: ComponentOutput = self.add_output(
@@ -417,12 +420,14 @@ class ExtendedController(Component):
             ExtendedController.RuntimeCounterCHP,
             lt.LoadTypes.ANY,
             lt.Units.ANY,
+            output_description="Consecutive-timestep runtime counter of the CHP.",
         )
         self.runtime_counter_gas_heater_channel: ComponentOutput = self.add_output(
             self.component_name,
             ExtendedController.RuntimeCounterGasHeater,
             lt.LoadTypes.ANY,
             lt.Units.ANY,
+            output_description="Consecutive-timestep runtime counter of the gas heater.",
         )
 
         self.extended_controller: ExtendedControllerSimulation = ExtendedControllerSimulation()

--- a/hisim/components/configuration.py
+++ b/hisim/components/configuration.py
@@ -829,7 +829,7 @@ class ExtendedControllerConfig(ConfigBase):
     ) -> Any:
         """Gets a default ExtendedControllerConfig."""
         if component_id is None:
-            component_id = ComponentID(name="Example Component")
+            component_id = ComponentID(name="ExtendedController")
         return ExtendedControllerConfig(
             component_id=component_id,
             chp=True,

--- a/hisim/components/controller_l1_example_controller.py
+++ b/hisim/components/controller_l1_example_controller.py
@@ -74,7 +74,6 @@ class SimpleController(Component):
 
     def __init__(
         self,
-        name: str,
         my_simulation_parameters: SimulationParameters,
         config: SimpleControllerConfig,
         my_display_config: DisplayConfig | None = None,
@@ -82,9 +81,8 @@ class SimpleController(Component):
         """Initialize the controller and register its input/output channels.
 
         Args:
-            name: Name of the controller instance.
             my_simulation_parameters: Parameters of the current simulation.
-            config: Configuration providing the building name and component name.
+            config: Configuration providing the structured component identity.
             my_display_config: Optional display configuration; defaults to a new
                 DisplayConfig when None.
         """
@@ -112,6 +110,7 @@ class SimpleController(Component):
             SimpleController.GasHeaterPowerPercent,
             lt.LoadTypes.ANY,
             lt.Units.PERCENT,
+            output_description="Requested gas heater power level in percent (0 = off, 100 = full power).",
         )
         self.heater_state: int = 0
         self.previous_heater_state: int = self.heater_state


### PR DESCRIPTION
Part of the cleanup for the new json interface.

SimpleController and ExtendedController took a positional name/component_name argument that both constructors immediately overwrote with self.get_component_name() - a dead parameter that broke the uniform cls(config=..., my_simulation_parameters=...) contract the v2 executor's default build path assumes. A repo-wide constructor scan found no further offenders: generic_car.Car keeps its extra argument by design (it gets a build_from_scenario override in the v2 B3 MR), and SimpleWaterStorage is a shared intermediate base like Component itself, never built directly.

Dropping the parameters surfaced what they had been hiding: neither component was constructible at all. SimpleController declared one output and ExtendedController six without the mandatory output description - the same defect class as the components moved to obsolete in #573/#574. Descriptions added; both components now build from their default configs, verified.

Also fixes ExtendedControllerConfig's copy-pasted default identity ("Example Component" -> "ExtendedController"); unused by any setup, scenario JSON or test, so format-neutral.