### PR TITLE
Make air_conditioned_house complete a KPI run

### DIFF
--- a/hisim/components/air_conditioner.py
+++ b/hisim/components/air_conditioner.py
@@ -22,7 +22,7 @@ from hisim.postprocessing.kpi_computation.kpi_structure import (
     KpiTagEnumClass,
 )
 from hisim.simulationparameters import SimulationParameters
-from hisim.loadtypes import LoadTypes, Units
+from hisim.loadtypes import InandOutputType, LoadTypes, Units
 from hisim.components.weather import Weather
 from hisim.components.building import Building
 from hisim import utils
@@ -338,6 +338,10 @@ class AirConditioner(cp.Component):
             self.ElectricalPowerConsumption,
             LoadTypes.ELECTRICITY,
             Units.WATT,
+            # Without this flag the KPI layer never counts the air conditioner: it gathers total
+            # electricity consumption from the postprocessing flags, not from the load type, so an
+            # untagged consumer makes grid import exceed total consumption and the KPI run refuses.
+            postprocessing_flag=[InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
             output_description="Electrical power consumption",
         )
         self.electrical_energy_consumption_channel = self.add_output(

--- a/system_setups/air_conditioned_house.py
+++ b/system_setups/air_conditioned_house.py
@@ -1,7 +1,6 @@
 """Air-conditioned household."""
 
 # clean
-from pathlib import Path
 from typing import Optional
 
 import pandas as pd
@@ -15,6 +14,8 @@ from hisim.components import weather
 from hisim.components import generic_pv_system
 from hisim.components import building
 from hisim.components import air_conditioner
+from hisim.components import electricity_meter
+from hisim import loadtypes
 from hisim.config import ComponentID
 
 
@@ -35,16 +36,16 @@ def setup_function(
     """Household Model.
 
     This setup function emulates an air-conditioned house.
-    Here the residents have their electricity covered by a photovoltaic system, a battery, and the electric grid.
+    Here the residents have their electricity covered by a photovoltaic system and the electric grid.
     Thermal load of the building is covered with an air conditioner.
 
     Connected components are:
         - Occupancy (Residents' Demands)
         - Weather
-        - Price signal
         - Photovoltaic System
         - Building
         - Air conditioner and controller
+        - Electricity meter
 
     Analyzed region: Southern Europe.
 
@@ -66,12 +67,6 @@ def setup_function(
         7. Cyprus: CY.N.SFH.03.Gen.ReEx.001.003, , construction year: 2007 - 2013
 
     """
-
-    # Delete all files in cache:
-    dir_cache = Path("..") / "hisim" / "inputs" / "cache"
-    if dir_cache.is_dir():
-        for file in dir_cache.iterdir():
-            file.unlink()
 
     # Set general simulation parameters
     year = 2021
@@ -219,3 +214,41 @@ def setup_function(
     )
 
     my_sim.add_component(my_air_conditioner_controller, connect_automatically=True)
+
+    """Electricity Meter"""
+    # Every electricity-balance KPI is derived from a meter: without one, the grid exchange is unknown
+    # and the self-sufficiency chain in kpi_preparation.py has nothing to work from.
+    my_electricity_meter = electricity_meter.ElectricityMeter(
+        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        my_simulation_parameters=my_simulation_parameters,
+    )
+    my_electricity_meter.add_component_input_and_connect(
+        source_object_name=my_photovoltaic_system.component_name,
+        source_component_output=my_photovoltaic_system.ElectricityOutput,
+        source_load_type=loadtypes.LoadTypes.ELECTRICITY,
+        source_unit=loadtypes.Units.WATT,
+        source_tags=[
+            loadtypes.ComponentType.PV,
+            loadtypes.InandOutputType.ELECTRICITY_PRODUCTION,
+        ],
+        source_weight=999,
+    )
+    my_electricity_meter.add_component_input_and_connect(
+        source_object_name=my_occupancy.component_name,
+        source_component_output=my_occupancy.ElectricalPowerConsumption,
+        source_load_type=loadtypes.LoadTypes.ELECTRICITY,
+        source_unit=loadtypes.Units.WATT,
+        source_tags=[loadtypes.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
+        source_weight=999,
+    )
+    # The air conditioner has no ComponentType of its own, so it is tagged only as uncontrolled
+    # consumption -- which is what it is: nothing dispatches it but its own on-off controller.
+    my_electricity_meter.add_component_input_and_connect(
+        source_object_name=my_air_conditioner.component_name,
+        source_component_output=my_air_conditioner.ElectricalPowerConsumption,
+        source_load_type=loadtypes.LoadTypes.ELECTRICITY,
+        source_unit=loadtypes.Units.WATT,
+        source_tags=[loadtypes.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
+        source_weight=999,
+    )
+    my_sim.add_component(my_electricity_meter)

--- a/system_setups/air_conditioned_house.scenario.json
+++ b/system_setups/air_conditioned_house.scenario.json
@@ -217,6 +217,60 @@
             "inputs": [],
             "outputs": [],
             "connect_automatically": true
+        },
+        {
+            "component_full_classname": "hisim.components.electricity_meter.ElectricityMeter",
+            "configuration": {
+                "component_id": {
+                    "name": "ElectricityMeter",
+                    "building": null,
+                    "unit": null
+                },
+                "device_co2_footprint_in_kg": null,
+                "investment_costs_in_euro": null,
+                "lifetime_in_years": null,
+                "maintenance_costs_in_euro_per_year": null,
+                "subsidy_as_percentage_of_investment_costs": null
+            },
+            "config_full_classname": "hisim.components.electricity_meter.ElectricityMeterConfig",
+            "inputs": [
+                {
+                    "dynamic": true,
+                    "source_component_output": "ElectricityOutput",
+                    "source_object_name": "PVSystem",
+                    "source_load_type": "Electricity",
+                    "source_unit": "W",
+                    "source_tags": [
+                        "PV",
+                        "ElectricityProduction"
+                    ],
+                    "source_weight": 999
+                },
+                {
+                    "dynamic": true,
+                    "source_component_output": "ElectricalPowerConsumption",
+                    "source_object_name": "UTSPConnector",
+                    "source_load_type": "Electricity",
+                    "source_unit": "W",
+                    "source_tags": [
+                        "Consumption without any EMS control"
+                    ],
+                    "source_weight": 999
+                },
+                {
+                    "dynamic": true,
+                    "source_component_output": "ElectricalPowerConsumption",
+                    "source_object_name": "AirConditioner",
+                    "source_load_type": "Electricity",
+                    "source_unit": "W",
+                    "source_tags": [
+                        "Consumption without any EMS control"
+                    ],
+                    "source_weight": 999
+                }
+            ],
+            "outputs": [],
+            "connect_automatically": false
         }
     ],
     "connections": [
@@ -228,6 +282,36 @@
             "target": {
                 "component_name": "Building",
                 "field_name": "ThermalPowerDelivered"
+            }
+        },
+        {
+            "source": {
+                "component_name": "PVSystem",
+                "field_name": "ElectricityOutput"
+            },
+            "target": {
+                "component_name": "ElectricityMeter",
+                "field_name": "Input_PVSystem_ElectricityOutput_0"
+            }
+        },
+        {
+            "source": {
+                "component_name": "UTSPConnector",
+                "field_name": "ElectricalPowerConsumption"
+            },
+            "target": {
+                "component_name": "ElectricityMeter",
+                "field_name": "Input_UTSPConnector_ElectricalPowerConsumption_1"
+            }
+        },
+        {
+            "source": {
+                "component_name": "AirConditioner",
+                "field_name": "ElectricalPowerConsumption"
+            },
+            "target": {
+                "component_name": "ElectricityMeter",
+                "field_name": "Input_AirConditioner_ElectricalPowerConsumption_2"
             }
         }
     ]

--- a/tests/test_system_setups_air_conditioned_house.py
+++ b/tests/test_system_setups_air_conditioned_house.py
@@ -1,0 +1,99 @@
+"""Test for the air_conditioned_house system setup.
+
+This module contains a single integration test that loads the
+air_conditioned_house.py setup, runs it for one day with the KPI and cost
+post-processing switched on, and verifies that a complete KPI collection comes
+out the other side.
+"""
+
+import json
+from pathlib import Path
+import pytest
+from hisim import hisim_main
+from hisim.postprocessingoptions import PostProcessingOptions
+from hisim.simulationparameters import SimulationParameters
+from hisim import utils
+
+
+class ExpectedKpis:
+    """The KPI names this setup must produce with a value.
+
+    These four are the end of the electricity-balance chain in
+    ``kpi_preparation.py``: grid exchange comes from the electricity meter, the
+    relative demand is derived from it, and both self-sufficiency figures are
+    derived from that in turn. A setup with no electricity meter yields ``None``
+    for every one of them, so asserting they carry numbers is what distinguishes
+    a setup that is genuinely wired from one that merely does not crash.
+    """
+
+    NAMES = (
+        "Total energy from grid",
+        "Relative electricity demand from grid",
+        "Self-sufficiency rate according to solar htw berlin",
+        "Self-consumption rate according to solar htw berlin",
+    )
+
+
+@pytest.mark.system_setups
+@utils.measure_execution_time
+def test_air_conditioned_house() -> None:
+    """Run the air-conditioned house for one day and check its KPIs are complete.
+
+    Loads the system setup from ../system_setups/air_conditioned_house.py and
+    executes a one-day simulation at 60-second timesteps with ``COMPUTE_KPIS``,
+    ``WRITE_KPIS_TO_JSON``, ``COMPUTE_CAPEX`` and ``COMPUTE_OPEX`` enabled.
+
+    The post-processing options matter more than the run itself. A setup can
+    complete every timestep and still fail the moment KPIs are computed -- which
+    is exactly how this one was broken for as long as it was, since the default
+    options leave KPI computation switched off and the failure therefore stayed
+    invisible to a test that only asserted the simulation finished. Enabling
+    them here means the test exercises the path that actually breaks.
+
+    ``finished.flag`` is written by ``Simulator.run_all_timesteps`` only after
+    post-processing has completed, so its presence separates a real run from a
+    silent no-op, and ``all_kpis.json`` must then contain a value for every KPI
+    in :class:`ExpectedKpis`.
+    """
+    path = Path("../system_setups/air_conditioned_house.py")
+
+    sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    sim_params.post_processing_options = [
+        PostProcessingOptions.COMPUTE_KPIS,
+        PostProcessingOptions.WRITE_KPIS_TO_JSON,
+        PostProcessingOptions.COMPUTE_CAPEX,
+        PostProcessingOptions.COMPUTE_OPEX,
+    ]
+    result_directory = hisim_main.main(str(path), sim_params)
+
+    result_path = Path(result_directory)
+    assert result_directory, "no result directory was configured for the run"
+    assert result_path.is_dir(), f"result directory does not exist: {result_directory}"
+    assert (result_path / "finished.flag").is_file(), (
+        f"finished.flag not found in result directory: {result_directory}"
+    )
+
+    kpi_path = result_path / "all_kpis.json"
+    assert kpi_path.is_file(), f"all_kpis.json not found in result directory: {result_directory}"
+
+    # Flatten the nested collection to {kpi name: value}; the nesting is by building
+    # object and tag, neither of which this test cares about.
+    values_by_name: dict = {}
+
+    def collect(node: object) -> None:
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            if isinstance(value, dict) and "value" in value and "unit" in value:
+                values_by_name[key] = value["value"]
+            else:
+                collect(value)
+
+    collect(json.loads(kpi_path.read_text(encoding="utf-8")))
+
+    for name in ExpectedKpis.NAMES:
+        assert name in values_by_name, f"KPI '{name}' is missing from {kpi_path}"
+        assert values_by_name[name] is not None, (
+            f"KPI '{name}' has no value -- the electricity balance could not be computed, "
+            "which usually means the setup has no electricity meter."
+        )


### PR DESCRIPTION
First of the failing system setups: `air_conditioned_house` now completes a KPI run.

## What was wrong

The setup could not compute KPIs. It died with
`TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'` at
`hisim/postprocessing/kpi_computation/kpi_preparation.py:596`.

The chain, all in that one file:

| Step | Behaviour |
|---|---|
| `get_electricity_to_and_from_grid_from_electricty_meter` | returns `None` when no `ElectricityMeter` KPIs exist |
| `compute_relative_electricity_demand:450` | `if ... is None: → None` — guarded, deliberate |
| `compute_self_sufficiency_according_to_solar_htw_berlin:489` | `if ... is None: → None` — guarded, deliberate |
| `read_opex_and_capex_costs_from_results:678` | reads that KPI's value back and passes it on |
| `get_total_energy_self_sufficiency:596` | multiplies it — **unguarded** |

The root cause is not the missing guard, though. It is that **this setup builds no
electricity meter**, so the grid exchange is genuinely unknown. The meter and the KPI layer
arrived long after the setup was written and it was never brought along. Rather than teach
the KPI chain to tolerate a setup that cannot answer the question, the setup is made able to
answer it.

## What changed

**The air conditioner now declares itself an electricity consumer.** The KPI layer gathers
total electricity consumption from output *postprocessing flags*, not from load types, and
`ElectricalPowerConsumption` carried no flag at all. With the meter added but the flag still
missing, the run got one step further and then refused with
`The relative elecricity demand should not be over 100 %` — grid import 24.8 kWh against a
total consumption of 10.9 kWh, because the air conditioner's own 26 kWh was invisible to the
sum. Only the watt output is tagged; tagging the watt-hour output beside it would count the
machine twice.

**The setup builds an electricity meter**, reading the photovoltaic system as production and
the occupancy and the air conditioner as uncontrolled consumption.

**The setup no longer deletes the cache.** It removed every file in `hisim/inputs/cache`
before building anything — an artefact of debugging that never worked out. It made the setup
unsafe to run beside anything else on the machine, and unusable as a declarative file, since
no such file should be able to delete a directory.

**The docstring now lists what the setup builds.** It promised a battery and a price signal
that are not there.

**The scenario JSON twin is regenerated** to match, via `scripts/regenerate_scenario_jsons.py`.

## The test

There was no test. There is now one, and it deliberately does something the other setup tests
do not: it switches KPI computation on.

Every `test_system_setups_*.py` in the suite runs its setup with the default post-processing
options, which leave `COMPUTE_KPIS` off. A setup can therefore run every timestep, write
`finished.flag`, pass its test, and still fail the instant anyone asks it for KPIs. That is
exactly how this stayed broken. `test_system_setups_basic_household_only_heating.py` passes
today against a setup that fails with the same TypeError.

The new test enables `COMPUTE_KPIS`, `WRITE_KPIS_TO_JSON`, `COMPUTE_CAPEX` and `COMPUTE_OPEX`,
and asserts four named KPIs at the end of the electricity-balance chain carry values rather
than `None`. Asserting on the values matters: a meterless setup produces the whole collection
with `None` in exactly those four places, so a test that only checked the file existed would
have passed against the bug.

## Results

82 KPIs, all with values, and the numbers reconcile:

| KPI | Value |
|---|---|
| Total electricity consumption | 37.3 kWh |
| Residents' consumption | 10.86 kWh |
| Total energy from grid | 24.78 kWh |
| Total energy to grid | 3.99 kWh |
| Self-sufficiency (solar htw berlin) | 33.51 % |
| Self-consumption (solar htw berlin) | 75.96 % |

Self-sufficiency checks out as (37.3 − 24.78) / 37.3 = 33.6 %, and self-consumption as
(16.56 − 3.99) / 16.56 = 75.9 % against a photovoltaic production of 12.57 + 3.99 kWh.

## Cache behaviour

Run under the cache protocol — wipe, run, record, run again, compare:

| Comparison | Differing KPIs |
|---|---|
| cold vs warm | **2 of 82** |
| warm vs warm | 0 of 82 |

The two are `Building / Solar energy gains` (5.587738877188691 vs 5.5877388771886904) and
`Building / Theoretical heating demand` (17.321961285766495 vs 17.32196128576649) — one to two
ULP each.

This is **not** caused by anything in this PR, and it is worth recording: the building cache
is written with `to_csv` and read with `read_csv`, a text round trip of float64, so a cached
building run and an uncached one are not the same run. `roadmap/pylpg_flakiness.md` §13
already documents the identical defect in the photovoltaic cache. Building is a second
confirmed instance, and this measurement is the evidence. It belongs to that work, not here.

## Two things found and deliberately not fixed here

**The building's internal-gain warning is a false positive.** Every run logs
`the 'HeatingByResidents' input is not connected. Internal heat gains from occupants default
to 0 W.` The check in `building.py:779` reads `source_output`, but `i_prepare_simulation` runs
from `prepare_calculation()` at `simulator.py:305`, and `source_output` is not bound until
`connect_all_components()` at `:307`. It is therefore always `None` at check time. I confirmed
the inputs of this setup and of `basic_household` are wired identically
(`src_object_name='UTSPConnector'`), and that `basic_household` — which passes — logs the same
two warnings. The diagnostic never fires on a real fault and hides one when it happens.

**`get_total_energy_self_sufficiency:596` is still unguarded.** With this setup fixed it is no
longer reachable from here, but five other meterless setups remain, and
`basic_household_only_heating` fails on that exact line today. It is the next one in the queue.
