### PR TITLE
Move ConfigBase, ComponentID and DisplayConfig into a hisim/config pa…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,14 @@ UTSP_API_KEY
 ### Core simulation loop (`hisim/simulator.py`)
 `Simulator` owns a list of `ComponentWrapper` objects and runs `run_all_timesteps()`. Each time step iterates through all wrapped components, calling `i_simulate()` on each, until all outputs converge (checked via `SingleTimeStepValues.is_close_enough_to_previous()`). After convergence, `PostProcessor` is invoked.
 
+### Config layer (`hisim/config/`)
+The bottom layer, imported by everything else and importing nothing from the rest of HiSim.
+`hisim/config/base.py` holds `ComponentID` (the structured component identity),
+`ConfigBase` (the base class of every component configuration dataclass) and
+`DisplayConfig`. Import them as `from hisim.config import ConfigBase, ComponentID,
+DisplayConfig` — `hisim/component.py` deliberately keeps no compatibility aliases for
+them, so the layering is visible at every call site.
+
 ### Component model (`hisim/component.py`)
 Every device is a `Component` subclass. Each component:
 - Declares `ComponentInput` and `ComponentOutput` objects in `__init__` via `add_input()` / `add_output()`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,17 @@
+Config Package
+==============
+
+The configuration layer of HiSim. It holds the classes every component configuration is
+built from — the structured component identity, the configuration base class and the
+display configuration — separated from the component runtime in :doc:`component` so that
+the dependency direction between the two is unambiguous.
+
+.. automodule:: hisim.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: hisim.config.base
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -4,6 +4,7 @@ HiSim Package Structure
 .. toctree::
    :maxdepth: 5
 
+   config
    component
    components
    modules/inputs

--- a/hisim/component.py
+++ b/hisim/component.py
@@ -1,6 +1,13 @@
 """Defines the component class and helpers.
 
 The component class is the base class for all other components.
+
+The configuration base classes this module used to define — ``ComponentID``,
+``ConfigBase`` and ``DisplayConfig`` — now live one layer below, in the
+:mod:`hisim.config` package, and are used here through the ``cfg`` module alias. No
+compatibility alias is left behind on purpose: ``hisim.component`` is the component
+*runtime*, and code that needs a configuration base class imports it from
+``hisim.config`` directly, which makes the layering visible at every call site.
 """
 
 # clean
@@ -10,11 +17,11 @@ import os
 import dataclasses as dc
 import typing
 from dataclasses import dataclass
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import json
 import pandas as pd
-from dataclasses_json import dataclass_json
 
+from hisim import config as cfg
 from hisim import loadtypes as lt
 from hisim import log
 from hisim.sim_repository import SimRepository
@@ -22,181 +29,6 @@ from hisim.simulationparameters import SimulationParameters
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiTagEnumClass
 
 # Package
-
-
-@dataclass_json
-@dataclass(frozen=True)
-class ComponentID:
-    """Structured, first-class identity of one component instance in a simulation.
-
-    A component used to be identified by a loose pair of strings on its configuration
-    (``name`` plus ``building_name``) that was collapsed into a runtime name by
-    ``Component.get_component_name()`` depending on the ``multiple_buildings`` simulation
-    parameter. ``ComponentID`` replaces that arrangement with a single immutable value
-    object: ``name`` says what the component is, ``building`` says which building object it
-    belongs to (``None`` for a plain single-building simulation), and ``unit`` says which
-    sub-unit of that building (for example an apartment) owns it. Only ``name`` is required;
-    the optional fields are simply absent when the surrounding simulation has no need for
-    them.
-
-    The unique runtime identifier is derived by the :py:attr:`key` property, which joins the
-    fields that are actually present with underscores in the order *building*, *unit*,
-    *name*. Absent fields contribute nothing at all, so ``ComponentID("Weather").key`` is
-    ``"Weather"``, ``ComponentID("Weather", building="BUI1").key`` is ``"BUI1_Weather"`` and
-    ``ComponentID("HeatPump", building="BUI1", unit="APT2").key`` is
-    ``"BUI1_APT2_HeatPump"``. The key is derived-only: it is written into component names,
-    output names and result columns, but it is never parsed back into its parts anywhere in
-    HiSim. Code that needs to know the building or the unit of a component reads the
-    structured fields instead.
-
-    Because the key merely concatenates the present fields, two different tuples can in
-    principle produce the same key (for example ``ComponentID("Pump", building="BUI1_APT2")``
-    and ``ComponentID("Pump", building="BUI1", unit="APT2")``). No new mechanism is needed to
-    catch that: such a collision shows up as two components claiming the same runtime name,
-    and the existing duplicate-component-name check performed when outputs are registered
-    with the simulator (see ``Simulator.add_component``) raises on it just as it does for any
-    other accidental name clash.
-
-    The class is frozen, so instances are hashable and safe to share between a configuration
-    and everything derived from it; use :py:func:`dataclasses.replace` to obtain a variant.
-    """
-
-    name: str
-    building: Optional[str] = None
-    unit: Optional[str] = None
-
-    #: Building label used for grouping when a component carries no explicit building.
-    #: Historically every configuration defaulted to the decorative string ``"BUI1"``, and
-    #: postprocessing (KPI collection, OPEX/CAPEX tables, the webtool result JSON) keys its
-    #: per-building groups by that string. Keeping the same label for building-less
-    #: components means the grouping output of a single-building simulation is byte-for-byte
-    #: what it was before ``ComponentID`` existed.
-    DEFAULT_BUILDING_LABEL: ClassVar[str] = "BUI1"
-
-    def __post_init__(self) -> None:
-        """Validates the identity right after construction.
-
-        The name is the only mandatory part of a component identity, and an empty or
-        whitespace-only name would silently produce an empty or malformed key later on.
-        Rejecting it here turns a confusing downstream naming problem into an immediate,
-        clearly attributable error.
-        """
-        if not isinstance(self.name, str) or not self.name.strip():
-            raise ValueError(f"A ComponentID needs a non-empty name, but got {self.name!r}.")
-
-    @property
-    def key(self) -> str:
-        """Derives the unique runtime identifier of this component.
-
-        The key is the string that HiSim uses as the component name, as the prefix of every
-        output's full name and therefore as the prefix of every result column. It is built by
-        joining the present fields with ``"_"`` in the order building, unit, name; fields that
-        are ``None`` simply do not appear. The key is derived-only and is never parsed back
-        into building/unit/name anywhere in the code base.
-        """
-        parts = [part for part in (self.building, self.unit, self.name) if part is not None]
-        return "_".join(parts)
-
-    @property
-    def building_label(self) -> str:
-        """Returns the building this component is grouped under in postprocessing.
-
-        Postprocessing aggregates results per building object (KPI collections, OPEX and
-        CAPEX tables, the building-sizer and webtool JSON exports), and those groups need a
-        string key even for components that carry no building of their own. This property
-        returns :py:attr:`building` when it is set and :py:attr:`DEFAULT_BUILDING_LABEL`
-        otherwise, which reproduces the historical behaviour where every configuration
-        carried the decorative default building name.
-        """
-        return self.building if self.building is not None else self.DEFAULT_BUILDING_LABEL
-
-
-@dataclass
-class ConfigBase:
-    """Base class for all configurations.
-
-    Every component configuration derives from this class and therefore carries exactly one
-    identity field, :py:attr:`component_id`, which replaces the former ``name`` plus
-    ``building_name`` string pair. In serialized form the identity is a nested object, i.e.
-    ``{"component_id": {"name": ..., "building": ..., "unit": ...}}``.
-
-    Serialization comes from the ``@dataclass_json`` decorator that every concrete config
-    class carries, which dumps and parses the dataclass field names verbatim (snake_case).
-    The :py:meth:`to_dict` defined here is only the fallback for the base class itself; a
-    decorated subclass shadows it with the dataclasses_json implementation.
-    """
-
-    component_id: ComponentID
-
-    if typing.TYPE_CHECKING:
-        # Historically ConfigBase inherited dataclass_wizard.JSONWizard, whose missing type
-        # stubs made the whole class hierarchy Any-based: mypy accepted any attribute on a
-        # ConfigBase-typed value. A lot of code depends on that leniency (components store
-        # their config in ConfigBase-typed slots and read/write subclass fields off it), so
-        # these type-checker-only escape hatches preserve it deliberately. Field-name
-        # correctness is enforced by scripts/check_config_attrs.py instead; making configs
-        # fully mypy-visible (a generic Component[TConfig]) is a planned sweep, see
-        # roadmap/json_cleanup.md. The classmethod stubs mirror the serialization API that
-        # the @dataclass_json decorator injects at runtime on every concrete config class.
-        def __getattr__(self, name: str) -> Any:
-            """Checking-only escape hatch: reads of undeclared fields resolve to Any."""
-            raise NotImplementedError
-
-        def __setattr__(self, name: str, value: Any) -> None:
-            """Checking-only escape hatch: writes to undeclared fields are accepted."""
-
-        def to_json(self, *args: Any, **kwargs: Any) -> str:  # pylint: disable=unused-argument
-            """Stub for the JSON dump that @dataclass_json injects at runtime."""
-            raise NotImplementedError
-
-        @classmethod
-        def from_dict(cls, kvs: Any, *args: Any, **kwargs: Any) -> Any:  # pylint: disable=unused-argument
-            """Stub for the dict decoder that @dataclass_json injects at runtime."""
-            raise NotImplementedError
-
-        @classmethod
-        def from_json(cls, data: Any, *args: Any, **kwargs: Any) -> Any:  # pylint: disable=unused-argument
-            """Stub for the JSON decoder that @dataclass_json injects at runtime."""
-            raise NotImplementedError
-
-    def __init__(self, component_id: ComponentID):
-        """Initializes a bare configuration from its structured identity.
-
-        Only :py:class:`ConfigBase` itself uses this constructor; every concrete subclass is a
-        dataclass and generates its own ``__init__`` that takes ``component_id`` as its first
-        field followed by the component-specific parameters.
-        """
-        self.component_id = component_id
-
-    @classmethod
-    def get_main_classname(cls):
-        """Returns the fully qualified class name for the class that is getting configured. Used for Json."""
-        raise NotImplementedError("Missing a definition of the ")
-
-    @classmethod
-    def get_config_classname(cls):
-        """Gets the class name. Helper function for default connections."""
-        return cls.__module__ + "." + cls.__name__
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Dumps this configuration as a plain dict of its dataclass fields.
-
-        Every concrete config class shadows this method through its ``@dataclass_json``
-        decorator, so this fallback only serves the bare base class (and would serve an
-        accidentally undecorated subclass with a plain, non-JSON-normalized dataclass dump
-        rather than an AttributeError).
-        """
-        return dc.asdict(self)
-
-    def get_string_dict(self) -> List[str]:
-        """Turns the config into a str list for the report."""
-        my_dict = self.to_dict()
-        my_list = []
-        if len(my_dict) > 0:
-            for entry in my_dict.items():
-                label = " ".join(entry[0].rsplit("_")).capitalize()
-                my_list.append(label + ": " + str(entry[1]))
-        return my_list
 
 
 @dataclass
@@ -223,14 +55,14 @@ class ComponentOutput:  # noqa: too-few-public-methods
         output_description: Optional[str] = None,
         source_component_class: Optional[str] = None,
         *,
-        component_id: ComponentID,
+        component_id: cfg.ComponentID,
     ):
         """Defines a component output.
 
         Besides the display and load-type metadata, an output carries the structured identity
         of the component that produced it. Postprocessing needs to know which building object
         an output belongs to, and it must not obtain that by taking the runtime name apart, so
-        the owning :py:class:`ComponentID` is stored alongside the derived ``component_name``.
+        the owning :py:class:`~hisim.config.ComponentID` is stored alongside the derived ``component_name``.
         The identity is deliberately REQUIRED (keyword-only): an output without an owner would
         silently fall into the default building group and corrupt per-building KPIs, so a
         missing identity must fail at construction rather than at aggregation.
@@ -246,7 +78,7 @@ class ComponentOutput:  # noqa: too-few-public-methods
         self.sankey_flow_direction: Optional[bool] = sankey_flow_direction
         self.output_description: Optional[str] = output_description
         self.source_component_class: Optional[str] = source_component_class
-        self.component_id: ComponentID = component_id
+        self.component_id: cfg.ComponentID = component_id
 
     @property
     def building_label(self) -> str:
@@ -355,19 +187,6 @@ class SingleTimeStepValues:
         return error_msg
 
 
-@dataclass
-class DisplayConfig:
-    """Configure how to display this component in postprocessing."""
-
-    pretty_name: str | None = None
-    display_in_webtool: bool = False
-
-    @classmethod
-    def show(cls, pretty_name):
-        """Shortcut for showing in webtool with a specified name."""
-        return DisplayConfig(pretty_name, display_in_webtool=True)
-
-
 class Component:
     """Base class for all components."""
 
@@ -385,8 +204,8 @@ class Component:
         self,
         name: str,
         my_simulation_parameters: SimulationParameters,
-        my_config: ConfigBase,
-        my_display_config: DisplayConfig,
+        my_config: cfg.ConfigBase,
+        my_display_config: cfg.DisplayConfig,
     ) -> None:
         """Initializes the component class."""
         self.component_name: str = name
@@ -400,22 +219,22 @@ class Component:
         self.simulation_repository: SimRepository
         # self.singleton_simulation_repository: SingletonSimRepository
         self.default_connections: Dict[str, List[ComponentConnection]] = {}
-        if isinstance(my_config, ConfigBase):
+        if isinstance(my_config, cfg.ConfigBase):
             # Subclasses read their concrete config's fields off this base-typed slot; that
             # works for the type checker because ConfigBase carries a checking-only
             # __getattr__/__setattr__ escape hatch (see there).
-            self.config: ConfigBase = my_config
+            self.config: cfg.ConfigBase = my_config
         else:
             raise ValueError(
                 "The argument my_config is not a ConfigBase object.",
                 "Please check your components' configuration classes and inherit from ConfigBase class according to hisim/components/example_component.py.",
             )
-        self.my_display_config: DisplayConfig = my_display_config
+        self.my_display_config: cfg.DisplayConfig = my_display_config
         self.log_connections: List[Any] = []
         self.enable_logging = my_simulation_parameters.log_connections
 
     @property
-    def component_id(self) -> ComponentID:
+    def component_id(self) -> cfg.ComponentID:
         """Returns the structured identity of this component.
 
         This is a convenience shortcut for ``self.config.component_id`` so that component code
@@ -429,7 +248,7 @@ class Component:
         """Creates the unique runtime name of this component.
 
         The name is derived purely from the structured identity on the configuration, i.e. it
-        is :py:attr:`ComponentID.key`. Unlike the previous implementation this no longer
+        is :py:attr:`~hisim.config.ComponentID.key`. Unlike the previous implementation this no longer
         consults the ``multiple_buildings`` simulation parameter: whether a building appears in
         the name is decided by whether the configuration carries a building at all, which makes
         the runtime name a property of the component itself rather than of a global flag.
@@ -627,7 +446,7 @@ class Component:
         raise NotImplementedError(f"{self.component_name} has no opex costs implemented.")
 
     @staticmethod
-    def get_cost_capex(config: ConfigBase, simulation_parameters: SimulationParameters) -> CapexCostDataClass:
+    def get_cost_capex(config: cfg.ConfigBase, simulation_parameters: SimulationParameters) -> CapexCostDataClass:
         # pylint: disable=unused-argument
         """Calculates lifetime, total capital expenditure cost and total co2 footprint of production of device."""
         raise NotImplementedError(f"{config.get_main_classname()} has no capex costs implemented.")

--- a/hisim/components/advanced_battery_bslib.py
+++ b/hisim/components/advanced_battery_bslib.py
@@ -12,16 +12,14 @@ import pandas as pd
 
 # Import modules from HiSim
 from hisim.component import (
-    ComponentID,
     Component,
     ComponentInput,
     ComponentOutput,
     SingleTimeStepValues,
-    ConfigBase,
     OpexCostDataClass,
-    DisplayConfig,
     CapexCostDataClass,
 )
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim.loadtypes import LoadTypes, Units, InandOutputType, ComponentType
 from hisim.simulationparameters import SimulationParameters

--- a/hisim/components/advanced_ev_battery_bslib.py
+++ b/hisim/components/advanced_ev_battery_bslib.py
@@ -13,17 +13,15 @@ from dataclasses_json import dataclass_json
 
 # Import modules from HiSim
 from hisim.component import (
-    ComponentID,
     Component,
     ComponentConnection,
     ComponentInput,
     ComponentOutput,
-    ConfigBase,
     SingleTimeStepValues,
     OpexCostDataClass,
-    DisplayConfig,
     CapexCostDataClass,
 )
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.loadtypes import ComponentType, InandOutputType, LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass, KpiEntry, KpiHelperClass

--- a/hisim/components/advanced_fuel_cell.py
+++ b/hisim/components/advanced_fuel_cell.py
@@ -10,8 +10,8 @@ import copy
 from dataclasses_json import dataclass_json
 
 import pandas as pd
-from hisim.component import ComponentID
-from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput, ConfigBase, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput
 from hisim import loadtypes as lt
 
 from hisim.components.configuration import PhysicsConfig

--- a/hisim/components/advanced_fuel_cell_controller.py
+++ b/hisim/components/advanced_fuel_cell_controller.py
@@ -2,7 +2,8 @@
 
 # clean
 from math import ceil
