### PR TITLE
Land cache entries atomically, in a new hisim/caching package

### DIFF
--- a/hisim/caching/__init__.py
+++ b/hisim/caching/__init__.py
@@ -1,0 +1,18 @@
+"""Public API of the HiSim cache service client.
+
+The package is the home of everything the simulation knows about caching, as laid out in
+``roadmap/cache_service_spec.md`` §4: local paths and atomic writes, key construction, the remote
+HTTP tier, curated-dataset retrieval and the client that orchestrates them. Only the local tier of
+§10 phase 1 has been built, so the public surface is deliberately one context manager; the remaining
+modules arrive with the later phases and this file is where they will be re-exported from.
+
+Importing this package must stay cheap and free of side effects, because it sits at the same layer as
+``hisim/config/`` and is imported by both components and ``hisim/utils.py``. It therefore imports the
+standard library only -- never a component, the simulator or the singleton repository.
+"""
+
+# clean
+
+from hisim.caching.local import atomic_cache_write
+
+__all__ = ["atomic_cache_write"]

--- a/hisim/caching/local.py
+++ b/hisim/caching/local.py
@@ -1,0 +1,88 @@
+"""Local tier of the HiSim cache service: entries land on disk atomically.
+
+This module is phase 1 of the cache service described in ``roadmap/cache_service_spec.md`` §4, and
+so far it is the *only* tier that exists. The eventual package holds key construction, a remote HTTP
+tier, curated-dataset retrieval and the client that orchestrates them; none of that is here yet, and
+nothing in this module talks to the network or reads any configuration. It is a package rather than a
+single helper function because the rest of that spec will grow around it, and because the spec puts
+the whole of it at the same layer as ``hisim/config/`` -- it may import the standard library and
+nothing else, so a component, the simulator and the singleton repository are all off limits and the
+module stays importable without starting HiSim.
+
+The spec calls out the atomic write as the one piece worth shipping ahead of the rest, because it
+repairs a bug that exists independently of the service: two processes sharing a cache directory can
+read a ``.cache`` file that a third is still writing. See :func:`atomic_cache_write` for the race in
+full.
+"""
+
+# clean
+
+import os
+import tempfile
+from contextlib import contextmanager
+from typing import Iterator
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+@contextmanager
+def atomic_cache_write(cache_filepath: str) -> Iterator[str]:
+    """Yields a temporary path to write a cache entry to, then moves it into place atomically.
+
+    Cache entries used to be written straight to their final path, which made every entry corruptible
+    by concurrency. ``hisim.utils.get_cache_file`` decides that an entry exists with a plain
+    ``os.path.isfile`` check, so two processes computing the same key race like this: worker A sees no
+    file, computes, and starts writing ``Weather_<hash>.cache``; worker B arrives a second later, sees
+    a file that exists, and reads it while it is still half written. Depending on where A had got to,
+    B either fails to parse the file or -- far worse -- parses it happily and continues with truncated
+    data. That is what broke one setup of a parallel scenario regeneration in CI while its near-twin,
+    which shares its weather cache key, succeeded beside it; the same race is waiting on any shared
+    filesystem, which is why the spec ships this tier first.
+
+    Writing to a temporary name and renaming closes the window: ``os.replace`` is atomic on POSIX and
+    on Windows, so a concurrent reader observes either the previous entry or the complete new one and
+    never anything in between. The temporary file is created **in the same directory** as the target,
+    because a rename across filesystems is a copy and would not be atomic. If the caller's write
+    raises, the temporary file is removed so a failed write leaves no debris behind.
+
+    Note what this deliberately does not do. The ``exists`` flag returned by
+    ``hisim.utils.get_cache_file`` stays advisory: two processes may still both miss the cache and
+    both compute the same entry, and both then write it. That wastes work but is harmless once the
+    landing is atomic, because the two results are equal by construction -- they are a pure function
+    of the key. Locking the key to prevent the duplicate work would buy very little and would add a
+    failure mode of its own, so it is not done here.
+
+    Args:
+        cache_filepath: the final path the entry must appear at. Its directory is created if missing.
+
+    Yields:
+        str: the temporary path to write to. It is replaced onto ``cache_filepath`` when the ``with``
+            block exits normally.
+
+    Raises:
+        OSError: if the temporary file cannot be created or cannot be renamed into place.
+    """
+    cache_directory = os.path.dirname(os.path.abspath(cache_filepath))
+    os.makedirs(cache_directory, exist_ok=True)
+    file_descriptor, temporary_filepath = tempfile.mkstemp(
+        prefix=os.path.basename(cache_filepath) + ".", suffix=".partial", dir=cache_directory
+    )
+    os.close(file_descriptor)
+    # mkstemp creates the file 0600, which would make a shared cache directory unreadable to the other
+    # users the spec expects to share it; the direct writes this helper replaces produced the usual
+    # umask-governed permissions.
+    os.chmod(temporary_filepath, 0o644)
+    try:
+        yield temporary_filepath
+        os.replace(temporary_filepath, cache_filepath)
+    finally:
+        # A successful replace has already consumed the temporary file, so this only ever fires when
+        # the caller's write raised or the block was abandoned.
+        if os.path.exists(temporary_filepath):
+            os.remove(temporary_filepath)

