### PR TITLE
Raise the one-day snapshot ULP band to 16 for CI-fleet SIMD variance

### DIFF
--- a/tests/test_building_one_day_snapshot.py
+++ b/tests/test_building_one_day_snapshot.py
@@ -459,11 +459,16 @@ class OneDaySnapshot:
     #: legitimately platform-dependent — different libm builds round them differently — so a
     #: golden generated on one machine can differ from another machine's run by a few ULPs on
     #: the trig-derived columns (observed 2026-08-21: glibc 2.43 vs the ubuntu-latest CI
-    #: runner, 1-ULP shifts on 6–8 daylight timesteps of the solar-gain chain). Four ULPs
-    #: absorbs that noise while staying ~three orders of magnitude below anything a real
-    #: model change produces; the pure-arithmetic layer-1 golden stays bit-exact and remains
-    #: the referee for summation-order-level changes.
-    PLATFORM_ULP_TOLERANCE: ClassVar[int] = 4
+    #: runner, 1-ULP shifts on 6–8 daylight timesteps of the solar-gain chain). The variance
+    #: also exists *within* the CI fleet: the pinned Docker image runs on heterogeneous host
+    #: CPUs, numpy dispatches different SIMD kernels per CPU family, and the same commit then
+    #: passes on one runner and fails on the next (observed 2026-08-22: a deterministic 5-ULP
+    #: shift on 2 daylight timesteps of ``HeatFluxToThermalMass``, appearing and vanishing
+    #: across reruns on main). Sixteen ULPs gives headroom over the largest observed shift for
+    #: runner CPU families not yet sampled while staying ~three orders of magnitude below
+    #: anything a real model change produces; the pure-arithmetic layer-1 golden stays
+    #: bit-exact and remains the referee for summation-order-level changes.
+    PLATFORM_ULP_TOLERANCE: ClassVar[int] = 16
 
     @classmethod
     def values_match(cls, expected: Any, actual: Any) -> bool:


### PR DESCRIPTION
## Why

The `buildingtest` job has been failing intermittently since #583 — on `main` itself (run [32591745626](https://github.com/FZJ-IEK3-VSA/HiSim/actions/runs/32591745626)) and on PR #582 (runs [32587069405](https://github.com/FZJ-IEK3-VSA/HiSim/actions/runs/32587069405), [32594966092](https://github.com/FZJ-IEK3-VSA/HiSim/actions/runs/32594966092)) — while the identical commits pass on reruns. Every failure is byte-identical:

```
HeatFluxToThermalMass: 2 of 96 timesteps differ, first at timestep 45:
golden = 878.8237798469282, current = 878.8237798469277
```

That difference is exactly **5.0 ULPs** (relative error ~6.5e-16, about 3 machine epsilons) — one ULP over the 4-ULP band #583 introduced.

The 4-ULP band was calibrated against local-vs-CI libm differences, but the variance also exists *within* the CI fleet: the pinned Docker image runs on heterogeneous host CPUs, numpy dispatches different SIMD kernels per CPU family, and the pvlib solar-position trigonometry feeding the solar-gain chain then rounds its last bits differently depending on which physical runner the job lands on. Same commit, same image → pass on one runner, deterministic 5-ULP failure on the next.

## What

Bump `OneDaySnapshot.PLATFORM_ULP_TOLERANCE` from 4 to 16 and document the new observation on the constant. Sixteen ULPs gives headroom over the largest observed shift for runner CPU families not yet sampled, while staying orders of magnitude below anything a real model change produces. The pure-arithmetic layer-1 golden stays bit-exact and remains the referee for summation-order-level changes.

No golden regeneration needed — the goldens are unchanged; only the comparison band widens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)