-from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput, DisplayConfig
+from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput
+from hisim.config import DisplayConfig
 from hisim import loadtypes as lt
 
 from hisim.components.configuration import (

--- a/hisim/components/advanced_heat_pump_hplib.py
+++ b/hisim/components/advanced_heat_pump_hplib.py
@@ -16,17 +16,15 @@ from hplib import hplib as hpl
 
 # Import modules from HiSim
 from hisim.component import (
-    ComponentID,
     Component,
     ComponentInput,
     ComponentOutput,
     SingleTimeStepValues,
-    ConfigBase,
     ComponentConnection,
     OpexCostDataClass,
     CapexCostDataClass,
-    DisplayConfig,
 )
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components import weather, simple_water_storage, heat_distribution_system
 from hisim.components.heat_distribution_system import HeatDistributionSystemType
 from hisim.loadtypes import LoadTypes, Units, InandOutputType, OutputPostprocessingRules, ComponentType

--- a/hisim/components/air_conditioner.py
+++ b/hisim/components/air_conditioner.py
@@ -10,12 +10,10 @@ from hisim import log
 
 from hisim import component as cp
 from hisim.component import (
-    ComponentID,
     CapexCostDataClass,
-    ConfigBase,
-    DisplayConfig,
     OpexCostDataClass,
 )
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.configuration import (
     EmissionFactorsAndCostsForFuelsConfig,
 )

--- a/hisim/components/building/building.py
+++ b/hisim/components/building/building.py
@@ -25,6 +25,7 @@ from hisim.loadtypes import OutputPostprocessingRules
 from hisim.sim_repository_singleton import SingletonDictKeyEnum, SingletonSimRepository
 from hisim.simulationparameters import SimulationParameters
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiTagEnumClass, KpiHelperClass
+from hisim.config import DisplayConfig
 
 
 class BuildingState:
@@ -128,7 +129,7 @@ class Building(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: BuildingConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Construct all the neccessary attributes."""
         self.buildingconfig = config

--- a/hisim/components/building/config.py
+++ b/hisim/components/building/config.py
@@ -16,13 +16,12 @@ from typing import Optional
 
 from dataclasses_json import dataclass_json
 
-from hisim import component as cp
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID
 
 
 @dataclass_json
 @dataclass
-class BuildingConfig(cp.ConfigBase):
+class BuildingConfig(ConfigBase):
     """Configuration of the Building class."""
 
     @classmethod

--- a/hisim/components/configuration.py
+++ b/hisim/components/configuration.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
 from hisim.loadtypes import LoadTypes, ComponentType
-from hisim.component import ComponentID, ConfigBase
+from hisim.config import ConfigBase, ComponentID
 from hisim import log
 
 """

--- a/hisim/components/controller_l1_chp.py
+++ b/hisim/components/controller_l1_chp.py
@@ -16,7 +16,7 @@ from dataclasses_json import dataclass_json
 # Generic/Built-in
 from hisim import component as cp
 from hisim import utils
-from hisim.component import ComponentID, ConfigBase
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.loadtypes import LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters
 
@@ -242,7 +242,7 @@ class L1CHPController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: L1CHPControllerConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """For initializing."""
         if not config.__class__.__name__ == L1CHPControllerConfig.__name__:

--- a/hisim/components/controller_l1_electrolyzer.py
+++ b/hisim/components/controller_l1_electrolyzer.py
@@ -14,12 +14,12 @@ from hisim import utils
 from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 
 
 @dataclass_json
 @dataclass
-class L1ElectrolyzerControllerConfig(cp.ConfigBase):
+class L1ElectrolyzerControllerConfig(ConfigBase):
     """Electrolyzer Controller Config."""
 
     component_id: ComponentID
@@ -121,12 +121,12 @@ class L1GenericElectrolyzerController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: L1ElectrolyzerControllerConfig,
-        my_display_config: cp.DisplayConfig | None = None,
+        my_display_config: DisplayConfig | None = None,
     ) -> None:
         """Initialize the class."""
 
         if my_display_config is None:
-            my_display_config = cp.DisplayConfig()
+            my_display_config = DisplayConfig()
         self.my_simulation_parameters = my_simulation_parameters
         self.config = config
         component_name = self.get_component_name()

--- a/hisim/components/controller_l1_electrolyzer_h2.py
+++ b/hisim/components/controller_l1_electrolyzer_h2.py
@@ -8,8 +8,8 @@ from pathlib import Path
 import json
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
-from hisim.component import ComponentID
-from hisim.component import ConfigBase, Component, ComponentInput, ComponentOutput, SingleTimeStepValues, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.component import Component, ComponentInput, ComponentOutput, SingleTimeStepValues
 
 from hisim import loadtypes as lt
 from hisim import utils

--- a/hisim/components/controller_l1_example_controller.py
+++ b/hisim/components/controller_l1_example_controller.py
@@ -14,8 +14,8 @@ from typing import Optional
 from dataclasses_json import dataclass_json
 
 # Owned
-from hisim.component import ComponentID
-from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput, ConfigBase, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 

--- a/hisim/components/controller_l1_fuel_cell.py
+++ b/hisim/components/controller_l1_fuel_cell.py
@@ -6,8 +6,8 @@ from typing import Optional, List, Any
 import json
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
-from hisim.component import ComponentID
-from hisim.component import ConfigBase, Component, ComponentInput, ComponentOutput, SingleTimeStepValues, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.component import Component, ComponentInput, ComponentOutput, SingleTimeStepValues
 
 from hisim import loadtypes as lt
 from hisim import utils

--- a/hisim/components/controller_l1_generic_ev_charge.py
+++ b/hisim/components/controller_l1_generic_ev_charge.py
@@ -21,7 +21,8 @@ from hisim.components import advanced_ev_battery_bslib
 from hisim.loadtypes import Units, ComponentType, InandOutputType
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass, KpiEntry
 from hisim.postprocessing.cost_and_emission_computation.capex_computation import CapexComputationHelperFunctions
-from hisim.component import ComponentID, OpexCostDataClass, CapexCostDataClass
+from hisim.component import OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 
 __authors__ = "Johanna Ganglbauer"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -35,7 +36,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class ChargingStationConfig(cp.ConfigBase):
+class ChargingStationConfig(ConfigBase):
     """Definition of the configuration of Charging Station and the set point for the control."""
 
     component_id: ComponentID
@@ -135,7 +136,7 @@ class L1Controller(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: ChargingStationConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initializes Car."""
         self.my_simulation_parameters = my_simulation_parameters

--- a/hisim/components/controller_l1_heatpump.py
+++ b/hisim/components/controller_l1_heatpump.py
@@ -22,7 +22,7 @@ import pandas as pd
 # Generic/Built-in
 from hisim import component as cp
 from hisim import utils
-from hisim.component import ComponentID, ConfigBase
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.loadtypes import LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry
@@ -194,7 +194,7 @@ class L1HeatPumpController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: L1HeatPumpConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the L1 heat pump controller.
 

--- a/hisim/components/controller_l1_rsoc.py
+++ b/hisim/components/controller_l1_rsoc.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Optional, Any, ClassVar
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
-from hisim.component import ComponentID
-from hisim.component import ConfigBase, Component, ComponentInput, ComponentOutput, SingleTimeStepValues, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.component import Component, ComponentInput, ComponentOutput, SingleTimeStepValues
 from hisim import loadtypes as lt
 from hisim import utils
 from hisim.simulationparameters import SimulationParameters

--- a/hisim/components/controller_l2_energy_management_system.py
+++ b/hisim/components/controller_l2_energy_management_system.py
@@ -18,7 +18,8 @@ from hisim import component as cp
 from hisim import dynamic_component
 from hisim import loadtypes as lt
 from hisim import utils
-from hisim.component import ComponentID, ComponentInput, ComponentOutput
+from hisim.component import ComponentInput, ComponentOutput
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.simulationparameters import SimulationParameters
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiTagEnumClass, KpiHelperClass
 from hisim.postprocessing.cost_and_emission_computation.capex_computation import CapexComputationHelperFunctions
@@ -43,7 +44,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class EMSConfig(cp.ConfigBase):
+class EMSConfig(ConfigBase):
     """L1 Controller Config."""
 
     @classmethod
@@ -179,7 +180,7 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
         self,
         my_simulation_parameters: SimulationParameters,
         config: EMSConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ):
         """Initializes."""
         self.my_component_inputs: List[dynamic_component.DynamicConnectionInput] = []

--- a/hisim/components/controller_l2_ptx_energy_management_system.py
+++ b/hisim/components/controller_l2_ptx_energy_management_system.py
@@ -6,8 +6,8 @@ from typing import Optional, List, Any
 import json
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
-from hisim.component import ComponentID
-from hisim.component import ConfigBase, Component, ComponentInput, ComponentOutput, SingleTimeStepValues, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.component import Component, ComponentInput, ComponentOutput, SingleTimeStepValues
 
 from hisim import loadtypes as lt
 from hisim import utils

--- a/hisim/components/controller_l2_rsoc_battery_system.py
+++ b/hisim/components/controller_l2_rsoc_battery_system.py
@@ -7,8 +7,8 @@ import json
 from dataclasses import dataclass, field
 from dataclasses_json import config as dc_json_config
 from dataclasses_json import dataclass_json
-from hisim.component import ComponentID
-from hisim.component import ConfigBase, Component, ComponentInput, ComponentOutput, SingleTimeStepValues, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.component import Component, ComponentInput, ComponentOutput, SingleTimeStepValues
 
 from hisim import loadtypes as lt
 from hisim import utils

--- a/hisim/components/controller_l2_xtp_fuel_cell_ems.py
+++ b/hisim/components/controller_l2_xtp_fuel_cell_ems.py
@@ -9,8 +9,8 @@ import json
 import math
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
-from hisim.component import ComponentID
-from hisim.component import ConfigBase, Component, ComponentInput, ComponentOutput, SingleTimeStepValues, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.component import Component, ComponentInput, ComponentOutput, SingleTimeStepValues
 
 from hisim import loadtypes as lt
 from hisim import utils

--- a/hisim/components/controller_mpc.py
+++ b/hisim/components/controller_mpc.py
@@ -12,7 +12,7 @@ import casadi as ca
 # Owned
 from hisim import utils
 from hisim import component as cp
-from hisim.component import ComponentID, ConfigBase
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.loadtypes import LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters
 from hisim.components.weather import Weather
@@ -208,7 +208,7 @@ class MpcController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: MpcControllerConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Constructs all the neccessary attributes."""
 

--- a/hisim/components/controller_pid.py
+++ b/hisim/components/controller_pid.py
@@ -17,7 +17,7 @@ from hisim.simulationparameters import SimulationParameters
 from hisim.components.building import Building
 from hisim import log
 from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 
 __authors__ = "Marwa Alfouly"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -31,7 +31,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class PIDControllerConfig(cp.ConfigBase):
+class PIDControllerConfig(ConfigBase):
     """Configuration of the PID Controller."""
 
     @classmethod
@@ -349,7 +349,7 @@ class PIDController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: PIDControllerConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Constructs all the neccessary attributes."""
         self.my_simulation_parameters = my_simulation_parameters

--- a/hisim/components/csvloader.py
+++ b/hisim/components/csvloader.py
@@ -23,12 +23,12 @@ from hisim import loadtypes as lt
 from hisim import utils
 from hisim import component as cp
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 
 
 @dataclass_json
 @dataclass
-class CSVLoaderConfig(cp.ConfigBase):
+class CSVLoaderConfig(ConfigBase):
     """Configuration for the :class:`CSVLoader` component.
 
     Args:
@@ -129,7 +129,7 @@ class CSVLoader(cp.Component):
         self,
         config: CSVLoaderConfig,
         my_simulation_parameters: SimulationParameters,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
         inputs_dir: Path | None = None,
         dataframe: pd.DataFrame | None = None,
     ) -> None:
@@ -259,7 +259,7 @@ class CSVLoader(cp.Component):
         cls,
         config: CSVLoaderConfig,
         my_simulation_parameters: SimulationParameters,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
         inputs_dir: Path | None = None,
     ) -> "CSVLoader":
         """Construct a :class:`CSVLoader` by reading its CSV file from disk.

--- a/hisim/components/electricity_meter.py
+++ b/hisim/components/electricity_meter.py
@@ -10,7 +10,8 @@ from dataclasses_json import dataclass_json
 from hisim import component as cp
 from hisim import dynamic_component
 from hisim import loadtypes as lt
-from hisim.component import ComponentID, ComponentInput, OpexCostDataClass, CapexCostDataClass
+from hisim.component import ComponentInput, OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim.dynamic_component import (
     DynamicComponent,
@@ -25,7 +26,7 @@ from hisim.postprocessing.cost_and_emission_computation.capex_computation import
 
 @dataclass_json
 @dataclass
-class ElectricityMeterConfig(cp.ConfigBase):
+class ElectricityMeterConfig(ConfigBase):
     """Electricity Meter Config."""
 
     @classmethod
@@ -91,7 +92,7 @@ class ElectricityMeter(DynamicComponent):
         self,
         my_simulation_parameters: SimulationParameters,
         config: ElectricityMeterConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(display_in_webtool=True),
+        my_display_config: DisplayConfig = DisplayConfig(display_in_webtool=True),
     ):
         """Initialize the component."""
         self.grid_energy_balancer_config = config

--- a/hisim/components/example_component.py
+++ b/hisim/components/example_component.py
@@ -9,9 +9,9 @@ from dataclasses_json import dataclass_json
 
 # Owned
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID, Component, SingleTimeStepValues, ComponentInput, ComponentOutput, DisplayConfig
+from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim import loadtypes as lt
-from hisim.component import ConfigBase
 
 __authors__ = "Vitor Hugo Bellotto Zago"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -79,9 +79,9 @@ class ExampleComponent(Component):
         capacity, and initial temperature).
 
     my_display_config : DisplayConfig, optional
-        A :py:class:`~hisim.component.DisplayConfig` object that controls
+        A :py:class:`~hisim.config.DisplayConfig` object that controls
         how the component is displayed in the simulation results.
-        Defaults to an empty :py:class:`~hisim.component.DisplayConfig`.
+        Defaults to an empty :py:class:`~hisim.config.DisplayConfig`.
 
     """
 

--- a/hisim/components/example_storage.py
+++ b/hisim/components/example_storage.py
@@ -9,10 +9,10 @@ from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 
 # Owned
-from hisim.component import ComponentID, Component, SingleTimeStepValues, ComponentInput, ComponentOutput, DisplayConfig
+from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.simulationparameters import SimulationParameters
 from hisim import loadtypes as lt
-from hisim.component import ConfigBase
 
 
 class ExampleStorageState:

--- a/hisim/components/example_template.py
+++ b/hisim/components/example_template.py
@@ -15,10 +15,10 @@ from typing import Optional
 from dataclasses_json import dataclass_json
 
 # Import modules from HiSim
-from hisim.component import ComponentID, Component, ComponentInput, ComponentOutput, SingleTimeStepValues, DisplayConfig
+from hisim.component import Component, ComponentInput, ComponentOutput, SingleTimeStepValues
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim import loadtypes
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ConfigBase
 
 __authors__ = "Tjarko Tjaden, Kai Rösken"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"

--- a/hisim/components/example_transformer.py
+++ b/hisim/components/example_transformer.py
@@ -16,10 +16,10 @@ from typing import Optional
 from dataclasses_json import dataclass_json
 
 # Import modules from HiSim
-from hisim.component import ComponentID, Component, SingleTimeStepValues, ComponentInput, ComponentOutput, DisplayConfig
+from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ConfigBase
 
 
 @dataclass_json
@@ -92,9 +92,9 @@ class ExampleTransformer(Component):
         transformer configuration (name, loadtype, and unit).
 
     my_display_config : DisplayConfig, optional
-        A :py:class:`~hisim.component.DisplayConfig` object that controls
+        A :py:class:`~hisim.config.DisplayConfig` object that controls
         how the component is displayed in the simulation results.
-        Defaults to an empty :py:class:`~hisim.component.DisplayConfig`.
+        Defaults to an empty :py:class:`~hisim.config.DisplayConfig`.
 
     """
 

--- a/hisim/components/fuel_meter.py
+++ b/hisim/components/fuel_meter.py
@@ -9,7 +9,8 @@ from dataclasses_json import dataclass_json
 
 from hisim import component as cp
 from hisim import loadtypes as lt
-from hisim.component import ComponentID, ComponentInput, OpexCostDataClass
+from hisim.component import ComponentInput, OpexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim.dynamic_component import (
     DynamicComponent,
@@ -31,7 +32,7 @@ __status__ = ""
 
 @dataclass_json
 @dataclass
-class FuelMeterConfig(cp.ConfigBase):
+class FuelMeterConfig(ConfigBase):
     """Fuel Meter Config."""
 
     @classmethod
@@ -74,11 +75,11 @@ class FuelMeter(DynamicComponent):
         self,
         my_simulation_parameters: SimulationParameters,
         config: FuelMeterConfig,
-        my_display_config: Optional[cp.DisplayConfig] = None,
+        my_display_config: Optional[DisplayConfig] = None,
     ) -> None:
         """Initialize the component."""
         if my_display_config is None:
-            my_display_config = cp.DisplayConfig(display_in_webtool=True)
+            my_display_config = DisplayConfig(display_in_webtool=True)
         self.config: FuelMeterConfig = config
         self.name: str = self.config.component_id.name
         self.my_component_inputs: List[DynamicConnectionInput] = []

--- a/hisim/components/gas_meter.py
+++ b/hisim/components/gas_meter.py
@@ -15,7 +15,8 @@ from dataclasses_json import dataclass_json
 from hisim import component as cp
 from hisim import dynamic_component
 from hisim import loadtypes as lt
-from hisim.component import ComponentID, ComponentInput, ComponentOutput, OpexCostDataClass, CapexCostDataClass
+from hisim.component import ComponentInput, ComponentOutput, OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim.dynamic_component import (
     DynamicComponent,
@@ -29,7 +30,7 @@ from hisim.postprocessing.cost_and_emission_computation.capex_computation import
 
 @dataclass_json
 @dataclass
-class GasMeterConfig(cp.ConfigBase):
+class GasMeterConfig(ConfigBase):
     """Configuration dataclass for the GasMeter component.
 
     Holds the building name, gas load type (GAS or GREEN_HYDROGEN), and optional
@@ -96,7 +97,7 @@ class GasMeter(DynamicComponent):
         self,
         my_simulation_parameters: SimulationParameters,
         config: GasMeterConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(display_in_webtool=True),
+        my_display_config: DisplayConfig = DisplayConfig(display_in_webtool=True),
     ) -> None:
         """Initialize the component."""
         self.grid_energy_balancer_config = config

--- a/hisim/components/generic_boiler.py
+++ b/hisim/components/generic_boiler.py
@@ -24,17 +24,15 @@ from hisim.components.configuration import (
     PhysicsConfig,
 )
 from hisim.component import (
-    ComponentID,
     Component,
     ComponentConnection,
     SingleTimeStepValues,
     ComponentInput,
     ComponentOutput,
-    ConfigBase,
     OpexCostDataClass,
-    DisplayConfig,
     CapexCostDataClass,
 )
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.dual_circuit_system import (
     DiverterValve,
     HeatingMode,

--- a/hisim/components/generic_car.py
+++ b/hisim/components/generic_car.py
@@ -17,7 +17,8 @@ from dataclasses_json import dataclass_json
 from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim import utils, log
-from hisim.component import ComponentID, OpexCostDataClass, CapexCostDataClass
+from hisim.component import OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim.loadtypes import Units, ComponentType
 
@@ -143,7 +144,7 @@ class GenericCarInformation:
 
 @dataclass_json
 @dataclass
-class CarConfig(cp.ConfigBase):
+class CarConfig(ConfigBase):
     """Definition of configuration of Car."""
 
     component_id: ComponentID
@@ -240,7 +241,7 @@ class Car(cp.Component):
         my_simulation_parameters: SimulationParameters,
         config: CarConfig,
         data_dict_with_car_information: Dict,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(display_in_webtool=True),
+        my_display_config: DisplayConfig = DisplayConfig(display_in_webtool=True),
     ) -> None:
         """Initializes Car."""
         self.my_simulation_parameters = my_simulation_parameters

--- a/hisim/components/generic_chp.py
+++ b/hisim/components/generic_chp.py
@@ -16,7 +16,7 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.components import controller_l1_chp
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 
 __authors__ = "Frank Burkrad, Maximilian Hillen"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -30,7 +30,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class CHPConfig(cp.ConfigBase):
+class CHPConfig(ConfigBase):
     """Defininition of configuration of combined heat and power plant (CHP)."""
 
     component_id: ComponentID
