### PR TITLE
P2.1 — Exclusive variants: mutually exclusive alternatives in the file format

### DIFF
--- a/energy_systems/README.md
+++ b/energy_systems/README.md
@@ -56,8 +56,9 @@ hisim energy-system facts energy_systems/gas_boiler_household.energy_system.yaml
 `describe` prints one class in full: its fields, its named presets and what each of them leaves to
 be sized, its named constructors and their parameters, how each sizable field is computed and from
 which facts, and which facts it contributes to the rest of a system. `facts` prints, for a whole
-file and without running it, every fact somebody provides, every fact somebody reads, and which
-provider each read resolved to.
+file and without running it, the file's knobs — a flag per group and a selected option per variant,
+which is everything a consumer of a checked-in system edits — and then every fact somebody
+provides, every fact somebody reads, and which provider each read resolved to.
 
 Editors get the same knowledge from `hisim/energy_system_v3.schema.json`, which every file in this
 directory binds to with its first line. The schema is generated from the same declarations

--- a/hisim/cli.py
+++ b/hisim/cli.py
@@ -287,12 +287,21 @@ class FactsRenderer(Report):
     a given consumer actually read it from. Both halves are printed even when resolution fails,
     with the kernel's own refusal underneath, so that a file which does not resolve still shows
     how far it got.
+
+    The report opens with the file's knobs, which is what a consumer of a checked-in energy
+    system edits: one boolean per group and one option name per variant. The two are listed
+    together because they are one surface to whoever is configuring a run, even though they are
+    two constructs — an independent add-on and an exclusive choice — to whoever authored it.
     """
 
     #: Width the fact column is padded to before the list of components, and the wider width the
     #: resolution section needs because its left column carries a component name as well.
     FACT_WIDTH: int = 46
     CONSUMER_WIDTH: int = 54
+
+    #: Width the knob names are padded to before their value, wide enough for the dotted
+    #: ``variants.<name>`` spelling a caller edits.
+    KNOB_WIDTH: int = 46
 
     @classmethod
     def render(cls, path: Path, stream: TextIO) -> int:
@@ -306,10 +315,12 @@ class FactsRenderer(Report):
             The exit code: zero when the file resolves, and the file-rejected code when it does
             not, the refusal having been written to the report itself.
         """
-        expanded, _ = expand_groups(parse_energy_system(path))
+        authored = parse_energy_system(path)
+        expanded, _ = expand_groups(authored)
         validate_structure(expanded)
-        bindings = validate_classes(expanded)
         print(f"{expanded.name} ({path})", file=stream)
+        cls._knobs(authored, stream)
+        bindings = validate_classes(expanded)
         cls._provided(bindings, stream)
         cls._consumed(bindings, stream)
         try:
@@ -322,6 +333,29 @@ class FactsRenderer(Report):
         cls._resolved(configured, stream)
         cls._warnings(configured.warnings, stream)
         return ExitCodes.OK
+
+    @classmethod
+    def _knobs(cls, authored: Any, stream: TextIO) -> None:
+        """Writes the switches of the authored file: a flag per group, an option per variant.
+
+        The authored file is read rather than the expanded one, because expansion is exactly
+        what removes the knobs: a switched-off group is gone from it and a variant is resolved
+        into the top level. Every option a variant offers is listed after the selected one, so
+        the line says both what is set and what may be set instead.
+
+        Args:
+            authored: The parsed file, before expansion.
+            stream: Where to write the section.
+        """
+        cls._heading("knobs", stream)
+        if not authored.groups and not authored.variants:
+            cls._item("(none)", stream)
+        for name, group in authored.groups.items():
+            cls._item(f"{f'groups.{name}'.ljust(cls.KNOB_WIDTH)}{str(group.enabled).lower()}", stream)
+        for name, variant in authored.variants.items():
+            alternatives = ", ".join(option for option in variant.options if option != variant.selected)
+            knob = f"variants.{name}".ljust(cls.KNOB_WIDTH)
+            cls._item(f"{knob}{variant.selected}  (or {alternatives or '<nothing else>'})", stream)
 
     @classmethod
     def _provided(cls, bindings: Any, stream: TextIO) -> None:

--- a/hisim/energy_system/__init__.py
+++ b/hisim/energy_system/__init__.py
@@ -12,14 +12,18 @@ The modules, in dependency order:
 
     - :mod:`hisim.energy_system.errors` — the ``EF-`` catalogue of hard errors and the
       exception classes every rejection is raised through, one per lifecycle stage.
+    - :mod:`hisim.energy_system.names` — the identifier and reference grammar every name in
+      the format obeys, and the wildcard and path syntax it refuses.
     - :mod:`hisim.energy_system.model` — the frozen models of a file: components, groups,
-      the three input shapes, sizing source references, plus the format's name grammar.
+      variants with their options, the three input shapes and sizing source references.
     - :mod:`hisim.energy_system.document` — the YAML layer: which suffixes are read, the
       duplicate-key rule, the restricted boolean resolver, and typed value accessors.
     - :mod:`hisim.energy_system.emitter` — the canonical writer, shared by the plain
       round trip and by the annotated writer of a run record.
-    - :mod:`hisim.energy_system.groups` — the off rule: what a switched-off group removes from
-      a file, and the record of what it removed.
+    - :mod:`hisim.energy_system.entries` — reading one component entry, which is the same
+      block wherever it is written: at the top level, in a group or in a variant option.
+    - :mod:`hisim.energy_system.groups` — the two switches: what a switched-off group and an
+      unselected variant option remove from a file, and the record of what they removed.
     - :mod:`hisim.energy_system.validation` — the class-independent rules: names, groups,
       a closed reference graph, configuration origin, input consistency, portable paths.
     - :mod:`hisim.energy_system.loader` — the public read and write entry points that put
@@ -100,6 +104,7 @@ from hisim.energy_system.errors import (
     EnergySystemSizingError,
     EnergySystemWiringError,
 )