--- a/hisim/components/building/building.py
+++ b/hisim/components/building/building.py
@@ -16,6 +16,7 @@ import pandas as pd
 from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim import log, utils
+from hisim.caching import atomic_cache_write
 from hisim.components.building.config import BuildingConfig
 from hisim.components.building.information import BuildingInformation
 from hisim.components.building.window import Window
@@ -750,12 +751,13 @@ class Building(cp.Component):
                     self.cache,
                     columns=["solar_gain_through_windows"],
                 )
-                database.to_csv(
-                    self.cache_file_path,
-                    sep=",",
-                    decimal=".",
-                    index=False,
-                )
+                with atomic_cache_write(self.cache_file_path) as temporary_cache_filepath:
+                    database.to_csv(
+                        temporary_cache_filepath,
+                        sep=",",
+                        decimal=".",
+                        index=False,
+                    )
 
     # =================================================================================================================================
 

--- a/hisim/components/generic_car.py
+++ b/hisim/components/generic_car.py
@@ -17,6 +17,7 @@ from dataclasses_json import dataclass_json
 from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim import utils, log
+from hisim.caching import atomic_cache_write
 from hisim.component import OpexCostDataClass, CapexCostDataClass
 from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
@@ -567,7 +568,8 @@ class Car(cp.Component):
 
             # save data in cache
             car_cache_dataframe = pd.DataFrame({"car_location": self.car_location, "meters_driven": self.meters_driven})
-            car_cache_dataframe.to_csv(cache_filepath)
+            with atomic_cache_write(cache_filepath) as temporary_cache_filepath:
+                car_cache_dataframe.to_csv(temporary_cache_filepath)
             del car_cache_dataframe
 
     def resample_meters_driven(self, meters_driven: List, seconds_per_timestep: int) -> Any:

--- a/hisim/components/generic_pv_system.py
+++ b/hisim/components/generic_pv_system.py
@@ -29,6 +29,7 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim import log
 from hisim import utils
+from hisim.caching import atomic_cache_write
 from hisim.component import OpexCostDataClass, CapexCostDataClass
 from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.components.weather import Weather
@@ -787,7 +788,8 @@ class PVSystem(cp.Component):
                 {"output_power": self.ac_power_ratios_for_all_timesteps_output},
                 columns=["output_power"],
             )