@@ -142,7 +142,7 @@ class SimpleCHP(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: CHPConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initializes the class."""
         self.my_simulation_parameters: SimulationParameters = my_simulation_parameters
@@ -291,5 +291,5 @@ class SimpleCHP(cp.Component):
     def write_to_report(self) -> List[str]:
         """Writes the information of the current component to the report."""
         # Despite its name, ConfigBase.get_string_dict() returns a List[str] of
-        # formatted "key: value" entries (see cp.ConfigBase), not a dict.
+        # formatted "key: value" entries (see ConfigBase), not a dict.
         return self.config.get_string_dict()

--- a/hisim/components/generic_district_heating.py
+++ b/hisim/components/generic_district_heating.py
@@ -18,17 +18,15 @@ from dataclasses_json import dataclass_json
 from hisim.components.dual_circuit_system import DiverterValve, HeatingMode, SetTemperatureConfig
 from hisim.loadtypes import LoadTypes, Units, ComponentType
 from hisim.component import (
-    ComponentID,
     Component,
     ComponentConnection,
     SingleTimeStepValues,
     ComponentInput,
     ComponentOutput,
-    ConfigBase,
     OpexCostDataClass,
-    DisplayConfig,
     CapexCostDataClass,
 )
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.heat_distribution_system import (
     HeatDistributionController,
     HeatDistribution,

--- a/hisim/components/generic_electric_heating.py
+++ b/hisim/components/generic_electric_heating.py
@@ -12,17 +12,15 @@ from dataclasses_json import dataclass_json
 from hisim.components.dual_circuit_system import DiverterValve, HeatingMode, SetTemperatureConfig
 from hisim.loadtypes import LoadTypes, Units, InandOutputType, ComponentType
 from hisim.component import (
-    ComponentID,
     Component,
     ComponentConnection,
     SingleTimeStepValues,
     ComponentInput,
     ComponentOutput,
-    ConfigBase,
     OpexCostDataClass,
-    DisplayConfig,
     CapexCostDataClass,
 )
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.building import Building
 from hisim.components.weather import Weather
 from hisim.components.heat_distribution_system import HeatDistributionControllerConfig

--- a/hisim/components/generic_electrolyzer.py
+++ b/hisim/components/generic_electrolyzer.py
@@ -14,7 +14,7 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.components import controller_l1_electrolyzer
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 
 __authors__ = "Frank Burkrad, Maximilian Hillen"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -28,7 +28,7 @@ __status__ = ""
 
 @dataclass_json
 @dataclass
-class GenericElectrolyzerConfig(cp.ConfigBase):
+class GenericElectrolyzerConfig(ConfigBase):
     """Generic electrolyzer config."""
 
     component_id: ComponentID
@@ -115,7 +115,7 @@ class GenericElectrolyzer(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: GenericElectrolyzerConfig,
-        my_display_config: Optional[cp.DisplayConfig] = None,
+        my_display_config: Optional[DisplayConfig] = None,
     ) -> None:
         """Initialize the electrolyzer component.
 
@@ -131,7 +131,7 @@ class GenericElectrolyzer(cp.Component):
         self.my_simulation_parameters: SimulationParameters = my_simulation_parameters
         self.config: GenericElectrolyzerConfig = config
         if my_display_config is None:
-            my_display_config = cp.DisplayConfig()
+            my_display_config = DisplayConfig()
         component_name = self.get_component_name()
         super().__init__(
             name=component_name,

--- a/hisim/components/generic_electrolyzer_and_h2_storage.py
+++ b/hisim/components/generic_electrolyzer_and_h2_storage.py
@@ -7,8 +7,8 @@ from typing import Optional, List, Any
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 
-from hisim.component import ComponentID
-from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput, ConfigBase, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 

--- a/hisim/components/generic_electrolyzer_h2.py
+++ b/hisim/components/generic_electrolyzer_h2.py
@@ -10,7 +10,8 @@ from scipy.interpolate import interp1d
 import numpy as np
 
 # Import modules from HiSim
-from hisim.component import ComponentID, SingleTimeStepValues, ComponentInput, ComponentOutput, DisplayConfig
+from hisim.component import SingleTimeStepValues, ComponentInput, ComponentOutput
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim import loadtypes as lt
 from hisim import utils
 from hisim.simulationparameters import SimulationParameters
@@ -28,7 +29,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class ElectrolyzerConfig(cp.ConfigBase):
+class ElectrolyzerConfig(ConfigBase):
     """Configuration of the Electrolyzer."""
 
     @classmethod

--- a/hisim/components/generic_fuel_cell.py
+++ b/hisim/components/generic_fuel_cell.py
@@ -12,7 +12,8 @@ from scipy.interpolate import interp1d
 import numpy as np
 
 # Import modules from HiSim
-from hisim.component import ComponentID, SingleTimeStepValues, ComponentInput, ComponentOutput, DisplayConfig
+from hisim.component import SingleTimeStepValues, ComponentInput, ComponentOutput
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim import loadtypes as lt
 from hisim import utils
 from hisim.simulationparameters import SimulationParameters
@@ -34,7 +35,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class FuelCellConfig(cp.ConfigBase):
+class FuelCellConfig(ConfigBase):
     """Configuration of the `FuelCell` component.
 
     Holds configuration parameters for a PEM fuel cell: nominal, minimum

--- a/hisim/components/generic_heat_pump.py
+++ b/hisim/components/generic_heat_pump.py
@@ -22,7 +22,8 @@ from hisim import log
 
 # Owned
 from hisim import utils
-from hisim.component import ComponentID, OpexCostDataClass, CapexCostDataClass
+from hisim.component import OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.building import Building
 from hisim.components.weather import Weather
 import hisim.loadtypes as lt
@@ -41,7 +42,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class GenericHeatPumpConfig(cp.ConfigBase):
+class GenericHeatPumpConfig(ConfigBase):
     """Config for the generic heat pump."""
 
     @classmethod
@@ -74,7 +75,7 @@ class GenericHeatPumpConfig(cp.ConfigBase):
 
 @dataclass_json
 @dataclass
-class GenericHeatPumpControllerConfig(cp.ConfigBase):
+class GenericHeatPumpControllerConfig(ConfigBase):
     """Configuration for the generic heat pump controller."""
 
     @classmethod
@@ -196,7 +197,7 @@ class GenericHeatPump(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: GenericHeatPumpConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Construct all the necessary attributes."""
         self.heatpump_config = config
@@ -637,7 +638,7 @@ class GenericHeatPumpController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: GenericHeatPumpControllerConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Construct all the neccessary attributes."""
         self.heatpump_controller_config = config

--- a/hisim/components/generic_hydrogen_storage.py
+++ b/hisim/components/generic_hydrogen_storage.py
@@ -12,7 +12,7 @@ from hisim import loadtypes as lt
 from hisim.components import generic_chp
 from hisim.components import generic_electrolyzer
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 
 __authors__ = "Frank Burkrad, Maximilian Hillen"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -26,7 +26,7 @@ __status__ = ""
 
 @dataclass_json
 @dataclass
-class GenericHydrogenStorageConfig(cp.ConfigBase):
+class GenericHydrogenStorageConfig(ConfigBase):
     """Generic hydrogen storage config class."""
 
     component_id: ComponentID
@@ -120,7 +120,7 @@ class GenericHydrogenStorage(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: GenericHydrogenStorageConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the generic hydrogen storage component.
 

--- a/hisim/components/generic_price_signal.py
+++ b/hisim/components/generic_price_signal.py
@@ -17,7 +17,7 @@ from hisim.simulationparameters import SimulationParameters
 from hisim import utils
 from hisim import loadtypes as lt
 from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 
 __authors__ = "Johanna Ganglbauer"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -31,7 +31,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class PriceSignalConfig(cp.ConfigBase):
+class PriceSignalConfig(ConfigBase):
     """Configuration for the PriceSignal component.
 
     Holds all parameters required to configure the price signal component:
@@ -113,7 +113,7 @@ class PriceSignal(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: PriceSignalConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the PriceSignal component.
 

--- a/hisim/components/generic_pv_system.py
+++ b/hisim/components/generic_pv_system.py
@@ -30,7 +30,8 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim import log
 from hisim import utils
-from hisim.component import ComponentID, ConfigBase, OpexCostDataClass, CapexCostDataClass
+from hisim.component import OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.weather import Weather
 from hisim.sim_repository_singleton import (
     SingletonSimRepository,
@@ -322,7 +323,7 @@ class PVSystem(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: PVSystemConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(display_in_webtool=True),
+        my_display_config: DisplayConfig = DisplayConfig(display_in_webtool=True),
     ) -> None:
         """Initialize the class."""
         self.my_simulation_parameters = my_simulation_parameters

--- a/hisim/components/generic_rsoc.py
+++ b/hisim/components/generic_rsoc.py
@@ -9,7 +9,8 @@ from dataclasses_json import dataclass_json
 import numpy as np
 
 # Import modules from HiSim
-from hisim.component import ComponentID, SingleTimeStepValues, ComponentInput, ComponentOutput, DisplayConfig
+from hisim.component import SingleTimeStepValues, ComponentInput, ComponentOutput
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim import loadtypes as lt
 from hisim import utils
 from hisim.simulationparameters import SimulationParameters
@@ -27,7 +28,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class RsocConfig(cp.ConfigBase):
+class RsocConfig(ConfigBase):
     """Configuration of the rSOC."""
 
     @classmethod

--- a/hisim/components/generic_smart_device.py
+++ b/hisim/components/generic_smart_device.py
@@ -23,7 +23,8 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim import utils
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID, OpexCostDataClass
+from hisim.component import OpexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass
 
 __authors__ = "Johanna Ganglbauer"
@@ -38,7 +39,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class SmartDeviceConfig(cp.ConfigBase):
+class SmartDeviceConfig(ConfigBase):
     """Configuration of the smart device."""
 
     @classmethod
@@ -147,7 +148,7 @@ class SmartDevice(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: SmartDeviceConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the smart device component.
 

--- a/hisim/components/generic_windturbine.py
+++ b/hisim/components/generic_windturbine.py
@@ -16,7 +16,8 @@ from windpowerlib import ModelChain, WindTurbine
 from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim import utils
-from hisim.component import ComponentID, ConfigBase, OpexCostDataClass, CapexCostDataClass
+from hisim.component import OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.weather import Weather
 from hisim.simulationparameters import SimulationParameters
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass, KpiEntry
@@ -146,7 +147,7 @@ class Windturbine(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: WindturbineConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
         self.windturbineconfig = config

--- a/hisim/components/heat_distribution_system.py
+++ b/hisim/components/heat_distribution_system.py
@@ -17,7 +17,8 @@ from hisim.simulationparameters import SimulationParameters
 from hisim.components.configuration import PhysicsConfig
 from hisim import loadtypes as lt
 from hisim import utils
-from hisim.component import ComponentID, OpexCostDataClass, CapexCostDataClass
+from hisim.component import OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiHelperClass, KpiTagEnumClass
 from hisim.postprocessing.cost_and_emission_computation.capex_computation import CapexComputationHelperFunctions
 
@@ -72,7 +73,7 @@ class PositionHotWaterStorageInSystemSetup(str, Enum):
 
 @dataclass_json
 @dataclass
-class HeatDistributionConfig(cp.ConfigBase):
+class HeatDistributionConfig(ConfigBase):
     """Configuration of the HeatingWaterStorage class."""
 
     @classmethod
@@ -169,7 +170,7 @@ class HeatDistribution(cp.Component):
         self,
         config: HeatDistributionConfig,
         my_simulation_parameters: SimulationParameters,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Construct all the neccessary attributes."""
         self.my_simulation_parameters = my_simulation_parameters
@@ -840,7 +841,7 @@ class HeatDistribution(cp.Component):
 
 @dataclass_json
 @dataclass
-class HeatDistributionControllerConfig(cp.ConfigBase):
+class HeatDistributionControllerConfig(ConfigBase):
     """HeatDistribution Controller Config Class."""
 
     @classmethod
@@ -958,7 +959,7 @@ class HeatDistributionController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: HeatDistributionControllerConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Construct all the neccessary attributes."""
         self.hsd_controller_config = config

--- a/hisim/components/heating_meter.py
+++ b/hisim/components/heating_meter.py
@@ -10,7 +10,8 @@ from dataclasses_json import dataclass_json
 from hisim import component as cp
 from hisim import dynamic_component
 from hisim import loadtypes as lt
-from hisim.component import ComponentID, ComponentInput, OpexCostDataClass
+from hisim.component import ComponentInput, OpexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim.dynamic_component import (
     DynamicComponent,
@@ -32,7 +33,7 @@ __status__ = ""
 
 @dataclass_json
 @dataclass
-class HeatingMeterConfig(cp.ConfigBase):
+class HeatingMeterConfig(ConfigBase):
     """Configuration dataclass for the HeatingMeter component.
 
     Holds the building name and component name used to instantiate
@@ -82,7 +83,7 @@ class HeatingMeter(DynamicComponent):
         self,
         my_simulation_parameters: SimulationParameters,
         config: HeatingMeterConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(display_in_webtool=True),
+        my_display_config: DisplayConfig = DisplayConfig(display_in_webtool=True),
     ) -> None:
         """Initialize the component."""
         self.config: HeatingMeterConfig = config

--- a/hisim/components/idealized_electric_heater.py
+++ b/hisim/components/idealized_electric_heater.py
@@ -8,7 +8,8 @@ from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 import pandas as pd
 import hisim.component as cp
-from hisim.component import ComponentID, OpexCostDataClass, CapexCostDataClass
+from hisim.component import OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.simulationparameters import SimulationParameters
 from hisim import loadtypes as lt
 from hisim import utils
@@ -26,7 +27,7 @@ __status__ = ""
 
 @dataclass_json
 @dataclass
-class IdealizedHeaterConfig(cp.ConfigBase):
+class IdealizedHeaterConfig(ConfigBase):
     """Configuration of the Idealized Heater."""
 
     @classmethod
@@ -70,11 +71,11 @@ class IdealizedElectricHeater(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: IdealizedHeaterConfig,
-        my_display_config: cp.DisplayConfig | None = None,
+        my_display_config: DisplayConfig | None = None,
     ) -> None:
         """Construct all the necessary attributes."""
         self.my_simulation_parameters = my_simulation_parameters
-        my_display_config = my_display_config or cp.DisplayConfig()
+        my_display_config = my_display_config or DisplayConfig()
         self.config = config
         component_name = self.get_component_name()
         super().__init__(

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -45,7 +45,8 @@ from hisim import loadtypes as lt
 from hisim import log, utils
 from hisim.components.configuration import HouseholdWarmWaterDemandConfig, PhysicsConfig
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID, OpexCostDataClass
+from hisim.component import OpexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
 
 # Constants for warm water fallback values used in i_simulate
@@ -63,7 +64,7 @@ class LpgDataAcquisitionMode(enum.Enum):
 
 @dataclass_json
 @dataclass
-class UtspLpgConnectorConfig(cp.ConfigBase):
+class UtspLpgConnectorConfig(ConfigBase):
     """Config class for UtspLpgConnector. Contains LPG parameters and UTSP connection parameters."""
 
     component_id: ComponentID
@@ -155,7 +156,7 @@ class UtspLpgConnector(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: UtspLpgConnectorConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initializes the component and retrieves the LPG data."""
         self.utsp_config: UtspLpgConnectorConfig = config

--- a/hisim/components/more_advanced_heat_pump_hplib.py
+++ b/hisim/components/more_advanced_heat_pump_hplib.py
@@ -25,17 +25,15 @@ from hplib import hplib as hpl
 
 # Import modules from HiSim
 from hisim.component import (
-    ComponentID,
     Component,
     ComponentInput,
     ComponentOutput,
     SingleTimeStepValues,
-    ConfigBase,
     ComponentConnection,
     OpexCostDataClass,
-    DisplayConfig,
     CapexCostDataClass,
 )
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components import weather, simple_water_storage, heat_distribution_system
 from hisim.components.heat_distribution_system import HeatDistributionSystemType
 from hisim.loadtypes import LoadTypes, Units, InandOutputType, OutputPostprocessingRules, ComponentType

--- a/hisim/components/night_setback_controller.py
+++ b/hisim/components/night_setback_controller.py
@@ -18,7 +18,8 @@ from dataclasses_json import dataclass_json
 from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim import utils
-from hisim.component import ComponentID, CapexCostDataClass, OpexCostDataClass
+from hisim.component import CapexCostDataClass, OpexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.building import Building
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry
 from hisim.simulationparameters import SimulationParameters
@@ -41,7 +42,7 @@ SECONDS_PER_DAY: int = 24 * SECONDS_PER_HOUR  # s per day
 
 @dataclass_json
 @dataclass
-class NightSetbackConfig(cp.ConfigBase):
+class NightSetbackConfig(ConfigBase):
     """Configuration of the night setback controller."""
 
     @classmethod
@@ -85,11 +86,11 @@ class NightSetbackController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: NightSetbackConfig,
-        my_display_config: Optional[cp.DisplayConfig] = None,
+        my_display_config: Optional[DisplayConfig] = None,
     ) -> None:
         """Construct the controller."""
         if my_display_config is None:
-            my_display_config = cp.DisplayConfig()
+            my_display_config = DisplayConfig()
         self.my_simulation_parameters = my_simulation_parameters
         self.config = config
         component_name = self.get_component_name()

--- a/hisim/components/random_numbers.py
+++ b/hisim/components/random_numbers.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 
 # Owned
-from hisim.component import ComponentID, Component, SingleTimeStepValues, ConfigBase, DisplayConfig
+from hisim.component import Component, SingleTimeStepValues
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 

--- a/hisim/components/simple_air_conditioner.py
+++ b/hisim/components/simple_air_conditioner.py
@@ -21,12 +21,10 @@ from dataclasses_json import dataclass_json
 
 from hisim import component as cp
 from hisim.component import (
-    ComponentID,
     CapexCostDataClass,
-    ConfigBase,
-    DisplayConfig,
     OpexCostDataClass,
 )
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim.postprocessing.kpi_computation.kpi_structure import (
     KpiEntry,

--- a/hisim/components/simple_heat_source.py
+++ b/hisim/components/simple_heat_source.py
@@ -17,7 +17,8 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.loadtypes import Units
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID, ComponentInput, ComponentConnection, OpexCostDataClass, CapexCostDataClass
+from hisim.component import ComponentInput, ComponentConnection, OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components import weather
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass, KpiEntry
 
@@ -61,7 +62,7 @@ class FluidMediaType(str, Enum):
 
 @dataclass_json
 @dataclass
-class SimpleHeatSourceConfig(cp.ConfigBase):
+class SimpleHeatSourceConfig(ConfigBase):
     """Configuration of a generic HeatSource.
 
     JSON field-name migrations (issue #1603):
@@ -291,7 +292,7 @@ class SimpleHeatSource(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: SimpleHeatSourceConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
 

--- a/hisim/components/simple_water_storage.py
+++ b/hisim/components/simple_water_storage.py
@@ -14,14 +14,13 @@ import hisim.component as cp
 from hisim import loadtypes as lt
 from hisim import utils
 from hisim.component import (
-    ComponentID,
     SingleTimeStepValues,
     ComponentInput,
     ComponentOutput,
     OpexCostDataClass,
-    DisplayConfig,
     CapexCostDataClass,
 )
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.configuration import PhysicsConfig
 from hisim.components import configuration
 from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
@@ -71,7 +70,7 @@ class PositionHotWaterStorageInSystemSetup(str, Enum):
 
 @dataclass_json
 @dataclass
-class SimpleHotWaterStorageConfig(cp.ConfigBase):
+class SimpleHotWaterStorageConfig(ConfigBase):
     """Configuration of the SimpleHotWaterStorage class."""
 
     @classmethod
@@ -190,7 +189,7 @@ class SimpleHotWaterStorageConfig(cp.ConfigBase):
 
 @dataclass_json
 @dataclass
-class SimpleHotWaterStorageControllerConfig(cp.ConfigBase):
+class SimpleHotWaterStorageControllerConfig(ConfigBase):
     """Configuration of the SimpleHotWaterStorageController class."""
 
     @classmethod
@@ -213,7 +212,7 @@ class SimpleHotWaterStorageControllerConfig(cp.ConfigBase):
 
 @dataclass_json
 @dataclass
-class SimpleDHWStorageConfig(cp.ConfigBase):
+class SimpleDHWStorageConfig(ConfigBase):
     """Configuration of the SimpleHotWaterStorage class."""
 
     @classmethod
@@ -312,7 +311,7 @@ class SimpleWaterStorage(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         name: str,
-        my_config: cp.ConfigBase,
+        my_config: ConfigBase,
         my_display_config: DisplayConfig,
     ) -> None:
         """Construct all the neccessary attributes."""

--- a/hisim/components/solar_thermal_system.py
+++ b/hisim/components/solar_thermal_system.py
@@ -8,7 +8,6 @@ from dataclasses_json import dataclass_json
 import pandas as pd
 from oemof.thermal.solar_thermal_collector import flat_plate_precalc
 from hisim.component import (
-    ComponentID,
     CapexCostDataClass,
     Component,
     ComponentConnection,
@@ -17,14 +16,13 @@ from hisim.component import (
     Coordinates,
     OpexCostDataClass,
     SingleTimeStepValues,
-    DisplayConfig,
 )
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim import loadtypes, log, utils
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig, PhysicsConfig
 from hisim.components.simple_water_storage import SimpleDHWStorage
 from hisim.components.weather import Weather
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ConfigBase
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiTagEnumClass
 from hisim.postprocessing.cost_and_emission_computation.capex_computation import CapexComputationHelperFunctions
 

--- a/hisim/components/sumbuilder.py
+++ b/hisim/components/sumbuilder.py
@@ -8,13 +8,14 @@ from dataclasses_json import dataclass_json
 
 from hisim import component as cp
 from hisim import loadtypes as lt
-from hisim.component import ComponentID, Component
+from hisim.component import Component
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.simulationparameters import SimulationParameters
 
 
 @dataclass_json
 @dataclass
-class SumBuilderConfig(cp.ConfigBase):
+class SumBuilderConfig(ConfigBase):
     """Configuration dataclass for sum-builder components.
 
     ``loadtype`` and ``unit`` define the physical quantity and its unit for
@@ -52,7 +53,7 @@ class CalculateOperation(cp.Component):
         self,
         config: SumBuilderConfig,
         my_simulation_parameters: SimulationParameters,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initializes the class."""
         self.my_simulation_parameters = my_simulation_parameters
@@ -158,7 +159,7 @@ class SumBuilderForTwoInputs(Component):
         self,
         config: SumBuilderConfig,
         my_simulation_parameters: SimulationParameters,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initializes the class."""
         self.my_simulation_parameters = my_simulation_parameters
@@ -240,7 +241,7 @@ class SumBuilderForThreeInputs(Component):
         self,
         config: SumBuilderConfig,
         my_simulation_parameters: SimulationParameters,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initializes the class."""
         self.my_simulation_parameters = my_simulation_parameters

--- a/hisim/components/transformer_rectifier.py
+++ b/hisim/components/transformer_rectifier.py
@@ -8,11 +8,10 @@ from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 
 # Import modules from HiSim
-from hisim.component import ComponentID
-from hisim.component import StatelessComponent, SingleTimeStepValues, ComponentInput, ComponentOutput, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.component import StatelessComponent, SingleTimeStepValues, ComponentInput, ComponentOutput
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ConfigBase
 
 
 @dataclass_json
@@ -72,9 +71,9 @@ class Transformer(StatelessComponent):
         ``efficiency`` expressed as a fraction in [0, 1]).
 
     my_display_config : DisplayConfig, optional
-        A :py:class:`~hisim.component.DisplayConfig` object that controls
+        A :py:class:`~hisim.config.DisplayConfig` object that controls
         how the component is displayed in the simulation results.
-        Defaults to an empty :py:class:`~hisim.component.DisplayConfig`.
+        Defaults to an empty :py:class:`~hisim.config.DisplayConfig`.
 
     """
 

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -16,8 +16,8 @@ import pvlib
 
 from hisim import loadtypes as lt
 from hisim import log, utils
-from hisim.component import ComponentID
-from hisim.component import Component, ComponentOutput, ConfigBase, SingleTimeStepValues, DisplayConfig, OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.component import Component, ComponentOutput, SingleTimeStepValues, OpexCostDataClass, CapexCostDataClass
 from hisim.simulationparameters import SimulationParameters
 from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry

--- a/hisim/config/__init__.py
+++ b/hisim/config/__init__.py
@@ -1,0 +1,38 @@
+"""The configuration layer of HiSim: config base classes and the sizing machinery.
+
+This package is the *bottom* layer of HiSim. It holds everything a component
+configuration is made of, deliberately separated from the component runtime so that the
+dependency direction is unambiguous — ``hisim/component.py`` imports this package, never
+the other way round:
+
+    - :mod:`hisim.config.base` — ``ComponentID``, ``ConfigBase`` and ``DisplayConfig``,
+      the three classes every component configuration is built from.
+    - :mod:`hisim.config.sizing` — design B of ``system_docs/config_defaults_spec.md``:
+      the ``AUTO`` sentinel, ``sized_field``, the ``Size`` expression terms, the
+      ``SizingContext`` snapshot and the ``resolve_config`` resolver.
+    - :mod:`hisim.config.presets` — the ``Catalog`` helper giving a config class its
+      named default presets, plus the preset-provenance stamp.
+    - :mod:`hisim.config.engine` — the sizing-fact engine of spec §8.4, resolving
+      cross-component sizing to a fixed point over a scenario's configs.
+
+**Layering rule.** No module in this package imports anything from the rest of HiSim at
+module level. The single sanctioned exception is
+:meth:`hisim.config.sizing.SizingContext.for_building`, which imports the building
+package inside the method body: the building physics is what turns a ``BuildingConfig``
+into sizing facts, and the building package necessarily imports ``ConfigBase`` from here
+(see the §4.1 correction in the spec and entry 1 of ``roadmap/random_findings.md``).
+
+Importing the names from this package — ``from hisim.config import ConfigBase`` — is the
+canonical spelling; the submodules are equally importable for code that prefers the
+fully-qualified path.
+"""
+
+# clean
+
+from hisim.config.base import ComponentID, ConfigBase, DisplayConfig
+
+__all__ = [
+    "ComponentID",
+    "ConfigBase",
+    "DisplayConfig",
+]

--- a/hisim/config/base.py
+++ b/hisim/config/base.py
@@ -1,0 +1,213 @@
+"""Configuration base classes: component identity, config base, display config.
+
+Part of the layered ``hisim.config`` package (see the package ``__init__`` for the
+layering rule). Holds the three classes every component configuration is built from,
+moved verbatim out of ``hisim/component.py``:
+
+    1. class ComponentID - the structured, immutable identity of one component instance.
+    2. class ConfigBase - the base class of every component configuration dataclass.
+    3. class DisplayConfig - how a component is presented in postprocessing.
+
+The module imports nothing from the rest of HiSim, which is what lets the sizing
+machinery in this package depend on ``ConfigBase`` without closing an import cycle
+through ``hisim/component.py``.
+"""
+
+# clean
+
+from __future__ import annotations
+
+import dataclasses as dc
+import typing
+from dataclasses import dataclass
+from typing import Any, ClassVar, Dict, List, Optional
+
+from dataclasses_json import dataclass_json
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class ComponentID:
+    """Structured, first-class identity of one component instance in a simulation.
+
+    A component used to be identified by a loose pair of strings on its configuration
+    (``name`` plus ``building_name``) that was collapsed into a runtime name by
+    ``Component.get_component_name()`` depending on the ``multiple_buildings`` simulation
+    parameter. ``ComponentID`` replaces that arrangement with a single immutable value
+    object: ``name`` says what the component is, ``building`` says which building object it
+    belongs to (``None`` for a plain single-building simulation), and ``unit`` says which
+    sub-unit of that building (for example an apartment) owns it. Only ``name`` is required;
+    the optional fields are simply absent when the surrounding simulation has no need for
+    them.
+
+    The unique runtime identifier is derived by the :py:attr:`key` property, which joins the
+    fields that are actually present with underscores in the order *building*, *unit*,
+    *name*. Absent fields contribute nothing at all, so ``ComponentID("Weather").key`` is
+    ``"Weather"``, ``ComponentID("Weather", building="BUI1").key`` is ``"BUI1_Weather"`` and
+    ``ComponentID("HeatPump", building="BUI1", unit="APT2").key`` is
+    ``"BUI1_APT2_HeatPump"``. The key is derived-only: it is written into component names,
+    output names and result columns, but it is never parsed back into its parts anywhere in
+    HiSim. Code that needs to know the building or the unit of a component reads the
+    structured fields instead.
+
+    Because the key merely concatenates the present fields, two different tuples can in
+    principle produce the same key (for example ``ComponentID("Pump", building="BUI1_APT2")``
+    and ``ComponentID("Pump", building="BUI1", unit="APT2")``). No new mechanism is needed to
+    catch that: such a collision shows up as two components claiming the same runtime name,
+    and the existing duplicate-component-name check performed when outputs are registered
+    with the simulator (see ``Simulator.add_component``) raises on it just as it does for any
+    other accidental name clash.
+
+    The class is frozen, so instances are hashable and safe to share between a configuration
+    and everything derived from it; use :py:func:`dataclasses.replace` to obtain a variant.
+    """
+
+    name: str
+    building: Optional[str] = None
+    unit: Optional[str] = None
+
+    #: Building label used for grouping when a component carries no explicit building.
+    #: Historically every configuration defaulted to the decorative string ``"BUI1"``, and
+    #: postprocessing (KPI collection, OPEX/CAPEX tables, the webtool result JSON) keys its
+    #: per-building groups by that string. Keeping the same label for building-less
+    #: components means the grouping output of a single-building simulation is byte-for-byte
+    #: what it was before ``ComponentID`` existed.
+    DEFAULT_BUILDING_LABEL: ClassVar[str] = "BUI1"
+
+    def __post_init__(self) -> None:
+        """Validates the identity right after construction.
+
+        The name is the only mandatory part of a component identity, and an empty or
+        whitespace-only name would silently produce an empty or malformed key later on.
+        Rejecting it here turns a confusing downstream naming problem into an immediate,
+        clearly attributable error.
+        """
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError(f"A ComponentID needs a non-empty name, but got {self.name!r}.")
+
+    @property
+    def key(self) -> str:
+        """Derives the unique runtime identifier of this component.
+
+        The key is the string that HiSim uses as the component name, as the prefix of every
+        output's full name and therefore as the prefix of every result column. It is built by
+        joining the present fields with ``"_"`` in the order building, unit, name; fields that
+        are ``None`` simply do not appear. The key is derived-only and is never parsed back
+        into building/unit/name anywhere in the code base.
+        """
+        parts = [part for part in (self.building, self.unit, self.name) if part is not None]
+        return "_".join(parts)
+
+    @property
+    def building_label(self) -> str:
+        """Returns the building this component is grouped under in postprocessing.
+
+        Postprocessing aggregates results per building object (KPI collections, OPEX and
+        CAPEX tables, the building-sizer and webtool JSON exports), and those groups need a
+        string key even for components that carry no building of their own. This property
+        returns :py:attr:`building` when it is set and :py:attr:`DEFAULT_BUILDING_LABEL`
+        otherwise, which reproduces the historical behaviour where every configuration
+        carried the decorative default building name.
+        """
+        return self.building if self.building is not None else self.DEFAULT_BUILDING_LABEL
+
+
+@dataclass
+class ConfigBase:
+    """Base class for all configurations.
+
+    Every component configuration derives from this class and therefore carries exactly one
+    identity field, :py:attr:`component_id`, which replaces the former ``name`` plus
+    ``building_name`` string pair. In serialized form the identity is a nested object, i.e.
+    ``{"component_id": {"name": ..., "building": ..., "unit": ...}}``.
+
+    Serialization comes from the ``@dataclass_json`` decorator that every concrete config
+    class carries, which dumps and parses the dataclass field names verbatim (snake_case).
+    The :py:meth:`to_dict` defined here is only the fallback for the base class itself; a
+    decorated subclass shadows it with the dataclasses_json implementation.
+    """
+
+    component_id: ComponentID
+
+    if typing.TYPE_CHECKING:
+        # Historically ConfigBase inherited dataclass_wizard.JSONWizard, whose missing type
+        # stubs made the whole class hierarchy Any-based: mypy accepted any attribute on a
+        # ConfigBase-typed value. A lot of code depends on that leniency (components store
+        # their config in ConfigBase-typed slots and read/write subclass fields off it), so
+        # these type-checker-only escape hatches preserve it deliberately. Field-name
+        # correctness is enforced by scripts/check_config_attrs.py instead; making configs
+        # fully mypy-visible (a generic Component[TConfig]) is a planned sweep, see
+        # roadmap/json_cleanup.md. The classmethod stubs mirror the serialization API that
+        # the @dataclass_json decorator injects at runtime on every concrete config class.
+        def __getattr__(self, name: str) -> Any:
+            """Checking-only escape hatch: reads of undeclared fields resolve to Any."""
+            raise NotImplementedError
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            """Checking-only escape hatch: writes to undeclared fields are accepted."""
+
+        def to_json(self, *args: Any, **kwargs: Any) -> str:  # pylint: disable=unused-argument
+            """Stub for the JSON dump that @dataclass_json injects at runtime."""
+            raise NotImplementedError
+
+        @classmethod
+        def from_dict(cls, kvs: Any, *args: Any, **kwargs: Any) -> Any:  # pylint: disable=unused-argument
+            """Stub for the dict decoder that @dataclass_json injects at runtime."""
+            raise NotImplementedError
+
+        @classmethod
+        def from_json(cls, data: Any, *args: Any, **kwargs: Any) -> Any:  # pylint: disable=unused-argument
+            """Stub for the JSON decoder that @dataclass_json injects at runtime."""
+            raise NotImplementedError
+
+    def __init__(self, component_id: ComponentID):
+        """Initializes a bare configuration from its structured identity.
+
+        Only :py:class:`ConfigBase` itself uses this constructor; every concrete subclass is a
+        dataclass and generates its own ``__init__`` that takes ``component_id`` as its first
+        field followed by the component-specific parameters.
+        """
+        self.component_id = component_id
+
+    @classmethod
+    def get_main_classname(cls):
+        """Returns the fully qualified class name for the class that is getting configured. Used for Json."""
+        raise NotImplementedError("Missing a definition of the ")
+
+    @classmethod
+    def get_config_classname(cls):
+        """Gets the class name. Helper function for default connections."""
+        return cls.__module__ + "." + cls.__name__
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Dumps this configuration as a plain dict of its dataclass fields.
+
+        Every concrete config class shadows this method through its ``@dataclass_json``
+        decorator, so this fallback only serves the bare base class (and would serve an
+        accidentally undecorated subclass with a plain, non-JSON-normalized dataclass dump
+        rather than an AttributeError).
+        """
+        return dc.asdict(self)
+
+    def get_string_dict(self) -> List[str]:
+        """Turns the config into a str list for the report."""
+        my_dict = self.to_dict()
+        my_list = []
+        if len(my_dict) > 0:
+            for entry in my_dict.items():
+                label = " ".join(entry[0].rsplit("_")).capitalize()
+                my_list.append(label + ": " + str(entry[1]))
+        return my_list
+
+
+@dataclass
+class DisplayConfig:
+    """Configure how to display this component in postprocessing."""
+
+    pretty_name: str | None = None
+    display_in_webtool: bool = False
+
+    @classmethod
+    def show(cls, pretty_name):
+        """Shortcut for showing in webtool with a specified name."""
+        return DisplayConfig(pretty_name, display_in_webtool=True)

--- a/hisim/dynamic_component.py
+++ b/hisim/dynamic_component.py
@@ -6,7 +6,8 @@ from typing import List, Union, Dict, cast, Optional
 import dataclasses as dc
 import hisim.loadtypes as lt
 from hisim import log
-from hisim.component import Component, ComponentInput, ComponentOutput, ConfigBase, DisplayConfig
+from hisim.component import Component, ComponentInput, ComponentOutput
+from hisim.config import ConfigBase, DisplayConfig
 from hisim.simulationparameters import SimulationParameters
 
 

--- a/hisim/json_generator.py
+++ b/hisim/json_generator.py
@@ -15,7 +15,7 @@ from hisim.postprocessingoptions import PostProcessingOptions
 from hisim.components.controller_l2_energy_management_system import L2GenericEnergyManagementSystem
 from hisim.components.loadprofilegenerator_utsp_connector import UtspLpgConnector
 from hisim.components.generic_car import Car, GenericCarInformation
-from hisim.component import ConfigBase
+from hisim.config import ConfigBase, ComponentID
 import hisim.component as cp
 import hisim.dynamic_component as dcp
 from hisim.dynamic_component import DynamicComponent
@@ -428,12 +428,12 @@ def get_component_key_from_configuration(configuration: dict[str, Any]) -> str:
 
     A scenario JSON stores the component identity as a nested ``component_id`` object holding
     ``name``, ``building`` and ``unit``. This helper rebuilds the same runtime key that
-    :py:attr:`hisim.component.ComponentID.key` produces for the live configuration, so that a
+    :py:attr:`hisim.config.ComponentID.key` produces for the live configuration, so that a
     scenario entry can be matched against an already-instantiated component without anyone
     having to take an existing key apart.
     """
     identity = configuration.get("component_id") or {}
-    return cp.ComponentID(
+    return ComponentID(
         name=identity.get("name", ""),
         building=identity.get("building"),
         unit=identity.get("unit"),

--- a/hisim/postprocessing/cost_and_emission_computation/capex_computation.py
+++ b/hisim/postprocessing/cost_and_emission_computation/capex_computation.py
@@ -38,7 +38,8 @@ for the simulation year and country.
 """
 
 from typing import Optional, TypeVar
-from hisim.component import CapexCostDataClass, ConfigBase
+from hisim.component import CapexCostDataClass
+from hisim.config import ConfigBase
 from hisim.components.configuration import EmissionFactorsAndCostsForDevicesConfig
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass
 from hisim.simulationparameters import SimulationParameters

--- a/hisim/system_setup_configuration.py
+++ b/hisim/system_setup_configuration.py
@@ -29,7 +29,7 @@ class SystemSetupConfigBase:
     if TYPE_CHECKING:
         # The serialization API is injected at runtime by the @dataclass_json decorator on
         # each concrete subclass; these type-checker-only stubs mirror it (see the identical
-        # arrangement on hisim.component.ConfigBase).
+        # arrangement on hisim.config.ConfigBase).
         def to_dict(self) -> Dict[str, Any]:
             """Stub for the dict dump that @dataclass_json injects at runtime."""
             raise NotImplementedError

--- a/obsolete/PIDcontroller.py
+++ b/obsolete/PIDcontroller.py
@@ -20,11 +20,12 @@ from hisim.components.building import Building
 # from hisim.components.weather import Weather
 # from hisim.components.loadprofilegenerator_connector import Occupancy
 from hisim import log
+from hisim.config import ConfigBase
 
 
 @dataclass_json
 @dataclass
-class PIDControllerOneConfig(cp.ConfigBase):
+class PIDControllerOneConfig(ConfigBase):
     @classmethod
     def get_main_classname(cls):
         """Return the full class name of the base class."""

--- a/obsolete/building_controller.py
+++ b/obsolete/building_controller.py
@@ -30,6 +30,7 @@ from hisim import (
 from hisim import (
     loadtypes as lt,
 )
+from hisim.config import ConfigBase
 
 from hisim.components.configuration import (
     PhysicsConfig,
@@ -88,7 +89,7 @@ class Test_BuildingControllerConfig:
 
 @dataclass_json
 @dataclass
-class HeatingComponentInBuildingConfig(cp.ConfigBase):
+class HeatingComponentInBuildingConfig(ConfigBase):
 
     """Configuration of the heating component class."""
 

--- a/obsolete/controller_l1_building_heating.py
+++ b/obsolete/controller_l1_building_heating.py
@@ -29,7 +29,7 @@ from hisim.components.building import Building
 from hisim.components import controller_l2_energy_management_system
 from hisim.loadtypes import LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 
 __authors__ = "edited Johanna Ganglbauer"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -43,7 +43,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class L1BuildingHeatingConfig(cp.ConfigBase):
+class L1BuildingHeatingConfig(ConfigBase):
     """Configuration of Building Controller."""
 
     component_id: ComponentID
@@ -128,7 +128,7 @@ class L1BuildingHeatController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: L1BuildingHeatingConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the L1 building heat controller.
 

--- a/obsolete/controller_l1_generic_runtime.py
+++ b/obsolete/controller_l1_generic_runtime.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 from dataclasses_json import dataclass_json
 
 from hisim import utils
-from hisim.component import ComponentID, ConfigBase, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim import component as cp
 from hisim.loadtypes import LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters

--- a/obsolete/controller_l1_heat_old.py
+++ b/obsolete/controller_l1_heat_old.py
@@ -10,11 +10,12 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 from hisim import utils
+from hisim.config import ConfigBase, DisplayConfig
 
 
 @dataclass_json
 @dataclass
-class ControllerHeatConfig(cp.ConfigBase):
+class ControllerHeatConfig(ConfigBase):
     """Configuration of the Controller Heat class."""
 
     @classmethod
@@ -122,7 +123,7 @@ class ControllerHeat(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: ControllerHeatConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
         self.controller_heat_config = config

--- a/obsolete/controller_l2_generic_heat_clever_simple.py
+++ b/obsolete/controller_l2_generic_heat_clever_simple.py
@@ -16,6 +16,7 @@ from hisim.loadtypes import LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters
 from hisim.components import controller_l1_generic_runtime
 from hisim.components.building import Building
+from hisim.config import ConfigBase, DisplayConfig
 from repositories.HiSim.obsolete import generic_hot_water_storage_modular
 
 
@@ -31,7 +32,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class L2HeatSmartConfig(cp.ConfigBase):
+class L2HeatSmartConfig(ConfigBase):
     """L2 Config class."""
 
     building_name: str
@@ -158,7 +159,7 @@ class L2HeatSmartController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: L2HeatSmartConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
         if not config.__class__.__name__ == L2HeatSmartConfig.__name__:

--- a/obsolete/controller_l2_generic_heat_simple.py
+++ b/obsolete/controller_l2_generic_heat_simple.py
@@ -15,6 +15,7 @@ from repositories.HiSim.obsolete import generic_hot_water_storage_modular
 from hisim.components.building import Building
 from hisim.loadtypes import LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters
+from hisim.config import ConfigBase, DisplayConfig
 
 __authors__ = "edited Johanna Ganglbauer"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -28,7 +29,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class L2GenericHeatConfig(cp.ConfigBase):
+class L2GenericHeatConfig(ConfigBase):
     """L2 Controller Config."""
 
     building_name: str
@@ -200,11 +201,11 @@ class L2GenericHeatController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: L2GenericHeatConfig,
-        my_display_config: Optional[cp.DisplayConfig] = None,
+        my_display_config: Optional[DisplayConfig] = None,
     ) -> None:
         """For initializing."""
         if my_display_config is None:
-            my_display_config = cp.DisplayConfig()
+            my_display_config = DisplayConfig()
         if not config.__class__.__name__ == L2GenericHeatConfig.__name__:
             raise ValueError("Wrong config class.")
         self.my_simulation_parameters = my_simulation_parameters

--- a/obsolete/controller_l2_smart_controller.py
+++ b/obsolete/controller_l2_smart_controller.py
@@ -6,7 +6,8 @@
 from typing import List, Union, Dict, Optional, Any
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
-from hisim.component import ComponentID, Component, SingleTimeStepValues, ConfigBase, DisplayConfig
+from hisim.component import Component, SingleTimeStepValues
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.generic_heat_pump import (
     GenericHeatPumpController,
     GenericHeatPumpControllerConfig,

--- a/obsolete/district_buildings/controller_l2_district_energy_management_system.py
+++ b/obsolete/district_buildings/controller_l2_district_energy_management_system.py
@@ -20,6 +20,7 @@ from hisim import dynamic_component
 from hisim import loadtypes as lt
 from hisim import utils
 from hisim.component import ComponentInput, ComponentOutput
+from hisim.config import ConfigBase, DisplayConfig
 from hisim.simulationparameters import SimulationParameters
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiTagEnumClass, KpiHelperClass
 from hisim.components import (
@@ -48,7 +49,7 @@ class EMSControlStrategy(IntEnum):
 
 @dataclass_json
 @dataclass
-class EMSDistrictConfig(cp.ConfigBase):
+class EMSDistrictConfig(ConfigBase):
     """L1 Controller Config."""
 
     @classmethod
@@ -176,7 +177,7 @@ class L2GenericDistrictEnergyManagementSystem(dynamic_component.DynamicComponent
         self,
         my_simulation_parameters: SimulationParameters,
         config: EMSDistrictConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ):
         """Initializes."""
         self.my_component_inputs: List[dynamic_component.DynamicConnectionInput] = []

--- a/obsolete/district_buildings/district_system_setup/simple_generic_household.py
+++ b/obsolete/district_buildings/district_system_setup/simple_generic_household.py
@@ -23,10 +23,7 @@ from hisim.components import (
     controller_l1_heatpump,
     electricity_meter,
 )
-from hisim.component import (
-    ConfigBase,
-    DisplayConfig,
-)
+from hisim.config import ConfigBase, DisplayConfig
 from hisim import loadtypes as lt
 from hisim.units import Quantity, Celsius, Watt
 

--- a/obsolete/generic_battery.py
+++ b/obsolete/generic_battery.py
@@ -15,7 +15,7 @@ from hisim import utils
 from hisim.components.generic_ev_charger import SimpleStorageState
 from hisim.simulationparameters import SimulationParameters
 from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 
 __authors__ = "Vitor Hugo Bellotto Zago"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -81,7 +81,7 @@ class GenericBatteryState:
 
 @dataclass_json
 @dataclass
-class GenericBatteryConfig(cp.ConfigBase):
+class GenericBatteryConfig(ConfigBase):
     """Configuration of the Generic Battery."""
 
     @classmethod
@@ -116,7 +116,7 @@ class GenericBatteryConfig(cp.ConfigBase):
 
 @dataclass_json
 @dataclass
-class BatteryControllerConfig(cp.ConfigBase):
+class BatteryControllerConfig(ConfigBase):
     """Configuration of the Generic Battery Controller."""
 
     @classmethod
@@ -188,7 +188,7 @@ class GenericBattery(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: GenericBatteryConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
         battery_database: list[dict[str, Any]] | None = None,
     ) -> None:
         """Initialize the class.
@@ -398,7 +398,7 @@ class BatteryController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: BatteryControllerConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
         self.my_simulation_parameters = my_simulation_parameters

--- a/obsolete/generic_ev_charger.py
+++ b/obsolete/generic_ev_charger.py
@@ -38,7 +38,7 @@ from hisim.simulationparameters import SimulationParameters
 from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim import utils
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 
 
 __authors__ = "Vitor Hugo Bellotto Zago"
@@ -53,7 +53,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class VehiclePureConfig(cp.ConfigBase):
+class VehiclePureConfig(ConfigBase):
     """Vehicle Pure Config class."""
 
     component_id: ComponentID
@@ -104,7 +104,7 @@ class EVChargerMode(str, Enum):
 
 @dataclass_json
 @dataclass
-class EVChargerControllerConfig(cp.ConfigBase):
+class EVChargerControllerConfig(ConfigBase):
     """Electrical vehicle charger controller config class.
 
     ``mode`` selects the charging strategy and is typed as
@@ -136,7 +136,7 @@ class EVChargerControllerConfig(cp.ConfigBase):
 
 @dataclass_json
 @dataclass
-class VehicleConfig(cp.ConfigBase):
+class VehicleConfig(ConfigBase):
     """Vehicle config class."""
 
     component_id: ComponentID
@@ -167,7 +167,7 @@ class VehicleConfig(cp.ConfigBase):
 
 @dataclass_json
 @dataclass
-class EVChargerConfig(cp.ConfigBase):
+class EVChargerConfig(ConfigBase):
     """Electrical vehicle config class."""
 
     component_id: ComponentID
@@ -226,7 +226,7 @@ class VehiclePure(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: VehiclePureConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
         self.my_simulation_parameters = my_simulation_parameters
@@ -409,7 +409,7 @@ class Vehicle(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: VehicleConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
         self.my_simulation_parameters = my_simulation_parameters
@@ -659,7 +659,7 @@ class EVCharger(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: EVChargerConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
         self.my_simulation_parameters = my_simulation_parameters
@@ -919,7 +919,7 @@ class EVChargerController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: EVChargerControllerConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
         self.my_simulation_parameters = my_simulation_parameters

--- a/obsolete/generic_gas_heater.py
+++ b/obsolete/generic_gas_heater.py
@@ -16,11 +16,10 @@ from hisim.component import (
     SingleTimeStepValues,
     ComponentInput,
     ComponentOutput,
-    ConfigBase,
     OpexCostDataClass,
-    DisplayConfig,
-    CapexCostDataClass
+    CapexCostDataClass,
 )
+from hisim.config import ConfigBase, DisplayConfig
 from hisim.components.simple_water_storage import SimpleHotWaterStorage
 from hisim.components.weather import Weather
 from hisim.components.heat_distribution_system import HeatDistributionController

--- a/obsolete/generic_gas_heater_with_controller.py
+++ b/obsolete/generic_gas_heater_with_controller.py
@@ -10,6 +10,7 @@ from hisim.component import (
     ComponentInput,
     ComponentOutput,
 )
+from hisim.config import ConfigBase
 from hisim.simulationparameters import SimulationParameters
 from hisim import loadtypes as lt
 from hisim import utils
@@ -26,7 +27,7 @@ __status__ = ""
 
 @dataclass_json
 @dataclass
-class GenericGasHeaterWithControllerConfig(cp.ConfigBase):
+class GenericGasHeaterWithControllerConfig(ConfigBase):
 
     """Configuration of the GasHeater class."""
 
@@ -56,7 +57,7 @@ class GenericGasHeaterWithControllerConfig(cp.ConfigBase):
 
 @dataclass_json
 @dataclass
-class GenericGasHeaterControllerConfig(cp.ConfigBase):
+class GenericGasHeaterControllerConfig(ConfigBase):
 
     """Configuration of the GasHeaterController class."""
 

--- a/obsolete/generic_heat_pump_for_house_with_hds.py
+++ b/obsolete/generic_heat_pump_for_house_with_hds.py
@@ -23,6 +23,7 @@ from hisim.components.weather import Weather
 from hisim.loadtypes import LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters
 from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
+from hisim.config import ConfigBase
 
 __authors__ = "Katharina Rieck"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -36,7 +37,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class GenericHeatPumpConfigNew(cp.ConfigBase):
+class GenericHeatPumpConfigNew(ConfigBase):
 
     """HeatPump Config Class."""
 
@@ -69,7 +70,7 @@ class GenericHeatPumpConfigNew(cp.ConfigBase):
 
 @dataclass_json
 @dataclass
-class HeatPumpControllerConfigNew(cp.ConfigBase):
+class HeatPumpControllerConfigNew(ConfigBase):
 
     """HeatPump Controller Config Class."""
 

--- a/obsolete/generic_heat_source.py
+++ b/obsolete/generic_heat_source.py
@@ -24,6 +24,7 @@ from hisim.components.configuration import (
     PhysicsConfig,
 )
 from hisim.component import OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, DisplayConfig
 
 __authors__ = "Johanna Ganglbauer - johanna.ganglbauer@4wardenergy.at"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -37,7 +38,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class HeatSourceConfig(cp.ConfigBase):
+class HeatSourceConfig(ConfigBase):
     """Configuration of a generic HeatSource."""
 
     building_name: str
@@ -202,7 +203,7 @@ class HeatSource(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: HeatSourceConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
 

--- a/obsolete/generic_hot_water_storage_modular.py
+++ b/obsolete/generic_hot_water_storage_modular.py
@@ -21,6 +21,7 @@ import hisim.component as cp
 import hisim.log
 from hisim import loadtypes as lt
 from hisim.component import OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, DisplayConfig
 from hisim.components import (
     controller_l1_building_heating,
     generic_chp,
@@ -43,7 +44,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class StorageConfig(cp.ConfigBase):
+class StorageConfig(ConfigBase):
     """Used in the HotWaterStorageClass defining the basics."""
 
     building_name: str
@@ -283,7 +284,7 @@ class HotWaterStorage(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: StorageConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(display_in_webtool=True),
+        my_display_config: DisplayConfig = DisplayConfig(display_in_webtool=True),
     ):
         """Initializes instance of HotWaterStorage class."""
 

--- a/obsolete/generic_oil_heater.py
+++ b/obsolete/generic_oil_heater.py
@@ -16,11 +16,10 @@ from hisim.component import (
     SingleTimeStepValues,
     ComponentInput,
     ComponentOutput,
-    ConfigBase,
     OpexCostDataClass,
-    DisplayConfig,
-    CapexCostDataClass
+    CapexCostDataClass,
 )
+from hisim.config import ConfigBase, DisplayConfig
 from hisim.components.simple_water_storage import SimpleHotWaterStorage
 from hisim.components.weather import Weather
 from hisim.components.heat_distribution_system import HeatDistributionController

--- a/obsolete/loadprofilegenerator_connector.py
+++ b/obsolete/loadprofilegenerator_connector.py
@@ -17,6 +17,7 @@ from hisim import utils
 from hisim import log
 from hisim.simulationparameters import SimulationParameters
 from hisim.sim_repository_singleton import SingletonDictKeyEnum, SingletonSimRepository
+from hisim.config import ConfigBase, DisplayConfig
 
 __authors__ = "Vitor Hugo Bellotto Zago"
 __copyright__ = "Copyright 2021, the House Infrastructure Project"
@@ -30,7 +31,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class OccupancyConfig(cp.ConfigBase):
+class OccupancyConfig(ConfigBase):
 
     """Occupancy config class."""
 
@@ -156,7 +157,7 @@ class Occupancy(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: OccupancyConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
         super().__init__(

--- a/obsolete/obsolete_dynamic_component.py
+++ b/obsolete/obsolete_dynamic_component.py
@@ -3,7 +3,8 @@
 
 from typing import Any, List, Union, Dict
 import hisim.loadtypes as lt
-from hisim.component import Component, ConfigBase, SingleTimeStepValues, DisplayConfig
+from hisim.component import Component, SingleTimeStepValues
+from hisim.config import ConfigBase, DisplayConfig
 from hisim.simulationparameters import SimulationParameters
 from hisim.dynamic_component import (
     DynamicConnectionInput,

--- a/obsolete/obsolete_sumbuilder_electricity_grid.py
+++ b/obsolete/obsolete_sumbuilder_electricity_grid.py
@@ -9,12 +9,13 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim import utils
 from hisim.component import Component
+from hisim.config import ConfigBase
 from hisim.simulationparameters import SimulationParameters
 
 
 @dataclass_json
 @dataclass
-class ElectricityGridConfig(cp.ConfigBase):
+class ElectricityGridConfig(ConfigBase):
 
     """Electricity Grid Config."""
 

--- a/obsolete/scenario_evaluation/scenario_analysis_complete_with_config.py
+++ b/obsolete/scenario_evaluation/scenario_analysis_complete_with_config.py
@@ -7,7 +7,7 @@ results, processing them, and generating comparison charts.
 Configuration Schema
 --------------------
 
-:class:`ScenarioAnalysisConfig` (a :class:`~hisim.component.ConfigBase`
+:class:`ScenarioAnalysisConfig` (a :class:`~hisim.config.ConfigBase`
 dataclass) controls every aspect of the analysis.  Key fields include:
 
 * **Paths** -- ``cluster_storage_path``, ``module_results_directory``,
@@ -91,7 +91,7 @@ from dataclasses_json.core import _decode_dataclass
 from projects.HiSim.obsolete.scenario_evaluation import (
     result_data_processing,
 )
-from hisim.component import ConfigBase
+from hisim.config import ConfigBase
 from hisim import log
 from projects.HiSim.obsolete.scenario_evaluation import result_data_collection, result_data_plotting
 

--- a/obsolete/test_controller_l1_generic_runtime.py
+++ b/obsolete/test_controller_l1_generic_runtime.py
@@ -8,7 +8,7 @@ They need no ``SimulationParameters`` and no I/O.
 
 import pytest
 
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from hisim.components.controller_l1_generic_runtime import (
     L1Config,
     L1GenericRuntimeControllerState,

--- a/obsolete/test_controller_l2_smart_controller.py
+++ b/obsolete/test_controller_l2_smart_controller.py
@@ -3,7 +3,8 @@
 from typing import List
 
 import pytest
-from hisim.component import ComponentID, ComponentInput, ComponentOutput, SingleTimeStepValues
+from hisim.component import ComponentInput, ComponentOutput, SingleTimeStepValues
+from hisim.config import ComponentID
 from hisim.components import controller_l2_smart_controller
 from hisim.components.controller_l2_smart_controller import SmartController, SmartControllerConfig
 from hisim.components.generic_heat_pump import GenericHeatPumpController

--- a/obsolete/test_generic_battery.py
+++ b/obsolete/test_generic_battery.py
@@ -25,7 +25,7 @@ from projects.HiSim.obsolete.generic_battery import (
     select_battery_spec,
 )
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 # Mark every test in this module as a fast ``base`` test (see pytest.ini).

--- a/obsolete/test_generic_ev_charger_config.py
+++ b/obsolete/test_generic_ev_charger_config.py
@@ -20,7 +20,7 @@ from projects.HiSim.obsolete.generic_ev_charger import (
     EVChargerControllerConfig,
     EVChargerMode,
 )
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 @pytest.mark.base

--- a/obsolete/webtool_old/generic_heat_pump_modular.py
+++ b/obsolete/webtool_old/generic_heat_pump_modular.py
@@ -13,6 +13,7 @@ from dataclasses_json import dataclass_json
 import hisim.loadtypes as lt
 from hisim import component as cp
 from hisim.component import OpexCostDataClass, CapexCostDataClass
+from hisim.config import ConfigBase, DisplayConfig
 
 # Owned
 from hisim import utils
@@ -35,7 +36,7 @@ __status__ = "development"
 
 @dataclass_json
 @dataclass
-class HeatPumpConfig(cp.ConfigBase):
+class HeatPumpConfig(ConfigBase):
     """Configuration of a HeatPump."""
 
     building_name: str
@@ -234,7 +235,7 @@ class ModularHeatPump(cp.Component):
         self,
         config: HeatPumpConfig,
         my_simulation_parameters: SimulationParameters,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ):
         """Initialize the class."""
         self.my_simulation_parameters = my_simulation_parameters

--- a/obsolete/webtool_old/generic_heat_water_storage.py
+++ b/obsolete/webtool_old/generic_heat_water_storage.py
@@ -10,7 +10,8 @@ from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 
 # Owned
-from hisim.component import Component, ComponentInput, ComponentOutput, ConfigBase
+from hisim.component import Component, ComponentInput, ComponentOutput
+from hisim.config import ConfigBase, DisplayConfig
 from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
@@ -147,7 +148,7 @@ class HeatStorage(Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: HeatStorageConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
         self.heat_storage_config = config
@@ -465,7 +466,7 @@ class HeatStorageController(cp.Component):
         self,
         my_simulation_parameters: SimulationParameters,
         config: HeatStorageControllerConfig,
-        my_display_config: cp.DisplayConfig = cp.DisplayConfig(),
+        my_display_config: DisplayConfig = DisplayConfig(),
     ) -> None:
         """Initialize the class."""
         self.heat_storage_controller_config = config

--- a/obsolete/webtool_old/household_gas_heater.py
+++ b/obsolete/webtool_old/household_gas_heater.py
@@ -14,7 +14,7 @@ from utspclient.helpers.lpgdata import (
 )
 from repositories.HiSim.hisim.system_setup_configuration import SystemSetupConfigBase
 from hisim.simulator import SimulationParameters
-from hisim.component import DisplayConfig
+from hisim.config import DisplayConfig
 from hisim.components import loadprofilegenerator_utsp_connector
 from hisim.components import weather
 from hisim.components import generic_boiler

--- a/obsolete/webtool_old/household_heat_pump.py
+++ b/obsolete/webtool_old/household_heat_pump.py
@@ -14,7 +14,7 @@ from utspclient.helpers.lpgdata import (
 )
 from hisim.system_setup_configuration import SystemSetupConfigBase
 from hisim.simulator import Simulator, SimulationParameters
-from hisim.component import DisplayConfig
+from hisim.config import DisplayConfig
 from hisim.components import loadprofilegenerator_utsp_connector
 from hisim.components import weather
 from hisim.components import advanced_heat_pump_hplib

--- a/scripts/check_config_attrs.py
+++ b/scripts/check_config_attrs.py
@@ -114,7 +114,7 @@ class Finding:
 
 
 def bare_name(node: Optional[ast.expr]) -> Optional[str]:
-    """Reduce an expression to its bare class name (``cp.ConfigBase`` -> ``ConfigBase``)."""
+    """Reduce an expression to its bare class name (``cp.Component`` -> ``Component``)."""
     if isinstance(node, ast.Name):
         return node.id
     if isinstance(node, ast.Attribute):

--- a/system_setups/air_conditioned_house.py
+++ b/system_setups/air_conditioned_house.py
@@ -15,7 +15,7 @@ from hisim.components import weather
 from hisim.components import generic_pv_system
 from hisim.components import building
 from hisim.components import air_conditioner
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 __authors__ = "Marwa Alfouly, Sebastian Dickler, Kristina Dabrock"

--- a/system_setups/basic_household.py
+++ b/system_setups/basic_household.py
@@ -10,7 +10,7 @@ from hisim.components import building
 from hisim.components import generic_heat_pump
 from hisim.components import electricity_meter
 from hisim import loadtypes
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 __authors__ = "Vitor Hugo Bellotto Zago, Noah Pflugradt"

--- a/system_setups/basic_household_with_weather_data_request.py
+++ b/system_setups/basic_household_with_weather_data_request.py
@@ -14,7 +14,7 @@ from hisim.components import electricity_meter
 from hisim.components.weather_data_import import WeatherDataImport
 from hisim import utils
 from hisim import loadtypes
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 __authors__ = "Jonas Hoppe"

--- a/system_setups/default_connections.py
+++ b/system_setups/default_connections.py
@@ -11,7 +11,7 @@ from hisim.components import building
 from hisim.components import generic_heat_pump
 from hisim.components import electricity_meter
 from hisim import loadtypes
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 def setup_function(

--- a/system_setups/dynamic_components.py
+++ b/system_setups/dynamic_components.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 # import hisim.components.random_numbers
 from hisim.simulator import SimulationParameters, Simulator
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from hisim.components import loadprofilegenerator_utsp_connector
 from hisim.components import advanced_battery_bslib
 from hisim.components import weather

--- a/system_setups/electrolyzer_with_renewables.py
+++ b/system_setups/electrolyzer_with_renewables.py
@@ -13,7 +13,7 @@ from hisim.components.generic_electrolyzer_h2 import (
     Electrolyzer,
     ElectrolyzerConfig,
 )
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 from hisim import loadtypes as lt
 

--- a/system_setups/household_heatpump_car_building_sizer.py
+++ b/system_setups/household_heatpump_car_building_sizer.py
@@ -12,7 +12,7 @@ from utspclient.helpers.lpgdata import (
     Households,
 )
 from hisim.simulator import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from hisim.components import loadprofilegenerator_utsp_connector
 from hisim.components import weather
 from hisim.components import generic_pv_system

--- a/system_setups/simple_system_setup_one.py
+++ b/system_setups/simple_system_setup_one.py
@@ -12,7 +12,7 @@ from hisim.simulationparameters import SimulationParameters
 from hisim.postprocessingoptions import PostProcessingOptions
 from hisim.components.random_numbers import RandomNumbers, RandomNumbersConfig
 from hisim.components.sumbuilder import SumBuilderForTwoInputs, SumBuilderConfig
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]) -> None:

--- a/system_setups/simple_system_setup_two.py
+++ b/system_setups/simple_system_setup_two.py
@@ -15,7 +15,7 @@ from hisim.components.example_transformer import (
     ExampleTransformerConfig,
 )
 from hisim.components.sumbuilder import SumBuilderForTwoInputs, SumBuilderConfig
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[SimulationParameters]) -> None:

--- a/tests/components/test_advanced_ev_battery_bslib.py
+++ b/tests/components/test_advanced_ev_battery_bslib.py
@@ -18,7 +18,7 @@ from hisim.components.advanced_ev_battery_bslib import (
     CarBatteryConfig,
     EVBatteryState,
 )
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 @pytest.mark.base

--- a/tests/components/test_fuel_meter.py
+++ b/tests/components/test_fuel_meter.py
@@ -20,7 +20,7 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 from hisim.components.fuel_meter import FuelMeter, FuelMeterConfig, FuelMeterState
-from hisim.component import ComponentID
+from hisim.config import ComponentID, DisplayConfig
 
 # Heating-oil density expressed in kg per liter. The stored field
 # ``fuel_density_in_kg_per_m3`` uses kg/m^3, and since 1 L == 1e-3 m^3 the
@@ -131,8 +131,8 @@ def test_fuel_meter_display_config_not_shared() -> None:
     )
 
     assert meter_a.my_display_config is not meter_b.my_display_config
-    assert isinstance(meter_a.my_display_config, cp.DisplayConfig)
-    assert isinstance(meter_b.my_display_config, cp.DisplayConfig)
+    assert isinstance(meter_a.my_display_config, DisplayConfig)
+    assert isinstance(meter_b.my_display_config, DisplayConfig)
 
     # mutating one must not affect the other
     meter_a.my_display_config.pretty_name = "meter_a"

--- a/tests/test_advanced_battery_bslib.py
+++ b/tests/test_advanced_battery_bslib.py
@@ -7,7 +7,7 @@ from hisim.components import advanced_battery_bslib
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -59,7 +59,7 @@ def test_advanced_battery_bslib() -> None:
         "LoadingPowerInput",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeLoadingPowerInput"),
+        component_id=ComponentID("FakeLoadingPowerInput"),
     )
 
     number_of_outputs = fft.get_number_of_outputs([my_advanced_battery, loading_power_input])

--- a/tests/test_advanced_fuel_cell.py
+++ b/tests/test_advanced_fuel_cell.py
@@ -12,6 +12,7 @@ from hisim.components import advanced_fuel_cell
 from hisim import loadtypes as lt
 from hisim import log
 from hisim.simulationparameters import SimulationParameters
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -55,21 +56,21 @@ def build_chp_system(
         "ControlSignal",
         lt.LoadTypes.ANY,
         lt.Units.PERCENT,
-        component_id=cp.ComponentID("FakeControlSignal"),
+        component_id=ComponentID("FakeControlSignal"),
     )
     massflow_input_temperature = cp.ComponentOutput(
         "FakeMassflowInputTemperature",
         "MassflowInputTemperature",
         lt.LoadTypes.WATER,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeMassflowInputTemperature"),
+        component_id=ComponentID("FakeMassflowInputTemperature"),
     )
     electricity_from_chp_target = cp.ComponentOutput(
         "FakeElectricityFromCHPTarget",
         "ElectricityFromCHPTarget",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeElectricityFromCHPTarget"),
+        component_id=ComponentID("FakeElectricityFromCHPTarget"),
     )
 
     my_chp_system.control_signal_channel.source_output = control_signal

--- a/tests/test_advanced_heat_pump_hplib.py
+++ b/tests/test_advanced_heat_pump_hplib.py
@@ -13,7 +13,7 @@ from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
 from hisim.units import Quantity, Watt, Celsius, Seconds, Kilogram, Euro, Years, Unitless
-from hisim.component import ComponentID
+from hisim.config import ComponentID, DisplayConfig
 
 
 def _make_heatpump_instance() -> HeatPumpHplib:
@@ -65,24 +65,24 @@ def test_heat_pump_hplib() -> None:
         "Fake_on_off_switch",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_on_off_switch"),
+        component_id=ComponentID("Fake_on_off_switch"),
     )
     t_in_primary: cp.ComponentOutput = cp.ComponentOutput(
         "Fake_t_in_primary",
         "Fake_t_in_primary",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_t_in_primary"),
+        component_id=ComponentID("Fake_t_in_primary"),
     )
     t_in_secondary: cp.ComponentOutput = cp.ComponentOutput(
         "Fake_t_in_secondary",
         "Fake_t_in_secondary",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_t_in_secondary"),
+        component_id=ComponentID("Fake_t_in_secondary"),
     )
     t_amb: cp.ComponentOutput = cp.ComponentOutput(
-        "Fake_t_amb", "Fake_t_amb", lt.LoadTypes.ANY, lt.Units.ANY, component_id=cp.ComponentID("Fake_t_amb")
+        "Fake_t_amb", "Fake_t_amb", lt.LoadTypes.ANY, lt.Units.ANY, component_id=ComponentID("Fake_t_amb")
     )
 
     # Initialize component
@@ -159,7 +159,7 @@ def test_get_heatpump_cycles_counts_off_to_on_transitions(time_off_series: list[
         HeatPumpHplib.TimeOff,
         lt.LoadTypes.TIME,
         lt.Units.SECONDS,
-        component_id=cp.ComponentID("Heat Pump"),
+        component_id=ComponentID("Heat Pump"),
     )
     assert (
         instance.get_heatpump_cycles(output=output, index=1, postprocessing_results=postprocessing_results)
@@ -178,7 +178,7 @@ def test_get_heatpump_cycles_ignores_non_timeoff_output() -> None:
         HeatPumpHplib.ThermalOutputPower,
         lt.LoadTypes.HEATING,
         lt.Units.WATT,
-        component_id=cp.ComponentID("Heat Pump"),
+        component_id=ComponentID("Heat Pump"),
     )
     assert instance.get_heatpump_cycles(output=output, index=0, postprocessing_results=postprocessing_results) == 0
 
@@ -201,7 +201,7 @@ def test_get_heatpump_cycles_propagates_non_index_errors() -> None:
         HeatPumpHplib.TimeOff,
         lt.LoadTypes.TIME,
         lt.Units.SECONDS,
-        component_id=cp.ComponentID("Heat Pump"),
+        component_id=ComponentID("Heat Pump"),
     )
     with pytest.raises(TypeError, match="comparison failure should propagate"):
         instance.get_heatpump_cycles(output=output, index=1, postprocessing_results=postprocessing_results)
@@ -228,5 +228,5 @@ def test_heatpump_display_config_instance_isolation() -> None:
 
     # Identity check: they must NOT be the same object
     assert hp1.my_display_config is not hp2.my_display_config
-    assert isinstance(hp1.my_display_config, cp.DisplayConfig)
-    assert isinstance(hp2.my_display_config, cp.DisplayConfig)
+    assert isinstance(hp1.my_display_config, DisplayConfig)
+    assert isinstance(hp2.my_display_config, DisplayConfig)

--- a/tests/test_air_conditioner.py
+++ b/tests/test_air_conditioner.py
@@ -10,6 +10,7 @@ from hisim.components.air_conditioner import (
 )
 from hisim import component
 from hisim import simulator as sim
+from hisim.config import DisplayConfig
 from tests import functions_for_testing as fft
 
 
@@ -202,6 +203,6 @@ def given_default_testee(
     testee: AirConditionerController = AirConditionerController(
         simulationparameters,
         config,
-        component.DisplayConfig(),
+        DisplayConfig(),
     )
     return testee

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -14,6 +14,7 @@ from hisim.loadtypes import LoadTypes, Units
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
 from hisim import utils
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -93,7 +94,7 @@ def test_building() -> None:
         "ThermalDelivery",
         LoadTypes.HEATING,
         Units.WATT,
-        component_id=component.ComponentID("FakeThermalDeliveryMachine"),
+        component_id=ComponentID("FakeThermalDeliveryMachine"),
     )
     t_five = time.perf_counter()
     log.profile(f"T4: {t_four - t_five}")

--- a/tests/test_building_characterization.py
+++ b/tests/test_building_characterization.py
@@ -61,7 +61,7 @@ import pandas
 import pytest
 
 from hisim import utils
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from hisim.components.building import BuildingConfig, BuildingInformation
 from tests import building_golden_support as golden_support
 

--- a/tests/test_building_heating_demand.py
+++ b/tests/test_building_heating_demand.py
@@ -17,7 +17,7 @@ from hisim.components import building
 from hisim.components import idealized_electric_heater
 from hisim import log
 from hisim import utils
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 __authors__ = "Vitor Hugo Bellotto Zago, Noah Pflugradt"
 __copyright__ = "Copyright 2022, FZJ-IEK-3"

--- a/tests/test_building_one_day_snapshot.py
+++ b/tests/test_building_one_day_snapshot.py
@@ -58,7 +58,7 @@ import pytest
 
 from hisim import component as cp
 from hisim import utils
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from hisim.components.building import Building, BuildingConfig
 from hisim.simulationparameters import SimulationParameters
 from tests import building_golden_support as golden_support

--- a/tests/test_building_theoretical_thermal_demand.py
+++ b/tests/test_building_theoretical_thermal_demand.py
@@ -12,7 +12,7 @@ from hisim.components import loadprofilegenerator_utsp_connector
 from hisim.components import weather
 from hisim.components import building
 from hisim.components import idealized_electric_heater
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from tests.testing_utils import TestingUtils
 
 

--- a/tests/test_building_with_external_u_values.py
+++ b/tests/test_building_with_external_u_values.py
@@ -18,7 +18,7 @@ from hisim.components import building
 from hisim.components import idealized_electric_heater
 from hisim import log
 from hisim import utils
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 # PATH and FUNC needed to build simulator, PATH is fake

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -14,7 +14,7 @@ from hisim import loadtypes as lt
 from hisim import log
 from hisim.components import example_component
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from tests import functions_for_testing as fft
 
 
@@ -38,7 +38,7 @@ def test_component_output_and_input() -> None:
         sankey_flow_direction=True,
         output_description="Test output description",
         source_component_class="TestComponentClass",
-        component_id=cp.ComponentID("TestComponent"),
+        component_id=ComponentID("TestComponent"),
     )
 
     # Verify output attributes
@@ -108,12 +108,12 @@ def test_single_time_step_values() -> None:
 
     # Create outputs for testing
     output1 = cp.ComponentOutput(
-        "Component1", "Output1", lt.LoadTypes.ELECTRICITY, lt.Units.WATT, component_id=cp.ComponentID("Component1")
+        "Component1", "Output1", lt.LoadTypes.ELECTRICITY, lt.Units.WATT, component_id=ComponentID("Component1")
     )
     output1.global_index = 0
 
     output2 = cp.ComponentOutput(
-        "Component2", "Output2", lt.LoadTypes.HEATING, lt.Units.WATT, component_id=cp.ComponentID("Component2")
+        "Component2", "Output2", lt.LoadTypes.HEATING, lt.Units.WATT, component_id=ComponentID("Component2")
     )
     output2.global_index = 1
 
@@ -166,7 +166,7 @@ def test_single_time_step_values() -> None:
         output1,
         output2,
         cp.ComponentOutput(
-            "Component3", "Output3", lt.LoadTypes.ANY, lt.Units.ANY, component_id=cp.ComponentID("Component3")
+            "Component3", "Output3", lt.LoadTypes.ANY, lt.Units.ANY, component_id=ComponentID("Component3")
         ),
     ]
     outputs[2].global_index = 2
@@ -192,7 +192,7 @@ def test_config_base() -> None:
     - ConfigBase.get_main_classname() method
     """
     # Create a minimal config
-    config = cp.ConfigBase(component_id=ComponentID(name="TestConfig"))
+    config = ConfigBase(component_id=ComponentID(name="TestConfig"))
 
     # Verify config attributes
     assert config.component_id.name == "TestConfig"
@@ -305,7 +305,7 @@ def test_component_connections() -> None:
         field_name="ElectricityOutput",
         load_type=lt.LoadTypes.ELECTRICITY,
         unit=lt.Units.WATT,
-        component_id=cp.ComponentID("SourceComponent"),
+        component_id=ComponentID("SourceComponent"),
     )
     source_output.global_index = 0
 
@@ -501,7 +501,7 @@ def test_example_component_simulation() -> None:
         load_type=lt.LoadTypes.HEATING,
         unit=lt.Units.WATT,
         output_description="Thermal energy delivered",
-        component_id=cp.ComponentID("Source"),
+        component_id=ComponentID("Source"),
     )
 
     # Set source output
@@ -548,18 +548,18 @@ def test_component_name_with_multiple_buildings() -> None:
     sim_params.multiple_buildings = True
 
     # Create a minimal component with ConfigBase
-    config = cp.ConfigBase(component_id=ComponentID(name="TestComponent", building="Building1"))
+    config = ConfigBase(component_id=ComponentID(name="TestComponent", building="Building1"))
 
     # Create a simple component subclass for testing
     class TestComponent(cp.Component):
         """Minimal component subclass for testing component name generation."""
 
-        def __init__(self, config: cp.ConfigBase, my_simulation_parameters: SimulationParameters) -> None:
+        def __init__(self, config: ConfigBase, my_simulation_parameters: SimulationParameters) -> None:
             super().__init__(
                 name="TestComponent",
                 my_simulation_parameters=my_simulation_parameters,
                 my_config=config,
-                my_display_config=cp.DisplayConfig(),
+                my_display_config=DisplayConfig(),
             )
 
         def i_prepare_simulation(self) -> None:
@@ -590,7 +590,7 @@ def test_component_name_with_multiple_buildings() -> None:
     assert comp_name2 == "Building1_TestComponent"
 
     # A component whose identity carries no building keeps the bare name in both cases.
-    building_less = TestComponent(cp.ConfigBase(component_id=ComponentID(name="TestComponent")), sim_params)
+    building_less = TestComponent(ConfigBase(component_id=ComponentID(name="TestComponent")), sim_params)
     assert building_less.get_component_name() == "TestComponent"
 
     log.information(f"Component name with multiple_buildings=True: {comp_name}")
@@ -627,17 +627,17 @@ def test_component_base_still_raises_not_implemented_for_state_hooks() -> None:
     StatelessComponent (opt-in) provides the no-op defaults.
     """
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    config = cp.ConfigBase(component_id=ComponentID(name="TestComponent"))
+    config = ConfigBase(component_id=ComponentID(name="TestComponent"))
 
     class _StatefulComponent(cp.Component):
         """A minimal Component that does NOT override the state hooks."""
 
-        def __init__(self, config: cp.ConfigBase, my_simulation_parameters: SimulationParameters) -> None:
+        def __init__(self, config: ConfigBase, my_simulation_parameters: SimulationParameters) -> None:
             super().__init__(
                 name="TestComponent",
                 my_simulation_parameters=my_simulation_parameters,
                 my_config=config,
-                my_display_config=cp.DisplayConfig(),
+                my_display_config=DisplayConfig(),
             )
 
         def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
@@ -664,17 +664,17 @@ def test_stateless_component_noop_hooks_are_callable() -> None:
     inherited as no-ops.
     """
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    config = cp.ConfigBase(component_id=ComponentID(name="TestComponent"))
+    config = ConfigBase(component_id=ComponentID(name="TestComponent"))
 
     class _MinimalStateless(cp.StatelessComponent):
         """Minimal stateless component for testing inherited no-op hooks."""
 
-        def __init__(self, config: cp.ConfigBase, my_simulation_parameters: SimulationParameters) -> None:
+        def __init__(self, config: ConfigBase, my_simulation_parameters: SimulationParameters) -> None:
             super().__init__(
                 name="TestComponent",
                 my_simulation_parameters=my_simulation_parameters,
                 my_config=config,
-                my_display_config=cp.DisplayConfig(),
+                my_display_config=DisplayConfig(),
             )
 
         def i_simulate(self, timestep: int, stsv: cp.SingleTimeStepValues, force_convergence: bool) -> None:
@@ -802,14 +802,14 @@ def test_add_component_input_and_connect_propagates_allow_unconnected() -> None:
     from hisim.dynamic_component import DynamicComponent
 
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    config = cp.ConfigBase(component_id=ComponentID(name="TestDynamic"))
+    config = ConfigBase(component_id=ComponentID(name="TestDynamic"))
     dyn_component = DynamicComponent(
         my_component_inputs=[],
         my_component_outputs=[],
         name="TestDynamic",
         my_simulation_parameters=sim_params,
         my_config=config,
-        my_display_config=cp.DisplayConfig(),
+        my_display_config=DisplayConfig(),
     )
 
     dyn_component.add_component_input_and_connect(

--- a/tests/test_component_id.py
+++ b/tests/test_component_id.py
@@ -1,4 +1,4 @@
-"""Tests for the structured component identity :py:class:`hisim.component.ComponentID`.
+"""Tests for the structured component identity :py:class:`hisim.config.ComponentID`.
 
 These tests pin down the behaviour that the whole identity sweep rests on: how a runtime
 component name is derived from the structured fields, that the identity is an immutable and
@@ -20,7 +20,7 @@ from dataclasses_json import dataclass_json
 
 from hisim import component as cp
 from hisim import loadtypes as lt
-from hisim.component import ComponentID, ConfigBase
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components import example_component
 from hisim.simulationparameters import SimulationParameters
 
@@ -64,7 +64,7 @@ class _NamedComponent(cp.Component):
             name=config.component_id.key,
             my_simulation_parameters=my_simulation_parameters,
             my_config=config,
-            my_display_config=cp.DisplayConfig(),
+            my_display_config=DisplayConfig(),
         )
 
     def i_prepare_simulation(self) -> None:

--- a/tests/test_config_enum_serialization.py
+++ b/tests/test_config_enum_serialization.py
@@ -30,7 +30,7 @@ from typing import Any, Dict, List, Tuple, Type
 import pytest
 
 import hisim.components
-from hisim.component import ConfigBase
+from hisim.config import ConfigBase
 from hisim.components import generic_boiler
 from hisim.components import generic_pv_system
 from hisim.components import heat_distribution_system

--- a/tests/test_controller_l1_example_controller.py
+++ b/tests/test_controller_l1_example_controller.py
@@ -17,7 +17,7 @@ from hisim.components.controller_l1_example_controller import (
     SimpleController,
     SimpleControllerConfig,
 )
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 def _assert_defaults(config: SimpleControllerConfig, expected_building: Optional[str]) -> None:

--- a/tests/test_controller_l1_fuel_cell.py
+++ b/tests/test_controller_l1_fuel_cell.py
@@ -16,6 +16,7 @@ from hisim import component as cp
 from hisim.components import controller_l1_fuel_cell as fc
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -40,7 +41,7 @@ def build_controller(seconds_per_timestep: int = 3600) -> _ControllerSetup:
     controller = fc.FuelCellController(my_simulation_parameters=my_simulation_parameters, config=config)
 
     demand = cp.ComponentOutput(
-        "FakeDemand", "Demand", lt.LoadTypes.ELECTRICITY, lt.Units.KILOWATT, component_id=cp.ComponentID("FakeDemand")
+        "FakeDemand", "Demand", lt.LoadTypes.ELECTRICITY, lt.Units.KILOWATT, component_id=ComponentID("FakeDemand")
     )
     controller.demand_profile.source_output = demand
 

--- a/tests/test_controller_l1_generic_electrolyzer.py
+++ b/tests/test_controller_l1_generic_electrolyzer.py
@@ -7,7 +7,7 @@ from hisim.components import controller_l1_electrolyzer_h2
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 @pytest.mark.base
@@ -49,7 +49,7 @@ def test_electrolyzer_controller() -> None:
         "Provided Load",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.KILOWATT,
-        component_id=cp.ComponentID("FakeProvidedLoad"),
+        component_id=ComponentID("FakeProvidedLoad"),
     )
 
     number_of_outputs = fft.get_number_of_outputs([my_controller, load_input])

--- a/tests/test_controller_l1_rsoc.py
+++ b/tests/test_controller_l1_rsoc.py
@@ -18,6 +18,7 @@ from hisim import component as cp
 from hisim.components import controller_l1_rsoc
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -66,7 +67,7 @@ def test_config_rsoc_building_override_and_defaults() -> None:
     """config_rsoc forwards the component identity and applies defaults for missing keys."""
     config = controller_l1_rsoc.RsocControllerConfig.config_rsoc(
         rsoc_name="RSOC_TEST",
-        component_id=cp.ComponentID(name="rSCO l1 Controller", building="BUI2"),
+        component_id=ComponentID(name="rSCO l1 Controller", building="BUI2"),
         config_json={"nom_load_soec": 40.0},
     )
     assert config.component_id.building == "BUI2"
@@ -120,7 +121,7 @@ def test_rsoc_controller_built_from_in_memory_config() -> None:
         controller_l1_rsoc.RsocController.ProvidedPower,
         lt.LoadTypes.ELECTRICITY,
         lt.Units.KILOWATT,
-        component_id=cp.ComponentID("FakeProvidedPower"),
+        component_id=ComponentID("FakeProvidedPower"),
     )
 
     number_of_outputs = fft.get_number_of_outputs([my_controller, provided_power])

--- a/tests/test_controller_l2_energy_management_system.py
+++ b/tests/test_controller_l2_energy_management_system.py
@@ -26,7 +26,7 @@ from hisim.components import (
     more_advanced_heat_pump_hplib
 )
 from hisim import utils
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 import hisim.loadtypes as lt
 
 from hisim.postprocessingoptions import PostProcessingOptions

--- a/tests/test_controller_l2_energy_management_system_error_handling.py
+++ b/tests/test_controller_l2_energy_management_system_error_handling.py
@@ -17,6 +17,7 @@ from hisim.components.controller_l2_energy_management_system import (
     L2GenericEnergyManagementSystem,
 )
 from hisim.dynamic_component import DynamicConnectionInput, DynamicConnectionOutput
+from hisim.config import ComponentID
 
 
 def _make_ems() -> L2GenericEnergyManagementSystem:
@@ -92,7 +93,7 @@ def test_sort_source_weights_returns_outputs_when_connected() -> None:
         "ElectricityTarget",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.WATT,
-        component_id=cp.ComponentID("Electrolyzer"),
+        component_id=ComponentID("Electrolyzer"),
     )
     _add_electrolyzer_output(ems, weight=5, label="Output_Test_Electrolyzer", value=output)
 

--- a/tests/test_controller_l2_ptx_ems_display_config.py
+++ b/tests/test_controller_l2_ptx_ems_display_config.py
@@ -17,7 +17,7 @@ the misleading ``PowerToThird``/``EnergyToThird``) and the instance attribute
 
 import pytest
 
-from hisim.component import ComponentID, DisplayConfig
+from hisim.config import ComponentID, DisplayConfig
 from hisim.components.controller_l2_ptx_energy_management_system import (
     PTXController,
     PTXControllerConfig,

--- a/tests/test_controller_l2_rsoc_battery_system.py
+++ b/tests/test_controller_l2_rsoc_battery_system.py
@@ -18,6 +18,7 @@ from hisim import component as cp
 from hisim.components import controller_l2_rsoc_battery_system as l2
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -60,7 +61,7 @@ def test_config_rsoc_building_override_and_defaults() -> None:
     config = l2.RsocBatteryControllerConfig.config_rsoc(
         rsoc_name="RSOC_TEST",
         operation_mode="MinimumLoad",
-        component_id=cp.ComponentID(name="rSOC and Battery Controller", building="BUI2"),
+        component_id=ComponentID(name="rSOC and Battery Controller", building="BUI2"),
         config_data={"nom_load_soec": 40.0},
     )
     assert config.component_id.building == "BUI2"
@@ -123,14 +124,14 @@ def test_rsoc_battery_controller_built_from_in_memory_config() -> None:
         l2.RsocBatteryController.RESLoad,
         lt.LoadTypes.ELECTRICITY,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeRESLoad"),
+        component_id=ComponentID("FakeRESLoad"),
     )
     demand = cp.ComponentOutput(
         "FakeDemand",
         l2.RsocBatteryController.Demand,
         lt.LoadTypes.ELECTRICITY,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeDemand"),
+        component_id=ComponentID("FakeDemand"),
     )
 
     number_of_outputs = fft.get_number_of_outputs([my_controller, res_load, demand])

--- a/tests/test_controller_l2_xtp_fuel_cell_ems.py
+++ b/tests/test_controller_l2_xtp_fuel_cell_ems.py
@@ -11,7 +11,7 @@ from hisim import component as cp
 from hisim.components import controller_l2_xtp_fuel_cell_ems
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -52,7 +52,7 @@ def _set_demand(
         "DemandLoad",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeDemandLoad"),
+        component_id=ComponentID("FakeDemandLoad"),
     )
     number_of_outputs = fft.get_number_of_outputs([controller, load_input])
     stsv: cp.SingleTimeStepValues = cp.SingleTimeStepValues(number_of_outputs)

--- a/tests/test_controller_mpc.py
+++ b/tests/test_controller_mpc.py
@@ -13,7 +13,7 @@ import pytest
 from hisim.components.controller_mpc import MpcController, MpcControllerConfig
 from hisim.loadtypes import Units
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 # Non-zero thermal coefficients so statespace() does not divide by zero.
 H_TR_W = 50.0

--- a/tests/test_controller_pid.py
+++ b/tests/test_controller_pid.py
@@ -16,6 +16,7 @@ from hisim.components.controller_pid import (
 from hisim.loadtypes import LoadTypes, Units
 from hisim.sim_repository_singleton import SingletonDictKeyEnum, SingletonSimRepository
 from hisim.simulationparameters import SimulationParameters
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 # 5R1C thermal coefficients used across the tests (W/K and J/K).
@@ -158,17 +159,17 @@ def _build_controller_with_inputs(
         "TemperatureMean",
         LoadTypes.TEMPERATURE,
         Units.CELSIUS,
-        component_id=cp.ComponentID("FakeBuilding"),
+        component_id=ComponentID("FakeBuilding"),
     )
     fake_phi_st = cp.ComponentOutput(
-        "FakeBuilding", "HeatFluxWallNode", LoadTypes.HEATING, Units.WATT, component_id=cp.ComponentID("FakeBuilding")
+        "FakeBuilding", "HeatFluxWallNode", LoadTypes.HEATING, Units.WATT, component_id=ComponentID("FakeBuilding")
     )
     fake_phi_m = cp.ComponentOutput(
         "FakeBuilding",
         "HeatFluxThermalMassNode",
         LoadTypes.HEATING,
         Units.WATT,
-        component_id=cp.ComponentID("FakeBuilding"),
+        component_id=ComponentID("FakeBuilding"),
     )
     controller.temperature_mean_channel.source_output = fake_temperature
     controller.heat_flow_rate_to_internal_surface_node_channel.source_output = fake_phi_st

--- a/tests/test_csvloader.py
+++ b/tests/test_csvloader.py
@@ -16,7 +16,7 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.components.csvloader import CSVLoader, CSVLoaderConfig
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 # Conversion factors used to derive the seconds-per-timestep of a
 # full-year simulation from the requested number of timesteps:

--- a/tests/test_electricity_meter_config.py
+++ b/tests/test_electricity_meter_config.py
@@ -16,7 +16,7 @@ from hisim.components.electricity_meter import (
     ElectricityMeterConfig,
     ElectricityMeterState,
 )
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 _OPTIONAL_FIELDS: tuple[str, ...] = (

--- a/tests/test_example_component.py
+++ b/tests/test_example_component.py
@@ -8,6 +8,7 @@ from hisim import loadtypes as lt
 from hisim import log
 from hisim.components import example_component
 from hisim.simulationparameters import SimulationParameters
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -37,7 +38,7 @@ def test_example_component() -> None:
         field_name="thermal energy delivered",
         load_type=lt.LoadTypes.HEATING,
         unit=lt.Units.WATT,
-        component_id=cp.ComponentID("source"),
+        component_id=ComponentID("source"),
     )
     my_example_component.thermal_energy_delivered_c.source_output = thermal_energy_delivered_output
 

--- a/tests/test_example_storage.py
+++ b/tests/test_example_storage.py
@@ -9,6 +9,7 @@ from hisim.components import example_storage
 from hisim.simulationparameters import SimulationParameters
 from hisim import loadtypes as lt
 from hisim import log
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -37,14 +38,14 @@ def test_example_storage() -> None:
         field_name="charging",
         load_type=lt.LoadTypes.WARM_WATER,
         unit=lt.Units.KWH,
-        component_id=cp.ComponentID("source"),
+        component_id=ComponentID("source"),
     )
     discharging_output: cp.ComponentOutput = cp.ComponentOutput(
         object_name="source",
         field_name="discharging",
         load_type=lt.LoadTypes.WARM_WATER,
         unit=lt.Units.KWH,
-        component_id=cp.ComponentID("source"),
+        component_id=ComponentID("source"),
     )
 
     my_example_storage.charging_input.source_output = charging_output

--- a/tests/test_example_template.py
+++ b/tests/test_example_template.py
@@ -7,7 +7,7 @@ from hisim.components import example_template
 from hisim.simulationparameters import SimulationParameters
 from hisim import loadtypes as lt
 from hisim import log
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -36,7 +36,7 @@ def test_example_template() -> None:
         field_name="input_from_another_component",
         load_type=lt.LoadTypes.ELECTRICITY,
         unit=lt.Units.WATT,
-        component_id=cp.ComponentID("source"),
+        component_id=ComponentID("source"),
     )
     my_example_template.input_from_other_component.source_output = input_from_another_component_output
 

--- a/tests/test_example_transformer.py
+++ b/tests/test_example_transformer.py
@@ -7,6 +7,7 @@ from hisim.components import example_transformer
 from hisim.simulationparameters import SimulationParameters
 from hisim import loadtypes as lt
 from hisim import log
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -38,7 +39,7 @@ def test_example_transformer() -> None:
         load_type=lt.LoadTypes.ANY,
         unit=lt.Units.ANY,
         output_description="Source 2",
-        component_id=cp.ComponentID("source"),
+        component_id=ComponentID("source"),
     )
     transformerinput2_output = cp.ComponentOutput(
         object_name="source",
@@ -46,7 +47,7 @@ def test_example_transformer() -> None:
         load_type=lt.LoadTypes.ANY,
         unit=lt.Units.ANY,
         output_description="Source 2",
-        component_id=cp.ComponentID("source"),
+        component_id=ComponentID("source"),
     )
     my_example_transformer.input1.source_output = transformerinput1_output
     my_example_transformer.input2.source_output = transformerinput2_output

--- a/tests/test_generic_boiler.py
+++ b/tests/test_generic_boiler.py
@@ -2,13 +2,13 @@
 
 from typing import Any, Dict, Optional
 import pytest
-from hisim import component
 from hisim import simulator as sim
 from hisim.components.dual_circuit_system import HeatingMode
 from hisim.components.generic_boiler import (
     GenericBoilerController,
     GenericBoilerControllerConfig,
 )
+from hisim.config import DisplayConfig
 
 
 @pytest.mark.base
@@ -92,7 +92,7 @@ def given_default_testee(
     testee = GenericBoilerController(
         simulationparameters,
         config,
-        component.DisplayConfig(),
+        DisplayConfig(),
     )
     return testee
 

--- a/tests/test_generic_chp.py
+++ b/tests/test_generic_chp.py
@@ -16,6 +16,7 @@ from hisim.components import (
     controller_l1_chp,
 )
 from hisim.simulationparameters import SimulationParameters
+from hisim.config import ComponentID
 
 
 @pytest.mark.base
@@ -52,28 +53,28 @@ def test_chp_system() -> None:
         "BufferTemperature",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeBuffer"),
+        component_id=ComponentID("FakeBuffer"),
     )
     boiler_temperature = cp.ComponentOutput(
         "FakeBoilerTemperature",
         "HotWaterStorageTemperature",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeBoilerTemperature"),
+        component_id=ComponentID("FakeBoilerTemperature"),
     )
     electricity_target = cp.ComponentOutput(
         "FakeElectricityTarget",
         "ElectricityTarget",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeElectricityTarget"),
+        component_id=ComponentID("FakeElectricityTarget"),
     )
     hydrogensoc = cp.ComponentOutput(
         "FakeH2SOC",
         "HydrogenSOC",
         lt.LoadTypes.GREEN_HYDROGEN,
         lt.Units.PERCENT,
-        component_id=cp.ComponentID("FakeH2SOC"),
+        component_id=ComponentID("FakeH2SOC"),
     )
 
     number_of_outputs = fft.get_number_of_outputs(
@@ -229,7 +230,7 @@ def test_get_default_config_chp_default_building() -> None:
 def test_get_default_config_chp_custom_building_and_powers() -> None:
     """Test CHPConfig.get_default_config_chp with a custom building name and thermal_power=500."""
     config = generic_chp.CHPConfig.get_default_config_chp(
-        thermal_power=500, component_id=cp.ComponentID(name="CHP", building="Custom")
+        thermal_power=500, component_id=ComponentID(name="CHP", building="Custom")
     )
     assert config.component_id.building == "Custom"
     assert config.p_th == 500

--- a/tests/test_generic_electric_heating.py
+++ b/tests/test_generic_electric_heating.py
@@ -20,7 +20,8 @@ import pandas as pd
 import pytest
 
 from hisim import loadtypes as lt
-from hisim.component import ComponentOutput, DisplayConfig
+from hisim.component import ComponentOutput
+from hisim.config import DisplayConfig
 from hisim.components.generic_electric_heating import ElectricHeating, ElectricHeatingConfig
 from hisim.simulationparameters import SimulationParameters
 

--- a/tests/test_generic_electrolyzer.py
+++ b/tests/test_generic_electrolyzer.py
@@ -13,6 +13,7 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 from hisim.components import generic_electrolyzer, controller_l1_electrolyzer
+from hisim.config import ComponentID, DisplayConfig
 
 
 @pytest.mark.base
@@ -47,14 +48,14 @@ def test_chp_system() -> None:
         "ElectricityTarget",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeElectricityTarget"),
+        component_id=ComponentID("FakeElectricityTarget"),
     )
     hydrogensoc = cp.ComponentOutput(
         "FakeH2SOC",
         "HydrogenSOC",
         lt.LoadTypes.GREEN_HYDROGEN,
         lt.Units.PERCENT,
-        component_id=cp.ComponentID("FakeH2SOC"),
+        component_id=ComponentID("FakeH2SOC"),
     )
 
     number_of_outputs = fft.get_number_of_outputs(
@@ -142,8 +143,8 @@ def test_electrolyzer_controller_display_config_not_shared() -> None:
     )
 
     assert controller_a.my_display_config is not controller_b.my_display_config
-    assert isinstance(controller_a.my_display_config, cp.DisplayConfig)
-    assert isinstance(controller_b.my_display_config, cp.DisplayConfig)
+    assert isinstance(controller_a.my_display_config, DisplayConfig)
+    assert isinstance(controller_b.my_display_config, DisplayConfig)
 
     # mutating one must not affect the other
     controller_a.my_display_config.pretty_name = "controller_a"

--- a/tests/test_generic_electrolyzer_and_h2_storage.py
+++ b/tests/test_generic_electrolyzer_and_h2_storage.py
@@ -14,7 +14,7 @@ from hisim.components import generic_electrolyzer_and_h2_storage
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
-from hisim.component import ComponentID
+from hisim.config import ComponentID, DisplayConfig
 
 
 @pytest.mark.base
@@ -96,21 +96,21 @@ def test_hydrogen_generator() -> None:
         "ElectricityInput",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeElectricityInput"),
+        component_id=ComponentID("FakeElectricityInput"),
     )
     hydrogen_not_stored = cp.ComponentOutput(
         "FakeHydrogenNotStored",
         "HydrogenNotStored",
         lt.LoadTypes.GREEN_HYDROGEN,
         lt.Units.KG,
-        component_id=cp.ComponentID("FakeHydrogenNotStored"),
+        component_id=ComponentID("FakeHydrogenNotStored"),
     )
     discharging_hydrogen_amount_target = cp.ComponentOutput(
         "DischargingHydrogenAmountTarget",
         "DischargingHydrogenAmountTarget",
         lt.LoadTypes.GREEN_HYDROGEN,
         lt.Units.KG_PER_SEC,
-        component_id=cp.ComponentID("DischargingHydrogenAmountTarget"),
+        component_id=ComponentID("DischargingHydrogenAmountTarget"),
     )
 
     number_of_outputs = fft.get_number_of_outputs(
@@ -219,5 +219,5 @@ def test_display_config_instance_isolation() -> None:
     assert electrolyzer_1.my_display_config is not storage_1.my_display_config
 
     # Verify type correctness
-    assert isinstance(electrolyzer_1.my_display_config, cp.DisplayConfig)
-    assert isinstance(storage_1.my_display_config, cp.DisplayConfig)
+    assert isinstance(electrolyzer_1.my_display_config, DisplayConfig)
+    assert isinstance(storage_1.my_display_config, DisplayConfig)

--- a/tests/test_generic_electrolyzer_h2.py
+++ b/tests/test_generic_electrolyzer_h2.py
@@ -12,7 +12,7 @@ from hisim import loadtypes as lt
 from hisim import log
 from hisim.components import generic_electrolyzer_h2
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -65,7 +65,7 @@ def test_electrolyzer() -> None:
         "LoadInput",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.KILOWATT,
-        component_id=cp.ComponentID("FakeLoadInput"),
+        component_id=ComponentID("FakeLoadInput"),
     )
 
     input_state = cp.ComponentOutput(
@@ -73,7 +73,7 @@ def test_electrolyzer() -> None:
         "InputState",
         lt.LoadTypes.ACTIVATION,
         lt.Units.ANY,
-        component_id=cp.ComponentID("FakeInputState"),
+        component_id=ComponentID("FakeInputState"),
     )
 
     number_of_outputs = fft.get_number_of_outputs([load_input, input_state])

