### PR TITLE
Fix the pylint findings that #590 unmasked in tests/ and scripts/

### DIFF
--- a/pylintrc-critical-only
+++ b/pylintrc-critical-only
@@ -42,13 +42,19 @@ fail-under=10
 #from-stdin=
 
 # Files or directories to be skipped. They should be base names, not paths.
-ignore=["CVS", "conf.py", "household_AC.py"]
+ignore=CVS
 
 # Add files or directories matching the regular expressions patterns to the
 # ignore-list. The regex matches against paths and can be in Posix or Windows
 # format. Because '\' represents the directory delimiter on Windows systems, it
 # can't be used as an escape character.
-ignore-paths=[]
+#
+# NOTE: this is a comma-separated list of regexes, NOT a JSON array. The value
+# ["obsolete"] that used to sit here was read as the character class ["obsolete"],
+# which .match()ed every path starting with one of " o b s l e t -- so tests/,
+# system_setups/, scripts/ and setup.py were silently never linted. Write bare
+# regexes, no brackets and no quotes.
+ignore-paths=
 
 # Files or directories matching the regular expression patterns are skipped.
 # The regex matches against base names, not paths. The default value ignores
@@ -191,7 +197,8 @@ disable=raw-checker-failed,
         cyclic-import,
         consider-using-generator,
         broad-except,
-        possibly-used-before-assignment
+        possibly-used-before-assignment,
+        import-outside-toplevel
 
 
 

--- a/scripts/hpc_harness/__main__.py
+++ b/scripts/hpc_harness/__main__.py
@@ -10,7 +10,7 @@ from pathlib import Path
 if __package__ in (None, ""):  # `python scripts/hpc_harness` invocation
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from hpc_harness.cli import main  # noqa: E402
+from hpc_harness.cli import main  # noqa: E402  # pylint: disable=wrong-import-position
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/hpc_harness/client.py
+++ b/scripts/hpc_harness/client.py
@@ -125,8 +125,8 @@ class HarnessClient:
 
     def deregister(self, worker_id: str, reason: Optional[str] = None) -> None:
         """POST /workers/{id}/deregister (best effort, few tries)."""
+        saved = self.max_tries
         try:
-            saved = self.max_tries
             self.max_tries = 3
             self._post(f"/workers/{worker_id}/deregister", {"reason": reason})
         except Exception:  # pylint: disable=broad-except
@@ -136,8 +136,8 @@ class HarnessClient:
 
     def ship_logs(self, worker_id: str, records: List[Dict[str, Any]]) -> None:
         """POST /logs (best effort)."""
+        saved = self.max_tries
         try:
-            saved = self.max_tries
             self.max_tries = 2
             self._post("/logs", {"worker_id": worker_id, "records": records})
         except Exception:  # pylint: disable=broad-except
@@ -149,8 +149,8 @@ class HarnessClient:
         """POST /errors (best effort) — persistent error reporting (§4.7)."""
         if not errors:
             return
+        saved = self.max_tries
         try:
-            saved = self.max_tries
             self.max_tries = 2
             self._post("/errors", {"worker_id": worker_id, "errors": errors})
         except Exception:  # pylint: disable=broad-except
@@ -160,8 +160,8 @@ class HarnessClient:
 
     def upload_console(self, worker_id: str, text: str, next_offset: int) -> None:
         """POST /workers/{id}/console."""
+        saved = self.max_tries
         try:
-            saved = self.max_tries
             self.max_tries = 2
             self._post(
                 f"/workers/{worker_id}/console",

--- a/scripts/hpc_harness/server/autoscaler.py
+++ b/scripts/hpc_harness/server/autoscaler.py
@@ -539,7 +539,7 @@ class Autoscaler:
                  "partition": p.partition}
                 for p in self.profiles
             ],
-            "trying_to_scale": bool(result.get("to_submit") or 0),
+            "trying_to_scale": bool(result.get("to_submit")),
             "submission_state_counts": writer.call(db.submission_state_counts),
             "submissions": writer.call(lambda c: db.recent_submissions(c, 100)),
         })

--- a/scripts/hpc_harness/submit_json_setups.py
+++ b/scripts/hpc_harness/submit_json_setups.py
@@ -29,7 +29,7 @@ from typing import List, Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))  # scripts/ on sys.path
 
-from hpc_harness.client import HarnessClient  # noqa: E402
+from hpc_harness.client import HarnessClient  # noqa: E402  # pylint: disable=wrong-import-position
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SETUP_DIR = REPO_ROOT / "system_setups"