-            database.to_csv(self.cache_filepath, sep=",", decimal=".", index=False)
+            with atomic_cache_write(self.cache_filepath) as temporary_cache_filepath:
+                database.to_csv(temporary_cache_filepath, sep=",", decimal=".", index=False)
 
         if self.pvconfig.predictive:
             pv_forecast_yearly = [

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -43,6 +43,7 @@ from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim import log, utils
+from hisim.caching import atomic_cache_write
 from hisim.components.configuration import HouseholdWarmWaterDemandConfig, PhysicsConfig
 from hisim.simulationparameters import SimulationParameters
 from hisim.component import OpexCostDataClass
@@ -2009,8 +2010,9 @@ class UtspLpgConnector(cp.Component):
                     d_f_str = cache_file.getvalue()
                     cache_content.update({key: d_f_str})
 
-                with open(cache_filepath, "w", encoding="utf-8") as file:
-                    json.dump(cache_content, file)
+                with atomic_cache_write(cache_filepath) as temporary_cache_filepath:
+                    with open(temporary_cache_filepath, "w", encoding="utf-8") as file:
+                        json.dump(cache_content, file)
 
                 del loadprofile_dataframe
                 del car_dataframe

--- a/hisim/components/solar_thermal_system.py
+++ b/hisim/components/solar_thermal_system.py
@@ -19,6 +19,7 @@ from hisim.component import (
 )
 from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim import loadtypes, log, utils
+from hisim.caching import atomic_cache_write
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig, PhysicsConfig
 from hisim.components.simple_water_storage import SimpleDHWStorage
 from hisim.components.weather import Weather
@@ -739,8 +740,10 @@ class SolarThermalSystem(Component):
             # Combine all into one large DataFrame
             full_df = pd.concat(self.precalc_data_for_all_timesteps_data, ignore_index=True)
 
-            # Save directly as flat CSV
-            full_df.to_csv(self.cache_filepath, sep=",", decimal=".", index=False)
+            # Save as a flat CSV, landed atomically so a concurrent reader never sees it half written.
+            assert self.cache_filepath is not None
+            with atomic_cache_write(self.cache_filepath) as temporary_cache_filepath:
+                full_df.to_csv(temporary_cache_filepath, sep=",", decimal=".", index=False)
 
 
 @dataclass

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -16,6 +16,7 @@ import pvlib
 
 from hisim import loadtypes as lt
 from hisim import log, utils
+from hisim.caching import atomic_cache_write
 from hisim.config import ConfigBase, ComponentID, DisplayConfig, constructor, preset
 from hisim.component import Component, ComponentOutput, SingleTimeStepValues, OpexCostDataClass, CapexCostDataClass
 from hisim.simulationparameters import SimulationParameters
@@ -870,7 +871,8 @@ class Weather(Component):
                     "t_out_daily_average",
                 ],
             )
-            database.to_csv(cache_filepath)
+            with atomic_cache_write(cache_filepath) as temporary_cache_filepath:
+                database.to_csv(temporary_cache_filepath)
 
         # Publish the full-year weather series to the singleton repository unconditionally.
         # The PV system precomputes its whole-year output from these arrays in its