--- a/tests/test_generic_fuel_cell.py
+++ b/tests/test_generic_fuel_cell.py
@@ -8,7 +8,7 @@ from hisim import loadtypes as lt
 from hisim import log
 from hisim.components import generic_fuel_cell
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -61,7 +61,7 @@ def test_electrolyzer() -> None:
         "DemandProfile",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.KILOWATT,
-        component_id=cp.ComponentID("FakeDemandProfile"),
+        component_id=ComponentID("FakeDemandProfile"),
     )
 
     control_signal = cp.ComponentOutput(
@@ -69,7 +69,7 @@ def test_electrolyzer() -> None:
         "ControlSignal",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("FakeControlSignal"),
+        component_id=ComponentID("FakeControlSignal"),
     )
 
     number_of_outputs = fft.get_number_of_outputs([demand_profile_target, control_signal])

--- a/tests/test_generic_gas_heater.py
+++ b/tests/test_generic_gas_heater.py
@@ -10,6 +10,7 @@ from hisim.components import generic_boiler
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -47,21 +48,21 @@ def test_gas_heater() -> None:
         "ControlSignal",
         lt.LoadTypes.ANY,
         lt.Units.PERCENT,
-        component_id=cp.ComponentID("FakeControlSignal"),
+        component_id=ComponentID("FakeControlSignal"),
     )
     operating_mode_channel = cp.ComponentOutput(
         "FakeOperatingMode",
         "OperatingMode",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("FakeOperatingMode"),
+        component_id=ComponentID("FakeOperatingMode"),
     )
     temperature_delta_channel = cp.ComponentOutput(
         "FakeTemperatureDelta",
         "TemperatureDelta",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.KELVIN,
-        component_id=cp.ComponentID("FakeTemperatureDelta"),
+        component_id=ComponentID("FakeTemperatureDelta"),
     )
 
     mass_flow_input_temperature_channel = cp.ComponentOutput(
@@ -69,7 +70,7 @@ def test_gas_heater() -> None:
         "MassflowInputTemperature",
         lt.LoadTypes.WATER,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeMassflowInputTemperature"),
+        component_id=ComponentID("FakeMassflowInputTemperature"),
     )
 
     test_components = [

--- a/tests/test_generic_heat_pump.py
+++ b/tests/test_generic_heat_pump.py
@@ -6,7 +6,7 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.components import generic_heat_pump
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 @pytest.mark.base
@@ -68,7 +68,7 @@ def test_generic_heat_pump() -> None:
         "TemperatureAir",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeTemperatureOutside"),
+        component_id=ComponentID("FakeTemperatureOutside"),
     )
 
     t_m_output = cp.ComponentOutput(
@@ -76,7 +76,7 @@ def test_generic_heat_pump() -> None:
         "TemperatureMean",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeHouse"),
+        component_id=ComponentID("FakeHouse"),
     )
 
     my_heat_pump_controller.temperature_mean_channel.source_output = t_m_output