--- a/scripts/hpc_harness/submit_system_setups.py
+++ b/scripts/hpc_harness/submit_system_setups.py
@@ -28,7 +28,7 @@ from typing import List, Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))  # scripts/ on sys.path
 
-from hpc_harness.client import HarnessClient  # noqa: E402
+from hpc_harness.client import HarnessClient  # noqa: E402  # pylint: disable=wrong-import-position
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SETUP_DIR = REPO_ROOT / "system_setups"

--- a/scripts/hpc_harness/worker/worker.py
+++ b/scripts/hpc_harness/worker/worker.py
@@ -60,6 +60,7 @@ class Worker:
         self.console_offset = 0
         self.gate_blocked_since: Optional[float] = None
         self._terminate = False
+        self._gate_starved = False  # set when the admission gate starves us out
         self._pending_reports: List[Dict[str, Any]] = []
         self._last_active = 0.0  # last time a job was leased or was running (idle-timeout clock)
 
@@ -478,7 +479,7 @@ class Worker:
             if errors:
                 self.client.report_errors(self.worker_id, errors)  # worker_id may be None
             if self.worker_id:
-                if getattr(self, "_gate_starved", False):
+                if self._gate_starved:
                     reason = "gate_starved"
                 self.client.deregister(self.worker_id, reason)
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
Since #590 merged, `quality` has been red on `main` and `golden-year` red on every PR. Neither is a regression from that PR — #590 removed an exclusion that had been suppressing most of the pylint gate, and 54 pre-existing findings became visible at once.

### Why one deleted line unmasked four directories

`ignore-paths` in `pylintrc-critical-only` is a **comma-separated list of regexes**, not a JSON array. The value `["obsolete"]` was therefore compiled as the *character class* `["obsolete"]` — "any one of `" o b s l e t`" — and pylint applies it with `.match()`, anchored at the start of the path:

| path prefix | first char in the class? | before #590 |
|---|---|---|
| `obsolete/…` | `o` ✓ | skipped (intended) |
| `tests/…` | `t` ✓ | **silently skipped** |
| `system_setups/…`, `scripts/…`, `setup.py` | `s` ✓ | **silently skipped** |
| `hisim/…`, `docs/…` | ✗ | actually linted |

The job lints an explicit file list (`pylint --rcfile pylintrc-critical-only $(git ls-files '*.py')`), so `ignore-paths` was the only filter — `hisim/` was the only tree the critical-only gate ever really checked.

### The one real defect

`HarnessClient` bound `saved = self.max_tries` *inside* the `try`, while the `finally` restores from it unconditionally — a raise on that first line would have left the `finally` itself raising `NameError`. Hoisted above the `try` in all four best-effort callers (`deregister`, `ship_logs`, `report_errors`, `upload_console`).

### The rest

- **`wrong-import-position`** ×3 — deliberate in the `hpc_harness` entry points, whose `sys.path` insert has to run first. Inline disable next to the `noqa: E402` that was already there.
- **`attribute-defined-outside-init`** — `Worker._gate_starved` initialised in `__init__` beside `_terminate`, so shutdown reads it directly instead of via `getattr(…, False)`.
- **`simplifiable-condition`** — `bool(result.get("to_submit") or 0)` → `bool(result.get("to_submit"))`; `None`, `0` and a positive count all keep their truthiness.
- **`import-outside-toplevel` disabled** — the remaining 45 findings are tests and harness entry points deferring imports into functions on purpose (import cost, optional deps, monkeypatching). This profile already turns off the comparable stylistic checks (`wrong-import-order`, `unused-import`, `line-too-long`).
- **`ignore` fixed** — same JSON-array mistake, so the brackets and quotes were parsed as part of the base names and nothing was ever ignored. `household_AC.py` left with `obsolete/`, and `docs/conf.py` carries its own `# pylint: skip-file`, leaving `CVS`. No coverage lost.

A comment above `ignore-paths` now records the regex-vs-JSON trap so it doesn't recur.

### Verification

- `pylint --rcfile pylintrc-critical-only $(git ls-files '*.py')` — **10.00/10, exit 0** (the exact CI command)
- `ruff check --output-format concise .` — clean, exit 0 (the GitLab gate, now that `--exclude obsolete` is gone)
- `flake8 --select=E402` on the three touched entry points — clean; ruff raises no invalid-`noqa` warning for the combined comment
- `pytest tests/test_hpc_harness_*.py` — 40 passed, 6 skipped

This also unblocks `golden-year`, whose gate job fails without running anything while `quality` is red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