--- a/hisim/utils.py
+++ b/hisim/utils.py
@@ -350,6 +350,15 @@ def get_cache_file(
     It works by turning the class into a json string, hashing the string and then using that as filename.
     The idea is to have a unique file path for every possible configuration.
 
+    The ``exists`` flag is advisory and nothing more. It is a plain ``os.path.isfile`` check, so two
+    processes that miss the same key concurrently will both compute the entry and both write it; that
+    wastes work but is harmless, because the contents are a pure function of the key. What is *not*
+    harmless is writing the entry straight to the returned path, which lets a concurrent reader see it
+    half written -- so every writer must land its entry through
+    :func:`hisim.caching.atomic_cache_write`. This function keeps its own hashing for now and becomes
+    a thin delegating wrapper over ``hisim/caching/`` in a later phase of
+    ``roadmap/cache_service_spec.md`` §4.
+
     Args:
         component_key: filename prefix for the component type.
         parameter_class: dataclass with a ``to_json`` method; the building of its
@@ -358,7 +367,7 @@ def get_cache_file(
         cache_dir_path: optional override; defaults to ``my_simulation_parameters.cache_dir_path``.
 
     Returns:
-        Tuple[bool, str]: ``(exists, absolute_path)``.
+        Tuple[bool, str]: ``(exists, absolute_path)``. ``exists`` is advisory, see above.
 
     Raises:
         ValueError: if ``my_simulation_parameters`` is None or the JSON string is too short.

--- a/tests/test_caching_local.py
+++ b/tests/test_caching_local.py
@@ -1,0 +1,168 @@
+"""Tests for the local tier of the HiSim cache service, :mod:`hisim.caching.local`.
+
+The one behaviour this module has to pin is atomicity, because it is the whole reason the local tier
+of ``roadmap/cache_service_spec.md`` §4 ships ahead of the rest of the cache service. A cache entry
+that lands in place by rename can never be read half written; one that is written straight to its
+final path can, and used to be, which is what broke a parallel scenario regeneration in CI.
+
+The first test is the control: it pins the old behaviour so the second test cannot quietly stop
+proving anything if the harness ever loses its grip on the timing.
+"""
+
+# clean
+
+import pathlib
+import threading
+from typing import Any, Callable, ClassVar, List
+
+import pytest
+
+from hisim.caching import atomic_cache_write
+
+
+class CacheRaceHarness:
+    """Drives two writers and one reader at a single cache path with no sleeps.
+
+    The point of the harness is to make the half-written window observable on demand rather than by
+    luck. Both writers emit their payload in chunks and then block on an event until the reader has
+    probed the target path at least once, so the reader is guaranteed to look while the writers are
+    mid-payload. Whether it actually *sees* something half written is then purely a property of the
+    write strategy under test, which is what the tests below assert.
+
+    The two writers emit byte-identical payloads because that is what really happens in HiSim: two
+    processes that miss the same cache key compute the same entry, the contents being a pure function
+    of the key. So any difference the reader observes is truncation, never disagreement.
+    """
+
+    CHUNK_COUNT: ClassVar[int] = 8
+    LINES_PER_CHUNK: ClassVar[int] = 512
+    HANDSHAKE_TIMEOUT_SECONDS: ClassVar[float] = 10.0
+
+    def __init__(self, target_path: str) -> None:
+        """Builds the payload and the events that sequence the writers against the reader."""
+        self.target_path = target_path
+        self.chunks = [
+            "".join(f"chunk={chunk_index},line={line_index},{'p' * 64}\n" for line_index in range(self.LINES_PER_CHUNK))
+            for chunk_index in range(self.CHUNK_COUNT)
+        ]
+        self.expected_content = "".join(self.chunks)
+        self.first_chunks_written = [threading.Event() for _ in range(2)]
+        self.reader_has_probed = threading.Event()
+        self.writers_finished = threading.Event()
+        self.observed_contents: List[str] = []
+
+    def _emit(self, handle: Any, writer_index: int) -> None:
+        """Writes the payload chunk by chunk, pausing after the first chunk for the reader."""
+        handle.write(self.chunks[0])
+        handle.flush()
+        self.first_chunks_written[writer_index].set()
+        self.reader_has_probed.wait(self.HANDSHAKE_TIMEOUT_SECONDS)
+        for chunk in self.chunks[1:]:
+            handle.write(chunk)
+            handle.flush()
+
+    def write_directly(self, writer_index: int) -> None:
+        """Writes straight to the final path -- the pattern every cache writer used before the fix."""
+        with open(self.target_path, "w", encoding="utf-8") as handle:
+            self._emit(handle, writer_index)
+
+    def write_atomically(self, writer_index: int) -> None:
+        """Writes through :func:`hisim.caching.atomic_cache_write`, the pattern the fix introduces."""
+        with atomic_cache_write(self.target_path) as temporary_path:
+            with open(temporary_path, "w", encoding="utf-8") as handle:
+                self._emit(handle, writer_index)
+
+    def read_repeatedly(self) -> None:
+        """Polls the target path until both writers are done, recording every state it can read."""
+        for event in self.first_chunks_written:
+            event.wait(self.HANDSHAKE_TIMEOUT_SECONDS)
+        while True:
+            already_finished = self.writers_finished.is_set()
+            try:
+                with open(self.target_path, "r", encoding="utf-8") as handle:
+                    self.observed_contents.append(handle.read())
+            except FileNotFoundError:
+                # An absent entry is a legitimate observation: the reader simply missed the cache.
+                pass
+            self.reader_has_probed.set()
+            if already_finished:
+                return
+
+    def run(self, write: Callable[[int], None]) -> List[str]:
+        """Runs both writers and the reader to completion and returns everything the reader saw."""
+        threads = [threading.Thread(target=write, args=(index,)) for index in range(2)]
+        reader = threading.Thread(target=self.read_repeatedly)
+        reader.start()
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=self.HANDSHAKE_TIMEOUT_SECONDS)
+        self.writers_finished.set()
+        reader.join(timeout=self.HANDSHAKE_TIMEOUT_SECONDS)
+        assert not reader.is_alive(), "the reader thread did not finish"
+        return self.observed_contents
+
+
+@pytest.mark.base
+def test_writing_a_cache_entry_directly_exposes_a_partial_file(tmp_path: pathlib.Path) -> None:
+    """Pins the defect the atomic write exists to prevent, so the next test means something.
+
+    This is the control arm. Writing straight to the final cache path -- what all six cache writers
+    (``weather.py``, ``building/building.py``, ``generic_pv_system.py``, ``solar_thermal_system.py``,
+    ``generic_car.py`` and the UTSP connector) used to do -- lets a concurrent reader open the entry
+    while it is still being written and come away with a truncated prefix of it. In HiSim that prefix
+    is a weather year cut in half, which either fails to parse or, worse, parses cleanly and silently
+    shortens the simulation.
+
+    If this test ever stops observing a partial read, the harness has lost its grip on the timing and
+    the companion test below is no longer proving anything.
+    """
+    harness = CacheRaceHarness(str(tmp_path / "Weather_deadbeef.cache"))
+    observations = harness.run(harness.write_directly)
+
+    partial_observations = [seen for seen in observations if seen != harness.expected_content]
+    assert partial_observations, "expected the direct write to expose at least one half-written state"
+    assert all(harness.expected_content.startswith(seen) for seen in partial_observations)
+
+
+@pytest.mark.base
+def test_atomic_cache_write_never_exposes_a_partial_file(tmp_path: pathlib.Path) -> None:
+    """Two concurrent writers plus a reader: the reader sees the whole entry or no entry at all.
+
+    This is the regression guard for the CI failure in which one scenario setup read the weather
+    cache entry that its near-twin was still writing beside it. With the write landed by
+    ``os.replace`` the final path only ever holds a complete entry, so every read the harness manages
+    is byte-identical to the payload; reads that find nothing are fine, since a miss just means the
+    caller computes the entry itself.
+
+    The temporary file must also be gone afterwards, both because leftovers accumulate in a directory
+    nobody prunes and because a stray name there would eventually be mistaken for an entry.
+    """
+    harness = CacheRaceHarness(str(tmp_path / "Weather_deadbeef.cache"))
+    observations = harness.run(harness.write_atomically)
+
+    assert observations, "the reader never managed to read the entry at all"
+    assert all(seen == harness.expected_content for seen in observations)
+    assert pathlib.Path(harness.target_path).read_text(encoding="utf-8") == harness.expected_content
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["Weather_deadbeef.cache"]
+
+
+@pytest.mark.base
+def test_atomic_cache_write_leaves_no_debris_when_the_write_fails(tmp_path: pathlib.Path) -> None:
+    """A write that raises must leave the previous entry intact and no temporary file behind.
+
+    Cache computations are long and interruptible, so failures are not hypothetical. The helper has
+    to unwind cleanly: the exception reaches the caller unchanged, whatever was cached before is
+    still there for the next run, and the half-written temporary file is removed rather than left to
+    accumulate in ``hisim/inputs/cache``.
+    """
+    target_path = tmp_path / "Weather_deadbeef.cache"
+    target_path.write_text("the previous entry\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="computation blew up"):
+        with atomic_cache_write(str(target_path)) as temporary_path:
+            pathlib.Path(temporary_path).write_text("half of the new entry", encoding="utf-8")
+            raise RuntimeError("computation blew up")
+
+    assert target_path.read_text(encoding="utf-8") == "the previous entry\n"
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["Weather_deadbeef.cache"]


### PR DESCRIPTION
Cache entries are written straight to their final path, so two processes computing the same key race: one begins writing, the other sees a file that exists, reads it half-written, and either fails to parse it or silently gets truncated data.

**This is a live CI failure.** `scenario-json-freshness` runs `regenerate_scenario_jsons.py -j 4`; of 21 setups exactly one failed — `default_connections`, immediately after its near-twin `automatic_default_connections` succeeded. The two share weather and building configuration and therefore share cache keys.

It is also already specified: `roadmap/cache_service_spec.md` §4 (PR #584) names this bug as the reason its local tier ships first. This is that tier.

## The fix

`hisim/caching/` — a new package at the same layer as `hisim/config/`, importing only stdlib. `atomic_cache_write` writes to a temporary file **in the same directory** and `os.replace()`s it into position, so a reader sees either the previous entry or the complete new one, never a partial file. Only `__init__.py` and `local.py`; no networking, no settings, no key construction — those are later phases of #584.

`utils.get_cache_file` keeps its signature and `(exists, path)` return. `exists` stays advisory: two processes may still both compute the same entry, which wastes work and is harmless once the write is atomic. No locking — it would add a failure mode of its own.

Six modules call `get_cache_file`; all six disk write sites now land through the helper — weather, building solar gains, PV, solar thermal, car, UTSP connector.

## Reproduction, and why the obvious protocol doesn't work

Simultaneous starts **cannot** reproduce it: both processes miss the cache, both compute, both write identical bytes. Only a *reader* arriving inside a writer's window is dangerous.

So the window was measured. For `default_connections` the weather cache check lands at t≈5.5 s and the 91 MB `Weather_*.cache` is incomplete from t=26.40 s to t=29.28 s — a 2.9 s hole in a 31 s run. Staggering the twins into it fails deterministically:

```
ValueError: The yearly weather arrays in the singleton sim repository hold 313845 values
            but the simulation needs 525600.
  ... generic_pv_system.py:735 in i_prepare_simulation
```

A truncated weather read — the CI symptom. Note it surfaces as an error only because PV happens to length-check; without that guard it is a silent short year.

**After the fix:** both previously-failing staggers pass; three cold-cache `-j 4` fleet runs give 22 OK / 0 FAILED; no debris; no scenario-JSON drift.

## Tests

Three, in `tests/test_caching_local.py`, event-sequenced with no sleeps (~0.3 s):

- atomic write never exposes a partial file
- a failed write leaves no debris
- **a control test asserting the direct-write pattern *does* expose a prefix** — this is what keeps the first test meaningful if timing ever shifts, and it is the honest answer to "does the test fail against the old code": stashing the fix only yields `AttributeError`, which proves little.

## Two notes

The temporary file is `chmod`ed to 0644: `mkstemp` creates 0600, which would make a shared cache directory unreadable to other users, unlike the direct writes it replaces.

The UTSP connector already holds a `portalocker` lock around its cache write, but that serialises *writers* only — readers take no lock — so the atomic write is still what fixes it. The lock is left alone as out of scope.

Green: base 4481 passed / 1 skipped · extendedbase 13 · mypy 280/181/23 clean · pylint 10.00/10 · prospector 0/0/0 · golden check OK (verified running in `USE_LOCAL_LPG` with no downgrade, so the pass is real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