--- a/tests/test_generic_price_signal.py
+++ b/tests/test_generic_price_signal.py
@@ -13,7 +13,7 @@ from typing import Optional
 import pytest
 
 from hisim.components.generic_price_signal import PriceSignal, PriceSignalConfig
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 def _assert_defaults(config: PriceSignalConfig, expected_building: Optional[str]) -> None:

--- a/tests/test_generic_rsoc.py
+++ b/tests/test_generic_rsoc.py
@@ -22,7 +22,7 @@ from hisim.components import generic_rsoc
 from hisim import loadtypes as lt
 from hisim import utils
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 @pytest.mark.base
@@ -80,7 +80,7 @@ def test_rsoc() -> None:
         "PowerInput",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.KILOWATT,
-        component_id=cp.ComponentID("FakePowerInput"),
+        component_id=ComponentID("FakePowerInput"),
     )
 
     input_state_rsoc = cp.ComponentOutput(
@@ -88,7 +88,7 @@ def test_rsoc() -> None:
         "RSOCInputState",
         lt.LoadTypes.ACTIVATION,
         lt.Units.ANY,
-        component_id=cp.ComponentID("FakeRSOCInputState"),
+        component_id=ComponentID("FakeRSOCInputState"),
     )
 
     number_of_outputs = fft.get_number_of_outputs([power_input, input_state_rsoc])

