### PR TITLE
Give the one-day building snapshot a platform ULP band

### DIFF
--- a/roadmap/building_cleanup_findings.md
+++ b/roadmap/building_cleanup_findings.md
@@ -165,3 +165,20 @@ listed here for the design review's physics section.
     write-only. Strengthens the 6a.4 deletion (no historical consumer exists) and is
     the cleanest possible specimen of the tuple-unpack hazard class: the bug survived
     ~13 months precisely because it was harmless.
+25. **Layer 2's bitwise comparison did not survive contact with CI (fixed 2026-08-21).**
+    The day after the phase-1 merge, the one-day snapshot failed on the ubuntu-latest
+    runner: 1-ULP differences on 6–8 daylight timesteps of the trig-derived columns
+    (SolarGainThroughWindows and the heat fluxes computed from it), while OpenWindow,
+    the temperatures and every pure-arithmetic column matched exactly. Root cause:
+    `math.cos` (window model) and pvlib's numpy trigonometry bind to the platform's
+    libm, and this box's glibc 2.43 rounds those transcendentals' last bit differently
+    than the runner's older glibc — package versions were verified identical (pvlib
+    0.15.2 is the newest; numpy is forced <2 by oemof-solph on both sides). Fix: layer 2
+    compares floats up to `PLATFORM_ULP_TOLERANCE` (4 ULPs of the larger operand) —
+    verified to accept all eight CI-observed pairs and still reject sign flips and
+    1e-9-relative changes. Layer 1 (pure IEEE arithmetic, bit-exact on every platform)
+    stays strictly bitwise and remains the referee for ULP-level arithmetic changes;
+    the `sum()`-vs-chained-`+` and door-round-trip catches were layer-1 catches and are
+    unaffected. Lesson recorded: bitwise goldens are portable exactly as far as the
+    computation avoids transcendentals; the moment libm enters, the honest cross-platform
+    contract is a stated ULP band.

--- a/roadmap/building_cleanup_spec.md
+++ b/roadmap/building_cleanup_spec.md
@@ -57,6 +57,14 @@ that averages hide) to `tests/goldens/building_one_day.json`. One save/restore r
 mid-run exercises the convergence path. A second run with a scaled config (different
 floor area) covers the scaling branches. Target runtime: seconds.
 
+*Amended 2026-08-21 (findings entry 25):* layer-2 float comparison is exact **up to a
+few-ULP platform band** (`PLATFORM_ULP_TOLERANCE`), not bitwise — the trig-derived
+columns (window model `math.cos`, pvlib) legitimately differ in the last bit between
+libm builds, which turned CI red on 1-ULP shifts the day after the merge. Layer 1
+contains only IEEE basic arithmetic and stays strictly bitwise; it remains the referee
+for summation-order-level changes (the `sum()` and door-round-trip catches were layer-1
+catches and remain reproducible).
+
 **Layer 3: the existing golden / parity / scenario-freshness CI gates.**
 Nothing to build — declared here as the slow backstop every phase PR runs behind, exactly
 like every sweep before it.

--- a/tests/test_building_one_day_snapshot.py
+++ b/tests/test_building_one_day_snapshot.py
@@ -52,7 +52,7 @@ request and, during the cleanup, may only be justified by a metadata change.
 
 import dataclasses
 import math
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
 import pytest
 
@@ -453,6 +453,35 @@ class OneDaySnapshot:
             payload[cls.output_section_name(variant_name)] = dict(result.output_vectors)
         return payload
 
