### PR TITLE
Let the three main gates be run by hand

### DIFF
--- a/.github/workflows/golden-check.yml
+++ b/.github/workflows/golden-check.yml
@@ -10,6 +10,11 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # Runnable by hand as well, because the two automatic triggers above only fire for pull
+  # requests that target main. A stacked pull request — one whose base is the branch below it
+  # in a chain — therefore gets no run at all, and a whole stack can reach main having never
+  # been tested. Dispatching this workflow against such a branch is how that is avoided.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,6 +8,11 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # Runnable by hand as well, because the two automatic triggers above only fire for pull
+  # requests that target main. A stacked pull request — one whose base is the branch below it
+  # in a chain — therefore gets no run at all, and a whole stack can reach main having never
+  # been tested. Dispatching this workflow against such a branch is how that is avoided.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,11 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # Runnable by hand as well, because the two automatic triggers above only fire for pull
+  # requests that target main. A stacked pull request — one whose base is the branch below it
+  # in a chain — therefore gets no run at all, and a whole stack can reach main having never
+  # been tested. Dispatching this workflow against such a branch is how that is avoided.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
A pull request whose base is another branch never runs quality, tests or the golden check, because all three fire only on pull requests targeting main. The cost-module stack learned this the expensive way: eight stacked pull requests reached the front of the queue having never been tested once, and each one surfaced its own batch of drift the moment it was retargeted.

Adding workflow_dispatch costs nothing on the automatic path and makes any branch testable on demand, so a stack can be checked while it is still a stack instead of one part at a time at the end. The comment says why, since the reason is not visible from the trigger list.