--- a/tests/test_h2storage.py
+++ b/tests/test_h2storage.py
@@ -12,6 +12,7 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 from hisim.components import generic_hydrogen_storage
+from hisim.config import ComponentID
 
 
 @pytest.mark.base
@@ -40,14 +41,14 @@ def test_h2_storage() -> None:
         "HydrogenInput",
         lt.LoadTypes.GREEN_HYDROGEN,
         lt.Units.KG_PER_SEC,
-        component_id=cp.ComponentID("FakeHydrogenInput"),
+        component_id=ComponentID("FakeHydrogenInput"),
     )
     h2_output: cp.ComponentOutput = cp.ComponentOutput(
         "FakeHydrogenOutput",
         "HydrogenOutput",
         lt.LoadTypes.GREEN_HYDROGEN,
         lt.Units.KG_PER_SEC,
-        component_id=cp.ComponentID("FakeHydrogenOutput"),
+        component_id=ComponentID("FakeHydrogenOutput"),
     )
 
     number_of_outputs: int = fft.get_number_of_outputs([my_h2_storage, h2_input, h2_output])
@@ -102,14 +103,14 @@ def test_h2_storage_simultaneous_charge_dominates() -> None:
         "HydrogenInput",
         lt.LoadTypes.GREEN_HYDROGEN,
         lt.Units.KG_PER_SEC,
