### PR TITLE
Make basic_household_only_heating complete a KPI run

### DIFF
--- a/system_setups/basic_household_only_heating.py
+++ b/system_setups/basic_household_only_heating.py
@@ -5,6 +5,8 @@ from typing import Optional, Any
 from hisim.simulator import SimulationParameters
 from hisim.config import SizingContext
 from hisim.components import (
+    electricity_meter,
+    gas_meter,
     heat_distribution_system,
     loadprofilegenerator_utsp_connector,
     simple_water_storage,
@@ -36,9 +38,11 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     - Components
         - Occupancy (Residents' Demands)
         - Weather
-        - GasHeater
+        - GasHeater and its controller
         - HeatingStorage
-        - Controller2EMS
+        - Heat distribution system and its controller
+        - Electricity meter
+        - Gas meter
     """
 
     # =================================================================================================================================
@@ -137,6 +141,20 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         my_simulation_parameters=my_simulation_parameters,
     )
 
+    # Build Meters
+    # Both meters exist for the sake of the KPI layer, which derives every energy-balance
+    # figure from a meter rather than from the components themselves. Without the electricity
+    # meter the grid exchange is unknown, the self-sufficiency chain in kpi_preparation.py has
+    # nothing to work from, and the run dies in post-processing.
+    my_electricity_meter = electricity_meter.ElectricityMeter(
+        my_simulation_parameters=my_simulation_parameters,
+        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+    )
+    my_gas_meter = gas_meter.GasMeter(
+        my_simulation_parameters=my_simulation_parameters,
+        config=gas_meter.GasMeterConfig.get_gas_meter_default_config(),
+    )
+
     # =================================================================================================================================
     # Connect Component Inputs with Outputs
 
@@ -153,3 +171,9 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     my_sim.add_component(my_building)
     my_sim.add_component(my_weather)
     my_sim.add_component(my_occupancy)
+    # Both meters are wired by their own default connections and nothing else. Feeding a meter
+    # explicitly *and* registering it automatically is how household_gas_solar_thermal came to
+    # count the occupancy's electricity twice (P3 finding F-4): the simulator does not
+    # de-duplicate two feeds of one source, so the sum is genuinely taken twice.
+    my_sim.add_component(my_electricity_meter, connect_automatically=True)
+    my_sim.add_component(my_gas_meter, connect_automatically=True)

--- a/system_setups/basic_household_only_heating.scenario.json
+++ b/system_setups/basic_household_only_heating.scenario.json
@@ -229,6 +229,81 @@
             "inputs": [],
             "outputs": [],
             "connect_automatically": false
+        },
+        {
+            "component_full_classname": "hisim.components.electricity_meter.ElectricityMeter",
+            "configuration": {
+                "component_id": {
+                    "name": "ElectricityMeter",
+                    "building": null,
+                    "unit": null
+                },
+                "device_co2_footprint_in_kg": null,
+                "investment_costs_in_euro": null,
+                "lifetime_in_years": null,
+                "maintenance_costs_in_euro_per_year": null,
+                "subsidy_as_percentage_of_investment_costs": null
+            },
+            "config_full_classname": "hisim.components.electricity_meter.ElectricityMeterConfig",
+            "inputs": [
+                {
+                    "dynamic": true,
+                    "source_component_output": "ElectricalPowerConsumption",
+                    "source_object_name": "UTSPConnector",
+                    "source_load_type": "Electricity",
+                    "source_unit": "W",
+                    "source_tags": [
+                        "Consumption without any EMS control"
+                    ],
+                    "source_weight": 999
+                }
+            ],
+            "outputs": [],
+            "connect_automatically": false
+        },
+        {
+            "component_full_classname": "hisim.components.gas_meter.GasMeter",
+            "configuration": {
+                "component_id": {
+                    "name": "GasMeter",
+                    "building": null,
+                    "unit": null
+                },
+                "total_energy_from_grid_in_kwh": 0.0,
+                "gas_loadtype": "Gas",
+                "device_co2_footprint_in_kg": null,
+                "investment_costs_in_euro": null,
+                "lifetime_in_years": null,
+                "maintenance_costs_in_euro_per_year": null,
+                "subsidy_as_percentage_of_investment_costs": null
+            },
+            "config_full_classname": "hisim.components.gas_meter.GasMeterConfig",
+            "inputs": [
+                {
+                    "dynamic": true,
+                    "source_component_output": "EnergyDemandSh",
+                    "source_object_name": "CondensingGasBoiler",
+                    "source_load_type": "Gas",
+                    "source_unit": "Wh",
+                    "source_tags": [
+                        "Gas consumption without any control"
+                    ],
+                    "source_weight": 999
+                },
+                {
+                    "dynamic": true,
+                    "source_component_output": "EnergyDemandDhw",
+                    "source_object_name": "CondensingGasBoiler",
+                    "source_load_type": "Gas",
+                    "source_unit": "Wh",
+                    "source_tags": [
+                        "Gas consumption without any control"
+                    ],
+                    "source_weight": 999
+                }
+            ],
+            "outputs": [],
+            "connect_automatically": false
         }
     ],
     "connections": [
@@ -330,6 +405,36 @@
             "target": {
                 "component_name": "Building",
                 "field_name": "HeatingByDevices"
+            }
+        },
+        {
+            "source": {
+                "component_name": "UTSPConnector",
+                "field_name": "ElectricalPowerConsumption"
+            },
+            "target": {
+                "component_name": "ElectricityMeter",
+                "field_name": "Input_UTSPConnector_ElectricalPowerConsumption_0"
+            }
+        },
+        {
+            "source": {
+                "component_name": "CondensingGasBoiler",
+                "field_name": "EnergyDemandSh"
+            },
+            "target": {
+                "component_name": "GasMeter",
+                "field_name": "Input_CondensingGasBoiler_EnergyDemandSh_0"
+            }
+        },
+        {
+            "source": {
+                "component_name": "CondensingGasBoiler",
+                "field_name": "EnergyDemandDhw"
+            },
+            "target": {
+                "component_name": "GasMeter",
+                "field_name": "Input_CondensingGasBoiler_EnergyDemandDhw_1"
             }
         }
     ]

--- a/tests/test_system_setups_basic_household_only_heating.py
+++ b/tests/test_system_setups_basic_household_only_heating.py
@@ -1,50 +1,82 @@
 """Test for the basic_household_only_heating system setup.
 
 This module contains a single integration test that loads the
-basic_household_only_heating.py setup and verifies it runs without
-errors for a one-day simulation and produces result files.
+basic_household_only_heating.py setup, runs it for one day with the KPI and
+cost post-processing switched on, and verifies that a complete KPI collection
+comes out the other side.
 """
 
+import json
 from pathlib import Path
 import pytest
 from hisim import hisim_main
+from hisim.postprocessingoptions import PostProcessingOptions
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
 from hisim import utils
 
 
+class ExpectedKpis:
+    """The KPI names this setup must produce, and the one it must not.
+
+    ``REQUIRED`` is the end of the electricity-balance chain in
+    ``kpi_preparation.py``: grid exchange comes from the electricity meter, the
+    relative demand is derived from it, and self-sufficiency from that in turn.
+    A setup with no electricity meter yields ``None`` for every one of them, so
+    asserting they carry numbers is what distinguishes a setup that is genuinely
+    metered from one that merely does not crash.
+
+    ``NOT_COMPUTABLE`` is the counterpart. This household has no generation at
+    all, so the share of its own production that it consumes is undefined rather
+    than zero, and ``compute_self_consumption_rate_according_to_solar_htw_berlin``
+    correctly returns ``None`` for it. Pinning that keeps the distinction honest:
+    a ``None`` here is the right answer, and a number would mean the KPI layer had
+    invented one.
+    """
+
+    REQUIRED = (
+        "Total energy from grid",
+        "Total electricity consumption",
+        "Relative electricity demand from grid",
+        "Self-sufficiency rate according to solar htw berlin",
+        "Total gas consumption",
+    )
+    NOT_COMPUTABLE = ("Self-consumption rate according to solar htw berlin",)
+
+
 @pytest.mark.system_setups
 @utils.measure_execution_time
 def test_basic_household_only_heating() -> None:
-    """Run the basic household only heating system setup for one day.
+    """Run the basic household only heating setup for one day and check its KPIs.
 
     Loads the system setup from ../system_setups/basic_household_only_heating.py
-    and executes a one-day simulation with 60-second timesteps to verify
-    the setup initializes and runs without errors and writes its result
-    artefacts to the configured result directory.
+    and executes a one-day simulation at 60-second timesteps with
+    ``COMPUTE_KPIS``, ``WRITE_KPIS_TO_JSON``, ``COMPUTE_CAPEX`` and
+    ``COMPUTE_OPEX`` enabled.
 
-    ``hisim_main.main`` returns the directory the simulator actually wrote to,
-    which ``Simulator.prepare_simulation_directory`` records on the
-    ``SimulationParameters`` instance (configuring the
-    ``ResultPathProviderSingleton`` as a side effect when no directory was
-    pre-set). Asserting on that returned value keeps the test coupled to the
-    value the function under test produces, rather than to the singleton's
-    mutable global state.
+    The post-processing options are the point of this test. Its previous version
+    ran with the defaults, which leave KPI computation switched off, so it passed
+    for as long as the setup was broken: the failure lived entirely in
+    post-processing and nothing here reached it. Enabling the options means the
+    test exercises the path that actually breaks.
 
-    ``Simulator.run_all_timesteps`` only writes the ``finished.flag`` marker
-    after every timestep and the post-processing have completed successfully,
-    so checking for it (and a non-empty result directory) distinguishes a real
-    run from a silent no-op.
+    ``finished.flag`` is written by ``Simulator.run_all_timesteps`` only after
+    post-processing has completed, so its presence separates a real run from a
+    silent no-op, and ``all_kpis.json`` must then agree with
+    :class:`ExpectedKpis` about which figures exist and which cannot.
     """
     path = Path("../system_setups/basic_household_only_heating.py")
 
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    sim_params.post_processing_options = [
+        PostProcessingOptions.COMPUTE_KPIS,
+        PostProcessingOptions.WRITE_KPIS_TO_JSON,
+        PostProcessingOptions.COMPUTE_CAPEX,
+        PostProcessingOptions.COMPUTE_OPEX,
+    ]
     result_directory = hisim_main.main(str(path), sim_params)
     log.information(str(Path.cwd()))
 
-    # The run must have produced outputs. finished.flag is written by
-    # Simulator.run_all_timesteps once the simulation and post-processing have
-    # finished, so its presence confirms a completed (not no-op) run.
     result_path = Path(result_directory)
     assert result_directory, "no result directory was configured for the run"
     assert result_path.is_dir(), f"result directory does not exist: {result_directory}"
@@ -52,3 +84,35 @@ def test_basic_household_only_heating() -> None:
     assert (result_path / "finished.flag").is_file(), (
         f"finished.flag not found in result directory: {result_directory}"
     )
+
+    kpi_path = result_path / "all_kpis.json"
+    assert kpi_path.is_file(), f"all_kpis.json not found in result directory: {result_directory}"
+
+    # Flatten the nested collection to {kpi name: value}; the nesting is by building
+    # object and tag, neither of which this test cares about.
+    values_by_name: dict = {}
+
+    def collect(node: object) -> None:
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            if isinstance(value, dict) and "value" in value and "unit" in value:
+                values_by_name[key] = value["value"]
+            else:
+                collect(value)
+
+    collect(json.loads(kpi_path.read_text(encoding="utf-8")))
+
+    for name in ExpectedKpis.REQUIRED:
+        assert name in values_by_name, f"KPI '{name}' is missing from {kpi_path}"
+        assert values_by_name[name] is not None, (
+            f"KPI '{name}' has no value -- the energy balance could not be computed, "
+            "which usually means the setup is missing a meter."
+        )
+
+    for name in ExpectedKpis.NOT_COMPUTABLE:
+        assert name in values_by_name, f"KPI '{name}' is missing from {kpi_path}"
+        assert values_by_name[name] is None, (
+            f"KPI '{name}' carries a value, but this household has no generation at all, "
+            "so the share of its own production that it consumes is undefined."
+        )


### PR DESCRIPTION
Second of the failing system setups: `basic_household_only_heating` now completes a KPI run.
Follows #605 (`air_conditioned_house`), same shape, different missing piece.

## What was wrong

The setup died in post-processing with
`TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'` at
`hisim/postprocessing/kpi_computation/kpi_preparation.py:596` — the identical line that broke
`air_conditioned_house`, and for the identical reason.

It builds an occupancy, which consumes electricity, and a gas boiler, which consumes gas, and
**no meter for either**. The KPI layer derives every energy-balance figure from a meter rather
than from the components themselves, so the grid exchange was unknown, the self-sufficiency
chain had nothing to work from, and the multiplication at `:596` got a `None`.

The meters and the KPI layer arrived long after this setup was written, and it was never
brought along.

## What changed

**An electricity meter and a gas meter**, both wired by their own default connections and
nothing else — the electricity meter already declares one from the occupancy, the gas meter one
from the generic boiler, so `connect_automatically=True` is the entire wiring.

That restraint is deliberate. Feeding a meter explicitly *and* registering it automatically is
exactly how `household_gas_solar_thermal` came to count the occupancy's electricity twice —
**P3 finding F-4**, verified: `hisim/simulator.py:636` does not de-duplicate two feeds of one
source, so the sum really is taken twice, which is the mechanism behind that setup's
long-standing `relative electricity demand should not be over 100 %` failure. Doing it one way
here avoids inheriting the bug.

**The docstring** listed a `Controller2EMS` the setup does not build and omitted the heat
distribution system it does. It now lists what is there.

**The scenario JSON twin** is regenerated to match.

## Results

102 KPIs, and they reconcile:

| KPI | Value |
|---|---|
| Total electricity consumption | 10.9 kWh |
| Total energy from grid | 10.86 kWh |
| Total energy to grid | 0.0 kWh |
| Relative electricity demand from grid | 100 % |
| Self-sufficiency (solar htw berlin) | 0 % |
| Total gas consumption | 124.5 kWh |
| Total gas demand from grid | 124.5 kWh |

All the electricity comes from the grid and none goes back, which is right for a household with
no generation, and the gas is consumed exactly as it is bought.

**One KPI stays `None` on purpose.** `Self-consumption rate according to solar htw berlin` is the
share of its own production that a household consumes, and this one produces nothing, so the
figure is undefined rather than zero. `compute_self_consumption_rate_according_to_solar_htw_berlin`
already returns `None` for that case; the test pins it.

## The test

There was a test, and it passed against the broken setup for as long as it was broken, because it
ran with the default post-processing options — which leave `COMPUTE_KPIS` **off**. The failure
lived entirely in post-processing and nothing in the test reached it. This is the same blind spot
#605 describes, and it is worth stating that it is not specific to these two files: every
`test_system_setups_*.py` in the suite has it.

The test now enables the KPI and cost options and checks the collection **in both directions**:
five figures at the end of the energy-balance chain must carry values, and the one that cannot be
computed must stay `None`. Pinning the `None` matters as much as pinning the values — asserting
only that the figures exist would pass against the original bug, and asserting only that they
carry values would invite someone to make the undefined one zero.

## Verification

- new test: passes
- mypy, pylint (10.00/10), prospector: clean
- `scripts/regenerate_scenario_jsons.py --all-py`: no drift
- `pytest -m base`: results below

Two pre-existing failures elsewhere in the suite are unrelated and fail identically on `main`:
`test_postprocessing_option_write_network_charts_to_report` and
`test_dynamic_components_system_setup`.

## Still open, and next

`kpi_preparation.py:596` remains unguarded. With this setup metered it is no longer reachable
from here, but the KPI layer still assumes every system has an electricity meter, and four
setups remain broken:

| Setup | Failure | Shape |
|---|---|---|
| `household_gas_solar_thermal` | `>100 %` relative demand | diagnosed in P3 F-4; wants the simulator to refuse duplicate feeds |
| `simple_air_conditioner_household_building_sizer` | `ZeroDivisionError` at `:560` | no occupancy at all, so total consumption is genuinely zero |
| `dynamic_components` | `CHP1 has no kpis implemented` | missing KPI implementation |
| `electrolyzer_with_renewables` | same, transformer/rectifier | missing KPI implementation |
| `simple_system_setup_one` / `_two` | `Random numbers has no kpis` | missing KPI implementation |

The last four are one question rather than four fixes: what a system with no electricity, or with
a component that has no KPIs, should produce.