+    #: Maximum distance, in units of the larger operand's ULP, at which two float outputs
+    #: still count as equal. The one-day outputs pass through transcendental functions
+    #: (``math.cos`` in the window model, numpy trigonometry inside pvlib) whose last bit is
+    #: legitimately platform-dependent — different libm builds round them differently — so a
+    #: golden generated on one machine can differ from another machine's run by a few ULPs on
+    #: the trig-derived columns (observed 2026-08-21: glibc 2.43 vs the ubuntu-latest CI
+    #: runner, 1-ULP shifts on 6–8 daylight timesteps of the solar-gain chain). Four ULPs
+    #: absorbs that noise while staying ~three orders of magnitude below anything a real
+    #: model change produces; the pure-arithmetic layer-1 golden stays bit-exact and remains
+    #: the referee for summation-order-level changes.
+    PLATFORM_ULP_TOLERANCE: ClassVar[int] = 4
+
+    @classmethod
+    def values_match(cls, expected: Any, actual: Any) -> bool:
+        """Compare one golden value against one current value, ULP-tolerantly for floats.
+
+        Exact equality short-circuits (also covering the non-float outputs); float pairs are
+        additionally accepted when they lie within :attr:`PLATFORM_ULP_TOLERANCE` ULPs of
+        each other, which is the cross-platform libm variance documented on that constant.
+        Anything else — differing types, integers that moved, floats beyond the ULP band —
+        is a genuine difference.
+        """
+        if expected == actual:
+            return True
+        if isinstance(expected, float) and isinstance(actual, float):
+            ulp_of_larger = math.ulp(max(abs(expected), abs(actual)))
+            return abs(expected - actual) <= cls.PLATFORM_ULP_TOLERANCE * ulp_of_larger
+        return False
+
     @classmethod
     def describe_vector_differences(cls, expected_vectors: Dict[str, Any], actual_vectors: Dict[str, Any]) -> str:
         """Describe how two sets of output vectors differ, compactly enough to read.
@@ -460,7 +489,8 @@ class OneDaySnapshot:
         A drifting thermal model moves whole vectors, so reporting every differing value
         would bury the signal. Instead each differing output is reported once with the number
         of differing timesteps and the first difference, which together identify both the
-        affected output and when it starts to deviate.
+        affected output and when it starts to deviate. Values are compared through
+        :meth:`values_match`, i.e. exactly except for the few-ULP platform band on floats.
         """
         report_lines: List[str] = []
         for field_name in sorted(set(expected_vectors) | set(actual_vectors)):
@@ -483,8 +513,10 @@ class OneDaySnapshot:
             differing_timesteps = [
                 timestep
                 for timestep, (expected, actual) in enumerate(zip(expected_vector, actual_vector))
-                if expected != actual
+                if not cls.values_match(expected, actual)
             ]
+            if not differing_timesteps:
+                continue
             first_timestep = differing_timesteps[0]
             report_lines.append(
                 f"  {field_name}: {len(differing_timesteps)} of {len(expected_vector)} timesteps differ, "
@@ -560,9 +592,12 @@ def test_one_day_output_vectors_match_golden(
 ) -> None:
     """Verify every output vector of one configuration variant against the golden.
 
-    All 96 values of all declared outputs are compared exactly, so a sign flip, a
-    one-timestep shift or a pair of swapped outputs fails here even though the daily totals
-    would be unchanged.
+    All 96 values of all declared outputs are compared, so a sign flip, a one-timestep
+    shift or a pair of swapped outputs fails here even though the daily totals would be
+    unchanged. Floats are compared up to the few-ULP platform band of
+    :attr:`OneDaySnapshot.PLATFORM_ULP_TOLERANCE` — the trig-derived columns legitimately
+    differ in the last bit between libm builds — while everything meaningful sits many
+    orders of magnitude above it.
     """
     expected_vectors = one_day_golden[OneDaySnapshot.output_section_name(variant_name)]
     actual_vectors = one_day_simulation_results[variant_name].output_vectors


### PR DESCRIPTION
Fixes the buildingtest failures on main since #577: the layer-2 golden was generated under glibc 2.43, and ubuntu-latest
  rounds the trig-derived columns' last bit differently (1-ULP shifts on 6-8 daylight timesteps; package versions identical both sides). Floats now compare within a documented 4-ULP band - verified to accept all CI-observed pairs and still reject sign flips and
  1e-9-relative changes. Layer 1 is pure IEEE arithmetic and deliberately stays bitwise. Spec amended; findings entry 25 records the incident. Goldens unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)