-        component_id=cp.ComponentID("FakeHydrogenInput"),
+        component_id=ComponentID("FakeHydrogenInput"),
     )
     h2_output: cp.ComponentOutput = cp.ComponentOutput(
         "FakeHydrogenOutput",
         "HydrogenOutput",
         lt.LoadTypes.GREEN_HYDROGEN,
         lt.Units.KG_PER_SEC,
-        component_id=cp.ComponentID("FakeHydrogenOutput"),
+        component_id=ComponentID("FakeHydrogenOutput"),
     )
 
     number_of_outputs: int = fft.get_number_of_outputs([my_h2_storage, h2_input, h2_output])
@@ -153,14 +154,14 @@ def test_h2_storage_simultaneous_discharge_dominates() -> None:
         "HydrogenInput",
         lt.LoadTypes.GREEN_HYDROGEN,
         lt.Units.KG_PER_SEC,
-        component_id=cp.ComponentID("FakeHydrogenInput"),
+        component_id=ComponentID("FakeHydrogenInput"),
     )
     h2_output: cp.ComponentOutput = cp.ComponentOutput(
         "FakeHydrogenOutput",
         "HydrogenOutput",
         lt.LoadTypes.GREEN_HYDROGEN,
         lt.Units.KG_PER_SEC,
-        component_id=cp.ComponentID("FakeHydrogenOutput"),
+        component_id=ComponentID("FakeHydrogenOutput"),
     )
 
     number_of_outputs: int = fft.get_number_of_outputs([my_h2_storage, h2_input, h2_output])

--- a/tests/test_heat_distribution_system.py
+++ b/tests/test_heat_distribution_system.py
@@ -8,7 +8,7 @@ from hisim.components import heat_distribution_system, building
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -157,21 +157,21 @@ def simulate_and_calculate_hds_outputs_for_a_given_theoretical_heating_demand_fr
         "WaterTemperatureInput",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeWaterTemperatureInput"),
+        component_id=ComponentID("FakeWaterTemperatureInput"),
     )
     residence_temperature_indoor_air = cp.ComponentOutput(
         "FakeResidenceTemperatureInput",
         "ResidenceTemperatureInput",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeResidenceTemperatureInput"),
+        component_id=ComponentID("FakeResidenceTemperatureInput"),
     )
     theoretical_thermal_building_demand = cp.ComponentOutput(
         "FakeTheoreticalThermalDemand",
         "TheoreticalThermalDemand",
         lt.LoadTypes.HEATING,
         lt.Units.WATT,
-        component_id=cp.ComponentID("FakeTheoreticalThermalDemand"),
+        component_id=ComponentID("FakeTheoreticalThermalDemand"),
     )
 
     state_from_hds_controller = cp.ComponentOutput(
@@ -179,7 +179,7 @@ def simulate_and_calculate_hds_outputs_for_a_given_theoretical_heating_demand_fr
         "StateController",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("FakeStateController"),
+        component_id=ComponentID("FakeStateController"),
     )
 
     # connect hds inputs to fake outputs