+from hisim.energy_system.names import NameRules
 from hisim.energy_system.model import (
     AggregatorFeed,
     ComponentEntry,
@@ -110,8 +115,9 @@ from hisim.energy_system.model import (
     ExplicitWire,
     Group,
     InputItem,
-    NameRules,
     SourceReference,
+    Variant,
+    VariantOption,
 )
 from hisim.energy_system.emitter import EnergySystemEmitter
 from hisim.energy_system.groups import (
@@ -119,6 +125,7 @@ from hisim.energy_system.groups import (
     ExpansionRecord,
     GroupExpander,
     ShrunkSizingList,
+    VariantSelection,
     enabled_component_names,
     expand_groups,
 )
@@ -161,6 +168,9 @@ __all__ = [
     "ShrunkSizingList",
     "SourceReference",
     "StructuralValidator",
+    "Variant",
+    "VariantOption",
+    "VariantSelection",
     "dump_energy_system",
     "enabled_component_names",
     "expand_groups",

--- a/hisim/energy_system/audit.py
+++ b/hisim/energy_system/audit.py
@@ -9,10 +9,12 @@ What a reader wants to know about a run divides into four questions, and the aud
 in that order. Where did each component's configuration come from — which preset, which named
 constructor with which arguments, or a block the file wrote out in full — and which of its
 fields did the file override, against what default. Which fields did a law compute, from which
-law, reading which value from which component, and what did it produce. What did the off switches
-remove: which groups, which components with them, which input items and which sizing lists that
-shrank rather than vanished. And what did the aggregators end up with: one entry per resolved
+law, reading which value from which component, and what did it produce. What did the switches
+remove: which groups were off, which option each variant chose, which components went with them,
+which input items and which sizing lists that shrank rather than vanished. And what did the aggregators end up with: one entry per resolved
 feed, with the weight, the tags and the port names resolution derived rather than any file wrote.
+The switches are two, so that section answers for both: which groups were off, and which option
+each variant selected together with the components that selection brought into the system.
 
 A third artifact travels with the two: the flat wire log, one entry per connection in the same
 ``From``/``To`` shape the older machinery appends when connection logging is switched on. It is
@@ -96,6 +98,15 @@ class AuditBuilder:
                 self.component(name) for name in self.built.model.all_components()
             ),
             disabled_groups=expansion.disabled_groups,
+            variant_selections=tuple(
+                {
+                    "variant": selection.variant,
+                    "selected": selection.selected,
+                    "components": list(selection.components),
+                    "rejected": list(selection.rejected),
+                }
+                for selection in expansion.selections
+            ),
             dropped_components=expansion.dropped_components,
             dropped_input_items=tuple(
                 {

--- a/hisim/energy_system/audit_records.py
+++ b/hisim/energy_system/audit_records.py
@@ -206,11 +206,17 @@ class AuditRecord:
     read it: the writer that serializes it next to the record, and the comment renderer that
     turns the same facts into the end-of-line annotations of the record itself. Both must say the
     same thing, which they do by construction when there is one source for both.
+
+    The selections are the one part of the audit without a counterpart in the record. A realized
+    record carries no variants — the selection is resolved into the top level — so a reader
+    comparing it with the authored file would find components that appear out of nowhere unless
+    something states which option each variant chose and what it contributed.
     """
 
     system: str
     components: Tuple[ComponentAudit, ...]
     disabled_groups: Tuple[str, ...]
+    variant_selections: Tuple[Dict[str, Any], ...]
     dropped_components: Tuple[str, ...]
     dropped_input_items: Tuple[Dict[str, Any], ...]
     shrunk_sizing_lists: Tuple[Dict[str, Any], ...]
@@ -244,6 +250,7 @@ class AuditRecord:
             "components": {entry.name: entry.to_document() for entry in self.components},
             "expansion": {
                 "disabled_groups": list(self.disabled_groups),
+                "variant_selections": [dict(selection) for selection in self.variant_selections],
                 "dropped_components": list(self.dropped_components),
                 "dropped_input_items": [dict(item) for item in self.dropped_input_items],
                 "shrunk_sizing_lists": [dict(item) for item in self.shrunk_sizing_lists],

--- a/hisim/energy_system/emitter.py
+++ b/hisim/energy_system/emitter.py
@@ -35,6 +35,7 @@ from hisim.energy_system.model import (
     ExplicitWire,
     Group,
     InputItem,
+    Variant,
 )
 
 
@@ -166,6 +167,8 @@ class EnergySystemEmitter:
         document["components"] = {name: cls._entry(entry) for name, entry in model.components.items()}
         if model.groups:
             document["groups"] = {name: cls._group(group) for name, group in model.groups.items()}
+        if model.variants:
+            document["variants"] = {name: cls._variant(variant) for name, variant in model.variants.items()}
         if model.metadata is not None:
             document["metadata"] = dict(model.metadata)
         return document
@@ -180,6 +183,26 @@ class EnergySystemEmitter:
         return {
             "enabled": group.enabled,
             "components": {name: cls._entry(entry) for name, entry in group.components.items()},
+        }
+
+    @classmethod
+    def _variant(cls, variant: Variant) -> Dict[str, Any]:
+        """Renders one variant: the option it selects first, then the options themselves.
+
+        The selection comes first because it is the one line a consumer of the file edits,
+        and the options follow in the order they were written; an option's mapping keeps its
+        ``components`` key even when empty, so that the world in which the variant adds
+        nothing is written down rather than implied by an absent block.
+
+        Returns:
+            The variant's mapping in canonical key order.
+        """
+        return {
+            "selected": variant.selected,
+            "options": {
+                name: {"components": {member: cls._entry(entry) for member, entry in option.components.items()}}
+                for name, option in variant.options.items()
+            },
         }
 
     @classmethod

--- a/hisim/energy_system/entries.py
+++ b/hisim/energy_system/entries.py
@@ -1,0 +1,305 @@
+"""Reading one component entry: its class, its configuration, its inputs and its sizing.
+
+An entry is where almost all of an energy-system file's text sits, and it is the same block
+wherever it is written — at the top level, inside a group or inside a variant option — so the
+code that reads one lives apart from the code that reads the document around it. That split is
+what lets a new container of components be added to the format without the entry reader
+learning about it, and it keeps both modules small enough to read in one sitting.
+
+Everything decided here is decidable from the document alone. The reader classifies each input
+item by the keys it carries, parses every reference through the format's one grammar and rejects
+the first shape problem it meets, naming the offending key and listing the ones the shape does
+accept. No component class is imported, so nothing is said yet about whether a preset, a field
+or a port exists — that is the class-bound stage's business, much later in the lifecycle.
+"""
+
+# clean
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Dict, Mapping, Optional, Sequence, Tuple
+
+from hisim.energy_system.document import RawDocument
+from hisim.energy_system.errors import EnergySystemErrorId, EnergySystemFormatError
+from hisim.energy_system.model import (
+    AggregatorFeed,
+    AnyInputItem,
+    ComponentEntry,
+    ConstructorCall,
+    DefaultInputs,
+    DispatchSpec,
+    ExplicitWire,
+    Group,
+    SourceReference,
+)
+from hisim.energy_system.names import NameRules
+
+
+class EntryReader:
+    """Builds component entries and the mappings that hold them, one block at a time.
+
+    The reader is a namespace of classmethods rather than an object: it carries no state
+    between two entries, because an entry is complete in itself and nothing about the one
+    before it changes how the next is read. Callers hand it a raw block and the dotted key
+    path that block sits at, and get back the frozen models or an exception naming the path.
+
+    Which keys classify an input item as which of the three shapes is the one piece of
+    knowledge that would otherwise be spread over several call sites, so it is pinned here as
+    class constants and used by both the classification and the per-shape key check.
+    """
+
+    #: The keys that classify an input item as an aggregator feed. Any one of them is
+    #: enough, so a feed missing its tags is reported as an incomplete feed rather than
+    #: as an item of no recognisable kind.
+    FEED_KEYS: ClassVar[Tuple[str, ...]] = ("tags", "weight", "dispatch", "component_type")
+
+    #: The keys an explicit wire may carry, in canonical order.
+    WIRE_KEYS: ClassVar[Tuple[str, ...]] = ("input", "from")
+
+    #: The keys an aggregator feed may carry, in canonical order.
+    FEED_ITEM_KEYS: ClassVar[Tuple[str, ...]] = ("from", "component_type", "tags", "weight", "dispatch")
+
+    #: The keys a dispatch back-channel may carry.
+    DISPATCH_KEYS: ClassVar[Tuple[str, ...]] = ("target_input", "tags")
+
+    @classmethod
+    def components(cls, raw: Any, location: str) -> Dict[str, ComponentEntry]:
+        """Builds the entries of one components mapping, at the top level or in a group.
+
+        Both places hold the same kind of block, because a group is a set of components
+        and not a different way of declaring one. The key of each entry is the component's
+        name and its whole identity, so it is checked against the identifier rule first.
+
+        Raises:
+            EnergySystemFormatError: ``EF-07`` for a non-mapping block, ``EF-08`` for an
+                unusable component name, plus whatever an entry raises.
+        """
+        block = RawDocument.mapping(raw, location)
+        entries: Dict[str, ComponentEntry] = {}
+        for name, value in block.items():
+            NameRules.check_identifier(name, location, "component")
+            entries[name] = cls.entry(name, value, f"{location}.{name}")
+        return entries
+
+    @classmethod
+    def entry(cls, name: str, raw: Any, location: str) -> ComponentEntry:
+        """Builds one component entry from its mapping.
+
+        An entry carrying a group's keys is reported as an attempted nested group rather
+        than as two unknown keys, because that is what the author meant and groups do not
+        nest.
+
+        Raises:
+            EnergySystemFormatError: ``EF-50`` if the entry looks like a group, ``EF-18``
+                for a key that is not an entry key, ``EF-07`` for a bad ``class``.
+        """
+        entry = RawDocument.mapping(raw, location)
+        if set(entry) & set(Group.GROUP_KEYS):
+            raise EnergySystemFormatError(
+                EnergySystemErrorId.NESTED_GROUP,
+                location,
+                f"'{name}' carries group keys, but groups do not nest and a component is not a group.",
+                alternatives=ComponentEntry.ENTRY_KEYS,
+                alternatives_label="entry keys",
+            )
+        for key in entry:
+            if key not in ComponentEntry.ENTRY_KEYS:
+                raise EnergySystemFormatError(
+                    EnergySystemErrorId.UNKNOWN_ENTRY_KEY,
+                    f"{location}.{key}",
+                    f"'{key}' is not a key of a component entry.",
+                    alternatives=ComponentEntry.ENTRY_KEYS,
+                    alternatives_label="entry keys",
+                    offending_value=str(key),
+                )
+        class_path = RawDocument.string(entry.get(ComponentEntry.CLASS_KEY), f"{location}.class", required=True)
+        return ComponentEntry(
+            name=name,
+            class_path=class_path or "",
+            preset=RawDocument.string(entry.get("preset"), f"{location}.preset", required=False),
+            constructor=cls._constructor(entry.get("constructor"), f"{location}.constructor"),
+            config=RawDocument.mapping(entry.get("config"), f"{location}.config"),
+            inputs=cls._inputs(entry.get("inputs"), f"{location}.inputs"),
+            sizing_sources=cls._sizing_sources(entry.get("sizing_sources"), f"{location}.sizing_sources"),
+        )
+
+    @classmethod
+    def _constructor(cls, raw: Any, location: str) -> Optional[ConstructorCall]:
+        """Builds the named-constructor call of an entry, if it has one.
+
+        The block maps exactly one constructor name to its arguments. Two names leave it
+        open which one runs and zero says nothing, so both are hard errors rather than a
+        choice the executor makes for the author.
+
+        Raises:
+            EnergySystemFormatError: ``EF-14`` if the block does not name exactly one
+                constructor, ``EF-07`` if its arguments are not a mapping.
+        """
+        if raw is None:
+            return None
+        block = RawDocument.mapping(raw, location)
+        if len(block) != 1:
+            raise EnergySystemFormatError(
+                EnergySystemErrorId.MALFORMED_CONSTRUCTOR,
+                location,
+                f"a constructor block names exactly one constructor, but {len(block)} are written.",
+                remedy="Write 'constructor: {<name>: {<argument>: <value>}}'.",
+            )
+        constructor_name = next(iter(block))
+        NameRules.check_identifier(constructor_name, location, "constructor")
+        return ConstructorCall(
+            name=constructor_name,
+            arguments=RawDocument.mapping(block[constructor_name], f"{location}.{constructor_name}"),
+        )
+
+    @classmethod
+    def _inputs(cls, raw: Any, location: str) -> Tuple[AnyInputItem, ...]:
+        """Builds the input list of an entry, classifying each item by the keys it carries.
+
+        The list keeps the order the file gives it, because that is what an author reads
+        and what a re-emitted file must reproduce; no meaning depends on it.
+
+        Raises:
+            EnergySystemFormatError: ``EF-07`` if the value is not a list, and whatever an
+                individual item raises.
+        """
+        if raw is None:
+            return ()
+        if not isinstance(raw, list):
+            raise RawDocument.malformed(location, raw, "a list of input items")
+        return tuple(cls._input_item(item, f"{location}[{index}]") for index, item in enumerate(raw))
+
+    @classmethod
+    def _input_item(cls, raw: Any, location: str) -> AnyInputItem:
+        """Classifies and builds one input item.
+
+        Classification is total and depends only on which keys are present: an ``input``
+        key makes it an explicit wire, any aggregator-feed key makes it a feed, and a bare
+        string asks for the target's declared defaults. Anything else, a bare string naming
+        a port included, is rejected rather than guessed at.
+
+        Raises:
+            EnergySystemFormatError: ``EF-19`` for an item of no recognisable shape or
+                with a foreign key, ``EF-06`` for a bad reference, ``EF-07`` for a bad value.
+        """
+        if isinstance(raw, str):
+            source, member = NameRules.split_reference(raw, location, require_member=False)
+            if member is not None:
+                raise cls._unclassifiable(location, "a bare input item names a component, not one of its outputs")
+            return DefaultInputs(source=source)
+        if not isinstance(raw, dict):
+            raise cls._unclassifiable(location, "an input item is a component name or a mapping")
+        if "input" in raw:
+            cls._check_item_keys(raw, location, cls.WIRE_KEYS)
+            source, member = NameRules.split_reference(raw.get("from"), f"{location}.from", require_member=True)
+            return ExplicitWire(
+                source=source,
+                input=RawDocument.string(raw.get("input"), f"{location}.input", required=True) or "",
+                output=member or "",
+            )
+        if set(raw) & set(cls.FEED_KEYS):
+            cls._check_item_keys(raw, location, cls.FEED_ITEM_KEYS)
+            source, member = NameRules.split_reference(raw.get("from"), f"{location}.from", require_member=False)
+            return AggregatorFeed(
+                source=source,
+                output=member,
+                component_type=RawDocument.string(
+                    raw.get("component_type"), f"{location}.component_type", required=False
+                ),
+                tags=RawDocument.string_tuple(raw.get("tags"), f"{location}.tags", required=True),
+                weight=RawDocument.integer(raw.get("weight"), f"{location}.weight"),
+                dispatch=cls._dispatch(raw.get("dispatch"), f"{location}.dispatch", "dispatch" in raw),
+            )
+        raise cls._unclassifiable(location, "the item has neither 'input' nor any aggregator-feed key")
+
+    @classmethod
+    def _dispatch(cls, raw: Any, location: str, present: bool) -> Optional[DispatchSpec]:
+        """Builds the optional dispatch back-channel of an aggregator feed.
+
+        Writing ``dispatch: {}`` and leaving the key out mean different things — the first
+        asks the aggregator to publish a control signal for this participant, the second
+        does not — so the caller passes whether the key was written at all.
+
+        Raises:
+            EnergySystemFormatError: ``EF-19`` for a key the block does not know, ``EF-07``
+                for a value of the wrong kind.
+        """
+        if not present:
+            return None
+        block = RawDocument.mapping(raw, location)
+        cls._check_item_keys(block, location, cls.DISPATCH_KEYS)
+        return DispatchSpec(
+            target_input=RawDocument.string(block.get("target_input"), f"{location}.target_input", required=False),
+            tags=RawDocument.string_tuple(block.get("tags"), f"{location}.tags", required=False),
+        )
+
+    @classmethod
+    def _sizing_sources(cls, raw: Any, location: str) -> Dict[str, Any]:
+        """Builds the ``sizing_sources`` block, parsing every reference it contains.
+
+        A value is either one reference or a list of them; the list form is how a field
+        whose law sums over many providers names all of them, and an empty list says
+        explicitly that no component feeds that fact. The two forms stay apart in the model
+        because a re-emitted file has to spell them the way they were written.
+
+        Raises:
+            EnergySystemFormatError: ``EF-07`` for a value that is neither a string nor a
+                list, ``EF-08`` for an unusable fact name, ``EF-06`` for a malformed
+                reference.
+        """
+        block = RawDocument.mapping(raw, location)
+        sources: Dict[str, Any] = {}
+        for fact, value in block.items():
+            NameRules.check_identifier(fact, location, "fact")
+            if isinstance(value, list):
+                sources[fact] = tuple(
+                    SourceReference.parse(item, f"{location}.{fact}[{index}]") for index, item in enumerate(value)
+                )
+            elif isinstance(value, str):
+                sources[fact] = SourceReference.parse(value, f"{location}.{fact}")
+            else:
+                raise RawDocument.malformed(f"{location}.{fact}", value, "a reference or a list of references")
+        return sources
+
+    @classmethod
+    def _check_item_keys(cls, raw: Mapping[str, Any], location: str, allowed: Sequence[str]) -> None:
+        """Rejects a key that the classified input-item shape does not know.
+
+        The check runs after classification, so the message lists the keys of the shape the
+        item was recognised as rather than the union of all three, which is what tells an
+        author that ``weight`` on an explicit wire is a shape mix-up and not a typo.
+
+        Raises:
+            EnergySystemFormatError: ``EF-19`` naming the unknown key and listing the keys
+                the shape does accept.
+        """
+        for key in raw:
+            if key not in allowed:
+                raise EnergySystemFormatError(
+                    EnergySystemErrorId.UNCLASSIFIABLE_INPUT_ITEM,
+                    f"{location}.{key}",
+                    f"'{key}' does not belong to this kind of input item.",
+                    alternatives=allowed,
+                    alternatives_label="keys",
+                    offending_value=str(key),
+                )
+
+    @classmethod
+    def _unclassifiable(cls, location: str, problem: str) -> EnergySystemFormatError:
+        """Builds the rejection for an input item that matches none of the three shapes.
+
+        The three spellings are repeated in the message because an item of no recognisable
+        kind usually means the author reached for one of them and mis-remembered it.
+
+        Returns:
+            The exception, which the caller raises so the traceback starts at the check.
+        """
+        return EnergySystemFormatError(
+            EnergySystemErrorId.UNCLASSIFIABLE_INPUT_ITEM,
+            location,
+            f"{problem}.",
+            remedy=(
+                "An input item is 'name', or '{input: Port, from: source.Output}', "
+                "or '{from: source, tags: [...], weight: N}'."
+            ),
+        )

--- a/hisim/energy_system/errors.py
+++ b/hisim/energy_system/errors.py
@@ -44,7 +44,8 @@ class EnergySystemErrorId(enum.Enum):
     The identifiers are grouped by the lifecycle stage that can first decide the
     condition: ``EF-0x`` for reading the document, ``EF-1x`` and ``EF-2x`` for the
     shape and the cross-references of component entries, ``EF-4x`` for sizing sources
-    and ``EF-5x`` for groups. A stage never re-checks what an earlier stage already
+    and ``EF-5x`` for the two constructs that switch components on and off, groups and
+    variants. A stage never re-checks what an earlier stage already
     decided, and each identifier is raised from exactly one place in the code so that
     a message cannot drift between two implementations of the same rule.
 
@@ -119,6 +120,9 @@ class EnergySystemErrorId(enum.Enum):
     DUPLICATE_NAME = "EF-52"
     GROUP_ENABLED_FLAG = "EF-53"
     EMPTY_GROUP = "EF-54"
+    UNKNOWN_VARIANT_OPTION = "EF-55"
+    EMPTY_VARIANT = "EF-56"
+    COMPONENT_IN_TWO_VARIANTS = "EF-57"
     RECORD_NOT_CONCRETE = "EF-60"
     RERUN_NOT_REPRODUCED = "EF-61"
 

--- a/hisim/energy_system/groups.py
+++ b/hisim/energy_system/groups.py
@@ -1,11 +1,16 @@
-"""Group expansion: turning a file with on/off switches into the system that actually runs.
+"""Expansion: turning a file with switches into the one system that actually runs.
 
-A group is a named set of components carrying one flag, and its whole purpose is that an
-add-on — a photovoltaic string, a battery with its energy management, an electric vehicle —
-can be switched off without deleting text and without keeping a second copy of the file.
-Switching it off has to be more than dropping the components, because the rest of the file
-still points at them: a consumer lists them under ``inputs`` and a sizing line may name one
-as the provider of a fact. This module removes all three together, so that what reaches
+The format has two switches. A group is a named set of components carrying one flag, so that
+an add-on — a photovoltaic string, a battery with its energy management, an electric vehicle
+— can be switched off without deleting text and without keeping a second copy of the file. A
+variant is an exclusive choice between named options, exactly one of which is live, so that
+two alternative worlds — a house with an energy management system, a house with a bare meter
+wired straight to every participant — can live in one file and wire the same component
+differently. Both are resolved here, in one pass, because they raise the same question.
+
+Switching something off has to be more than dropping the components, because the rest of the
+file still points at them: a consumer lists them under ``inputs`` and a sizing line may name
+one as the provider of a fact. This module removes all three together, so that what reaches
 validation, configuration and resolution is one plain system with no switched-off remnants.
 
 The rule the removal follows is deliberately asymmetric, and the asymmetry is the point. An
@@ -19,9 +24,16 @@ reference into a disabled group is a hard error naming the consumer, the fact an
 Everything the expansion removed or shrank is collected in an :class:`ExpansionRecord`, which
 is what lets a later stage show a reader why the running system differs from the file. The
 expansion is pure — it builds a new file and never mutates the one handed in — and it is
-idempotent, since expanding a file that has no disabled group left changes nothing. Enabled
-groups survive as groups: they are the file's structure, not its scope, and dissolving them
-would make the expanded file impossible to compare against the one on disk.
+idempotent, since expanding a file that has no disabled group and no variant left changes
+nothing.
+
+The two switches are treated differently in one respect, and the difference is deliberate.
+Enabled groups survive as groups: they are the file's structure, not its scope, and dissolving
+them would make the expanded file impossible to compare against the one on disk. A variant,
+by contrast, does not survive at all — the selected option's components join the top level and
+the block is gone — because a selection is a decision, not structure: once it is made there is
+nothing left to switch, and nothing downstream of this module ever has to know that a variant
+was there.
 """
 
 # clean
@@ -40,6 +52,39 @@ from hisim.energy_system.model import (
     Group,
     SourceReference,
 )
+
+
+@dataclass(frozen=True)
+class Removal:
+    """Why one component of the authored file is not part of the running system.
+
+    A removed component is named in two places a reader has to be able to act on: the report
+    of what the expansion took out, and the refusal of a scalar sizing line left without its
+    provider. Both need the switch that removed it and the repair that would bring it back,
+    and the two switches offer different repairs — a group is turned on, a variant selects a
+    different option — so the phrasing travels with the removal instead of being reinvented
+    at each message.
+    """
+
+    switch: str
+    remedy: str
+
+
+@dataclass(frozen=True)
+class VariantSelection:
+    """One variant's resolution: the option that won and the components it contributed.
+
+    The record of an expansion has to state what a variant decided, because a realized record
+    carries no variants at all — the selection is resolved into the top level — and a reader
+    comparing the two files would otherwise find components that appear out of nowhere. The
+    options that lost are named as well, since "which alternatives existed" is exactly what a
+    reader of a run asks next.
+    """
+
+    variant: str
+    selected: str
+    components: Tuple[str, ...]
+    rejected: Tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -91,16 +136,17 @@ class ExpansionRecord:
     """Everything the off rule removed from one file, ready to be shown to a reader.
 
     The record answers the question a realized run raises for anyone comparing it with the
-    authored file: which groups were off, which components therefore vanished, which input
-    items were dropped with them and which sizing lists shrank. It is deliberately data and
-    not prose, so the same record can be rendered into a log line, into an audit file or into
-    an assertion in a test.
+    authored file: which groups were off, which option each variant selected, which components
+    therefore vanished, which input items were dropped with them and which sizing lists shrank.
+    It is deliberately data and not prose, so the same record can be rendered into a log line,
+    into an audit file or into an assertion in a test.
 
     An expansion that removed nothing produces an empty record rather than ``None``, which
     keeps every consumer of the record free of a case distinction.
     """
 
     disabled_groups: Tuple[str, ...] = ()
+    selections: Tuple[VariantSelection, ...] = ()
     dropped_components: Tuple[str, ...] = ()
     dropped_input_items: Tuple[DroppedInputItem, ...] = ()
     shrunk_sizing_lists: Tuple[ShrunkSizingList, ...] = ()
@@ -110,10 +156,15 @@ class ExpansionRecord:
         """Whether the expansion changed nothing at all.
 
         Returns:
-            ``True`` when no group was disabled and consequently nothing was removed.
+            ``True`` when no group was disabled, no variant was resolved and consequently
+            nothing was removed.
         """
         return not (
-            self.disabled_groups or self.dropped_components or self.dropped_input_items or self.shrunk_sizing_lists
+            self.disabled_groups
+            or self.selections
+            or self.dropped_components
+            or self.dropped_input_items
+            or self.shrunk_sizing_lists
         )
 
     def describe(self) -> Tuple[str, ...]:
@@ -124,12 +175,19 @@ class ExpansionRecord:
         the line without opening the file next to it.
 
         Returns:
-            One line per disabled group, dropped item and shrunk list, groups first.
+            One line per disabled group, resolved variant, dropped item and shrunk list, in
+            that order.
         """
         lines: List[str] = []
         for group_name in self.disabled_groups:
             members = ", ".join(name for name in self.dropped_components)
             lines.append(f"group '{group_name}' is disabled; components removed: {members or '<none>'}.")
+        for selection in self.selections:
+            contributed = ", ".join(selection.components) or "<none>"
+            lines.append(
+                f"variant '{selection.variant}' selected '{selection.selected}', which contributed "
+                f"{contributed}; not selected: {', '.join(selection.rejected) or '<none>'}."
+            )
         for item in self.dropped_input_items:
             lines.append(
                 f"'{item.consumer}' lost its input item {item.index} from '{item.source}' "
@@ -144,10 +202,11 @@ class ExpansionRecord:
 
 
 class GroupExpander:
-    """Applies the off rule of one file and collects what it removed.
+    """Applies both switches of one file and collects what they removed.
 
-    The expander is built for a single file, computes the set of switched-off component names
-    once and then rewrites every surviving entry against it. It is single-use and holds no
+    The expander is built for a single file, computes the set of removed component names once
+    — the members of every disabled group plus the members of every option a variant did not
+    select — and then rewrites every surviving entry against it. It is single-use and holds no
     state a caller should read directly; :func:`expand_groups` is the entry point, and the
     two results — the expanded file and the record — are what the rest of the package works
     with.
@@ -158,45 +217,84 @@ class GroupExpander:
     """
 
     def __init__(self, model: EnergySystemFile) -> None:
-        """Prepares the expansion by collecting the components the disabled groups hold.
+        """Prepares the expansion by collecting the components both switches take away.
+
+        A name that a variant writes in several options is only removed when the selected
+        option does not have it: the two entries describe the same component in two worlds,
+        and the selected world's entry is the one that survives.
 
         Args:
-            model: The parsed energy system, before any group has been applied.
+            model: The parsed energy system, before any switch has been applied.
         """
         self.model = model
         self.disabled_groups: Tuple[str, ...] = tuple(
             name for name, group in model.groups.items() if not group.enabled
         )
-        self.dropped: Dict[str, str] = {}
+        self.selections: Tuple[VariantSelection, ...] = tuple(
+            VariantSelection(
+                variant=name,
+                selected=variant.selected,
+                components=tuple(variant.selected_components()),
+                rejected=tuple(option for option in variant.options if option != variant.selected),
+            )
+            for name, variant in model.variants.items()
+        )
+        surviving = set(model.all_components())
+        self.dropped: Dict[str, Removal] = {}
         for group_name in self.disabled_groups:
             for component_name in model.groups[group_name].components:
-                self.dropped[component_name] = group_name
+                self.dropped[component_name] = Removal(
+                    switch=f"group '{group_name}' disabled",
+                    remedy=f"enable the group '{group_name}'",
+                )
+        for name, variant in model.variants.items():
+            for option_name, option in variant.options.items():
+                if option_name == variant.selected:
+                    continue
+                for component_name in option.components:
+                    if component_name in surviving:
+                        continue
+                    self.dropped[component_name] = Removal(
+                        switch=f"variant '{name}' left out by selecting '{variant.selected}'",
+                        remedy=f"select the option '{option_name}' of the variant '{name}'",
+                    )
         self.dropped_input_items: List[DroppedInputItem] = []
         self.shrunk_sizing_lists: List[ShrunkSizingList] = []
 
     def expand(self) -> Tuple[EnergySystemFile, ExpansionRecord]:
-        """Builds the enabled system and the record of what was taken out of it.
+        """Builds the live system and the record of what was taken out of it.
+
+        The selected option's components are appended to the top level in document order,
+        which is where an author writing the same system without the variant would have put
+        them, and the variants block is dropped: from here on nothing knows that a choice was
+        ever offered.
 
         Returns:
-            The expanded file — the same document with the disabled groups and every
-            reference into them gone — and the record of the removals.
+            The expanded file — the same document with the disabled groups, the unselected
+            options and every reference into either gone — and the record of the removals.
 
         Raises:
             EnergySystemFormatError: ``EF-42`` when a scalar ``sizing_sources`` reference
-                names a component a disabled group took away, since that choice cannot be
-                remade automatically.
+                names a component a switch took away, since that choice cannot be remade
+                automatically.
         """
         components = {name: self._rewrite(entry) for name, entry in self.model.components.items()}
+        for variant in self.model.variants.values():
+            for name, entry in variant.selected_components().items():
+                components[name] = self._rewrite(entry)
         groups: Dict[str, Group] = {}
         for group_name, group in self.model.groups.items():
             if group_name in self.disabled_groups:
                 continue
             members = {name: self._rewrite(entry) for name, entry in group.components.items()}
             groups[group_name] = group.model_copy(update={"components": members})
-        expanded = self.model.model_copy(update={"components": components, "groups": groups})
+        expanded = self.model.model_copy(
+            update={"components": components, "groups": groups, "variants": {}}
+        )
         self._assert_no_dangling_reference(expanded)
         record = ExpansionRecord(
             disabled_groups=self.disabled_groups,
+            selections=self.selections,
             dropped_components=tuple(self.dropped),
             dropped_input_items=tuple(self.dropped_input_items),
             shrunk_sizing_lists=tuple(self.shrunk_sizing_lists),
@@ -204,14 +302,14 @@ class GroupExpander:
         return expanded, record
 
     def _rewrite(self, entry: ComponentEntry) -> ComponentEntry:
-        """Returns one surviving entry with every reference into a disabled group removed.
+        """Returns one surviving entry with every reference into a removed component gone.
 
         Args:
-            entry: A component that is part of the enabled set.
+            entry: A component that is part of the live set.
 
         Returns:
-            The entry itself when it names nothing switched off, or a copy without the
-            dropped input items and with the shrunk sizing lists.
+            The entry itself when it names nothing switched off or left out, or a copy
+            without the dropped input items and with the shrunk sizing lists.
 
         Raises:
             EnergySystemFormatError: ``EF-42`` for a dangling scalar sizing reference.
@@ -255,20 +353,20 @@ class GroupExpander:
             entry: The consuming component.
 
         Returns:
-            The block with every reference into a disabled group removed; a fact whose list
+            The block with every reference into a removed component gone; a fact whose list
             lost every member keeps an empty list, which is the format's explicit "nobody
             provides this".
 
         Raises:
             EnergySystemFormatError: ``EF-42`` when a scalar reference names a component a
-                disabled group took away.
+                switch took away.
         """
         rewritten: Dict[str, AnySizingSource] = {}
         for fact, value in entry.sizing_sources.items():
             if isinstance(value, SourceReference):
-                group_name = self.dropped.get(value.component)
-                if group_name is not None:
-                    raise self._dangling_scalar_error(entry.name, fact, value, group_name)
+                removal = self.dropped.get(value.component)
+                if removal is not None:
+                    raise self._dangling_scalar_error(entry.name, fact, value, removal)
                 rewritten[fact] = value
                 continue
             surviving = tuple(reference for reference in value if reference.component not in self.dropped)
@@ -286,20 +384,20 @@ class GroupExpander:
 
     @classmethod
     def _dangling_scalar_error(
-        cls, consumer: str, fact: str, reference: SourceReference, group_name: str
+        cls, consumer: str, fact: str, reference: SourceReference, removal: Removal
     ) -> EnergySystemFormatError:
         """Builds the ``EF-42`` rejection of a scalar source left without its provider.
 
-        The message names all three parties — the consumer, the fact and the group that took
+        The message names all three parties — the consumer, the fact and the switch that took
         the provider away — and offers the two repairs that exist, because the machine cannot
-        pick between them: the author either wanted the group on, or wanted a different
-        provider, and only the author knows which.
+        pick between them: the author either wanted the provider in the running system, or
+        wanted a different provider, and only the author knows which.
 
         Args:
             consumer: The component whose sizing line dangles.
             fact: The fact the line answers for.
             reference: The reference as written.
-            group_name: The disabled group the referenced component belonged to.
+            removal: The switch that removed the referenced component, and its repair.
 
         Returns:
             The exception to raise.
@@ -307,11 +405,11 @@ class GroupExpander:
         return EnergySystemFormatError(
             EnergySystemErrorId.DISABLED_SIZING_SOURCE,
             f"components.{consumer}.sizing_sources.{fact}",
-            f"'{consumer}' takes '{fact}' from '{reference.component}', which group "
-            f"'{group_name}' disabled.",
+            f"'{consumer}' takes '{fact}' from '{reference.component}', which "
+            f"{removal.switch}.",
             remedy=(
                 f"Remove the line and let the remaining providers decide, name another "
-                f"provider, or enable the group '{group_name}'."
+                f"provider, or {removal.remedy}."
             ),
         )
 
@@ -323,7 +421,7 @@ class GroupExpander:
         that could leave a dangling name has already been handled above, so a violation here
         is a bug in this module and not a problem with the file. Checking it on every run —
         not only in a test — is cheap and keeps a future edit from quietly reintroducing the
-        remnants the whole off rule exists to remove.
+        remnants the switches exist to remove.
 
         Args:
             expanded: The file the expansion produced.
@@ -339,27 +437,29 @@ class GroupExpander:
 
 
 def expand_groups(model: EnergySystemFile) -> Tuple[EnergySystemFile, ExpansionRecord]:
-    """Applies the off rule and returns the system that actually runs, plus what it lost.
+    """Applies both switches and returns the system that actually runs, plus what it lost.
 
     This is the second stage of the lifecycle, between reading the document and checking it:
     every later stage — structural validation, class binding, configuration, sizing, wiring —
-    sees only the enabled set, so no rule anywhere else has to know that groups exist. In
-    particular the sizing rule that a bare fact needs exactly one provider is evaluated over
-    the enabled components alone, which is what makes switching an add-on off a local edit
-    instead of a change rippling through every consumer's source lines.
+    sees only the live set, so no rule anywhere else has to know that groups exist and none
+    of them ever meets a variant at all. In particular the sizing rule that a bare fact needs
+    exactly one provider is evaluated over the live components alone, which is what makes
+    switching an add-on off, or selecting the other option, a local edit instead of a change
+    rippling through every consumer's source lines.
 
     The function is pure and idempotent: expanding an already expanded file returns an equal
-    file and an empty record, because a file whose groups are all enabled has nothing to drop.
+    file and an empty record, because a file whose groups are all enabled and whose variants
+    are resolved has nothing left to drop.
 
     Args:
-        model: The parsed energy system, groups included.
+        model: The parsed energy system, groups and variants included.
 
     Returns:
         A pair of the expanded file and the record of the removals.
 
     Raises:
         EnergySystemFormatError: ``EF-42`` when a scalar ``sizing_sources`` reference names a
-            component a disabled group removed, naming the consumer, the fact and the group.
+            component a switch removed, naming the consumer, the fact and the switch.
     """
     return GroupExpander(model).expand()
 
@@ -367,19 +467,22 @@ def expand_groups(model: EnergySystemFile) -> Tuple[EnergySystemFile, ExpansionR
 def enabled_component_names(model: EnergySystemFile) -> Tuple[str, ...]:
     """Returns the names of the components that survive expansion, in document order.
 
-    Several callers need the enabled set without needing the expanded file — a report
-    listing what a run contains, a check comparing the file against a realized record — and
-    computing it from the groups directly saves them the rewrite. Ungrouped components come
-    first, then the members of each enabled group in document order.
+    Several callers need the live set without needing the expanded file — a report listing
+    what a run contains, a check comparing the file against a realized record — and computing
+    it from the switches directly saves them the rewrite. Ungrouped components come first,
+    then the members of each enabled group, then the components of each variant's selected
+    option, all in document order.
 
     Args:
         model: The parsed energy system.
 
     Returns:
-        The enabled component names.
+        The live component names.
     """
     names: List[str] = list(model.components)
     for group in model.groups.values():
         if group.enabled:
             names.extend(group.components)
+    for variant in model.variants.values():
+        names.extend(variant.selected_components())
     return tuple(names)

--- a/hisim/energy_system/loader.py
+++ b/hisim/energy_system/loader.py
@@ -5,11 +5,14 @@ path or a piece of YAML text into a fully checked :class:`EnergySystemFile`, and
 :func:`dump_energy_system` writes such a file back in the one canonical style the format
 has, so a program that loads a file, edits it and rewrites it changes only what it edited.
 
-The reader raises the shape errors: an unusable suffix, a wrong schema version, an unknown
-key, an input item matching none of the three accepted forms. Rules that span more than
-one entry — unique names, group membership, a closed reference graph — belong to the
-structural validator, which :func:`load_energy_system` runs afterwards. Neither step
-imports a component class, so nothing is decided yet about presets, fields or ports.
+The reader raises the document's own shape errors: an unusable suffix, a wrong schema
+version, an unknown top-level key, a group without a flag, a variant whose selection names
+no option. What a single component entry looks like is read one module below, in
+:mod:`hisim.energy_system.entries`, so that this module is about the document and that one
+about the block every container of components repeats. Rules that span more than one entry —
+unique names, group and variant membership, a closed reference graph — belong to the
+structural validator, which :func:`load_energy_system` runs afterwards. No step here imports
+a component class, so nothing is decided yet about presets, fields or ports.
 """
 
 # clean
@@ -17,24 +20,14 @@ imports a component class, so nothing is decided yet about presets, fields or po
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, ClassVar, Dict, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, ClassVar, Dict, Mapping, Tuple, Union
 
 from hisim.energy_system.document import RawDocument
 from hisim.energy_system.emitter import EnergySystemEmitter
+from hisim.energy_system.entries import EntryReader
 from hisim.energy_system.errors import EnergySystemErrorId, EnergySystemFormatError
-from hisim.energy_system.model import (
-    AggregatorFeed,
-    AnyInputItem,
-    ComponentEntry,
-    ConstructorCall,
-    DefaultInputs,
-    DispatchSpec,
-    EnergySystemFile,
-    ExplicitWire,
-    Group,
-    NameRules,
-    SourceReference,
-)
+from hisim.energy_system.model import EnergySystemFile, Group, Variant, VariantOption
+from hisim.energy_system.names import NameRules
 from hisim.energy_system.validation import validate_structure
 
 
@@ -43,27 +36,18 @@ class EnergySystemReader:
 
     The reader descends the document once, checking the schema version before anything
     else is interpreted — a file written for another version may use the same keys for
-    different things — and then walking the components and the groups, raising on the
-    first shape problem it meets.
+    different things — and then walking the three places components are written: the top
+    level, the groups and the options of the variants. Every entry it meets is handed to
+    :class:`hisim.energy_system.entries.EntryReader`, and the first shape problem raises.
 
     Everything the reader decides is decidable from the document alone. It never imports a
     component class and never repairs, defaults or skips anything: a file is taken as
     written or rejected with a message naming the offending element and the valid values.
     """
 
-    #: The keys that classify an input item as an aggregator feed. Any one of them is
-    #: enough, so a feed missing its tags is reported as an incomplete feed rather than
-    #: as an item of no recognisable kind.
-    FEED_KEYS: ClassVar[Tuple[str, ...]] = ("tags", "weight", "dispatch", "component_type")
-
-    #: The keys an explicit wire may carry, in canonical order.
-    WIRE_KEYS: ClassVar[Tuple[str, ...]] = ("input", "from")
-
-    #: The keys an aggregator feed may carry, in canonical order.
-    FEED_ITEM_KEYS: ClassVar[Tuple[str, ...]] = ("from", "component_type", "tags", "weight", "dispatch")
-
-    #: The keys a dispatch back-channel may carry.
-    DISPATCH_KEYS: ClassVar[Tuple[str, ...]] = ("target_input", "tags")
+    #: The top-level blocks a component may be written in. A document naming none of them
+    #: describes nothing, which is reported as such rather than as an empty run.
+    COMPONENT_BLOCKS: ClassVar[Tuple[str, ...]] = ("components", "groups", "variants")
 
     @classmethod
     def read(cls, source: Union[str, Path]) -> EnergySystemFile:
@@ -108,19 +92,22 @@ class EnergySystemReader:
                 alternatives_label="top-level keys",
                 offending_value=str(unknown[0]),
             )
-        if "components" not in document and "groups" not in document:
+        if not any(key in document for key in cls.COMPONENT_BLOCKS):
             raise EnergySystemFormatError(
                 EnergySystemErrorId.TOP_LEVEL_SHAPE,
                 origin,
-                "the document declares neither 'components' nor 'groups'.",
+                "the document declares no components at all.",
+                alternatives=cls.COMPONENT_BLOCKS,
+                alternatives_label="blocks that hold components",
             )
         metadata = RawDocument.mapping(document["metadata"], f"{origin}.metadata") if "metadata" in document else None
         return EnergySystemFile(
             schema_version=EnergySystemFile.SUPPORTED_SCHEMA_VERSION,
             name=RawDocument.string(document.get("name"), f"{origin}.name", required=True) or "",
             description=RawDocument.string(document.get("description"), f"{origin}.description", required=False),
-            components=cls._build_components(document.get("components"), f"{origin}.components"),
+            components=EntryReader.components(document.get("components"), f"{origin}.components"),
             groups=cls._build_groups(document.get("groups"), f"{origin}.groups"),
+            variants=cls._build_variants(document.get("variants"), f"{origin}.variants"),
             metadata=metadata,
         )
 
@@ -148,210 +135,12 @@ class EnergySystemReader:
             )
 
     @classmethod
-    def _build_components(cls, raw: Any, location: str) -> Dict[str, ComponentEntry]:
-        """Builds the entries of one components mapping, at the top level or in a group.
-
-        Both places hold the same kind of block, because a group is a set of components
-        and not a different way of declaring one. The key of each entry is the component's
-        name and its whole identity, so it is checked against the identifier rule first.
-
-        Raises:
-            EnergySystemFormatError: ``EF-07`` for a non-mapping block, ``EF-08`` for an
-                unusable component name, plus whatever an entry raises.
-        """
-        block = RawDocument.mapping(raw, location)
-        entries: Dict[str, ComponentEntry] = {}
-        for name, value in block.items():
-            NameRules.check_identifier(name, location, "component")
-            entries[name] = cls._build_entry(name, value, f"{location}.{name}")
-        return entries
-
-    @classmethod
-    def _build_entry(cls, name: str, raw: Any, location: str) -> ComponentEntry:
-        """Builds one component entry from its mapping.
-
-        An entry carrying a group's keys is reported as an attempted nested group rather
-        than as two unknown keys, because that is what the author meant and groups do not
-        nest.
-
-        Raises:
-            EnergySystemFormatError: ``EF-50`` if the entry looks like a group, ``EF-18``
-                for a key that is not an entry key, ``EF-07`` for a bad ``class``.
-        """
-        entry = RawDocument.mapping(raw, location)
-        if set(entry) & set(Group.GROUP_KEYS):
-            raise EnergySystemFormatError(
-                EnergySystemErrorId.NESTED_GROUP,
-                location,
-                f"'{name}' carries group keys, but groups do not nest and a component is not a group.",
-                alternatives=ComponentEntry.ENTRY_KEYS,
-                alternatives_label="entry keys",
-            )
-        for key in entry:
-            if key not in ComponentEntry.ENTRY_KEYS:
-                raise EnergySystemFormatError(
-                    EnergySystemErrorId.UNKNOWN_ENTRY_KEY,
-                    f"{location}.{key}",
-                    f"'{key}' is not a key of a component entry.",
-                    alternatives=ComponentEntry.ENTRY_KEYS,
-                    alternatives_label="entry keys",
-                    offending_value=str(key),
-                )
-        class_path = RawDocument.string(entry.get(ComponentEntry.CLASS_KEY), f"{location}.class", required=True)
-        return ComponentEntry(
-            name=name,
-            class_path=class_path or "",
-            preset=RawDocument.string(entry.get("preset"), f"{location}.preset", required=False),
-            constructor=cls._build_constructor(entry.get("constructor"), f"{location}.constructor"),
-            config=RawDocument.mapping(entry.get("config"), f"{location}.config"),
-            inputs=cls._build_inputs(entry.get("inputs"), f"{location}.inputs"),
-            sizing_sources=cls._build_sizing_sources(entry.get("sizing_sources"), f"{location}.sizing_sources"),
-        )
-
-    @classmethod
-    def _build_constructor(cls, raw: Any, location: str) -> Optional[ConstructorCall]:
-        """Builds the named-constructor call of an entry, if it has one.
-
-        The block maps exactly one constructor name to its arguments. Two names leave it
-        open which one runs and zero says nothing, so both are hard errors rather than a
-        choice the executor makes for the author.
-
-        Raises:
-            EnergySystemFormatError: ``EF-14`` if the block does not name exactly one
-                constructor, ``EF-07`` if its arguments are not a mapping.
-        """
-        if raw is None:
-            return None
-        block = RawDocument.mapping(raw, location)
-        if len(block) != 1:
-            raise EnergySystemFormatError(
-                EnergySystemErrorId.MALFORMED_CONSTRUCTOR,
-                location,
-                f"a constructor block names exactly one constructor, but {len(block)} are written.",
-                remedy="Write 'constructor: {<name>: {<argument>: <value>}}'.",
-            )
-        constructor_name = next(iter(block))
-        NameRules.check_identifier(constructor_name, location, "constructor")
-        return ConstructorCall(
-            name=constructor_name,
-            arguments=RawDocument.mapping(block[constructor_name], f"{location}.{constructor_name}"),
-        )
-
-    @classmethod
-    def _build_inputs(cls, raw: Any, location: str) -> Tuple[AnyInputItem, ...]:
-        """Builds the input list of an entry, classifying each item by the keys it carries.
-
-        The list keeps the order the file gives it, because that is what an author reads
-        and what a re-emitted file must reproduce; no meaning depends on it.
-
-        Raises:
-            EnergySystemFormatError: ``EF-07`` if the value is not a list, and whatever an
-                individual item raises.
-        """
-        if raw is None:
-            return ()
-        if not isinstance(raw, list):
-            raise RawDocument.malformed(location, raw, "a list of input items")
-        return tuple(cls._build_input_item(item, f"{location}[{index}]") for index, item in enumerate(raw))
-
-    @classmethod
-    def _build_input_item(cls, raw: Any, location: str) -> AnyInputItem:
-        """Classifies and builds one input item.
-
-        Classification is total and depends only on which keys are present: an ``input``
-        key makes it an explicit wire, any aggregator-feed key makes it a feed, and a bare
-        string asks for the target's declared defaults. Anything else, a bare string naming
-        a port included, is rejected rather than guessed at.
-
-        Raises:
-            EnergySystemFormatError: ``EF-19`` for an item of no recognisable shape or
-                with a foreign key, ``EF-06`` for a bad reference, ``EF-07`` for a bad value.
-        """
-        if isinstance(raw, str):
-            source, member = NameRules.split_reference(raw, location, require_member=False)
-            if member is not None:
-                raise cls._unclassifiable(location, "a bare input item names a component, not one of its outputs")
-            return DefaultInputs(source=source)
-        if not isinstance(raw, dict):
-            raise cls._unclassifiable(location, "an input item is a component name or a mapping")
-        if "input" in raw:
-            cls._check_item_keys(raw, location, cls.WIRE_KEYS)
-            source, member = NameRules.split_reference(raw.get("from"), f"{location}.from", require_member=True)
-            return ExplicitWire(
-                source=source,
-                input=RawDocument.string(raw.get("input"), f"{location}.input", required=True) or "",
-                output=member or "",
-            )
-        if set(raw) & set(cls.FEED_KEYS):
-            cls._check_item_keys(raw, location, cls.FEED_ITEM_KEYS)
-            source, member = NameRules.split_reference(raw.get("from"), f"{location}.from", require_member=False)
-            return AggregatorFeed(
-                source=source,
-                output=member,
-                component_type=RawDocument.string(
-                    raw.get("component_type"), f"{location}.component_type", required=False
-                ),
-                tags=RawDocument.string_tuple(raw.get("tags"), f"{location}.tags", required=True),
-                weight=RawDocument.integer(raw.get("weight"), f"{location}.weight"),
-                dispatch=cls._build_dispatch(raw.get("dispatch"), f"{location}.dispatch", "dispatch" in raw),
-            )
-        raise cls._unclassifiable(location, "the item has neither 'input' nor any aggregator-feed key")
-
-    @classmethod
-    def _build_dispatch(cls, raw: Any, location: str, present: bool) -> Optional[DispatchSpec]:
-        """Builds the optional dispatch back-channel of an aggregator feed.
-
-        Writing ``dispatch: {}`` and leaving the key out mean different things — the first
-        asks the aggregator to publish a control signal for this participant, the second
-        does not — so the caller passes whether the key was written at all.
-
-        Raises:
-            EnergySystemFormatError: ``EF-19`` for a key the block does not know, ``EF-07``
-                for a value of the wrong kind.
-        """
-        if not present:
-            return None
-        block = RawDocument.mapping(raw, location)
-        cls._check_item_keys(block, location, cls.DISPATCH_KEYS)
-        return DispatchSpec(
-            target_input=RawDocument.string(block.get("target_input"), f"{location}.target_input", required=False),
-            tags=RawDocument.string_tuple(block.get("tags"), f"{location}.tags", required=False),
-        )
-
-    @classmethod
-    def _build_sizing_sources(cls, raw: Any, location: str) -> Dict[str, Any]:
-        """Builds the ``sizing_sources`` block, parsing every reference it contains.
-
-        A value is either one reference or a list of them; the list form is how a field
-        whose law sums over many providers names all of them, and an empty list says
-        explicitly that no component feeds that fact. The two forms stay apart in the model
-        because a re-emitted file has to spell them the way they were written.
-
-        Raises:
-            EnergySystemFormatError: ``EF-07`` for a value that is neither a string nor a
-                list, ``EF-08`` for an unusable fact name, ``EF-06`` for a malformed
-                reference.
-        """
-        block = RawDocument.mapping(raw, location)
-        sources: Dict[str, Any] = {}
-        for fact, value in block.items():
-            NameRules.check_identifier(fact, location, "fact")
-            if isinstance(value, list):
-                sources[fact] = tuple(
-                    SourceReference.parse(item, f"{location}.{fact}[{index}]") for index, item in enumerate(value)
-                )
-            elif isinstance(value, str):
-                sources[fact] = SourceReference.parse(value, f"{location}.{fact}")
-            else:
-                raise RawDocument.malformed(f"{location}.{fact}", value, "a reference or a list of references")
-        return sources
-
-    @classmethod
     def _build_groups(cls, raw: Any, location: str) -> Dict[str, Group]:
         """Builds the groups block: named sets of components, each with an on/off flag.
 
         Both keys of a group are required: a group without a flag cannot be switched and a
-        group without components cannot switch anything.
+        group without components cannot switch anything. An option of a variant is the one
+        components block that may legally be empty, which is why that check lives there.
 
         Raises:
             EnergySystemFormatError: ``EF-08`` for an unusable group name, ``EF-18`` for a
@@ -364,16 +153,7 @@ class EnergySystemReader:
             NameRules.check_identifier(name, location, "group")
             group_location = f"{location}.{name}"
             body = RawDocument.mapping(value, group_location)
-            for key in body:
-                if key not in Group.GROUP_KEYS:
-                    raise EnergySystemFormatError(
-                        EnergySystemErrorId.UNKNOWN_ENTRY_KEY,
-                        f"{group_location}.{key}",
-                        f"'{key}' is not a key of a group.",
-                        alternatives=Group.GROUP_KEYS,
-                        alternatives_label="group keys",
-                        offending_value=str(key),
-                    )
+            cls._check_block_keys(body, group_location, Group.GROUP_KEYS, "group")
             if not isinstance(body.get("enabled"), bool):
                 raise EnergySystemFormatError(
                     EnergySystemErrorId.GROUP_ENABLED_FLAG,
@@ -382,7 +162,7 @@ class EnergySystemReader:
                     alternatives=["false", "true"],
                     alternatives_label="flags",
                 )
-            members = cls._build_components(body.get("components"), f"{group_location}.components")
+            members = EntryReader.components(body.get("components"), f"{group_location}.components")
             if not members:
                 raise EnergySystemFormatError(
                     EnergySystemErrorId.EMPTY_GROUP,
@@ -394,47 +174,95 @@ class EnergySystemReader:
         return groups
 
     @classmethod
-    def _check_item_keys(cls, raw: Mapping[str, Any], location: str, allowed: Sequence[str]) -> None:
-        """Rejects a key that the classified input-item shape does not know.
+    def _build_variants(cls, raw: Any, location: str) -> Dict[str, Variant]:
+        """Builds the variants block: named exclusive choices, each resolved to one option.
 
-        The check runs after classification, so the message lists the keys of the shape the
-        item was recognised as rather than the union of all three, which is what tells an
-        author that ``weight`` on an explicit wire is a shape mix-up and not a typo.
+        Both keys of a variant are required, and the selection is checked against the options
+        right here rather than left to the validator, because the message that makes the
+        mistake trivial to fix is the one that lists the options the variant actually has.
 
         Raises:
-            EnergySystemFormatError: ``EF-19`` naming the unknown key and listing the keys
-                the shape does accept.
+            EnergySystemFormatError: ``EF-08`` for an unusable variant name, ``EF-18`` for a
+                key a variant does not have, ``EF-55`` for a selection naming no option of
+                this variant, ``EF-56`` for a variant offering no option at all.
         """
-        for key in raw:
-            if key not in allowed:
+        block = RawDocument.mapping(raw, location)
+        variants: Dict[str, Variant] = {}
+        for name, value in block.items():
+            NameRules.check_identifier(name, location, "variant")
+            variant_location = f"{location}.{name}"
+            body = RawDocument.mapping(value, variant_location)
+            cls._check_block_keys(body, variant_location, Variant.VARIANT_KEYS, "variant")
+            options = cls._build_options(body.get("options"), f"{variant_location}.options", name)
+            selected = RawDocument.string(body.get("selected"), f"{variant_location}.selected", required=True)
+            if selected not in options:
                 raise EnergySystemFormatError(
-                    EnergySystemErrorId.UNCLASSIFIABLE_INPUT_ITEM,
-                    f"{location}.{key}",
-                    f"'{key}' does not belong to this kind of input item.",
-                    alternatives=allowed,
-                    alternatives_label="keys",
-                    offending_value=str(key),
+                    EnergySystemErrorId.UNKNOWN_VARIANT_OPTION,
+                    f"{variant_location}.selected",
+                    f"variant '{name}' selects '{selected}', which is none of its options.",
+                    alternatives=tuple(options),
+                    alternatives_label=f"options of '{name}'",
+                    offending_value=str(selected),
                 )
+            variants[name] = Variant(name=name, selected=selected or "", options=options)
+        return variants
 
     @classmethod
-    def _unclassifiable(cls, location: str, problem: str) -> EnergySystemFormatError:
-        """Builds the rejection for an input item that matches none of the three shapes.
+    def _build_options(cls, raw: Any, location: str, variant_name: str) -> Dict[str, VariantOption]:
+        """Builds the options of one variant, each a complete alternative world of its own.
 
-        The three spellings are repeated in the message because an item of no recognisable
-        kind usually means the author reached for one of them and mis-remembered it.
+        An option with an empty ``components`` block is accepted, unlike an empty group: it is
+        how a file spells the world in which the variant contributes nothing, which is a real
+        alternative and not a mistake. A variant with no option at all is a mistake, since
+        there is then nothing for its selection to name.
 
-        Returns:
-            The exception, which the caller raises so the traceback starts at the check.
+        Raises:
+            EnergySystemFormatError: ``EF-56`` for an empty options mapping, ``EF-08`` for an
+                unusable option name, ``EF-18`` for a key an option does not have.
         """
-        return EnergySystemFormatError(
-            EnergySystemErrorId.UNCLASSIFIABLE_INPUT_ITEM,
-            location,
-            f"{problem}.",
-            remedy=(
-                "An input item is 'name', or '{input: Port, from: source.Output}', "
-                "or '{from: source, tags: [...], weight: N}'."
-            ),
-        )
+        block = RawDocument.mapping(raw, location)
+        if not block:
+            raise EnergySystemFormatError(
+                EnergySystemErrorId.EMPTY_VARIANT,
+                location,
+                f"variant '{variant_name}' offers no options.",
+                remedy="A variant is a choice between at least two alternative worlds; write them under 'options'.",
+            )
+        options: Dict[str, VariantOption] = {}
+        for name, value in block.items():
+            NameRules.check_identifier(name, location, "variant option")
+            option_location = f"{location}.{name}"
+            body = RawDocument.mapping(value, option_location)
+            cls._check_block_keys(body, option_location, VariantOption.OPTION_KEYS, "variant option")
+            options[name] = VariantOption(
+                name=name,
+                components=EntryReader.components(body.get("components"), f"{option_location}.components"),
+            )
+        return options
+
+    @classmethod
+    def _check_block_keys(cls, body: Mapping[str, Any], location: str, allowed: Tuple[str, ...], role: str) -> None:
+        """Rejects a key one of the document's named blocks does not know.
+
+        Groups, variants and options all have a small closed set of keys, and an author who
+        writes a fifth one has almost always reached for another block's vocabulary — an
+        ``enabled`` flag on a variant, an ``options`` mapping on a group. Naming the role in
+        the message is what turns that into one obvious edit.
+
+        Raises:
+            EnergySystemFormatError: ``EF-18`` naming the key and listing the ones the block
+                does accept.
+        """
+        for key in body:
+            if key not in allowed:
+                raise EnergySystemFormatError(
+                    EnergySystemErrorId.UNKNOWN_ENTRY_KEY,
+                    f"{location}.{key}",
+                    f"'{key}' is not a key of a {role}.",
+                    alternatives=allowed,
+                    alternatives_label=f"{role} keys",
+                    offending_value=str(key),
+                )
 
 
 def load_energy_system(source: Union[str, Path]) -> EnergySystemFile:

--- a/hisim/energy_system/model.py
+++ b/hisim/energy_system/model.py
@@ -1,4 +1,4 @@
-"""The in-memory model of an energy-system file: components, groups and their inputs.
+"""The in-memory model of an energy-system file: components, groups, variants and inputs.
 
 An energy-system file is a YAML document describing one simulated household in a single
 direction: every component entry states what the component is, how it is configured, where
@@ -15,147 +15,21 @@ and whether the field names are real can only be decided by importing the class,
 happens much later; keeping this module free of that knowledge is what lets an editor, a
 schema exporter or a batch tool inspect a file cheaply and without side effects.
 
-Two helpers accompany the models. :class:`NameRules` holds the identifier and reference
-grammar of the format — the character set a name may use and the rejection of wildcards,
-relative and absolute references — and :class:`SourceReference` is the parsed form of the
-``<component>.<fact>`` strings a ``sizing_sources`` block is made of.
+:class:`SourceReference` accompanies the models as the parsed form of the
+``<component>.<fact>`` strings a ``sizing_sources`` block is made of; the identifier and
+reference grammar both of them obey lives one module below, in
+:mod:`hisim.energy_system.names`.
 """
 
 # clean
 
 from __future__ import annotations
 
-import re
-from typing import Annotated, Any, ClassVar, Dict, Literal, Mapping, Optional, Pattern, Tuple, Union
+from typing import Annotated, Any, ClassVar, Dict, Literal, Mapping, Optional, Tuple, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from hisim.energy_system.errors import EnergySystemErrorId, EnergySystemFormatError
-
-
-class NameRules:
-    """The identifier and reference grammar shared by every part of the format.
-
-    Component names, group names, fact names and port names all use one identifier syntax
-    — a letter or underscore followed by letters, digits or underscores — so a reader never
-    has to remember which allows what. A reference joining two of them with a dot, such as
-    ``pv_south.pv_peak_power_in_watt``, is the only compound form the format has.
-
-    The class exists mainly for what it forbids. Wildcards (``pv_*``, ``[*]``) and relative
-    or absolute path syntax (``../pv``, ``/etc/x``) are deliberately not part of this format
-    version: they are the vocabulary of a future preprocessor, and accepting them silently
-    would make files written against that expectation resolve to something unintended.
-    """
-
-    #: The one identifier syntax of the format, used for component names, group names,
-    #: fact names and port names alike.
-    IDENTIFIER_PATTERN: ClassVar[Pattern[str]] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
-    #: Characters that only appear in wildcard or glob syntax. Their presence is always a
-    #: rejection rather than a name failing the identifier pattern: the author meant a
-    #: pattern, and patterns are not part of this format version.
-    WILDCARD_CHARACTERS: ClassVar[str] = "*?[]"
-
-    #: Characters that only appear in filesystem paths. A reference addresses a component
-    #: by name, never by location, so any of them means a path was written instead.
-    PATH_CHARACTERS: ClassVar[str] = "/\\"
-
-    #: The separator between the two halves of a reference.
-    REFERENCE_SEPARATOR: ClassVar[str] = "."
-
-    @classmethod
-    def check_identifier(cls, value: Any, location: str, role: str) -> str:
-        """Returns ``value`` unchanged if it is a well-formed name, and raises otherwise.
-
-        A name has to be a string matching the one identifier pattern of the format.
-        Numbers, booleans and nested blocks reach this check whenever an author writes an
-        unquoted YAML value the parser typed differently, so the type is verified here.
-
-        Args:
-            value: The raw YAML value that should be a name.
-            location: Dotted key path of the value, used in the message.
-            role: What the name stands for ("component", "group", "fact"), used in the
-                message so the author knows which rule was applied.
-
-        Returns:
-            The validated name.
-
-        Raises:
-            EnergySystemFormatError: ``EF-08`` if the value is not a string or does not
-                match the identifier pattern.
-        """
-        if not isinstance(value, str) or cls.IDENTIFIER_PATTERN.match(value) is None:
-            raise EnergySystemFormatError(
-                EnergySystemErrorId.INVALID_NAME,
-                location,
-                f"'{value}' is not a usable {role} name.",
-                remedy=(
-                    "A name starts with a letter or underscore and continues with "
-                    "letters, digits or underscores."
-                ),
-            )
-        return value
-
-    @classmethod
-    def split_reference(cls, value: Any, location: str, *, require_member: bool) -> Tuple[str, Optional[str]]:
-        """Splits ``component`` or ``component.member`` into its two halves.
-
-        This is the single place the reference grammar is enforced, for the ``from`` key of
-        an input item as well as for every value of a ``sizing_sources`` block. Both use the
-        same syntax and differ only in whether the second half is required: a sizing source
-        always names a fact, while an input may name a component alone and let the target's
-        declared defaults pick the ports.
-
-        Args:
-            value: The raw YAML value that should be a reference.
-            location: Dotted key path of the value, used in the message.
-            require_member: Whether the dotted second half must be present.
-
-        Returns:
-            A pair of the component name and either the member name or ``None``.
-
-        Raises:
-            EnergySystemFormatError: ``EF-06`` if the value is not a string, contains
-                wildcard or path characters, has the wrong number of dotted parts, or
-                has a part that is not a well-formed identifier.
-        """
-        if not isinstance(value, str) or not value:
-            raise cls._reference_error(location, value, "a reference must be a non-empty string")
-        if any(character in value for character in cls.WILDCARD_CHARACTERS):
-            raise cls._reference_error(location, value, "wildcards are not part of this format version")
-        if any(character in value for character in cls.PATH_CHARACTERS):
-            raise cls._reference_error(location, value, "a reference names a component, never a path")
-        parts = value.split(cls.REFERENCE_SEPARATOR)
-        if len(parts) > 2 or (require_member and len(parts) != 2):
-            expected = "'<component>.<fact>'" if require_member else "'<component>' or '<component>.<Output>'"
-            raise cls._reference_error(location, value, f"a reference is written {expected}")
-        for part in parts:
-            if cls.IDENTIFIER_PATTERN.match(part) is None:
-                raise cls._reference_error(location, value, f"'{part}' is not a usable name")
-        return parts[0], parts[1] if len(parts) == 2 else None
-
-    @classmethod
-    def _reference_error(cls, location: str, value: Any, problem: str) -> EnergySystemFormatError:
-        """Builds the single rejection used for every malformed reference.
-
-        All reference problems share one identifier because they share one cause: the author
-        wrote something that is not a plain name or dotted name. Funnelling them through one
-        builder keeps the wording identical whichever rule tripped, and keeps the reason
-        visible in the message rather than only in the identifier.
-
-        Args:
-            location: Dotted key path of the value.
-            value: The reference the author wrote.
-            problem: The specific rule that was broken.
-
-        Returns:
-            The exception to raise; the caller raises it so the traceback starts there.
-        """
-        return EnergySystemFormatError(
-            EnergySystemErrorId.WILDCARD_OR_RELATIVE_REFERENCE,
-            location,
-            f"'{value}' is not a valid reference: {problem}.",
-        )
+from hisim.energy_system.names import NameRules
 
 
 class SourceReference(BaseModel):
@@ -426,19 +300,87 @@ class Group(BaseModel):
     components: Mapping[str, ComponentEntry] = Field(default_factory=dict)
 
 
+class VariantOption(BaseModel):
+    """One complete alternative world a variant can be resolved to.
+
+    An option is not an override and not a patch: it is one of the shapes the system may
+    have, written out in full. Whatever component the surrounding variant touches, every
+    option that has that component spells the whole entry — its class, its configuration and
+    its wiring — because the two worlds may wire the same component differently and there is
+    nothing for a partial statement to be merged into.
+
+    An option holds components and nothing else. Nesting a group or another variant inside
+    one would make the exclusivity of the choice depend on a second switch, and the format's
+    exclusivity is carried by the shape of the document rather than by a rule a loader solves.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    #: The only key an option may carry. An option with an empty components block is legal
+    #: and meaningful: it is how a file spells the world in which the variant adds nothing.
+    OPTION_KEYS: ClassVar[Tuple[str, ...]] = ("components",)
+
+    name: str
+    components: Mapping[str, ComponentEntry] = Field(default_factory=dict)
+
+
+class Variant(BaseModel):
+    """An exclusive choice between named options, exactly one of which is live.
+
+    Where a group is an independent on/off switch, a variant is a decision: a house has an
+    energy management system with a battery, *or* a bare electricity meter wired straight to
+    every participant. The two cases cannot be groups, because a group can add and remove
+    components but cannot rewire one that survives, and they cannot be two flags either,
+    since nothing in the format expresses "on exactly when the other is off".
+
+    The exclusivity needs no constraint solver because the document can only ever name one
+    option: ``selected`` holds a single name. That is also why one component name may repeat
+    across the options of one variant — only one of them ever exists — while the same name
+    appearing outside the variant, or in a second variant, is rejected at load.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    #: The keys a variant may carry, in canonical order. Both are required: a variant
+    #: without a selection decides nothing and one without options offers nothing.
+    VARIANT_KEYS: ClassVar[Tuple[str, ...]] = ("selected", "options")
+
+    name: str
+    selected: str
+    options: Mapping[str, VariantOption] = Field(default_factory=dict)
+
+    def selected_components(self) -> Mapping[str, ComponentEntry]:
+        """Returns the components of the option this variant is resolved to.
+
+        Every stage that works with the running system asks for this rather than walking the
+        options itself, so that "the live world" has one definition. A selection naming no
+        option is rejected at load, which is what makes the lookup safe here.
+
+        Returns:
+            The selected option's components, or an empty mapping for the — already
+            rejected — case of a selection that names no option.
+        """
+        option = self.options.get(self.selected)
+        return option.components if option is not None else {}
+
+
 class EnergySystemFile(BaseModel):
     """A whole energy-system document as loaded from YAML.
 
     The document has a fixed, small top level: the schema version that pins the format, a
-    name and description, the ungrouped components, the groups, and a metadata block only
-    generated files carry. Simulation parameters — time range, resolution, post-processing —
-    are deliberately not part of it: the same energy system is run over different periods,
-    and mixing the two would force a copy of the system per run.
+    name and description, the ungrouped components, the groups, the variants, and a metadata
+    block only generated files carry. Simulation parameters — time range, resolution,
+    post-processing — are deliberately not part of it: the same energy system is run over
+    different periods, and mixing the two would force a copy of the system per run.
 
-    Components live in two places, at the top level and inside groups, and both are equally
-    components of the system; the split says only whether they can be switched off together.
-    Checks that reason about the whole system therefore use :meth:`all_components`, which
-    merges the two in document order, while the emitter keeps them apart so files round-trip.
+    Components live in three places — at the top level, inside groups and inside the options
+    of variants — and all of them are equally components of the system; the place says only
+    how the component can be switched. Two readings of the document follow from that and must
+    not be confused. :meth:`all_components` is the *selected* world: what actually runs, and
+    the set every reference resolves against. :meth:`declared_components` is everything the
+    document writes down, the options nobody selected included, which is what the loader
+    checks and what a reference into an unselected option is allowed to name — the reference
+    is dropped when the option loses, exactly as a reference into a disabled group is.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -454,6 +396,7 @@ class EnergySystemFile(BaseModel):
         "description",
         "components",
         "groups",
+        "variants",
         "metadata",
     )
 
@@ -462,14 +405,18 @@ class EnergySystemFile(BaseModel):
     description: Optional[str] = None
     components: Mapping[str, ComponentEntry] = Field(default_factory=dict)
     groups: Mapping[str, Group] = Field(default_factory=dict)
+    variants: Mapping[str, Variant] = Field(default_factory=dict)
     metadata: Optional[Mapping[str, Any]] = None
 
     def all_components(self) -> Dict[str, ComponentEntry]:
-        """Returns every component of the system, grouped or not, by name.
+        """Returns every component of the selected system, wherever it is written, by name.
 
         Names are global across the whole document, so this mapping is the file's namespace
-        and the set every reference resolves against. Ungrouped entries come first and groups
-        follow in document order, which makes the result stable enough to list in a message.
+        and the set every reference resolves against. It is selection-aware: a variant
+        contributes the components of the option it selects and nothing from the options it
+        does not, because those describe worlds this file is not. Ungrouped entries come
+        first, then the groups and then the variants in document order, which makes the
+        result stable enough to list in a message.
 
         Returns:
             A fresh mapping from component name to entry; mutating it does not affect
@@ -478,7 +425,53 @@ class EnergySystemFile(BaseModel):
         merged: Dict[str, ComponentEntry] = dict(self.components)
         for group in self.groups.values():
             merged.update(group.components)
+        for variant in self.variants.values():
+            merged.update(variant.selected_components())
         return merged
+
+    def declared_components(self) -> Dict[str, ComponentEntry]:
+        """Returns every component the document writes down, unselected options included.
+
+        The loader needs the wider set that :meth:`all_components` deliberately narrows. A
+        reference from a surviving component into a variant option is legal whichever option
+        wins — that is what lets a building list ``- ems`` while the metering variant may
+        resolve to a world without one — so a reference is checked against what the document
+        declares and dropped later if its target's option lost.
+
+        Where one name occurs in several options of one variant, the last of them wins; the
+        entries themselves are reached through :meth:`declared_entries`, which keeps all of
+        them, so no option escapes the per-entry checks.
+
+        Returns:
+            A fresh mapping from component name to entry.
+        """
+        merged: Dict[str, ComponentEntry] = dict(self.components)
+        for group in self.groups.values():
+            merged.update(group.components)
+        for variant in self.variants.values():
+            for option in variant.options.values():
+                merged.update(option.components)
+        return merged
+
+    def declared_entries(self) -> Tuple[ComponentEntry, ...]:
+        """Returns every entry the document holds, including two options' takes on one name.
+
+        The one place a component name can carry two different entries is two options of the
+        same variant, and both of them have to obey the rules a single entry obeys: a file is
+        wrong if the option nobody selected today is malformed, because tomorrow's file
+        selects it. So the per-entry checks walk this sequence rather than a mapping.
+
+        Returns:
+            The entries in document order: the ungrouped ones, then the groups', then every
+            option's, each entry carrying its own name.
+        """
+        entries = list(self.components.values())
+        for group in self.groups.values():
+            entries.extend(group.components.values())
+        for variant in self.variants.values():
+            for option in variant.options.values():
+                entries.extend(option.components.values())
+        return tuple(entries)
 
     def group_of(self, component_name: str) -> Optional[str]:
         """Returns the name of the group a component sits in, if any.

--- a/hisim/energy_system/names.py
+++ b/hisim/energy_system/names.py
@@ -1,0 +1,147 @@
+"""The name and reference grammar every part of the energy-system format shares.
+
+One identifier syntax runs through the whole format — component names, group names, variant
+and option names, fact names and port names all use it — and one compound form joins two of
+them with a dot. Keeping that grammar in a module of its own says what it is: a property of
+the wire format rather than of the models, which is why the loader, the schema exporter and
+the models themselves all reach for the same class instead of each spelling a pattern.
+
+The grammar matters most for what it refuses. Wildcards and path syntax are the vocabulary
+of a preprocessor this format version does not have, and accepting them silently would let a
+file written against that expectation resolve to something its author never meant. Both are
+therefore rejected here, at the one place a name or a reference enters the model at all.
+"""
+
+# clean
+
+from __future__ import annotations
+
+import re
+from typing import Any, ClassVar, Optional, Pattern, Tuple
+
+from hisim.energy_system.errors import EnergySystemErrorId, EnergySystemFormatError
+
+
+class NameRules:
+    """The identifier and reference grammar shared by every part of the format.
+
+    Component names, group names, variant and option names, fact names and port names all use
+    one identifier syntax — a letter or underscore followed by letters, digits or underscores —
+    so a reader never has to remember which allows what. A reference joining two of them with a
+    dot, such as ``pv_south.pv_peak_power_in_watt``, is the only compound form the format has.
+
+    The class exists mainly for what it forbids. Wildcards (``pv_*``, ``[*]``) and relative
+    or absolute path syntax (``../pv``, ``/etc/x``) are deliberately not part of this format
+    version: they are the vocabulary of a future preprocessor, and accepting them silently
+    would make files written against that expectation resolve to something unintended.
+    """
+
+    #: The one identifier syntax of the format, used for component names, group names,
+    #: variant and option names, fact names and port names alike.
+    IDENTIFIER_PATTERN: ClassVar[Pattern[str]] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+    #: Characters that only appear in wildcard or glob syntax. Their presence is always a
+    #: rejection rather than a name failing the identifier pattern: the author meant a
+    #: pattern, and patterns are not part of this format version.
+    WILDCARD_CHARACTERS: ClassVar[str] = "*?[]"
+
+    #: Characters that only appear in filesystem paths. A reference addresses a component
+    #: by name, never by location, so any of them means a path was written instead.
+    PATH_CHARACTERS: ClassVar[str] = "/\\"
+
+    #: The separator between the two halves of a reference.
+    REFERENCE_SEPARATOR: ClassVar[str] = "."
+
+    @classmethod
+    def check_identifier(cls, value: Any, location: str, role: str) -> str:
+        """Returns ``value`` unchanged if it is a well-formed name, and raises otherwise.
+
+        A name has to be a string matching the one identifier pattern of the format.
+        Numbers, booleans and nested blocks reach this check whenever an author writes an
+        unquoted YAML value the parser typed differently, so the type is verified here.
+
+        Args:
+            value: The raw YAML value that should be a name.
+            location: Dotted key path of the value, used in the message.
+            role: What the name stands for ("component", "group", "fact"), used in the
+                message so the author knows which rule was applied.
+
+        Returns:
+            The validated name.
+
+        Raises:
+            EnergySystemFormatError: ``EF-08`` if the value is not a string or does not
+                match the identifier pattern.
+        """
+        if not isinstance(value, str) or cls.IDENTIFIER_PATTERN.match(value) is None:
+            raise EnergySystemFormatError(
+                EnergySystemErrorId.INVALID_NAME,
+                location,
+                f"'{value}' is not a usable {role} name.",
+                remedy=(
+                    "A name starts with a letter or underscore and continues with "
+                    "letters, digits or underscores."
+                ),
+            )
+        return value
+
+    @classmethod
+    def split_reference(cls, value: Any, location: str, *, require_member: bool) -> Tuple[str, Optional[str]]:
+        """Splits ``component`` or ``component.member`` into its two halves.
+
+        This is the single place the reference grammar is enforced, for the ``from`` key of
+        an input item as well as for every value of a ``sizing_sources`` block. Both use the
+        same syntax and differ only in whether the second half is required: a sizing source
+        always names a fact, while an input may name a component alone and let the target's
+        declared defaults pick the ports.
+
+        Args:
+            value: The raw YAML value that should be a reference.
+            location: Dotted key path of the value, used in the message.
+            require_member: Whether the dotted second half must be present.
+
+        Returns:
+            A pair of the component name and either the member name or ``None``.
+
+        Raises:
+            EnergySystemFormatError: ``EF-06`` if the value is not a string, contains
+                wildcard or path characters, has the wrong number of dotted parts, or
+                has a part that is not a well-formed identifier.
+        """
+        if not isinstance(value, str) or not value:
+            raise cls._reference_error(location, value, "a reference must be a non-empty string")
+        if any(character in value for character in cls.WILDCARD_CHARACTERS):
+            raise cls._reference_error(location, value, "wildcards are not part of this format version")
+        if any(character in value for character in cls.PATH_CHARACTERS):
+            raise cls._reference_error(location, value, "a reference names a component, never a path")
+        parts = value.split(cls.REFERENCE_SEPARATOR)
+        if len(parts) > 2 or (require_member and len(parts) != 2):
+            expected = "'<component>.<fact>'" if require_member else "'<component>' or '<component>.<Output>'"
+            raise cls._reference_error(location, value, f"a reference is written {expected}")
+        for part in parts:
+            if cls.IDENTIFIER_PATTERN.match(part) is None:
+                raise cls._reference_error(location, value, f"'{part}' is not a usable name")
+        return parts[0], parts[1] if len(parts) == 2 else None
+
+    @classmethod
+    def _reference_error(cls, location: str, value: Any, problem: str) -> EnergySystemFormatError:
+        """Builds the single rejection used for every malformed reference.
+
+        All reference problems share one identifier because they share one cause: the author
+        wrote something that is not a plain name or dotted name. Funnelling them through one
+        builder keeps the wording identical whichever rule tripped, and keeps the reason
+        visible in the message rather than only in the identifier.
+
+        Args:
+            location: Dotted key path of the value.
+            value: The reference the author wrote.
+            problem: The specific rule that was broken.
+
+        Returns:
+            The exception to raise; the caller raises it so the traceback starts there.
+        """
+        return EnergySystemFormatError(
+            EnergySystemErrorId.WILDCARD_OR_RELATIVE_REFERENCE,
+            location,
+            f"'{value}' is not a valid reference: {problem}.",
+        )

--- a/hisim/energy_system/schema_export.py
+++ b/hisim/energy_system/schema_export.py
@@ -45,7 +45,8 @@ from typing import Any, Dict, Sequence
 from hisim.config.introspection import ConfigDescription, describe_config
 from hisim.config.presets import constructors_of
 from hisim.energy_system.bindings import facts_read_by
-from hisim.energy_system.model import ComponentEntry, EnergySystemFile, Group, NameRules
+from hisim.energy_system.model import ComponentEntry, EnergySystemFile, Group, Variant, VariantOption
+from hisim.energy_system.names import NameRules
 from hisim.energy_system.schema_classes import ComponentClassScan, JsonTypes
 
 
@@ -53,9 +54,10 @@ class SchemaBuilder:
     """Assembles the whole JSON Schema of one schema version from a set of component classes.
 
     Built for one export and used once. The document it produces has two halves: a fixed part
-    describing the format itself — the top level, the group block, the three input shapes, the
-    sizing-source references — which changes only when the format does, and a generated part
-    describing what the classes of this repository allow, which changes with every conversion.
+    describing the format itself — the top level, the group and variant blocks, the three input
+    shapes, the sizing-source references — which changes only when the format does, and a
+    generated part describing what the classes of this repository allow, which changes with
+    every conversion.
 
     The generated half is one conditional branch per component class. Branches are additive and
     independent: an entry naming a class matches exactly one of them, and an entry naming a class
@@ -125,6 +127,11 @@ class SchemaBuilder:
                 "propertyNames": {"$ref": "#/$defs/name"},
                 "additionalProperties": {"$ref": "#/$defs/group"},
             },
+            "variants": {
+                "type": "object",
+                "propertyNames": {"$ref": "#/$defs/name"},
+                "additionalProperties": {"$ref": "#/$defs/variant"},
+            },
             "metadata": {
                 "type": "object",
                 "description": (
@@ -138,8 +145,8 @@ class SchemaBuilder:
         """Builds the reusable definitions the top level refers to.
 
         Returns:
-            The ``$defs`` block: names, references, the component map, the entry, the group and
-            the three input shapes.
+            The ``$defs`` block: names, references, the component map, the entry, the group,
+            the variant with its options and the three input shapes.
         """
         return {
             "name": {"type": "string", "pattern": self.NAME_PATTERN},
@@ -157,6 +164,25 @@ class SchemaBuilder:
                 "properties": {
                     "enabled": {"type": "boolean"},
                     "components": {"$ref": "#/$defs/components"},
+                },
+            },
+            "variant": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": list(Variant.VARIANT_KEYS),
+                "properties": {
+                    "selected": {"$ref": "#/$defs/name"},
+                    "options": {
+                        "type": "object",
+                        "minProperties": 1,
+                        "propertyNames": {"$ref": "#/$defs/name"},
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "required": list(VariantOption.OPTION_KEYS),
+                            "properties": {"components": {"$ref": "#/$defs/components"}},
+                        },
+                    },
                 },
             },
             "entry": self._entry(),

--- a/hisim/energy_system/validation.py
+++ b/hisim/energy_system/validation.py
@@ -1,11 +1,11 @@
 """Structural validation: every rule an energy-system file must obey without its classes.
 
 Validation of an energy system happens on two levels, and this module is the first of
-them. It checks everything decidable from the document alone — that names are unique and
-each component belongs to at most one group, that every reference resolves to a component
-the file declares, that each entry says where its configuration comes from, that the input
-items of one consumer do not contradict each other, and that no value smuggles in an
-absolute filesystem path. The second level, which needs the component classes imported,
+them. It checks everything decidable from the document alone — that names are unique and each
+component belongs to at most one group and at most one variant, that every reference resolves
+to a component the file declares, that each entry says where its configuration comes from,
+that the input items of one consumer do not contradict each other, and that no value smuggles
+in an absolute filesystem path. The second level, which needs the component classes imported,
 decides whether a preset exists, whether a config field is real and whether two ports can
 be wired; nothing here reaches for it.
 
@@ -14,6 +14,13 @@ batch-authoring tool can check a file it is writing without importing HiSim's co
 tree, and a file whose classes have not been written yet can still be verified for shape.
 It also keeps the failure modes apart: a message from this module is always about the file,
 never about the code.
+
+Everything here is checked over the *declared* set rather than over the selected one. A
+component in a group nobody enabled and a component in a variant option nobody selected are
+both written down, so both have to be well formed — tomorrow's file enables the group and
+selects the option — and a reference into either is legal, because the expansion drops such a
+reference rather than failing on it. Which components actually run is a question for the
+expansion, one stage later.
 
 Validation stops at the first problem. The format's contract is that a file is taken as
 written or rejected, and the first violation is the one the author has to fix before the
@@ -47,6 +54,11 @@ class StructuralValidator:
     references between entries, then the shape agreements inside an input list, and finally
     the values of the configuration blocks.
 
+    The namespace is a mapping and the entries are a sequence, because the two answer
+    different questions. One name can carry two entries — the same component wired
+    differently in two options of one variant — and both of those entries have to obey every
+    per-entry rule, while a reference resolves against the name and cannot tell them apart.
+
     An instance is single-use and holds no state beyond the file and the derived name
     lookups. Callers normally use :func:`validate_structure` instead of building one.
     """
@@ -55,6 +67,11 @@ class StructuralValidator:
     #: after an underscore. A path written in an energy-system file is symbolic —
     #: ``${inputs}/weather/...`` — so that the file resolves on another machine.
     PATH_KEY_NOUNS: ClassVar[Tuple[str, ...]] = ("path", "paths", "directory", "file", "filename")
+
+    #: The owner recorded for a component written outside every group and every variant.
+    #: It is the ``components`` block's own key, so a message can name where the collision
+    #: it reports came from.
+    TOP_LEVEL_OWNER: ClassVar[str] = "components"
 
     #: Matches a Windows drive prefix, which is absolute even though it starts with a
     #: letter rather than with a separator.
@@ -67,17 +84,19 @@ class StructuralValidator:
             model: The parsed energy system to check.
         """
         self.model = model
-        self.components: Dict[str, ComponentEntry] = model.all_components()
+        self.components: Dict[str, ComponentEntry] = model.declared_components()
+        self.entries: Tuple[ComponentEntry, ...] = model.declared_entries()
         self.names: Tuple[str, ...] = tuple(self.components)
 
     def validate(self) -> None:
         """Runs every structural check, raising on the first violation.
 
         Raises:
-            EnergySystemFormatError: Naming the offending component, group or key path,
-                and listing the valid alternatives wherever the set of them is closed.
+            EnergySystemFormatError: Naming the offending component, group, variant or key
+                path, and listing the valid alternatives wherever the set of them is closed.
         """
         self._check_names()
+        self._check_variants()
         self._check_configuration_origin()
         self._check_reference_closure()
         self._check_input_shapes()
@@ -95,11 +114,11 @@ class StructuralValidator:
             EnergySystemFormatError: ``EF-51`` when two groups list the same component,
                 ``EF-52`` when a name collides with another component or with a group.
         """
-        owner: Dict[str, str] = {name: "components" for name in self.model.components}
+        owner: Dict[str, str] = self._component_owners()
         for group_name, group in self.model.groups.items():
             for member in group.components:
                 previous = owner.get(member)
-                if previous is not None and previous != "components":
+                if previous is not None and previous != self.TOP_LEVEL_OWNER:
                     raise EnergySystemFormatError(
                         EnergySystemErrorId.COMPONENT_IN_TWO_GROUPS,
                         f"groups.{group_name}.components.{member}",
@@ -123,6 +142,97 @@ class StructuralValidator:
                     remedy="A reference is a bare name, so a group and a component may not share one.",
                 )
 
+    def _component_owners(self) -> Dict[str, str]:
+        """Returns the block each top-level component name belongs to, as a starting point.
+
+        The two name checks below both walk the file building the same mapping of name to
+        owner, and both report the collision they find against what the mapping already
+        holds, so the seed is shared rather than written twice.
+
+        Returns:
+            One entry per ungrouped component, mapped to the literal block name.
+        """
+        return {name: self.TOP_LEVEL_OWNER for name in self.model.components}
+
+    def _check_variants(self) -> None:
+        """Rejects the ways a variant can claim a name that is not its to claim.
+
+        Three collisions are possible and each is a different mistake. One component name in
+        two variants means two exclusive choices both decide the same component, which no
+        selection can resolve. The same name at the top level, or in a group, and inside an
+        option means the file has both a permanent component and an alternative version of
+        it, which is the override R15.2 rules out: an option states its components in full.
+        And a variant sharing a name with a group or a component would make a bare reference
+        ambiguous, exactly as a group sharing one would.
+
+        A name repeated across the options of *one* variant is not a collision but the point
+        of the construct: only one of those options ever exists, which is what lets two worlds
+        wire the same component differently.
+
+        Raises:
+            EnergySystemFormatError: ``EF-57`` when two variants declare one component,
+                ``EF-52`` when a variant's component name or the variant's own name collides
+                with something outside it.
+        """
+        owner = self._component_owners()
+        for group_name, group in self.model.groups.items():
+            for member in group.components:
+                owner[member] = group_name
+        for variant_name, variant in self.model.variants.items():
+            if variant_name in self.components or variant_name in self.model.groups:
+                collided = "component" if variant_name in self.components else "group"
+                raise EnergySystemFormatError(
+                    EnergySystemErrorId.DUPLICATE_NAME,
+                    f"variants.{variant_name}",
+                    f"variant '{variant_name}' has the same name as a {collided}.",
+                    remedy="A reference is a bare name, so a variant, a group and a component may not share one.",
+                )
+            for option_name, option in variant.options.items():
+                for member in option.components:
+                    self._check_option_member(owner, variant_name, option_name, member)
+                    owner[member] = variant_name
+
+    def _check_option_member(
+        self, owner: Dict[str, str], variant_name: str, option_name: str, member: str
+    ) -> None:
+        """Rejects one option member whose name is already claimed outside this variant.
+
+        Args:
+            owner: Name to the block that claimed it, top-level components first, then the
+                groups, then the variants seen so far.
+            variant_name: The variant the option belongs to.
+            option_name: The option the member is written in.
+            member: The component name to check.
+
+        Raises:
+            EnergySystemFormatError: ``EF-57`` when another variant already declares the
+                name, ``EF-52`` when the top level or a group does.
+        """
+        previous = owner.get(member)
+        if previous is None or previous == variant_name:
+            return
+        location = f"variants.{variant_name}.options.{option_name}.components.{member}"
+        if previous in self.model.variants:
+            raise EnergySystemFormatError(
+                EnergySystemErrorId.COMPONENT_IN_TWO_VARIANTS,
+                location,
+                f"component '{member}' is already declared by the variant '{previous}'.",
+                remedy=(
+                    "A component belongs to at most one variant; two exclusive choices cannot "
+                    "both decide the same component."
+                ),
+            )
+        where = "an ungrouped component" if previous == self.TOP_LEVEL_OWNER else f"the group '{previous}'"
+        raise EnergySystemFormatError(
+            EnergySystemErrorId.DUPLICATE_NAME,
+            location,
+            f"component '{member}' has the same name as {where}.",
+            remedy=(
+                "An option states its components in full and never overrides one written "
+                "elsewhere; move the component into every option, or out of the variant."
+            ),
+        )
+
     def _check_configuration_origin(self) -> None:
         """Rejects an entry that names both a preset and a constructor, or neither.
 
@@ -136,7 +246,8 @@ class StructuralValidator:
             EnergySystemFormatError: ``EF-11`` when both are present, ``EF-12`` when
                 neither is and ``config`` is empty as well.
         """
-        for name, entry in self.components.items():
+        for entry in self.entries:
+            name = entry.name
             location = f"components.{name}"
             if entry.preset is not None and entry.constructor is not None:
                 raise EnergySystemFormatError(
@@ -167,7 +278,8 @@ class StructuralValidator:
                 an unknown sizing provider, ``EF-41`` when the reference's fact half
                 differs from the key it is written under.
         """
-        for name, entry in self.components.items():
+        for entry in self.entries:
+            name = entry.name
             for index, item in enumerate(entry.inputs):
                 if item.source not in self.components:
                     raise EnergySystemFormatError(
@@ -215,7 +327,8 @@ class StructuralValidator:
                 ``EF-25`` for a repeated aggregator feed, ``EF-26`` for two wires into one
                 input.
         """
-        for name, entry in self.components.items():
+        for entry in self.entries:
+            name = entry.name
             spellings: Dict[str, Set[str]] = {}
             wired_inputs: Set[str] = set()
             fed_outputs: Set[Tuple[str, str]] = set()
@@ -289,7 +402,8 @@ class StructuralValidator:
         Raises:
             EnergySystemFormatError: ``EF-05`` naming the key path of the value.
         """
-        for name, entry in self.components.items():
+        for entry in self.entries:
+            name = entry.name
             self._scan_for_absolute_paths(entry.config, f"components.{name}.config")
             if entry.constructor is not None:
                 self._scan_for_absolute_paths(

--- a/hisim/energy_system_v3.schema.json
+++ b/hisim/energy_system_v3.schema.json
@@ -33,6 +33,15 @@
         "$ref": "#/$defs/group"
       }
     },
+    "variants": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/name"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/variant"
+      }
+    },
     "metadata": {
       "type": "object",
       "description": "Written by a generated run record and never by hand; a file carrying it is re-run explicitly rather than run as an authored energy system."
@@ -73,6 +82,38 @@
         },
         "components": {
           "$ref": "#/$defs/components"
+        }
+      }
+    },
+    "variant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "selected",
+        "options"
+      ],
+      "properties": {
+        "selected": {
+          "$ref": "#/$defs/name"
+        },
+        "options": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": {
+            "$ref": "#/$defs/name"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "components"
+            ],
+            "properties": {
+              "components": {
+                "$ref": "#/$defs/components"
+              }
+            }
+          }
         }
       }
     },

--- a/roadmap/declarative_energy_systems/energy_system_mockup.yaml
+++ b/roadmap/declarative_energy_systems/energy_system_mockup.yaml
@@ -1,7 +1,9 @@
 # yaml-language-server: $schema=../../hisim/energy_system_v3.schema.json   # R13: autocompletion/validation in the editor
 # ---------------------------------------------------------------------------
-# MOCKUP 2 — flat energy-system file with groups (2026-08-25, rev. 2: connections
-# moved onto the consuming component, no central connections block).
+# MOCKUP 2 — flat energy-system file with groups and one variant (2026-08-25,
+# rev. 2: connections moved onto the consuming component, no central connections
+# block; rev. 3, 2026-08-31: metering became the `electricity_management` variant,
+# which resolves O2).
 # Written against roadmap/declarative_energy_systems/config_requirements_spec.md; §7 checklist at the end.
 # Hand-authored form: bare fact names wherever unique (R4.3); comments are the
 # author's own (a realized record carries machine comments instead, R8).
@@ -11,7 +13,10 @@
 #   class / preset / config     what it is and how it is configured
 #   inputs                      where its inputs come from (R2)
 #   sizing_sources              where its sizing facts come from, only if ambiguous (R4)
-# Nothing is ever declared at the source.
+# Nothing is ever declared at the source. Components live in three places, all of
+# them equally components of the system: at the top level (always on), in a group
+# (an on/off add-on, R14) and in a variant option (one of several exclusive worlds,
+# R15).
 # ---------------------------------------------------------------------------
 schema_version: 3
 name: Household with heat pump, two PV strings, battery and EMS
@@ -59,7 +64,8 @@ components:
       - weather
       - occupancy
       - hds
-      - ems                                 # lives in a group: dropped if that group is off (R14)
+      - ems                                 # lives in a variant option: dropped when the
+                                            # other option is selected (R15.3)
     # provides facts: heating_load_in_watt, number_of_apartments,
     # conditioned_floor_area_in_m2, heating_reference_temperature_in_celsius
 
@@ -69,7 +75,7 @@ components:
     inputs:
       - weather
       - building
-      - ems
+      - ems                                 # dropped with the ems, see building above
 
   hds:
     class: hisim.components.heat_distribution_system.HeatDistribution
@@ -134,16 +140,8 @@ components:
       - occupancy
       - heat_pump
 
-  meter:
-    class: hisim.components.electricity_meter.ElectricityMeter
-    preset: standard
-    inputs:                                 # an aggregator lists its feeds (R2.3)
-      - from: ems.TotalElectricityToOrFromGrid
-        tags: [ELECTRICITY_PRODUCTION]
-        weight: 999
-      # see O2: with the ems group off, nothing feeds the meter. The direct feeds
-      # (heat_pump, pv_*, occupancy) would have to be listed here as well, but then
-      # they double-count while the ems is on. -> needs its own group, see footer.
+  # The meter is not written here: it is wired differently in the two metering
+  # worlds, so it lives in every option of the `electricity_management` variant below.
 
 # --- groups: sets of components with a flag (R14) ----------------------------
 # Not scopes: names are still global. Off = the group's components vanish, along
@@ -169,70 +167,6 @@ groups:
           power_in_watt: 3000               # concrete: this string is not law-sized
         inputs:
           - weather
-
-  battery_and_ems:
-    enabled: true
-    components:
-      battery:
-        class: hisim.components.advanced_battery_bslib.Battery
-        preset: sized_to_pv                 # capacity law reads ONE pv_peak_power_in_watt
-        # two PV systems provide pv_peak_power_in_watt -> ambiguous -> must be written (R4.3).
-        # Without this line the executor errors:
-        #   "pv_peak_power_in_watt needed by 'battery' is provided by pv_east, pv_south;
-        #    add sizing_sources: {pv_peak_power_in_watt: <one of them>}"
-        sizing_sources:
-          pv_peak_power_in_watt: pv_south.pv_peak_power_in_watt
-
-      ems:
-        class: hisim.components.controller_l2_energy_management_system.L2GenericEnergyManagementSystem
-        preset: optimize_own_consumption
-        inputs:                             # the aggregator's participants, with tags/weights (R2.3)
-          - from: occupancy
-            tags: [ELECTRICITY_CONSUMPTION_UNCONTROLLED]
-            weight: 999                     # measured, never ranked: the channel forbids dispatch
-          - from: pv_south
-            component_type: PV
-            tags: [ELECTRICITY_PRODUCTION]
-            weight: 999
-          - from: pv_east
-            component_type: PV
-            tags: [ELECTRICITY_PRODUCTION]
-            weight: 999
-          - from: heat_pump
-            component_type: HEAT_PUMP_BUILDING
-            tags: [ELECTRICITY_CONSUMPTION_EMS_CONTROLLED]
-            weight: 2
-            dispatch: {}                    # recorded control signal, nothing consumes it
-          - from: heating_rod
-            component_type: ELECTRIC_HEATER
-            tags: [ELECTRICITY_CONSUMPTION_EMS_CONTROLLED]
-            weight: 3
-            dispatch: {}
-          - from: battery.AcBatteryPowerUsed
-            component_type: BATTERY
-            tags: [ELECTRICITY_CONSUMPTION_EMS_CONTROLLED]
-            weight: 6
-            dispatch: {target_input: LoadingPowerInput}   # back-channel: ems.DispatchTobattery_LoadingPowerInput -> battery.LoadingPowerInput
-        # --- many-facts example -----------------------------------------------
-        # The EMS class declares two MANY readers (shown by `hisim config describe`):
-        #   reads pv_peak_power_in_watt          (many)  -> production band
-        #   reads maximal_thermal_power_in_watt  (many)  -> controllable thermal load
-        # In the class (laws.py algebra, scalar laws unchanged):
-        #   Size.PV_PEAK_POWER_IN_WATT.many.sum()
-        #   Size.MAXIMAL_THERMAL_POWER_IN_WATT.many.sum()
-        # The file only says WHICH providers feed each list; the class aggregates.
-        # List order is not guaranteed to the law (aggregates are order-independent).
-        sizing_sources:
-          pv_peak_power_in_watt:                          # two providers of one class
-            - pv_south.pv_peak_power_in_watt
-            - pv_east.pv_peak_power_in_watt
-          maximal_thermal_power_in_watt:                  # mixed providers
-            - heat_pump.maximal_thermal_power_in_watt
-            - heating_rod.maximal_thermal_power_in_watt   # not group-qualified: names are global
-        # A MANY reader with zero providers must still be written, explicitly:
-        #   sizing_sources: {pv_peak_power_in_watt: []}
-        # With `pv` off the pv list shrinks to [] and the shrink is recorded (R14);
-        # with `backup_heater` off the thermal list shrinks to the heat pump alone.
 
   backup_heater:
     enabled: true
@@ -267,20 +201,124 @@ groups:
       # ev group is off, that entry would be dropped. It is omitted here since
       # the mockup shows the file as authored for the enabled set (see O3).
 
+# --- variants: exclusive choices, exactly one option live (R15) ---------------
+# A group is an independent on/off switch; a variant is a decision. Metering is a
+# decision: either an EMS with a battery nets the household and the meter reads its
+# grid total, or there is no EMS and every participant feeds the meter directly. A
+# group cannot express that — it can add and remove components, but not rewire one
+# that survives — and two groups cannot either, since nothing here says "on exactly
+# when the other is off". Each option is a complete alternative world: `meter` is
+# written out in both, which is legal precisely because only one option ever exists.
+variants:
+
+  electricity_management:
+    selected: ems_and_battery
+    options:
+
+      ems_and_battery:
+        components:
+          battery:
+            class: hisim.components.advanced_battery_bslib.Battery
+            preset: sized_to_pv                 # capacity law reads ONE pv_peak_power_in_watt
+            # two PV systems provide pv_peak_power_in_watt -> ambiguous -> must be written (R4.3).
+            # Without this line the executor errors:
+            #   "pv_peak_power_in_watt needed by 'battery' is provided by pv_east, pv_south;
+            #    add sizing_sources: {pv_peak_power_in_watt: <one of them>}"
+            sizing_sources:
+              pv_peak_power_in_watt: pv_south.pv_peak_power_in_watt
+
+          ems:
+            class: hisim.components.controller_l2_energy_management_system.L2GenericEnergyManagementSystem
+            preset: optimize_own_consumption
+            inputs:                             # the aggregator's participants, with tags/weights (R2.3)
+              - from: occupancy
+                tags: [ELECTRICITY_CONSUMPTION_UNCONTROLLED]
+                weight: 999                     # measured, never ranked: the channel forbids dispatch
+              - from: pv_south
+                component_type: PV
+                tags: [ELECTRICITY_PRODUCTION]
+                weight: 999
+              - from: pv_east
+                component_type: PV
+                tags: [ELECTRICITY_PRODUCTION]
+                weight: 999
+              - from: heat_pump
+                component_type: HEAT_PUMP_BUILDING
+                tags: [ELECTRICITY_CONSUMPTION_EMS_CONTROLLED]
+                weight: 2
+                dispatch: {}                    # recorded control signal, nothing consumes it
+              - from: heating_rod
+                component_type: ELECTRIC_HEATER
+                tags: [ELECTRICITY_CONSUMPTION_EMS_CONTROLLED]
+                weight: 3
+                dispatch: {}
+              - from: battery.AcBatteryPowerUsed
+                component_type: BATTERY
+                tags: [ELECTRICITY_CONSUMPTION_EMS_CONTROLLED]
+                weight: 6
+                dispatch: {target_input: LoadingPowerInput}   # back-channel: ems.DispatchTobattery_LoadingPowerInput -> battery.LoadingPowerInput
+            # --- many-facts example -----------------------------------------------
+            # The EMS class declares two MANY readers (shown by `hisim config describe`):
+            #   reads pv_peak_power_in_watt          (many)  -> production band
+            #   reads maximal_thermal_power_in_watt  (many)  -> controllable thermal load
+            # In the class (laws.py algebra, scalar laws unchanged):
+            #   Size.PV_PEAK_POWER_IN_WATT.many.sum()
+            #   Size.MAXIMAL_THERMAL_POWER_IN_WATT.many.sum()
+            # The file only says WHICH providers feed each list; the class aggregates.
+            # List order is not guaranteed to the law (aggregates are order-independent).
+            sizing_sources:
+              pv_peak_power_in_watt:                          # two providers of one class
+                - pv_south.pv_peak_power_in_watt
+                - pv_east.pv_peak_power_in_watt
+              maximal_thermal_power_in_watt:                  # mixed providers
+                - heat_pump.maximal_thermal_power_in_watt
+                - heating_rod.maximal_thermal_power_in_watt   # not group-qualified: names are global
+            # A MANY reader with zero providers must still be written, explicitly:
+            #   sizing_sources: {pv_peak_power_in_watt: []}
+            # With `pv` off the pv list shrinks to [] and the shrink is recorded (R14);
+            # with `backup_heater` off the thermal list shrinks to the heat pump alone.
+
+          meter:
+            class: hisim.components.electricity_meter.ElectricityMeter
+            preset: standard
+            inputs:                             # one feed: the EMS has already netted everything
+              - from: ems.TotalElectricityToOrFromGrid
+                tags: [ELECTRICITY_PRODUCTION]
+                weight: 999
+
+      direct_metering:
+        components:
+          meter:
+            class: hisim.components.electricity_meter.ElectricityMeter
+            preset: standard
+            inputs:                             # no EMS to net them: every participant feeds the meter
+              - { from: pv_south,    tags: [ELECTRICITY_PRODUCTION],               weight: 999 }
+              - { from: pv_east,     tags: [ELECTRICITY_PRODUCTION],               weight: 999 }
+              - { from: occupancy,   tags: [ELECTRICITY_CONSUMPTION_UNCONTROLLED], weight: 999 }
+              - { from: heat_pump,   tags: [ELECTRICITY_CONSUMPTION_UNCONTROLLED], weight: 999 }
+              - { from: heating_rod, tags: [ELECTRICITY_CONSUMPTION_UNCONTROLLED], weight: 999 }
+        # With this option selected, R15.3 drops the four bare `- ems` items (building,
+        # hds_controller, both heat-pump controllers) and the battery with its sizing
+        # line, exactly as R14.3 drops references into a disabled group. With
+        # `ems_and_battery` selected, the five direct feeds above are what goes instead.
+
 # ---------------------------------------------------------------------------
 # How RenoVisor / the building sizer use this (Q6): one such base file per heating
 # system in system_setups/. Load, set building.config.building_code /
-# occupancy.preset / weather.preset, flip groups.<x>.enabled, dump.
+# occupancy.preset / weather.preset, flip groups.<x>.enabled, set
+# variants.<x>.selected, dump. `hisim energy-system facts <file>` prints exactly
+# that surface: a boolean per group, an option name per variant (R15.8).
 #
 # Open points:
 #  O1  RESOLVED by rev. 2: connections live at the consumer, always. No placement
 #      choice; an entry pointing at a disabled component is dropped wherever it is.
-#  O2  Metering with and without EMS: the meter's feeds differ (grid total from the
-#      EMS vs. direct feeds). Either the direct feeds form their own group
-#      (`direct_metering`, enabled iff battery_and_ems is off — a constraint the
-#      data cannot express, cf. R14) or the EMS-less variant is a separate base
-#      file. Recommendation: separate base file; the R14 identity test would fail
-#      loudly on the double-count otherwise, which is the test doing its job.
+#  O2  RESOLVED by R15 (2026-08-28, built in P2.1): metering with and without EMS is
+#      neither a group nor a second base file but a VARIANT — the
+#      `electricity_management` block above. A group could not express it because
+#      the meter has to be rewired rather than removed, and "enabled iff the other
+#      is off" is a constraint the data cannot state; a variant needs no constraint
+#      because the file can only ever name one option. The double-count the earlier
+#      recommendation feared is impossible for the same reason.
 #  O3  Is fact uniqueness (R4.3) evaluated over the whole file or over the enabled
 #      set? Over the file: toggles never change what must be written, but a
 #      disabled backup_heater still forces three sizing_sources lines. Over the
@@ -304,6 +342,7 @@ groups:
 #  R8  realized record = this file, presets expanded, AUTO -> numbers, ev gone
 #  R9  recordable from Python: connect_input is target-centric already
 #  R10 RenoVisor pattern above; R11 one direction, no jumping between blocks
-#  R12 ${inputs}; R13 schema line at top; R14 four groups, one off
+#  R12 ${inputs}; R13 schema line at top; R14 three groups, one off;
+#     R15 one variant, two options, `meter` written out in both
 #  N1/N2 nothing here is component-specific beyond names/presets/fields
 # ---------------------------------------------------------------------------

--- a/roadmap/declarative_energy_systems/p2_file_format_requirements.md
+++ b/roadmap/declarative_energy_systems/p2_file_format_requirements.md
@@ -1,6 +1,6 @@
 # P2 — Energy-system file format and executor — requirements
 
-**Status:** in review · **Date:** 2026-08-28 (R15 exclusive variants added, Q-P2.2 re-answered, C-P2.5 rewritten — an amendment to the merged P2; 08-27: R2.5 dispatch rule; 08-26: Q8, Q-P2.4–Q-P2.6 decided; AC-P2.1 amended; RQ3 dropped)
+**Status:** in review · **Date:** 2026-08-31 (R15.9–R15.11 added while implementing R15; 08-28: R15 exclusive variants added, Q-P2.2 re-answered, C-P2.5 rewritten — an amendment to the merged P2; 08-27: R2.5 dispatch rule; 08-26: Q8, Q-P2.4–Q-P2.6 decided; AC-P2.1 amended; RQ3 dropped)
 **Author(s):** Noah Pflugradt (owner; `[given]`) · assistant (`[proposed]`, mockups)
 **Reviewers:** HiSim core team
 **Parent:** `roadmap/declarative_energy_systems/epic.md` (E1–E8 apply by reference) · **Plan:** `roadmap/declarative_energy_systems/plan.md` §P2 · **Depends on:** P1 accepted
@@ -117,6 +117,9 @@ Paths are `${var}/…` through the `PathResolver`; absolute paths in a file are 
 - R15.6 Groups and variants stay two constructs with one sentence each — a group is an independent on/off add-on, a variant an exclusive choice. Neither is expressed through the other, and there is no relation between them: no `requires`, no `enabled: not X`. Exclusivity lives in the shape of the file; the loader never solves a constraint (E1).
 - R15.7 A realized record carries no `variants` key (the selection is resolved); the audit companion (R8.2) records each variant's selection and the components it contributed.
 - R15.8 `hisim energy-system facts <file>` reports groups and variants together as the consumer knob surface: a boolean per group, an option name per variant (P5, UC4).
+- R15.9 `[added 2026-08-31, from implementing R15]` **Two namespaces, deliberately.** *Validation* works over the **declared** set — every entry of every option, selected or not — so an entry in a losing option must still be well formed. *Resolution* works over the **selected** set. The distinction is forced: with `direct_metering` selected, the four bare `- ems` items name a component that exists only in the losing option, and a selection-aware namespace at load time would **reject** them where R15.3 requires them to be **dropped**. Where one name carries an entry in two options, both are validated.
+- R15.10 `[added 2026-08-31, from implementing R15]` **Where the selected components land.** R15.4's byte-for-byte identity needs a position: the selected option's components are appended after the ungrouped components, variants in document order, each option's components in their own order, and the expanded file carries `variants: {}`. Without a stated convention the identity claim is not testable.
+- R15.11 `[open 2026-08-31]` A variant with exactly one option is currently accepted — it decides nothing, and R15.1 says "exactly one is live", not "at least two exist", while the empty-`options` refusal text says "at least two". Either R15.1 gains the minimum or the refusal text drops the phrase; the implementation follows R15.1 as written.
 
 The shape, written out on the case that asked for it — a house with an EMS and a battery, or a bare meter:
 
@@ -154,9 +157,11 @@ legal precisely because only one option ever exists (R15.2). With `direct_meteri
 items on the building, the heat-distribution controller and the two heat-pump controllers are dropped by
 R15.3, exactly as R14.3 drops references into a disabled group.
 
-**Not yet in the mockups.** `energy_system_mockup.yaml` is an executable fixture — AC-P2.1 requires every
-mockup to load and validate — so it gains this block in the same change that teaches the loader to read it
-(plan §P2.1), not before. Until then the syntax lives here.
+**In the mockups since 2026-08-31 (P2.1).** `energy_system_mockup.yaml` is an executable fixture — AC-P2.1
+requires every mockup to load and validate — so it gained this block in the same change that taught the loader
+to read it (plan §P2.1). Its `battery_and_ems` group and its top-level `meter` are now the
+`electricity_management` variant with the two options above; the example here is the abbreviated form of what
+the mockup carries.
 
 ### Quality
 - RQ2 `[proposed]` `schema_version: 3` is mandatory; other values are rejected with a message naming the supported version.

--- a/roadmap/declarative_energy_systems/plan.md
+++ b/roadmap/declarative_energy_systems/plan.md
@@ -70,14 +70,15 @@ Nothing in P3 or P4 consumes variants except P3's grouping pass (R10). `[decided
 starts** — the format is cheaper to settle while three mockups and one real file exist than after twenty-one recorded
 files do, and it answers the RenoVisor requirement in code rather than on paper.
 
-- [ ] `variants: {name: {selected, options: {name: {components}}}}` in the model, loader and JSON Schema
-- [ ] Selection folded into the existing group-expansion pre-pass; the selected option's components join the top level, so nothing downstream sees a variant
-- [ ] The five R15.5 rejections with their messages
-- [ ] Identity test extended to every (mockup, variant, option) triple; audit records the selection
-- [ ] `facts` reports groups and variants as one knob surface (R15.8)
-- [ ] UC2 mockup: move the `battery_and_ems` group and the meter into an `electricity_management` variant. This
+- [x] `variants: {name: {selected, options: {name: {components}}}}` in the model, loader and JSON Schema *(2026-08-31)*
+- [x] Selection folded into the existing group-expansion pre-pass; the selected option's components join the top level, so nothing downstream sees a variant *(2026-08-31)*
+- [x] The five R15.5 rejections with their messages *(2026-08-31: EF-55 unknown selection, EF-56 empty options, EF-57 two variants, EF-52 for the two name collisions)*
+- [x] Identity test extended to every (mockup, variant, option) triple; audit records the selection *(2026-08-31: `tests/test_energy_system_variants.py`; both directions of UC2's metering pinned, AC-P2.17–AC-P2.19)*
+- [x] `facts` reports groups and variants as one knob surface (R15.8) *(2026-08-31)*
+- [x] UC2 mockup: move the `battery_and_ems` group and the meter into an `electricity_management` variant. This
       belongs to the code change, not to the requirements: a mockup is an executable fixture (AC-P2.1), so the
       block may only enter it once the loader reads it. Until then the syntax lives in R15's example.
+      *(2026-08-31: `meter` written out in both options, O2 resolved in the mockup's footer)*
 
 ## P3 — Recording & setup migration
 

--- a/tests/test_energy_system_groups.py
+++ b/tests/test_energy_system_groups.py
@@ -9,7 +9,11 @@ had they deleted the add-on instead of switching it off.
 
 The identity property is checked mechanically over every group of every mockup, against a
 deletion written independently in this module. That independence is the point of the test: a
-hand-deletion that called the expander would only prove the expander equals itself.
+hand-deletion that called the expander would only prove the expander equals itself. The same
+hand-written equivalent resolves the variants of a file, because a mockup carrying one is
+expanded with its selection applied and the comparison would otherwise be against a file the
+author could not have written; the variants' own tests live in
+``tests/test_energy_system_variants.py``.
 
 Each test states the failure mode it catches, and the error tests assert the identifier and
 the names in the message, because a rejection that does not say which line to edit only moves
@@ -18,7 +22,7 @@ the guessing to the author.
 
 # clean
 
-from typing import ClassVar, Dict, List, Set, Tuple
+from typing import AbstractSet, ClassVar, Dict, List, Mapping, Optional, Tuple
 
 import pytest
 
@@ -129,32 +133,49 @@ def disable_group(model: EnergySystemFile, group_name: str) -> EnergySystemFile:
     return model.model_copy(update={"groups": groups})
 
 
-def delete_groups_by_hand(model: EnergySystemFile, group_names: Set[str]) -> EnergySystemFile:
-    """Deletes whole groups and every reference to them the way an author editing would.
+def hand_written_equivalent(
+    model: EnergySystemFile,
+    *,
+    deleted_groups: AbstractSet[str] = frozenset(),
+    selections: Optional[Mapping[str, str]] = None,
+) -> EnergySystemFile:
+    """Writes out the file an author would have written with the switches already decided.
 
-    This is the independent reference implementation the expander is compared against, so it
-    is written straight from the rule rather than from the expander's code: drop the groups,
-    drop every input item naming one of their components, drop those components from every
-    sizing list, and refuse when a scalar sizing source would be left without a provider.
+    This is the independent reference implementation both identity properties are compared
+    against, so it is written straight from the two rules rather than from the expander's
+    code: delete the named groups, resolve every variant to one option, drop every input item
+    naming a component that neither survives, drop those components from every sizing list,
+    and refuse when a scalar sizing source would be left without a provider.
 
-    Several groups are deleted at once because a file may already carry a switched-off add-on
-    of its own, and the comparison is only meaningful when both sides removed the same set.
+    Both switches are applied at once because a file carries both, and a comparison is only
+    meaningful when the two sides removed the same set: the mockup already has a group
+    switched off and a variant selected, so leaving either alone here would make the expander
+    look wrong for doing its job.
 
     Args:
         model: The parsed file.
-        group_names: The groups to delete.
+        deleted_groups: The groups to delete outright, as an author deleting the add-on would.
+        selections: The option each named variant resolves to; a variant that is not named
+            keeps the selection the file itself makes.
 
     Returns:
-        The file as it would read with those add-ons never written.
+        The file as it would read with those add-ons never written and each variant's chosen
+        option spelled out at the top level, in document order after the ungrouped components.
 
     Raises:
         DanglingScalarReference: When a surviving entry takes a fact from a component the
             deletion removes and named that component in a scalar source line.
     """
-    removed = {member for name in group_names for member in model.groups[name].components}
+    chosen = {name: (selections or {}).get(name, variant.selected) for name, variant in model.variants.items()}
+    removed = {member for name in deleted_groups for member in model.groups[name].components}
+    for name, variant in model.variants.items():
+        surviving_members = set(variant.options[chosen[name]].components)
+        for option_name, option in variant.options.items():
+            if option_name != chosen[name]:
+                removed.update(set(option.components) - surviving_members)
 
     def rewrite(entry: ComponentEntry) -> ComponentEntry:
-        """Returns one surviving entry with every reference into the deleted group gone."""
+        """Returns one surviving entry with every reference into the deleted parts gone."""
         inputs = tuple(item for item in entry.inputs if item.source not in removed)
         sources: Dict[str, object] = {}
         for fact, value in entry.sizing_sources.items():
@@ -167,13 +188,16 @@ def delete_groups_by_hand(model: EnergySystemFile, group_names: Set[str]) -> Ene
         return entry.model_copy(update={"inputs": inputs, "sizing_sources": sources})
 
     components = {name: rewrite(entry) for name, entry in model.components.items()}
+    for name, variant in model.variants.items():
+        for member, entry in variant.options[chosen[name]].components.items():
+            components[member] = rewrite(entry)
     groups: Dict[str, Group] = {}
     for name, group in model.groups.items():
-        if name in group_names:
+        if name in deleted_groups:
             continue
         members = {member: rewrite(entry) for member, entry in group.components.items()}
         groups[name] = group.model_copy(update={"components": members})
-    return model.model_copy(update={"components": components, "groups": groups})
+    return model.model_copy(update={"components": components, "groups": groups, "variants": {}})
 
 
 def mockup_group_pairs() -> List[Tuple[str, str]]:
@@ -360,7 +384,7 @@ def test_disabling_a_group_equals_deleting_it_by_hand(mockup: str, group: str) -
     model = parse_energy_system(Mockups.path(mockup))
     already_off = {name for name, other in model.groups.items() if not other.enabled}
     try:
-        expected = delete_groups_by_hand(model, already_off | {group})
+        expected = hand_written_equivalent(model, deleted_groups=already_off | {group})
     except DanglingScalarReference:
         with pytest.raises(EnergySystemFormatError) as raised:
             expand_groups(disable_group(model, group))

--- a/tests/test_energy_system_variants.py
+++ b/tests/test_energy_system_variants.py
@@ -1,0 +1,549 @@
+"""Tests for exclusive variants: what selecting one option of a variant does to a file.
+
+A variant names its options and selects exactly one, so the file can only ever describe one
+world and the loader never has a constraint to solve. What has to hold is that the world it
+describes is exactly the world an author would have written by hand: the selected option's
+components at the top level, the variant block gone, and every reference into an option that
+lost dropped the way a reference into a disabled group is dropped. That property is checked
+mechanically over every option of every variant of every mockup, against the hand-written
+equivalent the group tests already use — written from the rule and never through the expander,
+so the two sides cannot agree by sharing a bug.
+
+Around the identity property sit the checks that make it worth having. Both directions of the
+mockup's metering variant are pinned, because "no EMS feed survives" and "no direct feed
+survives" is the difference the whole construct was asked for and neither half is implied by
+the other. Each of the five ways a variant can be written wrong is exercised on the smallest
+document that shows it, asserting the catalogue identifier and the names in the message. And
+one real build proves what a consumer of a record sees: the selection is resolved, so the
+record carries no variants at all and the audit is the only place it is written down.
+"""
+
+# clean
+
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+
+from hisim.energy_system import (
+    EnergySystemErrorId,
+    EnergySystemFile,
+    EnergySystemFormatError,
+    dump_energy_system,
+    enabled_component_names,
+    expand_groups,
+    load_energy_system,
+    parse_energy_system,
+)
+from hisim.cli import ExitCodes, main
+from hisim.energy_system.audit import build_audit
+from hisim.energy_system.comments import AnnotatedEmitter
+from hisim.energy_system.model import Variant, VariantOption
+from hisim.energy_system.record import realize
+from tests.test_energy_system_groups import (
+    DanglingScalarReference,
+    hand_written_equivalent,
+)
+from tests.test_energy_system_loader import Mockups
+from tests.test_energy_system_record import Fixtures
+
+
+class Documents:
+    """The smallest documents that show each way a variant can be written wrong.
+
+    Every one of them is a valid file except for the single rule under test, so the rejection
+    a test asserts can only come from that rule. They are kept as text rather than built
+    through the models, because what is under test is what a file may say and an author writes
+    text.
+    """
+
+    #: A well-formed building entry, so that every document below is a system rather than an
+    #: empty file, and the rejections cannot be caused by a missing components block.
+    BUILDING: str = """schema_version: 3
+name: variant rule under test
+components:
+  building:
+    class: hisim.components.building.Building
+    preset: standard
+"""
+
+    #: One converted class, written out wherever a document needs a second component: once
+    #: indented for a top-level entry, once for an entry inside an option.
+    METER: str = "    class: hisim.components.electricity_meter.ElectricityMeter\n    preset: standard\n"
+    OPTION_METER: str = (
+        "            class: hisim.components.electricity_meter.ElectricityMeter\n"
+        "            preset: standard\n"
+    )
+
+    #: A selection naming no option of its variant (R15.5, first).
+    UNKNOWN_SELECTION: str = (
+        BUILDING
+        + """variants:
+  metering:
+    selected: with_battery
+    options:
+      with_ems:
+        components: {}
+      bare:
+        components: {}
+"""
+    )
+
+    #: A variant offering nothing to choose between (R15.5, second).
+    EMPTY_OPTIONS: str = (
+        BUILDING
+        + """variants:
+  metering:
+    selected: bare
+    options: {}
+"""
+    )
+
+    #: One component name claimed by two different variants (R15.5, third).
+    TWO_VARIANTS: str = (
+        BUILDING
+        + """variants:
+  metering:
+    selected: metered
+    options:
+      metered:
+        components:
+          meter:
+"""
+        + OPTION_METER
+        + """      bare:
+        components: {}
+  billing:
+    selected: billed
+    options:
+      billed:
+        components:
+          meter:
+"""
+        + OPTION_METER
+        + """      unbilled:
+        components: {}
+"""
+    )
+
+    #: One component name written both at the top level and inside an option (R15.5, fourth).
+    TOP_LEVEL_AND_OPTION: str = (
+        BUILDING
+        + "  meter:\n"
+        + METER
+        + """variants:
+  metering:
+    selected: metered
+    options:
+      metered:
+        components:
+          meter:
+"""
+        + OPTION_METER
+        + """      bare:
+        components: {}
+"""
+    )
+
+    #: An entry inside the option nobody selects that says nothing about how it is
+    #: configured, which is a defect in the file rather than in the world that runs.
+    SILENT_OPTION_ENTRY: str = (
+        BUILDING
+        + """variants:
+  metering:
+    selected: metered
+    options:
+      metered:
+        components:
+          meter:
+"""
+        + OPTION_METER
+        + """      bare:
+        components:
+          spare_meter:
+            class: hisim.components.electricity_meter.ElectricityMeter
+"""
+    )
+
+    #: A variant named after a component of the same file (R15.5, fifth).
+    NAME_COLLISION: str = (
+        BUILDING
+        + """variants:
+  building:
+    selected: heavy
+    options:
+      heavy:
+        components: {}
+      light:
+        components: {}
+"""
+    )
+
+
+class MinimalWithAVariant:
+    """The minimal mockup with its meter moved into a variant, as a buildable file.
+
+    A record can only be written from a system that actually builds, and the one mockup every
+    class of which is converted is the minimal household. Its meter is the component to move:
+    nothing reads it, so the household still wires in the world without one, which is what
+    lets the record and the audit be checked over a full build rather than over a parse.
+
+    The file is derived from the mockup rather than copied into this module, so that a change
+    to the mockup cannot leave a private copy behind to rot.
+    """
+
+    #: Name of the variant the meter is moved into.
+    VARIANT: str = "metering"
+
+    #: The option that keeps the meter, and the one that does without it.
+    METERED: str = "metered"
+    UNMETERED: str = "unmetered"
+
+    @classmethod
+    def model(cls) -> EnergySystemFile:
+        """Builds the model of the derived file.
+
+        Returns:
+            The minimal mockup with its ``meter`` entry moved out of the top level and into
+            the selected option of a two-option variant.
+        """
+        mockup = parse_energy_system(Mockups.path(Mockups.NAMES[0]))
+        meter = mockup.components["meter"]
+        variant = Variant(
+            name=cls.VARIANT,
+            selected=cls.METERED,
+            options={
+                cls.METERED: VariantOption(name=cls.METERED, components={meter.name: meter}),
+                cls.UNMETERED: VariantOption(name=cls.UNMETERED, components={}),
+            },
+        )
+        remaining = {name: entry for name, entry in mockup.components.items() if name != meter.name}
+        return mockup.model_copy(update={"components": remaining, "variants": {cls.VARIANT: variant}})
+
+    @classmethod
+    def write(cls, directory: Path) -> Path:
+        """Writes the derived file into a directory the test owns.
+
+        Args:
+            directory: Where the file goes; it is created if it does not exist.
+
+        Returns:
+            The path of the written file.
+        """
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / "uc1_with_a_variant.energy_system.yaml"
+        path.write_text(dump_energy_system(cls.model()), encoding="utf-8")
+        return path
+
+
+def select_option(model: EnergySystemFile, variant_name: str, option_name: str) -> EnergySystemFile:
+    """Returns the file with one variant's selection changed, and nothing else.
+
+    Args:
+        model: The parsed file.
+        variant_name: The variant to re-select.
+        option_name: The option it should resolve to.
+
+    Returns:
+        A copy of the file whose named variant selects the named option.
+    """
+    variants = {
+        name: (variant.model_copy(update={"selected": option_name}) if name == variant_name else variant)
+        for name, variant in model.variants.items()
+    }
+    return model.model_copy(update={"variants": variants})
+
+
+def mockup_variant_triples() -> List[Tuple[str, str, str]]:
+    """Lists every (mockup, variant, option) triple the identity property is checked over.
+
+    Reading the triples off the mockups rather than hard-coding them means an option added to
+    a mockup is covered without anyone remembering to extend the test.
+
+    Returns:
+        One triple per option of each variant of each mockup, mockups in canonical order.
+    """
+    triples: List[Tuple[str, str, str]] = []
+    for name in Mockups.NAMES:
+        model = parse_energy_system(Mockups.path(name))
+        for variant_name, variant in model.variants.items():
+            triples.extend((name, variant_name, option) for option in variant.options)
+    return triples
+
+
+def feeds_of(model: EnergySystemFile, consumer: str) -> List[str]:
+    """Lists the sources one component takes its inputs from, in the order written.
+
+    Args:
+        model: The expanded file.
+        consumer: The component whose input list is wanted.
+
+    Returns:
+        One source name per input item.
+    """
+    return [item.source for item in model.all_components()[consumer].inputs]
+
+
+@pytest.mark.base
+@pytest.mark.parametrize(("mockup", "variant", "option"), mockup_variant_triples())
+def test_selecting_an_option_equals_writing_that_world_by_hand(mockup: str, variant: str, option: str) -> None:
+    """Catches a selection producing something other than the hand-written alternative world.
+
+    This is the property that makes a variant a way of writing two files in one rather than a
+    semantic feature of its own: whichever option is selected, the system is exactly the one an
+    author would have written with that option's components at the top level and the variant
+    block deleted. Where the hand-written file cannot be completed — a scalar sizing line would
+    be left without its provider — the expander must refuse for the same reason.
+    """
+    model = parse_energy_system(Mockups.path(mockup))
+    already_off = {name for name, group in model.groups.items() if not group.enabled}
+    try:
+        expected = hand_written_equivalent(model, deleted_groups=already_off, selections={variant: option})
+    except DanglingScalarReference:
+        with pytest.raises(EnergySystemFormatError) as raised:
+            expand_groups(select_option(model, variant, option))
+        assert raised.value.error_id is EnergySystemErrorId.DISABLED_SIZING_SOURCE
+        return
+
+    expanded, _ = expand_groups(select_option(model, variant, option))
+    assert dump_energy_system(expanded) == dump_energy_system(expected)
+
+
+@pytest.mark.base
+def test_the_selected_option_joins_the_top_level_and_the_variant_is_gone() -> None:
+    """Catches a variant surviving expansion, which every later stage would have to know about.
+
+    Nothing downstream of expansion — validation of the live set, class binding, sizing, wiring,
+    the realized record — is written to handle a variant, so the pre-pass has to resolve it away
+    completely rather than hand a smaller variant on.
+    """
+    model = parse_energy_system(Mockups.path("energy_system_mockup.yaml"))
+
+    expanded, record = expand_groups(model)
+
+    assert not expanded.variants
+    assert [name for name in ("battery", "ems", "meter") if name in expanded.components] == [
+        "battery",
+        "ems",
+        "meter",
+    ]
+    assert tuple(expanded.components)[-3:] == ("battery", "ems", "meter")
+    assert set(enabled_component_names(expanded)) == set(expanded.all_components())
+    assert len(record.selections) == 1
+    selection = record.selections[0]
+    assert (selection.variant, selection.selected) == ("electricity_management", "ems_and_battery")
+    assert selection.components == ("battery", "ems", "meter")
+    assert selection.rejected == ("direct_metering",)
+    assert any("electricity_management" in line for line in record.describe())
+
+
+@pytest.mark.base
+def test_direct_metering_leaves_no_energy_management_behind() -> None:
+    """Catches the option that has no EMS keeping a reference to one, or missing a direct feed.
+
+    Both halves are the same rule seen from its two ends: the EMS and its battery vanish, and
+    with them the four bare items that named the EMS, while the meter is the one written in this
+    option and therefore reads every participant itself.
+    """
+    model = select_option(
+        parse_energy_system(Mockups.path("energy_system_mockup.yaml")),
+        "electricity_management",
+        "direct_metering",
+    )
+
+    expanded, record = expand_groups(model)
+
+    live = expanded.all_components()
+    assert "ems" not in live and "battery" not in live
+    assert feeds_of(expanded, "meter") == ["pv_south", "pv_east", "occupancy", "heat_pump", "heating_rod"]
+    assert [item.source for entry in live.values() for item in entry.inputs if item.source == "ems"] == []
+    assert {item.consumer for item in record.dropped_input_items if item.source == "ems"} == {
+        "building",
+        "hds_controller",
+        "heat_pump_controller_sh",
+        "heat_pump_controller_dhw",
+    }
+
+
+@pytest.mark.base
+def test_ems_and_battery_leaves_no_direct_feed_behind() -> None:
+    """Catches the two options' meters being merged rather than one of them replacing the other.
+
+    The meter is written out in both options and the two versions are wired differently, so an
+    expansion that let the losing option contribute anything would double-count the household:
+    every participant would be measured directly *and* through the EMS total.
+    """
+    expanded, _ = expand_groups(parse_energy_system(Mockups.path("energy_system_mockup.yaml")))
+
+    assert feeds_of(expanded, "meter") == ["ems"]
+    assert feeds_of(expanded, "ems") == [
+        "occupancy",
+        "pv_south",
+        "pv_east",
+        "heat_pump",
+        "heating_rod",
+        "battery",
+    ]
+
+
+@pytest.mark.base
+def test_a_selection_naming_no_option_lists_the_options_the_variant_has() -> None:
+    """Catches a rejection that leaves the author guessing which names would have worked.
+
+    A misspelled option name is the most likely mistake in a variant block, and the repair is one
+    of a closed and usually short set, so not listing it would waste the one thing the loader
+    knows and the author does not remember.
+    """
+    with pytest.raises(EnergySystemFormatError) as raised:
+        load_energy_system(Documents.UNKNOWN_SELECTION)
+
+    assert raised.value.error_id is EnergySystemErrorId.UNKNOWN_VARIANT_OPTION
+    message = str(raised.value)
+    assert "'metering'" in message and "with_battery" in message
+    assert "with_ems" in message and "bare" in message
+
+
+@pytest.mark.base
+def test_a_variant_with_no_options_is_refused() -> None:
+    """Catches an empty options mapping being read as a variant that decides nothing.
+
+    A variant is a choice, and a choice between nothing is a block whose ``selected`` line can
+    never be satisfied; accepting it would turn a typo in the indentation of the options into a
+    system silently missing everything the variant was meant to contribute.
+    """
+    with pytest.raises(EnergySystemFormatError) as raised:
+        load_energy_system(Documents.EMPTY_OPTIONS)
+
+    assert raised.value.error_id is EnergySystemErrorId.EMPTY_VARIANT
+    assert "'metering'" in str(raised.value)
+
+
+@pytest.mark.base
+def test_one_component_in_two_variants_is_refused() -> None:
+    """Catches two exclusive choices both deciding the same component.
+
+    Neither selection can resolve the other's, so whichever option wins the component would be
+    defined twice; the file is asking for an override, which an option never is.
+    """
+    with pytest.raises(EnergySystemFormatError) as raised:
+        load_energy_system(Documents.TWO_VARIANTS)
+
+    assert raised.value.error_id is EnergySystemErrorId.COMPONENT_IN_TWO_VARIANTS
+    message = str(raised.value)
+    assert "'meter'" in message and "'metering'" in message and "billing" in message
+
+
+@pytest.mark.base
+def test_a_component_written_both_at_the_top_level_and_in_an_option_is_refused() -> None:
+    """Catches the partial override an option is not allowed to be.
+
+    An option states its components in full, so a component that also exists permanently would
+    have two definitions with no rule saying which wins — the fallback semantics R15.2 rules out
+    precisely because two options must be free to wire the same component differently.
+    """
+    with pytest.raises(EnergySystemFormatError) as raised:
+        load_energy_system(Documents.TOP_LEVEL_AND_OPTION)
+
+    assert raised.value.error_id is EnergySystemErrorId.DUPLICATE_NAME
+    message = str(raised.value)
+    assert "'meter'" in message and "ungrouped component" in message
+
+
+@pytest.mark.base
+def test_a_variant_named_after_a_component_is_refused() -> None:
+    """Catches a variant taking a name a bare reference already resolves to.
+
+    References in this format are bare names, so a variant sharing one with a component or a
+    group would make ``- building`` ambiguous — the same reason two groups may not share a name.
+    """
+    with pytest.raises(EnergySystemFormatError) as raised:
+        load_energy_system(Documents.NAME_COLLISION)
+
+    assert raised.value.error_id is EnergySystemErrorId.DUPLICATE_NAME
+    assert "'building'" in str(raised.value)
+
+
+@pytest.mark.base
+def test_a_record_of_a_run_with_a_variant_carries_no_variants(tmp_path: Path) -> None:
+    """Catches a record that hands its reader a decision the run already made.
+
+    A record is re-executed, and re-executing it must reproduce the run rather than resolve a
+    choice again, so the selection is written out: the chosen option's components sit at the top
+    level and the block is gone. The audit is then the only place the selection is recorded,
+    which is exactly what a reader comparing the record with the authored file needs.
+    """
+    built = Fixtures.build(MinimalWithAVariant.write(tmp_path / "system"), tmp_path / "results")
+
+    record = realize(built)
+    audit = build_audit(built)
+
+    assert not record.variants
+    assert "meter" in record.components
+    assert "variants" not in dump_energy_system(record)
+    assert audit.variant_selections == (
+        {
+            "variant": MinimalWithAVariant.VARIANT,
+            "selected": MinimalWithAVariant.METERED,
+            "components": ["meter"],
+            "rejected": [MinimalWithAVariant.UNMETERED],
+        },
+    )
+    assert audit.to_document()["expansion"]["variant_selections"][0]["selected"] == MinimalWithAVariant.METERED
+
+
+@pytest.mark.base
+def test_re_running_that_record_reproduces_it_with_nothing_left_to_select(tmp_path: Path) -> None:
+    """Catches a resolved selection being decided a second time by the run that re-executes it.
+
+    A record is the run written back as a file, and re-running it has to reproduce the run rather
+    than make any choice again. The variant is the newest way that promise could break, so the
+    record is written, re-executed and realized once more: the second record equals the first, and
+    the re-run's own audit names no selection at all, because there is no variant left to resolve.
+    """
+    built = Fixtures.build(MinimalWithAVariant.write(tmp_path / "system"), tmp_path / "first")
+    first = realize(built)
+    written = tmp_path / "record.energy_system.yaml"
+    written.write_text(AnnotatedEmitter.render(first, build_audit(built)), encoding="utf-8")
+
+    again = Fixtures.build(written, tmp_path / "second", rerun=True)
+    second = realize(again)
+
+    assert Fixtures.without_sources(dump_energy_system(second)) == Fixtures.without_sources(
+        dump_energy_system(first)
+    )
+    assert not build_audit(again).variant_selections
+
+
+@pytest.mark.base
+def test_the_unselected_world_still_has_to_be_a_well_formed_file() -> None:
+    """Catches the losing option escaping the checks every entry has to pass.
+
+    An option nobody selected today is selected by tomorrow's copy of the file, so a malformed
+    entry in it is a defect now rather than later. It is also what lets the identity test trust
+    the hand-written side of its comparison: both worlds are known to be files.
+    """
+    with pytest.raises(EnergySystemFormatError) as raised:
+        load_energy_system(Documents.SILENT_OPTION_ENTRY)
+
+    assert raised.value.error_id is EnergySystemErrorId.NO_CONFIGURATION_SOURCE
+    assert "spare_meter" in str(raised.value)
+
+
+@pytest.mark.base
+def test_the_facts_report_names_both_switches_as_one_knob_surface(capsys) -> None:
+    """Catches the report a consumer configures a run from omitting half of the knobs.
+
+    Groups and variants are two constructs to an author and one surface to whoever runs the
+    file, so the report lists both: the flag of every group, and the selected option of every
+    variant with the alternatives after it. The heat-pump mockup is still refused by the
+    class-bound stage, which is what makes this worth asserting — the knobs have to be printed
+    before anything can fail, or the report would be useless for the file that needs it most.
+    """
+    code = main(["energy-system", "facts", str(Mockups.path("energy_system_mockup.yaml"))])
+    printed = capsys.readouterr().out
+
+    assert code == ExitCodes.FILE_REJECTED
+    assert "knobs" in printed
+    assert "groups.ev" in printed and "false" in printed
+    assert "variants.electricity_management" in printed
+    assert "ems_and_battery  (or direct_metering)" in printed


### PR DESCRIPTION
Implements **R15** of `p2_file_format_requirements.md`: mutually exclusive alternatives in the energy-system file format. 10 commits, 20 files, +1896/−631.

Asked for by the RenoVisor backend: a house has either an EMS with a battery **or** a plain electricity meter — and the meter is wired differently in the two worlds, so a group cannot express it. A group adds and removes components; it cannot rewire one that survives.

## The idea

`enabled iff the other is off` is a *constraint*, and constraints in a data file need a solver, unsatisfiability messages, and inference the epic forbids. A **choice** needs none of that: a variant names its options and selects one, so a file can only ever mean one of them and there is nothing to solve. Exclusivity is carried by the shape of the file.

```yaml
variants:
  electricity_management:
    selected: ems_and_battery
    options:
      ems_and_battery:
        components: {battery: {...}, ems: {...}, meter: {... inputs: [ems.TotalElectricityToOrFromGrid]}}
      direct_metering:
        components: {meter: {... inputs: [pv_south, pv_east, occupancy, heat_pump, heating_rod]}}
```

An option is a complete alternative world, not an override: whatever it touches it writes out in full. `meter` appears in both, and repeating the name is legal **precisely because only one option ever exists** — which is what lets two options wire one component differently.

## What it does

- `variants: {name: {selected, options: {name: {components}}}}` in the model, loader, emitter and JSON Schema
- Selection folded into the **existing** group-expansion pre-pass: unselected options are removed exactly as a disabled group is, then the selected option's components join the top level and the expanded file carries `variants: {}`. **Nothing downstream of expansion ever learns that variants exist.**
- The five R15.5 rejections, each naming what it found
- Audit records each selection and the options it rejected; `facts` reports groups and variants as one knob surface
- The UC2 mockup's `battery_and_ems` group and its meter become the `electricity_management` variant — the block enters the fixture in the same change that teaches the loader to read it
- 14 tests, including the identity test extended to every (mockup, variant, option) triple

## Reviewer notes

**A requirement that could not hold as written.** R15 said references resolve against the selected world. At load time that is impossible: with `direct_metering` selected, four components name an `ems` that exists only in the *losing* option, and a selection-aware namespace would **reject** them where R15.3 requires them to be **dropped**. So validation works over every entry of every option and resolution over the selected ones — which also means an entry nobody selects still has to be well formed. Written up as **R15.9**, with R15.10 (identity needs a stated landing position) and **R15.11 left open**: a variant with one option is accepted, because R15.1 asks for "exactly one live" while the empty-`options` refusal text promises "at least two". One of those two sentences should move.

**Two modules over the 500-line budget**: `hisim/cli.py` (535) and `schema_export.py` (517). Both were already at the ceiling; the additions are a renderer and a schema literal.

Green: `-m base` 4325 passed/1 skipped · `-m extendedbase` 13 · mypy 258/173/25 clean · pylint 10.00/10 · prospector 0/0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
