### PR TITLE
Building cleanup phase 3: the BuildingInformation hazards, one per commit

### DIFF
--- a/hisim/components/building/information.py
+++ b/hisim/components/building/information.py
@@ -236,13 +236,18 @@ class BuildingInformation:
         ):
             raise ValueError("Only one variable can be used, the other one must be None.")
 
-            # scaling conditioned floor area
+        # The TABULA row is read-only after lookup: when A_C_Ref is 0, the substituted
+        # floor area used to be written back into self.buildingdata_ref["A_C_Ref"]
+        # (findings log entry 3). The write-back was never re-read - A_C_Ref is read
+        # exactly once, before this method runs - so it is dropped here and the row keeps
+        # what the TABULA file says.
+
+        # scaling conditioned floor area
         if self.buildingconfig.absolute_conditioned_floor_area_in_m2 is not None:
             # this is for preventing that the conditioned_floor_area is 0 (some buildings in TABULA have conditioned_floor_area (A_C_Ref) = 0)
             if conditioned_floor_area_in_m2_tabula_ref == 0:
                 scaled_conditioned_floor_area_in_m2 = self.buildingconfig.absolute_conditioned_floor_area_in_m2
                 factor_of_absolute_floor_area_to_tabula_floor_area = 1.0
-                self.buildingdata_ref["A_C_Ref"] = scaled_conditioned_floor_area_in_m2
             # scaling conditioned floor area
             else:
                 factor_of_absolute_floor_area_to_tabula_floor_area = (
@@ -258,7 +263,6 @@ class BuildingInformation:
             if conditioned_floor_area_in_m2_tabula_ref == 0:
                 scaled_conditioned_floor_area_in_m2 = self.buildingconfig.total_base_area_in_m2
                 factor_of_total_base_area_to_tabula_floor_area = 1.0
-                self.buildingdata_ref["A_C_Ref"] = scaled_conditioned_floor_area_in_m2
             # scaling conditioned floor area
             else:
                 factor_of_total_base_area_to_tabula_floor_area = (
@@ -273,7 +277,6 @@ class BuildingInformation:
         else:
             if conditioned_floor_area_in_m2_tabula_ref == 0:
                 scaled_conditioned_floor_area_in_m2 = 500.0
-                self.buildingdata_ref["A_C_Ref"] = scaled_conditioned_floor_area_in_m2
                 log.warning(
                     "There is no reference given for absolute conditioned floor area in m^2, so a default of 500 m^2 is used."
                 )
@@ -520,10 +523,16 @@ class BuildingInformation:
         self,
     ):
         """Manipulate building data of heat transfer."""
-        if self.buildingdata_ref["delta_U_ThermalBridging"].values[0] == 0:
-            self.buildingdata_ref["delta_U_ThermalBridging"] = 0.1
-
-        delta_u_thermalbridging = float(self.buildingdata_ref["delta_U_ThermalBridging"].values[0])
+        # The TABULA row is read-only after lookup: rows with delta_U_ThermalBridging == 0
+        # used to be patched to 0.1 in place before being read back (findings log entry 6),
+        # so the object's view of the row silently differed from the file. The correction
+        # is now an explicit local value; whether the 0.1 W/(m2 K) surcharge is good
+        # physics is a design-review question, not changed here.
+        delta_u_thermalbridging_from_tabula = self.buildingdata_ref["delta_U_ThermalBridging"].values[0]
+        if delta_u_thermalbridging_from_tabula == 0:
+            delta_u_thermalbridging = 0.1
+        else:
+            delta_u_thermalbridging = float(delta_u_thermalbridging_from_tabula)
 
         self.heat_conductance_thermal_bridging_in_watt_per_kelvin = (
             delta_u_thermalbridging * self.building_total_area_in_m2

--- a/hisim/components/building/information.py
+++ b/hisim/components/building/information.py
@@ -7,7 +7,7 @@ verbatim from the former single-module ``building.py``.
 
 # clean
 
-from typing import Dict, List, Tuple
+from typing import ClassVar, Dict, List, Optional, Tuple
 
 import pandas as pd
 
@@ -21,6 +21,11 @@ class BuildingInformation:
     The class reads the building config and collects all the important parameters of the buidling.
 
     """
+
+    #: Process-wide cache of the TABULA housing CSV (class-scoped per repo convention).
+    #: The file is static for the lifetime of a process, so it is read at most once and
+    #: shared by every instantiation instead of being re-parsed per instance.
+    _housing_reference_dataframe: ClassVar[Optional[pd.DataFrame]] = None
 
     def __init__(
         self,
@@ -72,19 +77,35 @@ class BuildingInformation:
         """Actual U-value of the roof element from the TABULA reference data [W/(m2 K)]."""
         return float(self.buildingdata_ref["U_Actual_Roof_1"].values[0])
 
+    @classmethod
+    def read_housing_reference_dataframe(cls) -> pd.DataFrame:
+        """Return the TABULA housing CSV as a DataFrame, reading the file at most once per process.
+
+        ``BuildingInformation`` used to re-parse the 3281-row CSV on every instantiation,
+        which dominated the construction cost of the class (cleanup phase 3, hazard 5).
+        The parsed frame is cached in a class attribute because the file is static for the
+        lifetime of a process. The cached frame is shared, so callers must never mutate
+        it; :py:meth:`get_building_from_tabula` copies the selected row before exposing it.
+        """
+        housing_reference_dataframe = cls._housing_reference_dataframe
+        if housing_reference_dataframe is None:
+            housing_reference_dataframe = pd.read_csv(
+                utils.HISIMPATH["housing"],
+                decimal=",",
+                sep=";",
+                encoding="cp1252",
+                low_memory=False,
+            )
+            cls._housing_reference_dataframe = housing_reference_dataframe
+        return housing_reference_dataframe
+
     def get_building_from_tabula(
         self,
     ):
         """Get the building code from a TABULA building."""
-        d_f = pd.read_csv(
-            utils.HISIMPATH["housing"],
-            decimal=",",
-            sep=";",
-            encoding="cp1252",
-            low_memory=False,
-        )
+        d_f = self.read_housing_reference_dataframe()
 
-        # Gets parameters from chosen building
+        # Gets parameters from chosen building (copied, so the shared cached frame stays untouched)
         self.buildingdata_ref = d_f.loc[d_f["Code_BuildingVariant"] == self.buildingconfig.building_code].copy()
         self.buildingcode = self.buildingconfig.building_code
 

--- a/hisim/components/building/information.py
+++ b/hisim/components/building/information.py
@@ -7,18 +7,14 @@ verbatim from the former single-module ``building.py``.
 
 # clean
 
-from dataclasses import dataclass
 from typing import List, Tuple
 
 import pandas as pd
-from dataclasses_json import dataclass_json
 
 from hisim import log, utils
 from hisim.components.building.config import BuildingConfig
 
 
-@dataclass_json
-@dataclass
 class BuildingInformation:
     """Class for collecting important building parameters to pass to other components.
 

--- a/hisim/components/building/information.py
+++ b/hisim/components/building/information.py
@@ -89,21 +89,10 @@ class BuildingInformation:
 
         self.get_max_thermal_building_demand()
 
-        (
-            self.tabula_ref_solar_heat_load_during_heating_seasons_reference_in_kilowatthour_per_m2_per_year,
-            self.tabula_ref_internal_heat_sources_reference_in_kilowatthour_per_m2_per_year,
-            self.tabula_ref_total_heat_transfer_reference_in_kilowatthour_per_m2_per_year,
-            self.tabula_ref_transmission_heat_losses_ref_in_kilowatthour_per_m2_per_year,
-            self.tabula_ref_ventilation_heat_losses_ref_in_kilowatthour_per_m2_per_year,
-            self.tabula_ref_energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
-            self.tabula_ref_thermal_capacity_of_building_thermal_mass_reference_in_watthour_per_m2_per_kelvin,
-            self.tabula_ref_heat_transfer_coeff_by_ventilation_reference_in_watt_per_kelvin,
-            self.tabula_ref_heat_transfer_coeff_by_transmission_ref_in_watt_per_m2_per_kelvin,
-            self.tabula_ref_heat_transfer_coeff_by_ventilation_ref_in_watt_per_m2_per_kelvin,
-            self.tabula_ref_gain_utilisation_factor_reference,
-        ) = self.get_some_reference_data_from_tabula(
+        self.set_reference_data_from_tabula(
             buildingdata=self.buildingdata_ref,
-            scaled_conditioned_floor_area_in_m2=self.scaled_conditioned_floor_area_in_m2,)
+            scaled_conditioned_floor_area_in_m2=self.scaled_conditioned_floor_area_in_m2,
+        )
 
     @property
     def u_value_wall(self) -> float:
@@ -650,64 +639,69 @@ class BuildingInformation:
 
         return number_of_apartments
 
-    def get_some_reference_data_from_tabula(
+    def set_reference_data_from_tabula(
         self, buildingdata: pd.DataFrame, scaled_conditioned_floor_area_in_m2: float
-    ) -> Tuple[float, float, float, float, float, float, float, float, float, float, float]:
-        """Get some reference parameter from Tabula."""
+    ) -> None:
+        """Read the TABULA reference indicators off the building row into named attributes.
 
+        This replaces the former eleven-float positional tuple return that ``__init__``
+        unpacked into attributes (cleanup phase 3, hazard 1): two attribute names in that
+        tuple differed only by a ``ref``/``reference`` spelling and their unit suffix, so
+        a positional swap would have been invisible at the call site. Each attribute is
+        now assigned directly next to the TABULA column, comment and unit it belongs to,
+        which makes the pairing reviewable in one place. Values, column reads and read
+        order are unchanged.
+        """
         # Floor area related heat load during heating season
         # reference taken from TABULA (* Check header) Q_sol [kWh/m2.a], before q_sol_ref (or solar heat sources?)
-        tabula_ref_solar_heat_load_during_heating_seasons_reference_in_kilowatthour_per_m2_per_year = float(
+        self.tabula_ref_solar_heat_load_during_heating_seasons_reference_in_kilowatthour_per_m2_per_year = float(
             (buildingdata["q_sol"].values[0])
         )
         # Floor area related internal heat sources during heating season
         # reference taken from TABULA (* Check header) as Q_int [kWh/m2.a], before q_int_ref
-        tabula_ref_internal_heat_sources_reference_in_kilowatthour_per_m2_per_year = float(buildingdata["q_int"].values[0])
+        self.tabula_ref_internal_heat_sources_reference_in_kilowatthour_per_m2_per_year = float(
+            buildingdata["q_int"].values[0]
+        )
         # Floor area related annual losses
         # reference taken from TABULA (* Check header) as Q_ht [kWh/m2.a], before q_ht_ref
-        tabula_ref_total_heat_transfer_reference_in_kilowatthour_per_m2_per_year = float(buildingdata["q_ht"].values[0])
+        self.tabula_ref_total_heat_transfer_reference_in_kilowatthour_per_m2_per_year = float(
+            buildingdata["q_ht"].values[0]
+        )
         # transmission heat losses
-        tabula_ref_transmission_heat_losses_ref_in_kilowatthour_per_m2_per_year = float(buildingdata["q_ht_tr"].values[0])
+        self.tabula_ref_transmission_heat_losses_ref_in_kilowatthour_per_m2_per_year = float(
+            buildingdata["q_ht_tr"].values[0]
+        )
         # ventilation heat losses
-        tabula_ref_ventilation_heat_losses_ref_in_kilowatthour_per_m2_per_year = float(buildingdata["q_ht_ve"].values[0])
+        self.tabula_ref_ventilation_heat_losses_ref_in_kilowatthour_per_m2_per_year = float(
+            buildingdata["q_ht_ve"].values[0]
+        )
         # Energy need for heating
         # reference taken from TABULA (* Check header) as Q_H_nd [kWh/m2.a], before q_h_nd_ref
-        tabula_ref_energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year = float(buildingdata["q_h_nd"].values[0])
+        self.tabula_ref_energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year = float(
+            buildingdata["q_h_nd"].values[0]
+        )
         # Internal heat capacity per m2 reference area [Wh/(m^2.K)] (TABULA: Internal heat capacity)
-        tabula_ref_thermal_capacity_of_building_thermal_mass_reference_in_watthour_per_m2_per_kelvin = float(
+        self.tabula_ref_thermal_capacity_of_building_thermal_mass_reference_in_watthour_per_m2_per_kelvin = float(
             buildingdata["c_m"].values[0]
         )
         # gain utilisation factor eta_h_gn
-        tabula_ref_gain_utilisation_factor_reference = float(buildingdata["eta_h_gn"].values[0])
+        self.tabula_ref_gain_utilisation_factor_reference = float(buildingdata["eta_h_gn"].values[0])
 
-        # Heat transfer coefficient by ventilation in watt per m2 per kelvin
-        tabula_ref_heat_transfer_coeff_by_ventilation_reference_in_watt_per_m2_per_kelvin = float(
+        # Heat transfer coefficient by ventilation in watt per m2 per kelvin (TABULA column h_Ventilation)
+        self.tabula_ref_heat_transfer_coeff_by_ventilation_ref_in_watt_per_m2_per_kelvin = float(
             buildingdata["h_Ventilation"].values[0]
         )
-        if tabula_ref_heat_transfer_coeff_by_ventilation_reference_in_watt_per_m2_per_kelvin is None:
+        if self.tabula_ref_heat_transfer_coeff_by_ventilation_ref_in_watt_per_m2_per_kelvin is None:
             raise ValueError("h_Ventilation was none.")
         # Heat transfer coefficient by ventilation in watt per kelvin
-        tabula_ref_heat_transfer_coeff_by_ventilation_reference_in_watt_per_kelvin = (
+        # (the same TABULA column, made absolute with the scaled conditioned floor area)
+        self.tabula_ref_heat_transfer_coeff_by_ventilation_reference_in_watt_per_kelvin = (
             float(buildingdata["h_Ventilation"].values[0]) * scaled_conditioned_floor_area_in_m2
         )
 
-        # Heat transfer coefficient by transmission in watt per m2 per kelvin
-        tabula_ref_heat_transfer_coeff_by_transmission_reference_in_watt_per_m2_per_kelvin = float(
+        # Heat transfer coefficient by transmission in watt per m2 per kelvin (TABULA column h_Transmission)
+        self.tabula_ref_heat_transfer_coeff_by_transmission_ref_in_watt_per_m2_per_kelvin = float(
             buildingdata["h_Transmission"].values[0]
         )
-        if tabula_ref_heat_transfer_coeff_by_transmission_reference_in_watt_per_m2_per_kelvin is None:
+        if self.tabula_ref_heat_transfer_coeff_by_transmission_ref_in_watt_per_m2_per_kelvin is None:
             raise ValueError("h_Transmission was none.")
-
-        return (
-            tabula_ref_solar_heat_load_during_heating_seasons_reference_in_kilowatthour_per_m2_per_year,
-            tabula_ref_internal_heat_sources_reference_in_kilowatthour_per_m2_per_year,
-            tabula_ref_total_heat_transfer_reference_in_kilowatthour_per_m2_per_year,
-            tabula_ref_transmission_heat_losses_ref_in_kilowatthour_per_m2_per_year,
-            tabula_ref_ventilation_heat_losses_ref_in_kilowatthour_per_m2_per_year,
-            tabula_ref_energy_need_for_heating_reference_in_kilowatthour_per_m2_per_year,
-            tabula_ref_thermal_capacity_of_building_thermal_mass_reference_in_watthour_per_m2_per_kelvin,
-            tabula_ref_heat_transfer_coeff_by_ventilation_reference_in_watt_per_kelvin,
-            tabula_ref_heat_transfer_coeff_by_transmission_reference_in_watt_per_m2_per_kelvin,
-            tabula_ref_heat_transfer_coeff_by_ventilation_reference_in_watt_per_m2_per_kelvin,
-            tabula_ref_gain_utilisation_factor_reference,
-        )

--- a/hisim/components/building/information.py
+++ b/hisim/components/building/information.py
@@ -263,36 +263,35 @@ class BuildingInformation:
         # exactly once, before this method runs - so it is dropped here and the row keeps
         # what the TABULA file says.
 
-        # scaling conditioned floor area
+        # The absolute-conditioned-floor-area and total-base-area branches used to be two
+        # verbatim copies of the same arithmetic; they are one parameterized path now,
+        # with the configured target area as the only difference.
         if self.buildingconfig.absolute_conditioned_floor_area_in_m2 is not None:
+            target_floor_area_in_m2_from_config: Optional[float] = (
+                self.buildingconfig.absolute_conditioned_floor_area_in_m2
+            )
+        else:
+            target_floor_area_in_m2_from_config = self.buildingconfig.total_base_area_in_m2
+
+        # scaling conditioned floor area
+        if target_floor_area_in_m2_from_config is not None:
             # this is for preventing that the conditioned_floor_area is 0 (some buildings in TABULA have conditioned_floor_area (A_C_Ref) = 0)
             if conditioned_floor_area_in_m2_tabula_ref == 0:
-                scaled_conditioned_floor_area_in_m2 = self.buildingconfig.absolute_conditioned_floor_area_in_m2
-                factor_of_absolute_floor_area_to_tabula_floor_area = 1.0
+                scaled_conditioned_floor_area_in_m2 = target_floor_area_in_m2_from_config
+                factor_of_config_floor_area_to_tabula_floor_area = 1.0
             # scaling conditioned floor area
             else:
-                factor_of_absolute_floor_area_to_tabula_floor_area = (
-                    self.buildingconfig.absolute_conditioned_floor_area_in_m2 / conditioned_floor_area_in_m2_tabula_ref
+                factor_of_config_floor_area_to_tabula_floor_area = (
+                    target_floor_area_in_m2_from_config / conditioned_floor_area_in_m2_tabula_ref
                 )
+                # Deliberately ref * (target / ref) instead of plain target: the round
+                # trip through the ratio produces e.g. 249.99999999999997 from a
+                # configured 250.0, and that float artifact is pinned behavior
+                # (findings log entry 4) - do not simplify algebraically.
                 scaled_conditioned_floor_area_in_m2 = (
-                    conditioned_floor_area_in_m2_tabula_ref * factor_of_absolute_floor_area_to_tabula_floor_area
+                    conditioned_floor_area_in_m2_tabula_ref * factor_of_config_floor_area_to_tabula_floor_area
                 )
-            scaling_factor_according_to_conditioned_living_area = factor_of_absolute_floor_area_to_tabula_floor_area
-
-        elif self.buildingconfig.total_base_area_in_m2 is not None:
-            # this is for preventing that the conditioned_floor_area is 0
-            if conditioned_floor_area_in_m2_tabula_ref == 0:
-                scaled_conditioned_floor_area_in_m2 = self.buildingconfig.total_base_area_in_m2
-                factor_of_total_base_area_to_tabula_floor_area = 1.0
-            # scaling conditioned floor area
-            else:
-                factor_of_total_base_area_to_tabula_floor_area = (
-                    self.buildingconfig.total_base_area_in_m2 / conditioned_floor_area_in_m2_tabula_ref
-                )
-                scaled_conditioned_floor_area_in_m2 = (
-                    conditioned_floor_area_in_m2_tabula_ref * factor_of_total_base_area_to_tabula_floor_area
-                )
-            scaling_factor_according_to_conditioned_living_area = factor_of_total_base_area_to_tabula_floor_area
+            scaling_factor_according_to_conditioned_living_area = factor_of_config_floor_area_to_tabula_floor_area
 
             # if no value for building size is provided in config, use reference value from Tabula or 500 m^2.
         else:
@@ -596,34 +595,28 @@ class BuildingInformation:
 
         Either from config or from tabula or through approximation with data from
         https://www.umweltbundesamt.de/daten/private-haushalte-konsum/wohnen/wohnflaeche#zahl-der-wohnungen-gestiegen.
+        The config and TABULA sources shared verbatim fallback logic; it is one
+        parameterized path now. Only the TABULA source falls back on a rescaled building
+        (``scaling_factor != 1``), because a rescaled reference apartment count no longer
+        matches the scaled floor area - a configured count is trusted as given.
         """
 
         if self.buildingconfig.number_of_apartments is not None:
             number_of_apartments_origin = self.buildingconfig.number_of_apartments
-
-            if number_of_apartments_origin == 0:
-                # check table from the link for the year 2021
-                average_living_area_per_apartment_in_2021_in_m2 = 92.1
-                number_of_apartments = conditioned_floor_area_in_m2 / average_living_area_per_apartment_in_2021_in_m2
-            elif number_of_apartments_origin > 0:
-                number_of_apartments = number_of_apartments_origin
-
-            else:
-                raise ValueError("Number of apartments can not be negative.")
-
-        elif self.buildingconfig.number_of_apartments is None:
+            use_average_apartment_size_fallback = number_of_apartments_origin == 0
+        else:
             number_of_apartments_origin = float(buildingdata["n_Apartment"].values[0])
-
             # if no value given or if the area given in the config is bigger than the tabula ref area
-            if number_of_apartments_origin == 0 or scaling_factor != 1:
-                # check table from the link for the year 2021
-                average_living_area_per_apartment_in_2021_in_m2 = 92.1
-                number_of_apartments = conditioned_floor_area_in_m2 / average_living_area_per_apartment_in_2021_in_m2
-            elif number_of_apartments_origin > 0:
-                number_of_apartments = number_of_apartments_origin
+            use_average_apartment_size_fallback = number_of_apartments_origin == 0 or scaling_factor != 1
 
-            else:
-                raise ValueError("Number of apartments can not be negative.")
+        if use_average_apartment_size_fallback:
+            # check table from the link for the year 2021
+            average_living_area_per_apartment_in_2021_in_m2 = 92.1
+            number_of_apartments = conditioned_floor_area_in_m2 / average_living_area_per_apartment_in_2021_in_m2
+        elif number_of_apartments_origin > 0:
+            number_of_apartments = number_of_apartments_origin
+        else:
+            raise ValueError("Number of apartments can not be negative.")
 
         return number_of_apartments
 

--- a/hisim/components/building/information.py
+++ b/hisim/components/building/information.py
@@ -22,10 +22,47 @@ class BuildingInformation:
 
     """
 
+    # The derived attributes are computed by an ordered chain of set_*/get_* helper
+    # methods that __init__ invokes, partly two call levels deep - deeper than pylint's
+    # attribute-defined-outside-init follows. The former "fix" was ~40 dead bare
+    # annotations at the top of __init__ (removed in cleanup phase 3, hazard 3); the
+    # message is disabled explicitly instead until phase 4 replaces the mutation chain
+    # with an explicit pipeline.
+    # pylint: disable=attribute-defined-outside-init
+
     #: Process-wide cache of the TABULA housing CSV (class-scoped per repo convention).
     #: The file is static for the lifetime of a process, so it is read at most once and
     #: shared by every instantiation instead of being re-parsed per instance.
     _housing_reference_dataframe: ClassVar[Optional[pd.DataFrame]] = None
+
+    # Fixed model constants, named without changing any value (cleanup phase 3, hazard 7).
+    # Units and sources are stated as far as the code documents them.
+
+    #: Heat transfer coefficient between the thermal-mass node "m" and the internal-surface
+    #: node "s" [W/(m2 K)]; fixed value h_ms from ISO 13790 (12.2.2, eq. 64, p. 79).
+    HEAT_TRANSFER_COEFF_THERMAL_MASS_AND_INTERNAL_SURFACE_IN_WATT_PER_M2_PER_KELVIN: float = 9.1
+    #: Dimensionless ratio between the total internal surface area and the conditioned
+    #: floor area; A_at from ISO 13790 (7.2.2.2, eq. 9, p. 36), before labeled lambda_at.
+    RATIO_BETWEEN_INTERNAL_SURFACE_AREA_AND_FLOOR_AREA: float = 4.5
+    #: Heat transfer coefficient between the indoor-air node and the internal-surface node
+    #: "s" [W/(m2 K)]; fixed value h_is from ISO 13790 (7.2.2.2, eq. 9, p. 35).
+    HEAT_TRANSFER_COEFF_INDOOR_AIR_AND_INTERNAL_SURFACE_IN_WATT_PER_M2_PER_KELVIN: float = 3.45
+    #: Volumetric heat capacity of air [Wh/(m3 K)], used for the ventilation conductance.
+    HEAT_CAPACITY_OF_AIR_PER_VOLUME_IN_WATT_HOUR_PER_M3_PER_KELVIN: float = 0.34
+    #: Average living area per apartment in Germany in 2021 [m2], from the table at
+    #: https://www.umweltbundesamt.de/daten/private-haushalte-konsum/wohnen/wohnflaeche#zahl-der-wohnungen-gestiegen
+    AVERAGE_LIVING_AREA_PER_APARTMENT_IN_2021_IN_M2: float = 92.1
+    #: Conversion factor between joule and watt-hour: 1 Wh = 3600 J.
+    JOULE_PER_WATT_HOUR: float = 3.6e3
+    #: Fallback conditioned floor area [m2] used when TABULA's A_C_Ref is 0 and the config
+    #: provides no floor area either (findings log entry 3; a magic default, logged only).
+    FALLBACK_CONDITIONED_FLOOR_AREA_IN_M2: float = 500.0
+    #: Thermal-bridging surcharge delta_U [W/(m2 K)] substituted when the TABULA row says 0
+    #: (findings log entry 6; a physics question for the design review, value unchanged).
+    THERMAL_BRIDGING_DELTA_U_WHEN_TABULA_IS_ZERO_IN_WATT_PER_M2_PER_KELVIN: float = 0.1
+    #: Transmission adjustment factor b applied to a floor whose U-value comes from the
+    #: config instead of TABULA; the code does not document where the 0.5 comes from.
+    FLOOR_ADJUSTMENT_FACTOR_FOR_CONFIGURED_U_VALUE: float = 0.5
 
     def __init__(
         self,
@@ -124,7 +161,7 @@ class BuildingInformation:
         # Room Capacitance [Wh/m2K] (TABULA: Internal heat capacity) Ref: ISO standard 12.3.1.2
         self.thermal_capacity_of_building_thermal_mass_in_watthour_per_m2_per_kelvin = (
             self.thermal_capacity_of_building_thermal_mass_in_joule_per_kelvin
-            / (3.6e3 * self.scaled_conditioned_floor_area_in_m2)
+            / (self.JOULE_PER_WATT_HOUR * self.scaled_conditioned_floor_area_in_m2)
         )
         # before labeled as a_m
         self.effective_mass_area_in_m2 = (
@@ -154,11 +191,17 @@ class BuildingInformation:
         """Set important constants."""
 
         # Heat transfer coefficient between nodes "m" and "s" (12.2.2 E64 P79); labeled as h_ms in paper [2] (*** Check header)
-        self.heat_transfer_coeff_thermal_mass_and_internal_surface_fixed_value_in_watt_per_m2_per_kelvin = 9.1
+        self.heat_transfer_coeff_thermal_mass_and_internal_surface_fixed_value_in_watt_per_m2_per_kelvin = (
+            self.HEAT_TRANSFER_COEFF_THERMAL_MASS_AND_INTERNAL_SURFACE_IN_WATT_PER_M2_PER_KELVIN
+        )
         # Dimensionless ratio between surfaces and the useful surfaces (7.2.2.2 E9 P36); labeled as A_at in paper [2] (*** Check header); before lambda_at
-        self.ratio_between_internal_surface_area_and_floor_area = 4.5
+        self.ratio_between_internal_surface_area_and_floor_area = (
+            self.RATIO_BETWEEN_INTERNAL_SURFACE_AREA_AND_FLOOR_AREA
+        )
         # Heat transfer coefficient between nodes "air" and "s" (7.2.2.2 E9 P35); labeled as h_is in paper [2] (*** Check header)
-        self.heat_transfer_coeff_indoor_air_and_internal_surface_fixed_value_in_watt_per_m2_per_kelvin = 3.45
+        self.heat_transfer_coeff_indoor_air_and_internal_surface_fixed_value_in_watt_per_m2_per_kelvin = (
+            self.HEAT_TRANSFER_COEFF_INDOOR_AIR_AND_INTERNAL_SURFACE_IN_WATT_PER_M2_PER_KELVIN
+        )
 
         # heat capacity class values in ISO 13790, table 12, p.69/70
         self.building_heat_capacity_class_f_a: Dict[str, float] = {
@@ -296,7 +339,7 @@ class BuildingInformation:
             # if no value for building size is provided in config, use reference value from Tabula or 500 m^2.
         else:
             if conditioned_floor_area_in_m2_tabula_ref == 0:
-                scaled_conditioned_floor_area_in_m2 = 500.0
+                scaled_conditioned_floor_area_in_m2 = self.FALLBACK_CONDITIONED_FLOOR_AREA_IN_M2
                 log.warning(
                     "There is no reference given for absolute conditioned floor area in m^2, so a default of 500 m^2 is used."
                 )
@@ -310,8 +353,12 @@ class BuildingInformation:
     def set_floor_area_parameter(
         self,
     ):
-        """Manipulate building data of roof."""
+        """Set the floor area of the building.
 
+        Uses the configured floor area when given, otherwise the sum of the two TABULA
+        floor areas scaled with the conditioned-living-area scaling factor. (The former
+        docstring said "roof" - a copy-paste error, fixed in cleanup phase 3.)
+        """
         if self.buildingconfig.floor_area_in_m2 is None:
             area_floor_1 = float(self.buildingdata_ref["A_Floor_1"].values[0])
             area_floor_2 = float(self.buildingdata_ref["A_Floor_2"].values[0])
@@ -322,7 +369,11 @@ class BuildingInformation:
             self.floor_area_in_m2 = self.buildingconfig.floor_area_in_m2
 
     def set_wall_area_parameter(self):
-        """Manipulate building data of walls."""
+        """Set the facade (wall) area of the building.
+
+        Uses the configured facade area when given, otherwise the sum of the three TABULA
+        wall areas scaled with the conditioned-living-area scaling factor.
+        """
         if self.buildingconfig.facade_area_in_m2 is None:
             area_wall_1 = float(self.buildingdata_ref["A_Wall_1"].values[0])
             area_wall_2 = float(self.buildingdata_ref["A_Wall_2"].values[0])
@@ -337,7 +388,11 @@ class BuildingInformation:
     def set_roof_area_parameter(
         self,
     ):
-        """Manipulate building data of roof."""
+        """Set the roof area of the building.
+
+        Uses the configured roof area when given, otherwise the sum of the two TABULA
+        roof areas scaled with the conditioned-living-area scaling factor.
+        """
         if self.buildingconfig.roof_area_in_m2 is None:
             area_roof_1 = float(self.buildingdata_ref["A_Roof_1"].values[0])
             area_roof_2 = float(self.buildingdata_ref["A_Roof_2"].values[0])
@@ -350,7 +405,14 @@ class BuildingInformation:
     def set_window_area_parameter(
         self,
     ):
-        """Manipulate building data of windows."""
+        """Set the total and per-direction window areas of the building.
+
+        Uses the configured window area when given, otherwise the sum of the two TABULA
+        window areas scaled with the conditioned-living-area scaling factor. The
+        per-direction TABULA window areas are then rescaled so their total matches the
+        resulting window area; this divides by the TABULA reference window area, which is
+        zero for some codes and makes those raise (findings log entries 1 and 2).
+        """
         area_window_1_ref = float(self.buildingdata_ref["A_Window_1"].values[0])
         area_window_2_ref = float(self.buildingdata_ref["A_Window_2"].values[0])
         if self.buildingconfig.window_area_in_m2 is None:
@@ -380,7 +442,11 @@ class BuildingInformation:
     def set_door_area_parameter(
         self,
     ):
-        """Manipulate building data of door."""
+        """Set the door area of the building.
+
+        Uses the configured door area when given, otherwise the TABULA door area scaled
+        with the conditioned-living-area scaling factor.
+        """
         if self.buildingconfig.door_area_in_m2 is None:
             area_door_1 = float(self.buildingdata_ref["A_Door_1"].values[0])
             self.door_area_in_m2 = area_door_1 * self.scaling_factor_according_to_conditioned_living_area
@@ -390,7 +456,13 @@ class BuildingInformation:
     def set_floor_heat_transfer_parameter(
         self,
     ):
-        """Manipulate building data of floor."""
+        """Set the floor U-value, transmission adjustment factor and conductance.
+
+        Without a configured U-value, the area-weighted average of the two TABULA floor
+        U-values and the larger of their b_Transmission adjustment factors are used; with
+        one, the configured U-value is paired with a fixed adjustment factor of 0.5. The
+        conductance [W/K] is U-value times floor area times the adjustment factor.
+        """
         if self.buildingconfig.floor_u_value_in_watt_per_m2_per_kelvin is None:
 
             floor_u_value_in_watt_per_m2_per_kelvin_1 = float(self.buildingdata_ref["U_Actual_Floor_1"].values[0])
@@ -412,7 +484,7 @@ class BuildingInformation:
         else:
             self.floor_u_value_in_watt_per_m2_per_kelvin = self.buildingconfig.floor_u_value_in_watt_per_m2_per_kelvin
 
-            self.floor_adjustment_factor_from_tabula = 0.5
+            self.floor_adjustment_factor_from_tabula = self.FLOOR_ADJUSTMENT_FACTOR_FOR_CONFIGURED_U_VALUE
 
         self.heat_conductance_floor_in_watt_per_kelvin = (
             self.floor_u_value_in_watt_per_m2_per_kelvin
@@ -423,7 +495,13 @@ class BuildingInformation:
     def set_wall_heat_transfer_parameter(
         self,
     ):
-        """Manipulate building data of wall."""
+        """Set the facade (wall) U-value, transmission adjustment factor and conductance.
+
+        Without a configured U-value, the area-weighted average of the three TABULA wall
+        U-values and the largest of their b_Transmission adjustment factors are used; with
+        one, the configured U-value is paired with an adjustment factor of 1. The
+        conductance [W/K] is U-value times facade area times the adjustment factor.
+        """
         if self.buildingconfig.facade_u_value_in_watt_per_m2_per_kelvin is None:
 
             facade_u_value_in_watt_per_m2_per_kelvin_1 = float(self.buildingdata_ref["U_Actual_Wall_1"].values[0])
@@ -460,7 +538,13 @@ class BuildingInformation:
     def set_roof_heat_transfer_parameter(
         self,
     ):
-        """Manipulate building data of heat transfer."""
+        """Set the roof U-value, transmission adjustment factor and conductance.
+
+        Without a configured U-value, the area-weighted average of the two TABULA roof
+        U-values and the larger of their b_Transmission adjustment factors are used; with
+        one, the configured U-value is paired with an adjustment factor of 1. The
+        conductance [W/K] is U-value times roof area times the adjustment factor.
+        """
         if self.buildingconfig.roof_u_value_in_watt_per_m2_per_kelvin is None:
             roof_u_value_in_watt_per_m2_per_kelvin_1 = float(self.buildingdata_ref["U_Actual_Roof_1"].values[0])
             roof_u_value_in_watt_per_m2_per_kelvin_2 = float(self.buildingdata_ref["U_Actual_Roof_2"].values[0])
@@ -490,7 +574,12 @@ class BuildingInformation:
     def set_window_heat_transfer_parameter(
         self,
     ):
-        """Manipulate building data of heat transfer."""
+        """Set the window U-value, adjustment factor and heat-transfer conductance.
+
+        Without a configured U-value, the area-weighted average of the two TABULA window
+        U-values is used; the adjustment factor is always 1 for windows. The conductance
+        [W/K] is U-value times window area times the adjustment factor.
+        """
         if self.buildingconfig.window_u_value_in_watt_per_m2_per_kelvin is None:
             window_u_value_in_watt_per_m2_per_kelvin_1 = float(self.buildingdata_ref["U_Actual_Window_1"].values[0])
             window_u_value_in_watt_per_m2_per_kelvin_2 = float(self.buildingdata_ref["U_Actual_Window_2"].values[0])
@@ -516,14 +605,20 @@ class BuildingInformation:
     def set_door_heat_transfer_parameter(
         self,
     ):
-        """Manipulate building data of heat transfer."""
+        """Set the door U-value and heat-transfer conductance of the building.
+
+        The U-value comes from the config when given, otherwise from the TABULA row; the
+        conductance [W/K] is U-value times door area times the adjustment factor. The
+        ``(u * area) / area`` round trip below looks like a no-op but is NOT one in float
+        arithmetic: it shifts the last mantissa bit for 164 TABULA codes (e.g. a stored
+        2.2 becomes 2.2000000000000006), and that artifact is pinned behavior (findings
+        log entries 7 and 17) - do not simplify it away. The zero-area branch skips the
+        round trip to avoid dividing by zero and returns the U-value unchanged.
+        """
         if self.buildingconfig.door_u_value_in_watt_per_m2_per_kelvin is None:
             area_door_1 = float(self.buildingdata_ref["A_Door_1"].values[0])
             door_u_value_in_watt_per_m2_per_kelvin = float(self.buildingdata_ref["U_Actual_Door_1"].values[0])
 
-            # With a single door the area-weighted U-value is just the door's own
-            # U-value; guard against a zero door area (no door) to avoid dividing by
-            # zero, while keeping the exact expression for the non-zero case.
             if area_door_1 != 0:
                 self.door_u_value_in_watt_per_m2_per_kelvin = (
                     door_u_value_in_watt_per_m2_per_kelvin * area_door_1
@@ -542,7 +637,11 @@ class BuildingInformation:
     def set_thermal_bridging_parameter(
         self,
     ):
-        """Manipulate building data of heat transfer."""
+        """Set the thermal-bridging heat-transfer conductance of the building.
+
+        The conductance [W/K] is the TABULA delta_U_ThermalBridging surcharge times the
+        total envelope area, with rows that report 0 substituted by 0.1 W/(m2 K).
+        """
         # The TABULA row is read-only after lookup: rows with delta_U_ThermalBridging == 0
         # used to be patched to 0.1 in place before being read back (findings log entry 6),
         # so the object's view of the row silently differed from the file. The correction
@@ -550,7 +649,7 @@ class BuildingInformation:
         # physics is a design-review question, not changed here.
         delta_u_thermalbridging_from_tabula = self.buildingdata_ref["delta_U_ThermalBridging"].values[0]
         if delta_u_thermalbridging_from_tabula == 0:
-            delta_u_thermalbridging = 0.1
+            delta_u_thermalbridging = self.THERMAL_BRIDGING_DELTA_U_WHEN_TABULA_IS_ZERO_IN_WATT_PER_M2_PER_KELVIN
         else:
             delta_u_thermalbridging = float(delta_u_thermalbridging_from_tabula)
 
@@ -559,11 +658,14 @@ class BuildingInformation:
         )
 
     def set_ventilation_heat_transfer_parameter(self):
-        """Manipulate building data of heat transfer."""
-        heat_capacity_of_air_per_volume_in_watt_hour_per_m3_per_kelvin = 0.34
+        """Set the ventilation heat-transfer conductance of the building.
 
+        The conductance [W/K] is the volumetric heat capacity of air times the total air
+        exchange rate (use plus infiltration, from the TABULA row), the room height and
+        the scaled conditioned floor area.
+        """
         self.heat_conductance_ventilation_in_watt_per_kelvin = (
-            heat_capacity_of_air_per_volume_in_watt_hour_per_m3_per_kelvin
+            self.HEAT_CAPACITY_OF_AIR_PER_VOLUME_IN_WATT_HOUR_PER_M3_PER_KELVIN
             * (
                 float(self.buildingdata_ref["n_air_use"].values[0])
                 + float(self.buildingdata_ref["n_air_infiltration"].values[0])
@@ -611,8 +713,7 @@ class BuildingInformation:
 
         if use_average_apartment_size_fallback:
             # check table from the link for the year 2021
-            average_living_area_per_apartment_in_2021_in_m2 = 92.1
-            number_of_apartments = conditioned_floor_area_in_m2 / average_living_area_per_apartment_in_2021_in_m2
+            number_of_apartments = conditioned_floor_area_in_m2 / self.AVERAGE_LIVING_AREA_PER_APARTMENT_IN_2021_IN_M2
         elif number_of_apartments_origin > 0:
             number_of_apartments = number_of_apartments_origin
         else:

--- a/hisim/components/building/information.py
+++ b/hisim/components/building/information.py
@@ -7,7 +7,7 @@ verbatim from the former single-module ``building.py``.
 
 # clean
 
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import pandas as pd
 
@@ -28,42 +28,6 @@ class BuildingInformation:
     ):
         """Initialize the class."""
 
-        self.window_scaling_factor: float
-        self.heat_transfer_coeff_thermal_mass_and_internal_surface_fixed_value_in_watt_per_m2_per_kelvin: float
-        self.ratio_between_internal_surface_area_and_floor_area: float
-        self.heat_transfer_coeff_indoor_air_and_internal_surface_fixed_value_in_watt_per_m2_per_kelvin: float
-        self.building_heat_capacity_class_f_a: dict
-        self.building_heat_capacity_class_f_c_in_joule_per_m2_per_kelvin: dict
-        self.conditioned_floor_area_in_m2_tabula_ref: float
-        self.scaled_conditioned_floor_area_in_m2: float
-        self.scaling_factor_according_to_conditioned_living_area: float
-        self.building_total_area_in_m2: float
-        self.total_heat_conductance_transmission: float
-        self.total_heat_conductance_ventilation: float
-        self.floor_area_in_m2: float
-        self.facade_area_in_m2: float
-        self.roof_area_in_m2: float
-        self.window_area_in_m2: float
-        self.scaled_window_areas_in_m2: list
-        self.max_thermal_building_demand_in_watt: float
-        self.door_area_in_m2: float
-        self.floor_u_value_in_watt_per_m2_per_kelvin: float
-        self.floor_adjustment_factor_from_tabula: float
-        self.heat_conductance_floor_in_watt_per_kelvin: float
-        self.facade_u_value_in_watt_per_m2_per_kelvin: float
-        self.facade_adjustment_factor_from_tabula: float
-        self.roof_adjustment_factor_from_tabula: float
-        self.door_adjustment_factor_from_tabula: float
-        self.window_adjustment_factor_from_tabula: float
-        self.roof_u_value_in_watt_per_m2_per_kelvin: float
-        self.window_u_value_in_watt_per_m2_per_kelvin: float
-        self.door_u_value_in_watt_per_m2_per_kelvin: float
-        self.heat_conductance_facade_in_watt_per_kelvin: float
-        self.heat_conductance_roof_in_watt_per_kelvin: float
-        self.heat_conductance_window_in_watt_per_kelvin: float
-        self.heat_conductance_door_in_watt_per_kelvin: float
-        self.heat_conductance_thermal_bridging_in_watt_per_kelvin: float
-        self.heat_conductance_ventilation_in_watt_per_kelvin: float
         self.buildingconfig = config
 
         # get set temperatures for building
@@ -72,8 +36,6 @@ class BuildingInformation:
         self.heating_reference_temperature_in_celsius = self.buildingconfig.heating_reference_temperature_in_celsius
 
         self.building_heat_capacity_class = self.buildingconfig.building_heat_capacity_class
-
-        self.windows_directions: List[str]
 
         self.get_building_from_tabula()
 
@@ -178,7 +140,7 @@ class BuildingInformation:
         self.heat_transfer_coeff_indoor_air_and_internal_surface_fixed_value_in_watt_per_m2_per_kelvin = 3.45
 
         # heat capacity class values in ISO 13790, table 12, p.69/70
-        self.building_heat_capacity_class_f_a = {
+        self.building_heat_capacity_class_f_a: Dict[str, float] = {
             "very light": 2.5,
             "light": 2.5,
             "medium": 2.5,
@@ -186,7 +148,7 @@ class BuildingInformation:
             "very heavy": 3.5,
         }
 
-        self.building_heat_capacity_class_f_c_in_joule_per_m2_per_kelvin = {
+        self.building_heat_capacity_class_f_c_in_joule_per_m2_per_kelvin: Dict[str, float] = {
             "very light": 8e4,
             "light": 1.1e5,
             "medium": 1.65e5,
@@ -378,7 +340,7 @@ class BuildingInformation:
         self.window_scaling_factor = self.window_area_in_m2 / (area_window_1_ref + area_window_2_ref)
 
         # scaling window areas over wall area
-        self.windows_directions = [
+        self.windows_directions: List[str] = [
             "South",
             "East",
             "North",
@@ -386,7 +348,7 @@ class BuildingInformation:
             "Horizontal",
         ]
 
-        self.scaled_window_areas_in_m2 = []
+        self.scaled_window_areas_in_m2: List[float] = []
         for windows_direction in self.windows_directions:
             window_area_of_direction_in_m2 = float(self.buildingdata_ref["A_Window_" + windows_direction].iloc[0])
 


### PR DESCRIPTION
Phase 3 of the building cleanup (spec: `roadmap/building_cleanup_spec.md`). **Stacked on #578 — review only the top seven commits.** One hazard per commit, all behavior-identical: the phase-1 harness (3,000 snapshots over every TABULA code + the one-day output vectors) passes with untouched goldens after every single commit.

The hazards removed from `BuildingInformation`:

1. **The 11-tuple return** — eleven positional floats unpacked into eleven attributes, two of whose names differ only by `ref`/`reference` and unit suffix. Now direct named assignments beside their TABULA columns. (History has since shown this hazard class is not theoretical: see findings entry 24 — the component carried a 10-tuple unpacked in the wrong order for 13 months, saved only by all ten values being dead.)
2. **The fake dataclass decoration** — `@dataclass_json @dataclass` on a class with a hand-written `__init__` and zero fields; proven caller-free by repo-wide greps for every piece of dataclass machinery.
3. **~40 dead bare annotations** at the top of `__init__`; real type information moved to the assignment sites.
4. **In-place mutation of the TABULA reference row** (`A_C_Ref` write-backs, the `delta_U_ThermalBridging` 0→0.1 patch) — the row is read-only after lookup; the trace proving the mutations were never load-bearing is findings entry 18.
5. **The housing-CSV read** now cached at class scope: one read per process, 68 ms → 4.1 ms per instantiation.
6. **Twin-branch deduplication** in the scaling-factor and apartment-count helpers — reproducing the exact float operations (the `250.0 → 249.99999999999997` round-trip artifact is pinned by a snapshot and survives).
7. **Magic numbers named** as documented class constants (values untouched), copy-paste-wrong docstrings fixed, and the door's `(u*area)/area` round trip **deliberately kept**: findings entry 17 — it is NOT a float no-op, simplifying it shifts 164 snapshots by 1 ulp.

Two findings worth reading: entry 17 (the door round trip) and entry 20 (the "dead" annotations were load-bearing for pylint's attribute tracking — replaced by one justified suppression that phase 4 removes again).

Gates: harness 3,006 passed after every commit, goldens untouched; base suite 3,988 passed; prospector 0 messages and mypy clean on `information.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