--- a/tests/test_lpg_utsp_connector_local_lpg.py
+++ b/tests/test_lpg_utsp_connector_local_lpg.py
@@ -17,7 +17,7 @@ from hisim import component
 from hisim.components import loadprofilegenerator_utsp_connector
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 load_dotenv()

--- a/tests/test_lpg_utsp_connector_scaling.py
+++ b/tests/test_lpg_utsp_connector_scaling.py
@@ -17,7 +17,7 @@ from hisim import component
 from hisim.components import loadprofilegenerator_utsp_connector
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 load_dotenv()

--- a/tests/test_more_advanced_heat_pump_hplib.py
+++ b/tests/test_more_advanced_heat_pump_hplib.py
@@ -13,7 +13,7 @@ from hisim.components.more_advanced_heat_pump_hplib import (
 )
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 # Heat pump configuration constants
 CO2_FOOTPRINT_COEFFICIENT: float = 165.84  # kg CO2 per kW thermal power over lifetime
@@ -49,45 +49,45 @@ def test_heat_pump_hplib_new() -> None:
         "Fake_on_off_switch",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_on_off_switch"),
+        component_id=ComponentID("Fake_on_off_switch"),
     )
     on_off_switch_dhw = cp.ComponentOutput(
         "Fake_on_off_switch",
         "Fake_on_off_switch",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_on_off_switch"),
+        component_id=ComponentID("Fake_on_off_switch"),
     )
     const_thermal_power_value_dhw = cp.ComponentOutput(
         "Fake_const_thermal_power_value_dhw",
         "Fake_const_thermal_power_value_dhw",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_const_thermal_power_value_dhw"),
+        component_id=ComponentID("Fake_const_thermal_power_value_dhw"),
     )
     t_in_primary = cp.ComponentOutput(
         "Fake_t_in_primary",
         "Fake_t_in_primary",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_t_in_primary"),
+        component_id=ComponentID("Fake_t_in_primary"),
     )
     t_in_secondary_sh = cp.ComponentOutput(
         "Fake_t_in_secondary_hot_water",
         "Fake_t_in_secondary_hot_water",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_t_in_secondary_hot_water"),
+        component_id=ComponentID("Fake_t_in_secondary_hot_water"),
     )
     t_in_secondary_dhw = cp.ComponentOutput(
         "Fake_t_in_secondary_dhw",
         "Fake_t_in_secondary_dhw",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_t_in_secondary_dhw"),
+        component_id=ComponentID("Fake_t_in_secondary_dhw"),
     )
     t_amb = cp.ComponentOutput(
-        "Fake_t_amb", "Fake_t_amb", lt.LoadTypes.ANY, lt.Units.ANY, component_id=cp.ComponentID("Fake_t_amb")
+        "Fake_t_amb", "Fake_t_amb", lt.LoadTypes.ANY, lt.Units.ANY, component_id=ComponentID("Fake_t_amb")
     )
 
     # Initialize component
@@ -202,14 +202,14 @@ def test_get_heatpump_cycles_counts_transitions() -> None:
     heatpump = MoreAdvancedHeatPumpHPLib(config=config, my_simulation_parameters=simpars)
 
     time_off_output = cp.ComponentOutput(
-        "HeatPump", heatpump.TimeOff, lt.LoadTypes.ANY, lt.Units.ANY, component_id=cp.ComponentID("HeatPump")
+        "HeatPump", heatpump.TimeOff, lt.LoadTypes.ANY, lt.Units.ANY, component_id=ComponentID("HeatPump")
     )
     other_output = cp.ComponentOutput(
         "HeatPump",
         heatpump.ThermalOutputPowerSH,
         lt.LoadTypes.HEATING,
         lt.Units.WATT,
-        component_id=cp.ComponentID("HeatPump"),
+        component_id=ComponentID("HeatPump"),
     )
 
     # Column 0 holds the TimeOff series; an unrelated column sits at index 1.
@@ -253,7 +253,7 @@ def test_get_heatpump_cycles_propagates_non_index_errors() -> None:
     heatpump = MoreAdvancedHeatPumpHPLib(config=config, my_simulation_parameters=simpars)
 
     time_off_output = cp.ComponentOutput(
-        "HeatPump", heatpump.TimeOff, lt.LoadTypes.ANY, lt.Units.ANY, component_id=cp.ComponentID("HeatPump")
+        "HeatPump", heatpump.TimeOff, lt.LoadTypes.ANY, lt.Units.ANY, component_id=ComponentID("HeatPump")
     )
     # A numpy array as an element makes ``off_time != 0`` return an array whose
     # truth value is ambiguous, raising ValueError — a non-IndexError that the

--- a/tests/test_more_advanced_heat_pump_hplib_only_sh.py
+++ b/tests/test_more_advanced_heat_pump_hplib_only_sh.py
@@ -16,7 +16,7 @@ from hisim.components.more_advanced_heat_pump_hplib import (
 )
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 
 
 @pytest.mark.base
@@ -48,24 +48,24 @@ def test_heat_pump_hplib_new() -> None:
         "Fake_on_off_switch",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_on_off_switch"),
+        component_id=ComponentID("Fake_on_off_switch"),
     )
     t_in_primary = cp.ComponentOutput(
         "Fake_t_in_primary",
         "Fake_t_in_primary",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_t_in_primary"),
+        component_id=ComponentID("Fake_t_in_primary"),
     )
     t_in_secondary_sh = cp.ComponentOutput(
         "Fake_t_in_secondary_hot_water",
         "Fake_t_in_secondary_hot_water",
         lt.LoadTypes.ANY,
         lt.Units.ANY,
-        component_id=cp.ComponentID("Fake_t_in_secondary_hot_water"),
+        component_id=ComponentID("Fake_t_in_secondary_hot_water"),
     )
     t_amb = cp.ComponentOutput(
-        "Fake_t_amb", "Fake_t_amb", lt.LoadTypes.ANY, lt.Units.ANY, component_id=cp.ComponentID("Fake_t_amb")
+        "Fake_t_amb", "Fake_t_amb", lt.LoadTypes.ANY, lt.Units.ANY, component_id=ComponentID("Fake_t_amb")
     )
 
     # Initialize component

--- a/tests/test_night_setback_controller.py
+++ b/tests/test_night_setback_controller.py
@@ -6,7 +6,7 @@ import pytest
 from hisim import component as cp
 from hisim.components import night_setback_controller
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 

--- a/tests/test_postprocessing_options.py
+++ b/tests/test_postprocessing_options.py
@@ -27,6 +27,7 @@ from hisim.postprocessingoptions import PostProcessingOptions
 from hisim.result_path_provider import ResultPathProviderSingleton, RunMode
 from hisim.simulationparameters import SimulationParameters
 from hisim.simulator import Simulator
+from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from tests.postprocessing_option_test_framework import PostProcessingOptionTestFramework
 
 
@@ -65,8 +66,8 @@ class _ConvergingFeedbackComponent(cp.StatelessComponent):
         super().__init__(
             name=name,
             my_simulation_parameters=my_simulation_parameters,
-            my_config=cp.ConfigBase(component_id=cp.ComponentID(name=name)),
-            my_display_config=cp.DisplayConfig(),
+            my_config=ConfigBase(component_id=ComponentID(name=name)),
+            my_display_config=DisplayConfig(),
         )
         self._offset: float = offset
         self.feedback_input: cp.ComponentInput = self.add_input(

--- a/tests/test_random_numbers.py
+++ b/tests/test_random_numbers.py
@@ -22,7 +22,7 @@ import random
 
 import pytest
 
-from hisim.component import ComponentID, DisplayConfig
+from hisim.config import ComponentID, DisplayConfig
 from hisim.components.random_numbers import RandomNumbers, RandomNumbersConfig
 from hisim.simulationparameters import SimulationParameters
 

--- a/tests/test_simple_air_conditioner.py
+++ b/tests/test_simple_air_conditioner.py
@@ -14,6 +14,7 @@ from hisim.components.simple_air_conditioner import (
 )
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass
 from hisim.simulationparameters import SimulationParameters
+from hisim.config import ComponentID
 
 
 def _make_simulation_parameters() -> SimulationParameters:
@@ -46,7 +47,7 @@ def _wire_controller_inputs(controller: SimpleAirConditionerController, t_indoor
         "TemperatureIndoorAir",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeBuilding"),
+        component_id=ComponentID("FakeBuilding"),
     )
     t_indoor_output.global_index = 0
     controller.indoor_air_temperature_channel.source_output = t_indoor_output
@@ -201,21 +202,21 @@ def _wire_component_inputs(component: SimpleAirConditioner, t_out_c: float, t_in
         "TemperatureOutside",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeWeather"),
+        component_id=ComponentID("FakeWeather"),
     )
     t_in_output = cp.ComponentOutput(
         "FakeBuilding",
         "TemperatureIndoorAir",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeBuilding"),
+        component_id=ComponentID("FakeBuilding"),
     )
     modulation_output = cp.ComponentOutput(
         "FakeController",
         "ModulatingPowerSignal",
         lt.LoadTypes.ANY,
         lt.Units.PERCENT,
-        component_id=cp.ComponentID("FakeController"),
+        component_id=ComponentID("FakeController"),
     )
 
     # Assign indices: 0=t_out, 1=t_in, 2=modulation, 3..8=outputs
@@ -444,14 +445,14 @@ def test_integration_controller_and_component_end_to_end() -> None:
         "TemperatureOutside",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeWeather"),
+        component_id=ComponentID("FakeWeather"),
     )
     t_in_output = cp.ComponentOutput(
         "FakeBuilding",
         "TemperatureIndoorAir",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeBuilding"),
+        component_id=ComponentID("FakeBuilding"),
     )
 
     # Assign indices
@@ -529,14 +530,14 @@ def test_integration_controller_off_and_component_idle() -> None:
         "TemperatureOutside",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeWeather"),
+        component_id=ComponentID("FakeWeather"),
     )
     t_in_output = cp.ComponentOutput(
         "FakeBuilding",
         "TemperatureIndoorAir",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeBuilding"),
+        component_id=ComponentID("FakeBuilding"),
     )
 
     t_out_output.global_index = 1

--- a/tests/test_simple_heat_source.py
+++ b/tests/test_simple_heat_source.py
@@ -8,6 +8,7 @@ from hisim import component as cp
 from hisim.components import simple_heat_source
 from hisim.simulationparameters import SimulationParameters
 from hisim import loadtypes as lt
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -39,10 +40,10 @@ def test_heat_source() -> None:
     )
 
     massflow = cp.ComponentOutput(
-        "Fake_massflow", "Fake_massflow", lt.LoadTypes.ANY, lt.Units.ANY, component_id=cp.ComponentID("Fake_massflow")
+        "Fake_massflow", "Fake_massflow", lt.LoadTypes.ANY, lt.Units.ANY, component_id=ComponentID("Fake_massflow")
     )
     temperature_input = cp.ComponentOutput(
-        "Fake_t_in", "Fake_t_in", lt.LoadTypes.ANY, lt.Units.ANY, component_id=cp.ComponentID("Fake_t_in")
+        "Fake_t_in", "Fake_t_in", lt.LoadTypes.ANY, lt.Units.ANY, component_id=ComponentID("Fake_t_in")
     )
 
     number_of_outputs = fft.get_number_of_outputs(

--- a/tests/test_simple_hot_water_storage.py
+++ b/tests/test_simple_hot_water_storage.py
@@ -7,7 +7,7 @@ from hisim import component as cp
 from hisim.components import simple_water_storage
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
-from hisim.component import ComponentID
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -87,7 +87,7 @@ def simulate_simple_water_storage(sec_per_timesteps: int, factor_for_water_stora
         "WaterMassFlowRateFromHeatDistributionSystem",
         lt.LoadTypes.WARM_WATER,
         lt.Units.KG_PER_SEC,
-        component_id=cp.ComponentID("FakeWaterInputTemperatureFromHds"),
+        component_id=ComponentID("FakeWaterInputTemperatureFromHds"),
     )
 
     water_temperature_input_from_heat_distribution_system = cp.ComponentOutput(
@@ -95,7 +95,7 @@ def simulate_simple_water_storage(sec_per_timesteps: int, factor_for_water_stora
         "WaterTemperatureInputFromHeatDistributionSystem",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeWaterInputTemperatureFromHds"),
+        component_id=ComponentID("FakeWaterInputTemperatureFromHds"),
     )
 
     water_temperature_input_from_heat_generator = cp.ComponentOutput(
@@ -103,7 +103,7 @@ def simulate_simple_water_storage(sec_per_timesteps: int, factor_for_water_stora
         "WaterTemperatureInputFromHeatGenerator",
         lt.LoadTypes.TEMPERATURE,
         lt.Units.CELSIUS,
-        component_id=cp.ComponentID("FakeWaterInputTemperatureFromHeatGenerator"),
+        component_id=ComponentID("FakeWaterInputTemperatureFromHeatGenerator"),
     )
 
     water_mass_flow_rate_from_heat_generator = cp.ComponentOutput(
@@ -111,11 +111,11 @@ def simulate_simple_water_storage(sec_per_timesteps: int, factor_for_water_stora
         "WaterMassFlowRateFromHeatGenerator",
         lt.LoadTypes.WARM_WATER,
         lt.Units.KG_PER_SEC,
-        component_id=cp.ComponentID("FakeWaterMassFlowRateFromHeatGenerator"),
+        component_id=ComponentID("FakeWaterMassFlowRateFromHeatGenerator"),
     )
 
     state_controller = cp.ComponentOutput(
-        "FakeState", "State", lt.LoadTypes.ANY, lt.Units.ANY, component_id=cp.ComponentID("FakeState")
+        "FakeState", "State", lt.LoadTypes.ANY, lt.Units.ANY, component_id=ComponentID("FakeState")
     )
 
     # connect fake inputs to simple hot water storage

--- a/tests/test_simulator_get_std_results.py
+++ b/tests/test_simulator_get_std_results.py
@@ -22,6 +22,7 @@ import pytest
 from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.simulator import Simulator
+from hisim.config import ComponentID
 
 
 def _make_outputs(units: list[lt.Units]) -> list[cp.ComponentOutput]:
@@ -34,7 +35,7 @@ def _make_outputs(units: list[lt.Units]) -> list[cp.ComponentOutput]:
                 field_name=f"Output{i}",
                 load_type=lt.LoadTypes.ANY,
                 unit=unit,
-                component_id=cp.ComponentID(f"Comp{i}"),
+                component_id=ComponentID(f"Comp{i}"),
             )
         )
     return outputs

--- a/tests/test_solar_thermal_system.py
+++ b/tests/test_solar_thermal_system.py
@@ -7,6 +7,7 @@ from oemof.thermal.solar_thermal_collector import flat_plate_precalc
 from hisim import sim_repository, component, log, simulator as sim
 from hisim.components import weather, solar_thermal_system
 from hisim.loadtypes import LoadTypes, Units
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -41,7 +42,7 @@ def test_solar_thermal_system() -> None:
         "ControlSignal",
         LoadTypes.ANY,
         Units.BINARY,
-        component_id=component.ComponentID("FakeControlState"),
+        component_id=ComponentID("FakeControlState"),
     )
     my_sts.control_signal_channel.source_output = state_controller
 

--- a/tests/test_sumbuilder.py
+++ b/tests/test_sumbuilder.py
@@ -7,6 +7,7 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.components import sumbuilder
 from hisim.simulationparameters import SimulationParameters
+from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
@@ -29,21 +30,21 @@ def test_sum_builder_for_three_inputs() -> None:
         field_name="input1",
         load_type=lt.LoadTypes.ANY,
         unit=lt.Units.ANY,
-        component_id=cp.ComponentID("fake1"),
+        component_id=ComponentID("fake1"),
     )
     fake_input2 = cp.ComponentOutput(
         object_name="fake2",
         field_name="input2",
         load_type=lt.LoadTypes.ANY,
         unit=lt.Units.ANY,
-        component_id=cp.ComponentID("fake2"),
+        component_id=ComponentID("fake2"),
     )
     fake_input3 = cp.ComponentOutput(
         object_name="fake3",
         field_name="input3",
         load_type=lt.LoadTypes.ANY,
         unit=lt.Units.ANY,
-        component_id=cp.ComponentID("fake3"),
+        component_id=ComponentID("fake3"),
     )
 
     # Connect fake inputs using source_output
@@ -101,14 +102,14 @@ def test_sum_builder_for_two_inputs() -> None:
         field_name="input1",
         load_type=lt.LoadTypes.ANY,
         unit=lt.Units.ANY,
-        component_id=cp.ComponentID("fake1"),
+        component_id=ComponentID("fake1"),
     )
     fake_input2 = cp.ComponentOutput(
         object_name="fake2",
         field_name="input2",
         load_type=lt.LoadTypes.ANY,
         unit=lt.Units.ANY,
-        component_id=cp.ComponentID("fake2"),
+        component_id=ComponentID("fake2"),
     )
 
     # Connect fake inputs using source_output
@@ -175,14 +176,14 @@ def test_calculate_operation_subtract() -> None:
         field_name="out1",
         load_type=lt.LoadTypes.ANY,
         unit=lt.Units.ANY,
-        component_id=cp.ComponentID("fake1"),
+        component_id=ComponentID("fake1"),
     )
     fake_output2 = cp.ComponentOutput(
         object_name="fake2",
         field_name="out2",
         load_type=lt.LoadTypes.ANY,
         unit=lt.Units.ANY,
-        component_id=cp.ComponentID("fake2"),
+        component_id=ComponentID("fake2"),
     )
     input1.source_output = fake_output1
     input2.source_output = fake_output2
@@ -247,14 +248,14 @@ def test_calculate_operation_simulate_invalid_operation_raises_value_error() -> 
         field_name="out1",
         load_type=lt.LoadTypes.ANY,
         unit=lt.Units.ANY,
-        component_id=cp.ComponentID("fake1"),
+        component_id=ComponentID("fake1"),
     )
     fake_output2 = cp.ComponentOutput(
         object_name="fake2",
         field_name="out2",
         load_type=lt.LoadTypes.ANY,
         unit=lt.Units.ANY,
-        component_id=cp.ComponentID("fake2"),
+        component_id=ComponentID("fake2"),
     )
     input1.source_output = fake_output1
     input2.source_output = fake_output2

--- a/tests/test_system_chart_build_graph.py
+++ b/tests/test_system_chart_build_graph.py
@@ -21,7 +21,8 @@ import pandas as pd
 import pydot
 import pytest
 
-from hisim.component import ComponentID, ComponentInput, ComponentOutput
+from hisim.component import ComponentInput, ComponentOutput
+from hisim.config import ComponentID
 from hisim.loadtypes import LoadTypes, Units
 from hisim.postprocessing.postprocessing_datatransfer import PostProcessingDataTransfer
 from hisim.postprocessing.system_chart import SystemChart

--- a/tests/test_transformer_rectifier.py
+++ b/tests/test_transformer_rectifier.py
@@ -12,13 +12,12 @@ import pytest
 
 from hisim.components.transformer_rectifier import Transformer, TransformerConfig
 from hisim.component import (
-    ComponentID,
     Component,
     ComponentOutput,
-    DisplayConfig,
     SingleTimeStepValues,
     StatelessComponent,
 )
+from hisim.config import ComponentID, DisplayConfig
 from hisim import loadtypes as lt
 from hisim.simulationparameters import SimulationParameters
 from tests import functions_for_testing as fft

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -14,6 +14,7 @@ from hisim import component
 from hisim import utils
 from hisim.components import weather
 from hisim.simulationparameters import SimulationParameters
+from hisim.config import DisplayConfig
 from tests import functions_for_testing as fft
 
 
@@ -239,8 +240,8 @@ def test_weather_default_display_config_is_not_shared() -> None:
         config=my_config, my_simulation_parameters=mysim
     )
 
-    assert isinstance(first.my_display_config, component.DisplayConfig)
-    assert isinstance(second.my_display_config, component.DisplayConfig)
+    assert isinstance(first.my_display_config, DisplayConfig)
+    assert isinstance(second.my_display_config, DisplayConfig)
     # Identity check: must not be the same shared instance.
     assert first.my_display_config is not second.my_display_config
 


### PR DESCRIPTION
…ckage

The three classes every component configuration is built from lived in hisim/component.py, the component *runtime* module. That placement is what forces every future config-layer addition (named presets, sizing laws) either into the already 766-line component module or into a module that closes an import cycle with it. This commit creates the layer they belong to and moves them there, with no behavior change of any kind.

- hisim/config/base.py holds ComponentID, ConfigBase and DisplayConfig with verbatim bodies (checked line-by-line against the removed block). The module imports nothing from the rest of HiSim, which is the property that makes the package a genuine bottom layer.
- hisim/config/__init__.py exports the three names and states the layering rule the package exists to enforce.
- No compatibility alias is left behind in hisim/component.py. Instead all 169 call sites now import from hisim.config directly, so the layering is visible where it matters and cannot silently rot back into the old path. component.py itself uses the classes through a `cfg` module alias, the repo's usual spelling for a cross-module dependency, so `hisim.component.ConfigBase` no longer resolves at all.
- docs gains a config page (the three classes would otherwise have dropped out of the generated API reference) and CLAUDE.md gains the layer.

Purely mechanical: 499 insertions against 633 deletions are import lines and `cp.` prefix removals for exactly these three names. Nothing about the wire format changes -- scenario JSONs name concrete config classes under hisim.components.*, never these base classes (verified over two of them).