### PR TITLE
Fail loudly when the configured profile source cannot deliver (recovers #603)

### DIFF
--- a/hisim/caching/__init__.py
+++ b/hisim/caching/__init__.py
@@ -3,8 +3,9 @@
 The package is the home of everything the simulation knows about caching, as laid out in
 ``roadmap/cache_service_spec.md`` §4: local paths and atomic writes, key construction, the remote
 HTTP tier, curated-dataset retrieval and the client that orchestrates them. Only the local tier of
-§10 phase 1 has been built, so the public surface is deliberately one context manager; the remaining
-modules arrive with the later phases and this file is where they will be re-exported from.
+§10 phase 1 has been built, so the public surface is deliberately one context manager and the metadata
+rule it enforces; the remaining modules arrive with the later phases and this file is where they will
+be re-exported from.
 
 Importing this package must stay cheap and free of side effects, because it sits at the same layer as
 ``hisim/config/`` and is imported by both components and ``hisim/utils.py``. It therefore imports the
@@ -13,6 +14,6 @@ standard library only -- never a component, the simulator or the singleton repos
 
 # clean
 
-from hisim.caching.local import atomic_cache_write
+from hisim.caching.local import CacheEntryMetadata, atomic_cache_write
 
-__all__ = ["atomic_cache_write"]
+__all__ = ["CacheEntryMetadata", "atomic_cache_write"]

--- a/hisim/caching/local.py
+++ b/hisim/caching/local.py
@@ -13,14 +13,20 @@ The spec calls out the atomic write as the one piece worth shipping ahead of the
 repairs a bug that exists independently of the service: two processes sharing a cache directory can
 read a ``.cache`` file that a third is still writing. See :func:`atomic_cache_write` for the race in
 full.
+
+Beside every entry the same write lands a companion ``.meta`` file holding the string the entry's
+name was hashed from, which makes the cache self-describing: an entry can be read and understood
+without the code that wrote it, and validating one is a matter of recomputing the hash and comparing
+it with the filename. See :class:`CacheEntryMetadata`.
 """
 
 # clean
 
+import hashlib
 import os
 import tempfile
 from contextlib import contextmanager
-from typing import Iterator
+from typing import ClassVar, Iterator
 
 __authors__ = "Noah Pflugradt"
 __copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
@@ -31,9 +37,123 @@ __email__ = "n.pflugradt@fz-juelich.de"
 __status__ = "development"
 
 
+class CacheEntryMetadata:
+    """Describes a cache entry in a file beside it, so the entry can be validated and understood.
+
+    A cache entry used to be an opaque blob under a name nobody could read: the filename holds a
+    sha256 of a configuration JSON, and nothing anywhere recorded what that JSON had been. Two things
+    followed. Nobody could tell what an entry was for without re-deriving the hash by hand, and when
+    the key scheme changed the only safe response was to delete the whole directory, because a
+    surviving entry could not be told apart from a current one.
+
+    The companion file fixes both, and one thing more. It is written from the inputs that actually
+    produced the bytes rather than from the ones that were requested, so validating an entry is a
+    comparison: recompute the hash from the metadata and check it against the filename. Agreement
+    proves the contents belong to the key. Disagreement is a poisoned entry -- something ran that was
+    not what the key describes -- and is found automatically rather than by clearing everything. It is
+    also tamper-evident, since the metadata cannot be edited into agreement without recomputing the
+    hash it is checked against.
+
+    What it does **not** do is make an incomplete key complete. If a key omits the weather, so does
+    the metadata, and the two agree happily; ``roadmap/pylpg_flakiness.md`` F7 is the fix for that.
+    This makes migration systematic and auditing possible, nothing more.
+    """
+
+    SUFFIX: ClassVar[str] = ".meta"
+
+    @staticmethod
+    def hash_of(cache_key_string: str) -> str:
+        """Hashes the string a cache entry is named after, in the one place that defines the scheme.
+
+        Both the writer of an entry's name and the validator of an existing entry have to agree on
+        the digest exactly, so the algorithm lives here rather than being spelled out at each site.
+
+        Args:
+            cache_key_string: the raw string that identifies the entry's inputs.
+
+        Returns:
+            str: the hexadecimal sha256 digest that appears in the entry's filename.
+        """
+        return hashlib.sha256(cache_key_string.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def metadata_filepath(cls, cache_filepath: str) -> str:
+        """Returns the path of the companion metadata file for a cache entry.
+
+        Args:
+            cache_filepath: the path of the data file, ``<prefix>_<hash>.cache``.
+
+        Returns:
+            str: the same path with :attr:`SUFFIX` appended, which keeps the pair adjacent in a
+                listing and keeps the entry's identity visible in the metadata's own name.
+        """
+        return cache_filepath + cls.SUFFIX
+
+    @staticmethod
+    def hash_in_filename(cache_filepath: str) -> str:
+        """Extracts the digest a cache entry is filed under from its filename.
+
+        Entry names are ``<component_key>_<hash>.cache`` and a component key may itself contain
+        underscores, so the digest is taken from the last separator rather than the first.
+
+        Args:
+            cache_filepath: the path of the data file.
+
+        Returns:
+            str: the digest portion of the filename, or an empty string if the name does not have
+                that shape -- which is itself a reason to treat the entry as unvalidatable.
+        """
+        filename = os.path.basename(cache_filepath)
+        if not filename.endswith(".cache") or "_" not in filename:
+            return ""
+        return filename[: -len(".cache")].rsplit("_", 1)[1]
+
+    @classmethod
+    def describes(cls, cache_filepath: str) -> bool:
+        """Says whether the entry's metadata exists and agrees with the name the entry is filed under.
+
+        Args:
+            cache_filepath: the path of the data file.
+
+        Returns:
+            bool: True if the metadata file is present and its hash equals the one in the filename.
+        """
+        metadata_filepath = cls.metadata_filepath(cache_filepath)
+        if not os.path.isfile(metadata_filepath):
+            return False
+        try:
+            with open(metadata_filepath, encoding="utf-8") as metadata_file:
+                recorded_inputs = metadata_file.read()
+        except OSError:
+            return False
+        return cls.hash_of(recorded_inputs) == cls.hash_in_filename(cache_filepath)
+
+    @classmethod
+    def discard(cls, cache_filepath: str) -> None:
+        """Deletes an entry and its metadata, so the next lookup misses and recomputes.
+
+        An entry that cannot be validated is not merely unknown, it is unusable: either it predates
+        the metadata scheme, or its contents came from something other than what its key describes.
+        Deleting it on sight is what makes the migration self-executing -- every entry written before
+        this landed clears itself the first time it is looked up -- and it is also the response to a
+        poisoning, because keeping such an entry means serving it again.
+
+        Failures to delete are ignored. A concurrent process may have removed the same entry for the
+        same reason, and the caller has already decided to treat the lookup as a miss either way.
+
+        Args:
+            cache_filepath: the path of the data file; its metadata goes with it.
+        """
+        for path in (cls.metadata_filepath(cache_filepath), cache_filepath):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
 @contextmanager
-def atomic_cache_write(cache_filepath: str) -> Iterator[str]:
-    """Yields a temporary path to write a cache entry to, then moves it into place atomically.
+def atomic_cache_write(cache_filepath: str, effective_cache_key_string: str) -> Iterator[str]:
+    """Yields a temporary path to write a cache entry to, then moves it and its metadata into place.
 
     Cache entries used to be written straight to their final path, which made every entry corruptible
     by concurrency. ``hisim.utils.get_cache_file`` decides that an entry exists with a plain
@@ -51,6 +171,18 @@ def atomic_cache_write(cache_filepath: str) -> Iterator[str]:
     because a rename across filesystems is a copy and would not be atomic. If the caller's write
     raises, the temporary file is removed so a failed write leaves no debris behind.
 
+    The companion metadata of :class:`CacheEntryMetadata` lands in the same operation, and the order
+    is load-bearing. ``get_cache_file`` decides an entry exists by looking at the *data* file, so the
+    metadata is renamed into place first and the data second. A crash between the two then leaves an
+    orphan metadata file, which is harmless and ignored, rather than a data file that nothing can
+    validate -- which is exactly the state the deletion rule exists to clean up, and which there is no
+    reason to manufacture.
+
+    The string recorded is the **effective** one: the inputs that actually produced these bytes, not
+    the ones the caller asked for. Where the two can differ, recording the request would make a
+    poisoned entry look sound, because its metadata would agree with a filename the contents do not
+    belong to.
+
     Note what this deliberately does not do. The ``exists`` flag returned by
     ``hisim.utils.get_cache_file`` stays advisory: two processes may still both miss the cache and
     both compute the same entry, and both then write it. That wastes work but is harmless once the
@@ -60,29 +192,59 @@ def atomic_cache_write(cache_filepath: str) -> Iterator[str]:
 
     Args:
         cache_filepath: the final path the entry must appear at. Its directory is created if missing.
+        effective_cache_key_string: the raw string describing the inputs that produced the entry.
+            Its hash must equal the digest in ``cache_filepath``, or the entry it names will be
+            discarded as poisoned the next time it is looked up.
 
     Yields:
         str: the temporary path to write to. It is replaced onto ``cache_filepath`` when the ``with``
             block exits normally.
 
     Raises:
-        OSError: if the temporary file cannot be created or cannot be renamed into place.
+        OSError: if a temporary file cannot be created or cannot be renamed into place.
     """
     cache_directory = os.path.dirname(os.path.abspath(cache_filepath))
     os.makedirs(cache_directory, exist_ok=True)
+    temporary_data_filepath = _make_temporary_file(cache_filepath, cache_directory)
+    try:
+        yield temporary_data_filepath
+        temporary_metadata_filepath = _make_temporary_file(cache_filepath, cache_directory)
+        try:
+            with open(temporary_metadata_filepath, "w", encoding="utf-8") as metadata_file:
+                metadata_file.write(effective_cache_key_string)
+            # Metadata first, data second: see the docstring. An orphan metadata file is ignorable,
+            # an unvalidatable data file is not.
+            os.replace(temporary_metadata_filepath, CacheEntryMetadata.metadata_filepath(cache_filepath))
+        finally:
+            if os.path.exists(temporary_metadata_filepath):
+                os.remove(temporary_metadata_filepath)
+        os.replace(temporary_data_filepath, cache_filepath)
+    finally:
+        # A successful replace has already consumed the temporary file, so this only ever fires when
+        # the caller's write raised or the block was abandoned.
+        if os.path.exists(temporary_data_filepath):
+            os.remove(temporary_data_filepath)
+
+
+def _make_temporary_file(cache_filepath: str, cache_directory: str) -> str:
+    """Creates an empty, world-readable temporary file next to the cache entry being written.
+
+    The file has to sit in the target's own directory, because a rename across filesystems is a copy
+    and would stop being atomic. ``mkstemp`` creates it 0600, which would make a shared cache
+    directory unreadable to the other users the spec expects to share it, so the mode is widened back
+    to what the direct writes this helper replaces used to produce.
+
+    Args:
+        cache_filepath: the entry the temporary file will become; its basename seeds the prefix so a
+            stray temporary is traceable to the entry that produced it.
+        cache_directory: the directory to create the temporary file in.
+
+    Returns:
+        str: the path of the new empty file.
+    """
     file_descriptor, temporary_filepath = tempfile.mkstemp(
         prefix=os.path.basename(cache_filepath) + ".", suffix=".partial", dir=cache_directory
     )
     os.close(file_descriptor)
-    # mkstemp creates the file 0600, which would make a shared cache directory unreadable to the other
-    # users the spec expects to share it; the direct writes this helper replaces produced the usual
-    # umask-governed permissions.
     os.chmod(temporary_filepath, 0o644)
-    try:
-        yield temporary_filepath
-        os.replace(temporary_filepath, cache_filepath)
-    finally:
-        # A successful replace has already consumed the temporary file, so this only ever fires when
-        # the caller's write raised or the block was abandoned.
-        if os.path.exists(temporary_filepath):
-            os.remove(temporary_filepath)
+    return temporary_filepath

--- a/hisim/components/building/building.py
+++ b/hisim/components/building/building.py
@@ -751,7 +751,10 @@ class Building(cp.Component):
                     self.cache,
                     columns=["solar_gain_through_windows"],
                 )
-                with atomic_cache_write(self.cache_file_path) as temporary_cache_filepath:
+                with atomic_cache_write(
+                    self.cache_file_path,
+                    utils.build_cache_key_string(self.buildingconfig, self.my_simulation_parameters),
+                ) as temporary_cache_filepath:
                     database.to_csv(
                         temporary_cache_filepath,
                         sep=",",

--- a/hisim/components/generic_car.py
+++ b/hisim/components/generic_car.py
@@ -568,7 +568,9 @@ class Car(cp.Component):
 
             # save data in cache
             car_cache_dataframe = pd.DataFrame({"car_location": self.car_location, "meters_driven": self.meters_driven})
-            with atomic_cache_write(cache_filepath) as temporary_cache_filepath:
+            with atomic_cache_write(
+                cache_filepath, utils.build_cache_key_string(config, self.my_simulation_parameters)
+            ) as temporary_cache_filepath:
                 car_cache_dataframe.to_csv(temporary_cache_filepath)
             del car_cache_dataframe
 

--- a/hisim/components/generic_pv_system.py
+++ b/hisim/components/generic_pv_system.py
@@ -788,7 +788,9 @@ class PVSystem(cp.Component):
                 {"output_power": self.ac_power_ratios_for_all_timesteps_output},
                 columns=["output_power"],
             )
-            with atomic_cache_write(self.cache_filepath) as temporary_cache_filepath:
+            with atomic_cache_write(
+                self.cache_filepath, utils.build_cache_key_string(self.pvconfig, self.my_simulation_parameters)
+            ) as temporary_cache_filepath:
                 database.to_csv(temporary_cache_filepath, sep=",", decimal=".", index=False)
 
         if self.pvconfig.predictive:

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -7,7 +7,6 @@ import errno
 import io
 import json
 import os
-import shutil
 import contextlib
 from ast import literal_eval
 from dataclasses import dataclass
@@ -339,6 +338,10 @@ class UtspLpgConnector(cp.Component):
         self.calculation_index_for_local_lpg: int = (
             config.calculation_index_for_local_lpg or PylpgWorkspace.default_base_index()
         )
+        # Every index this run has claimed a pylpg working directory for. The cleanup is driven from
+        # here rather than from the result folder, because a run that fails before producing one
+        # still has a directory to remove -- see PylpgWorkspace.release.
+        self.claimed_pylpg_calculation_indices: List[int] = []
 
         self.build()
         # dummy value as long as there is no way to consider multiple households in one house
@@ -910,7 +913,6 @@ class UtspLpgConnector(cp.Component):
                 # invitation to substitute a different household. See roadmap/pylpg_flakiness.md F1.
                 if (self.utsp_config.data_acquisition_mode in
                         (LpgDataAcquisitionMode.USE_UTSP, LpgDataAcquisitionMode.USE_LOCAL_LPG)):
-                    result_folder: Optional[Union[str, List[str]]] = None
                     try:
                         if self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_UTSP:
                             # These raise when the .env is missing, and that is the intent: an
@@ -938,7 +940,7 @@ class UtspLpgConnector(cp.Component):
                             )
                         elif self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_LOCAL_LPG:
                             (
-                                result_folder,
+                                _result_folder,
                                 electricity_file,
                                 warm_water_file,
                                 inner_device_heat_gains_file,
@@ -1095,27 +1097,12 @@ class UtspLpgConnector(cp.Component):
                         raise
 
                     finally:
-                        if result_folder is not None:
-                            folders_to_process: List[str] = []
-                            if isinstance(result_folder, list):
-                                folders_to_process = result_folder
-                            elif isinstance(result_folder, str):
-                                folders_to_process = [result_folder]
-
-                            for folder in folders_to_process:
-                                folder_to_delete = os.path.dirname(folder)
-                                try:
-                                    if folder_to_delete and os.path.exists(folder_to_delete):
-                                        shutil.rmtree(folder_to_delete)
-                                        log.information(
-                                            f"Folder with local lpg result '{os.path.basename(folder_to_delete)}' deleted.")
-                                    else:
-                                        log.warning(
-                                            f"Error: Folder '{folder_to_delete}' does not exist and cannot be deleted.")
-                                except (OSError, TypeError) as e:
-                                    log.warning(f"Error during folder cleanup: {e}")
-                        else:
-                            log.warning("LPG result folder was None; cleanup skipped.")
+                        # Runs whether the attempt succeeded, raised or was interrupted. The
+                        # directories are resolved from the indices claimed above, which are known
+                        # before the calculation starts, so a failure cannot leave debris for the
+                        # next run to trip over.
+                        PylpgWorkspace.release(self.claimed_pylpg_calculation_indices)
+                        self.claimed_pylpg_calculation_indices.clear()
 
                 if self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_PREDEFINED_PROFILE:
                     log.information(
@@ -1321,6 +1308,7 @@ class UtspLpgConnector(cp.Component):
                 # using it or to one that died, and both deserve a named failure rather than a shared
                 # folder.
                 PylpgWorkspace.claim(calculation_index)
+                self.claimed_pylpg_calculation_indices.append(calculation_index)
                 lpe: lpg_execution.LPGExecutor = lpg_execution.LPGExecutor(calculation_index, True)
 
                 request = lpe.make_default_lpg_settings(self.my_simulation_parameters.year)

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -39,6 +39,7 @@ from pylpg import lpg_execution
 
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiHelperClass, KpiTagEnumClass
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
+from hisim.components.pylpg_workspace import PylpgWorkspace
 # Owned
 from hisim import component as cp
 from hisim import loadtypes as lt
@@ -332,12 +333,12 @@ class UtspLpgConnector(cp.Component):
         self.name_of_predefined_loadprofile: Optional[str] = config.name_of_predefined_loadprofile
         self.predefined_loadprofile_filepaths: Optional[str] = config.predefined_loadprofile_filepaths
 
-        self.calculation_index_for_local_lpg: Optional[int] = config.calculation_index_for_local_lpg
-        if not self.calculation_index_for_local_lpg:
-            # Fall back to 1, but allow an override via env var so that several local-LPG
-            # runs in parallel (e.g. batch scenario-JSON regeneration) use distinct
-            # pylpg working directories (C<index>) instead of colliding on C1.
-            self.calculation_index_for_local_lpg = int(os.environ.get("HISIM_LOCAL_LPG_CALC_INDEX", "1"))
+        # The base index decides which pylpg/C<index> directories this process computes in. It used
+        # to default to the constant 1, so every local-LPG run in one virtual environment shared one
+        # directory; the default is now derived from the process instead. See PylpgWorkspace.
+        self.calculation_index_for_local_lpg: int = (
+            config.calculation_index_for_local_lpg or PylpgWorkspace.default_base_index()
+        )
 
         self.build()
         # dummy value as long as there is no way to consider multiple households in one house
@@ -1315,6 +1316,11 @@ class UtspLpgConnector(cp.Component):
                     CalcOption.FlexibilityEvents,
                 ]
 
+                # Claimed before the executor is built, because LPGExecutor clears whatever it finds
+                # and starts writing: a directory that already exists belongs either to a run still
+                # using it or to one that died, and both deserve a named failure rather than a shared
+                # folder.
+                PylpgWorkspace.claim(calculation_index)
                 lpe: lpg_execution.LPGExecutor = lpg_execution.LPGExecutor(calculation_index, True)
 
                 request = lpe.make_default_lpg_settings(self.my_simulation_parameters.year)
@@ -1384,7 +1390,8 @@ class UtspLpgConnector(cp.Component):
 
         log.information("Requesting LPG profiles from local lpg for one household.")
 
-        result_folder = self.execute_local_lpg_single_household(calculation_index=self.calculation_index_for_local_lpg,
+        calculation_index = PylpgWorkspace.calculation_index(self.calculation_index_for_local_lpg, 0)
+        result_folder = self.execute_local_lpg_single_household(calculation_index=calculation_index,
                                                                 household=household,
                                                                 random_seed=None)
 
@@ -1451,12 +1458,17 @@ class UtspLpgConnector(cp.Component):
 
         log.information("Requesting LPG profiles from local lpg for multiple household.")
         result_folder_list = []
-        calculation_index = 1
-        for household in households:
+        # The households of one request are computed one after another but read together at the end,
+        # so each needs a directory of its own that outlives its calculation. They come out of this
+        # run's base index rather than restarting at 1, which is what used to make two concurrent
+        # multi-household requests compute in the same folders.
+        for household_ordinal, household in enumerate(households):
+            calculation_index = PylpgWorkspace.calculation_index(
+                self.calculation_index_for_local_lpg, household_ordinal
+            )
             result_folder = self.execute_local_lpg_single_household(calculation_index=calculation_index,
                                                                     household=household,
                                                                     random_seed=None)
-            calculation_index = calculation_index + 1
             result_folder_list.append(result_folder)
 
         # append all results in lists

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -998,6 +998,7 @@ class UtspLpgConnector(cp.Component):
                             # cache results for each household individually
                             self.cache_results(
                                 cache_filepath=cache_filepath,
+                                effective_household_config=new_unique_config,
                                 number_of_residents=number_of_residents,
                                 electricity_consumption=electricity_consumption,
                                 heating_by_residents=heating_by_residents,
@@ -1077,6 +1078,7 @@ class UtspLpgConnector(cp.Component):
                             # cache for multiple results at a time
                             self.cache_results(
                                 cache_filepath=cache_filepath,
+                                effective_household_config=new_unique_config,
                                 number_of_residents=self.number_of_residents,
                                 heating_by_residents=self.heating_by_residents,
                                 water_consumption=self.water_consumption,
@@ -1958,6 +1960,7 @@ class UtspLpgConnector(cp.Component):
     def cache_results(
         self,
         cache_filepath: str,
+        effective_household_config: "UtspLpgConnectorConfig",
         number_of_residents: List,
         heating_by_residents: List,
         electricity_consumption: List,
@@ -1969,7 +1972,29 @@ class UtspLpgConnector(cp.Component):
         driving_distances: Any,
         # saved_files: List,
     ) -> None:
-        """Make caching file for the results."""
+        """Writes the profiles of one household into the cache, with the configuration that produced them.
+
+        The configuration passed here is the effective one -- the single-household config the request
+        was actually made with -- and its hash has to equal the digest in ``cache_filepath``. That is
+        what the companion metadata file records, so that a later lookup can prove the contents belong
+        to the key rather than assuming it. See ``roadmap/pylpg_flakiness.md`` F5.
+
+        Args:
+            cache_filepath: the entry to write, from ``get_cache_file``.
+            effective_household_config: the configuration the profiles were actually produced from.
+            number_of_residents: per-timestep resident count.
+            heating_by_residents: per-timestep heat gain from the residents.
+            electricity_consumption: per-timestep electricity demand.
+            water_consumption: per-timestep warm-water draw.
+            heating_by_devices: per-timestep heat gain from the devices.
+            flexibility: the flexibility events of this household.
+            car_states: the car state series of this household.
+            car_locations: the car location series of this household.
+            driving_distances: the driving distance series of this household.
+
+        Raises:
+            portalocker.exceptions.LockException: if the entry's lock cannot be acquired in time.
+        """
 
         lock_filepath = cache_filepath + ".lock"
         try:
@@ -2008,7 +2033,10 @@ class UtspLpgConnector(cp.Component):
                     d_f_str = cache_file.getvalue()
                     cache_content.update({key: d_f_str})
 
-                with atomic_cache_write(cache_filepath) as temporary_cache_filepath:
+                with atomic_cache_write(
+                    cache_filepath,
+                    utils.build_cache_key_string(effective_household_config, self.my_simulation_parameters),
+                ) as temporary_cache_filepath:
                     with open(temporary_cache_filepath, "w", encoding="utf-8") as file:
                         json.dump(cache_content, file)
 

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -771,6 +771,34 @@ class UtspLpgConnector(cp.Component):
 
         return filepath
 
+    def describe_unreachable_profile_source(self) -> str:
+        """Builds the guidance printed when the configured profile source cannot deliver a profile.
+
+        The connector used to answer an unreachable profile source by rewriting its own
+        ``data_acquisition_mode`` and continuing with a shipped profile, which produced a full set of
+        plausible results for a household nobody had asked for. That chain is gone, so the remaining
+        job is to make the resulting failure worth reading: name the mode that was configured, and
+        say exactly which one-line configuration change reaches a source that works.
+
+        The note about the predefined profile is the important half. It is not a degraded version of
+        the requested household but a different household altogether, so anyone switching to it has
+        to know that the numbers stop being comparable with the other two modes.
+
+        Returns:
+            str: a multi-line message meant to be logged next to the original traceback, never in
+                place of it.
+        """
+        return (
+            f"Occupancy profile could not be obtained in {self.utsp_config.data_acquisition_mode.name} mode; "
+            "the underlying error follows this message.\n"
+            "\n"
+            "USE_UTSP needs UTSP_URL and UTSP_API_KEY in a .env file at the repository root.\n"
+            "If you do not have UTSP access, set data_acquisition_mode on UtspLpgConnectorConfig to one of\n"
+            "  USE_LOCAL_LPG          - generate the profile locally with pylpg (slower)\n"
+            "  USE_PREDEFINED_PROFILE - use a shipped profile; NOTE this is a DIFFERENT household\n"
+            "                           and results are not comparable with the other two modes."
+        )
+
     def build(self):
         """Retrieves and preprocesses all data for this component."""
 
@@ -876,197 +904,107 @@ class UtspLpgConnector(cp.Component):
                 log.information(
                     "LPG data cannot be taken from cache. It will be taken from UTSP or from predefined profile."
                 )
-                # if taking results from cache not possible, check lpg data acquition mode
-                if self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_UTSP:
-                    # try to get utsp url and api from .env if possible
-                    try:
-                        self.utsp_url = utils.get_environment_variable("UTSP_URL")
-                        self.utsp_api_key = utils.get_environment_variable("UTSP_API_KEY")
-
-                    except Exception:
-                        log.warning(
-                            "You chose USE_UTSP as data_acquition_mode but it is not possible to read the url and api_key from the .env file."
-                            "Please check if this file is present in your system."
-                            "Otherwise the Local LPG will be used."
-                        )
-                        self.utsp_config.data_acquisition_mode = LpgDataAcquisitionMode.USE_LOCAL_LPG
-
-                if self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_LOCAL_LPG:
-                    try:
-                        pass
-                        # todo: use lokal lpg --> check if package is installed
-
-                    except Exception:
-                        log.warning(
-                            "You chose USE_LOCAL_LPG as data_acquition_mode but it is not possible to start local lpg."
-                            "Please check if lpg repo is installed."
-                            "Otherwise the predefined LPG profile in hisim/inputs/loadprofiles will be used."
-                        )
-                        self.utsp_config.data_acquisition_mode = LpgDataAcquisitionMode.USE_PREDEFINED_PROFILE
-
+                # There is deliberately no fallback chain here. The configured mode is the mode that
+                # runs: a profile source that cannot be reached is a configuration error, not an
+                # invitation to substitute a different household. See roadmap/pylpg_flakiness.md F1.
                 if (self.utsp_config.data_acquisition_mode in
                         (LpgDataAcquisitionMode.USE_UTSP, LpgDataAcquisitionMode.USE_LOCAL_LPG)):
-                    max_attempts = 2
-                    attempt = 0
                     result_folder: Optional[Union[str, List[str]]] = None
-                    while attempt < max_attempts:
-                        try:
-                            log.information(f"LPG data acquisition mode: {self.utsp_config.data_acquisition_mode}")
-                            new_unique_config = list_of_unique_household_configs[list_index]
-                            if self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_UTSP:
-                                (
-                                    electricity_file,
-                                    warm_water_file,
-                                    inner_device_heat_gains_file,
-                                    high_activity_file,
-                                    low_activity_file,
-                                    flexibility_file,
-                                    car_states_file,
-                                    car_locations_file,
-                                    driving_distances_file,
-                                ) = self.get_profiles_from_utsp(
-                                    lpg_households=new_unique_config.household,
-                                    guid=new_unique_config.guid,
+                    try:
+                        if self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_UTSP:
+                            # These raise when the .env is missing, and that is the intent: an
+                            # unconfigured UTSP must stop the run rather than quietly become a
+                            # different profile source.
+                            self.utsp_url = utils.get_environment_variable("UTSP_URL")
+                            self.utsp_api_key = utils.get_environment_variable("UTSP_API_KEY")
+
+                        log.information(f"LPG data acquisition mode: {self.utsp_config.data_acquisition_mode}")
+                        new_unique_config = list_of_unique_household_configs[list_index]
+                        if self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_UTSP:
+                            (
+                                electricity_file,
+                                warm_water_file,
+                                inner_device_heat_gains_file,
+                                high_activity_file,
+                                low_activity_file,
+                                flexibility_file,
+                                car_states_file,
+                                car_locations_file,
+                                driving_distances_file,
+                            ) = self.get_profiles_from_utsp(
+                                lpg_households=new_unique_config.household,
+                                guid=new_unique_config.guid,
+                            )
+                        elif self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_LOCAL_LPG:
+                            (
+                                result_folder,
+                                electricity_file,
+                                warm_water_file,
+                                inner_device_heat_gains_file,
+                                high_activity_file,
+                                low_activity_file,
+                                flexibility_file,
+                                car_states_file,
+                                car_locations_file,
+                                driving_distances_file,
+                            ) = self.get_profiles_from_local_lpg(lpg_households=new_unique_config.household)
+
+                        # only one result obtained
+                        if isinstance(electricity_file, str):
+                            log.information(f"One result obtained from {self.utsp_config.data_acquisition_mode}.")
+                            (
+                                electricity_consumption,
+                                heating_by_devices,
+                                water_consumption,
+                                heating_by_residents,
+                                number_of_residents,
+                            ) = self.load_result_files_and_transform_to_lists(
+                                electricity=electricity_file,
+                                warm_water=warm_water_file,
+                                inner_device_heat_gains=inner_device_heat_gains_file,
+                                high_activity=high_activity_file,
+                                low_activity=low_activity_file,
+                                data_acquisition_mode=self.utsp_config.data_acquisition_mode,
+                            )
+                            list_of_flexibility_and_car_files = [
+                                flexibility_file,
+                                car_states_file,
+                                car_locations_file,
+                                driving_distances_file,
+                            ]
+                            if all(isinstance(file, str) for file in list_of_flexibility_and_car_files):
+                                list_of_flexibility_and_car_data = self.load_results_and_transform_string_to_data(
+                                    list_of_result_files=list_of_flexibility_and_car_files  # type: ignore
                                 )
-                            elif self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_LOCAL_LPG:
-                                (
-                                    result_folder,
-                                    electricity_file,
-                                    warm_water_file,
-                                    inner_device_heat_gains_file,
-                                    high_activity_file,
-                                    low_activity_file,
-                                    flexibility_file,
-                                    car_states_file,
-                                    car_locations_file,
-                                    driving_distances_file,
-                                ) = self.get_profiles_from_local_lpg(lpg_households=new_unique_config.household)
-
-                            # only one result obtained
-                            if isinstance(electricity_file, str):
-                                log.information(f"One result obtained from {self.utsp_config.data_acquisition_mode}.")
-                                (
-                                    electricity_consumption,
-                                    heating_by_devices,
-                                    water_consumption,
-                                    heating_by_residents,
-                                    number_of_residents,
-                                ) = self.load_result_files_and_transform_to_lists(
-                                    electricity=electricity_file,
-                                    warm_water=warm_water_file,
-                                    inner_device_heat_gains=inner_device_heat_gains_file,
-                                    high_activity=high_activity_file,
-                                    low_activity=low_activity_file,
-                                    data_acquisition_mode=self.utsp_config.data_acquisition_mode,
-                                )
-                                list_of_flexibility_and_car_files = [
-                                    flexibility_file,
-                                    car_states_file,
-                                    car_locations_file,
-                                    driving_distances_file,
-                                ]
-                                if all(isinstance(file, str) for file in list_of_flexibility_and_car_files):
-                                    list_of_flexibility_and_car_data = self.load_results_and_transform_string_to_data(
-                                        list_of_result_files=list_of_flexibility_and_car_files  # type: ignore
-                                    )
-                                else:
-                                    raise TypeError(
-                                        f"Type of flexibility and car files should be str, but it's {[type(i) for i in list_of_flexibility_and_car_files]}"
-                                    )
-
-                                # write lists to dict
-                                value_dict["electricity_consumption"].append(electricity_consumption)
-                                value_dict["heating_by_devices"].append(heating_by_devices)
-                                value_dict["heating_by_residents"].append(heating_by_residents)
-                                value_dict["water_consumption"].append(water_consumption)
-                                value_dict["number_of_residents"].append(number_of_residents)
-                                self.flexibility_data_dict["flexibility"].append(list_of_flexibility_and_car_data[0])
-                                self.car_data_dict["car_states"].append(list_of_flexibility_and_car_data[1])
-                                self.car_data_dict["car_locations"].append(list_of_flexibility_and_car_data[2])
-                                self.car_data_dict["driving_distances"].append(list_of_flexibility_and_car_data[3])
-
-                                # cache results for each household individually
-                                self.cache_results(
-                                    cache_filepath=cache_filepath,
-                                    number_of_residents=number_of_residents,
-                                    electricity_consumption=electricity_consumption,
-                                    heating_by_residents=heating_by_residents,
-                                    water_consumption=water_consumption,
-                                    heating_by_devices=heating_by_devices,
-                                    flexibility=list_of_flexibility_and_car_data[0],
-                                    car_states=list_of_flexibility_and_car_data[1],
-                                    car_locations=list_of_flexibility_and_car_data[2],
-                                    driving_distances=list_of_flexibility_and_car_data[3],
+                            else:
+                                raise TypeError(
+                                    f"Type of flexibility and car files should be str, but it's {[type(i) for i in list_of_flexibility_and_car_files]}"
                                 )
 
-                            # multiple results obtained (when multiple households in utsp_config given and the guid in the config is not "" but has a specific value)
-                            elif isinstance(electricity_file, List):
-                                log.information(f"Multiple results obtained from {self.utsp_config.data_acquisition_mode}.")
+                            # write lists to dict
+                            value_dict["electricity_consumption"].append(electricity_consumption)
+                            value_dict["heating_by_devices"].append(heating_by_devices)
+                            value_dict["heating_by_residents"].append(heating_by_residents)
+                            value_dict["water_consumption"].append(water_consumption)
+                            value_dict["number_of_residents"].append(number_of_residents)
+                            self.flexibility_data_dict["flexibility"].append(list_of_flexibility_and_car_data[0])
+                            self.car_data_dict["car_states"].append(list_of_flexibility_and_car_data[1])
+                            self.car_data_dict["car_locations"].append(list_of_flexibility_and_car_data[2])
+                            self.car_data_dict["driving_distances"].append(list_of_flexibility_and_car_data[3])
 
-                                for index, electricity in enumerate(electricity_file):
-                                    warm_water = warm_water_file[index]
-                                    inner_device_heat_gains = inner_device_heat_gains_file[index]
-                                    high_activity = high_activity_file[index]
-                                    low_activity = low_activity_file[index]
-                                    flexibility = flexibility_file[index]
-                                    car_states = car_states_file[index]
-                                    car_locations = car_locations_file[index]
-                                    driving_distances = driving_distances_file[index]
-
-                                    (
-                                        electricity_consumption,
-                                        heating_by_devices,
-                                        water_consumption,
-                                        heating_by_residents,
-                                        number_of_residents,
-                                    ) = self.load_result_files_and_transform_to_lists(
-                                        electricity=electricity,
-                                        warm_water=warm_water,
-                                        inner_device_heat_gains=inner_device_heat_gains,
-                                        high_activity=high_activity,
-                                        low_activity=low_activity,
-                                        data_acquisition_mode=self.utsp_config.data_acquisition_mode,
-                                    )
-                                    list_of_flexibility_and_car_data = self.load_results_and_transform_string_to_data(
-                                        list_of_result_files=[flexibility, car_states, car_locations, driving_distances]
-                                    )
-
-                                    # write lists to dict
-                                    value_dict["electricity_consumption"].append(electricity_consumption)
-                                    value_dict["heating_by_devices"].append(heating_by_devices)
-                                    value_dict["heating_by_residents"].append(heating_by_residents)
-                                    value_dict["water_consumption"].append(water_consumption)
-                                    value_dict["number_of_residents"].append(number_of_residents)
-                                    self.flexibility_data_dict["flexibility"].append(list_of_flexibility_and_car_data[0])
-                                    self.car_data_dict["car_states"].append(list_of_flexibility_and_car_data[1])
-                                    self.car_data_dict["car_locations"].append(list_of_flexibility_and_car_data[2])
-                                    self.car_data_dict["driving_distances"].append(list_of_flexibility_and_car_data[3])
-
-                                # get sum of all household profiles
-                                (
-                                    self.electricity_consumption,
-                                    self.heating_by_residents,
-                                    self.water_consumption,
-                                    self.heating_by_devices,
-                                    self.number_of_residents,
-                                ) = self.get_result_lists_by_summing_over_value_dict(value_dict=value_dict)
-
-                                self.max_hot_water_demand = max(self.water_consumption)
-
-                                # cache for multiple results at a time
-                                self.cache_results(
-                                    cache_filepath=cache_filepath,
-                                    number_of_residents=self.number_of_residents,
-                                    heating_by_residents=self.heating_by_residents,
-                                    water_consumption=self.water_consumption,
-                                    heating_by_devices=self.heating_by_devices,
-                                    electricity_consumption=self.electricity_consumption,
-                                    flexibility=list_of_flexibility_and_car_data[0],
-                                    car_states=list_of_flexibility_and_car_data[1],
-                                    car_locations=list_of_flexibility_and_car_data[2],
-                                    driving_distances=list_of_flexibility_and_car_data[3],
-                                )
-                                break
+                            # cache results for each household individually
+                            self.cache_results(
+                                cache_filepath=cache_filepath,
+                                number_of_residents=number_of_residents,
+                                electricity_consumption=electricity_consumption,
+                                heating_by_residents=heating_by_residents,
+                                water_consumption=water_consumption,
+                                heating_by_devices=heating_by_devices,
+                                flexibility=list_of_flexibility_and_car_data[0],
+                                car_states=list_of_flexibility_and_car_data[1],
+                                car_locations=list_of_flexibility_and_car_data[2],
+                                driving_distances=list_of_flexibility_and_car_data[3],
+                            )
 
                             # get sum of all household profiles
                             (
@@ -1079,44 +1017,104 @@ class UtspLpgConnector(cp.Component):
 
                             self.max_hot_water_demand = max(self.water_consumption)
 
-                            break
+                        # multiple results obtained (when multiple households in utsp_config given and the guid in the config is not "" but has a specific value)
+                        elif isinstance(electricity_file, List):
+                            log.information(f"Multiple results obtained from {self.utsp_config.data_acquisition_mode}.")
 
-                        except Exception as e:
-                            log.warning(f"Error while {self.utsp_config.data_acquisition_mode} request: {e}")
-                            if self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_UTSP:
-                                self.utsp_config.data_acquisition_mode = LpgDataAcquisitionMode.USE_LOCAL_LPG
-                            elif self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_LOCAL_LPG:
-                                attempt = 1
-                                self.utsp_config.data_acquisition_mode = LpgDataAcquisitionMode.USE_PREDEFINED_PROFILE
-                            else:
-                                break
-                            log.warning(
-                                f"LPG data acquisition mode will be set to: {self.utsp_config.data_acquisition_mode}!"
+                            for index, electricity in enumerate(electricity_file):
+                                warm_water = warm_water_file[index]
+                                inner_device_heat_gains = inner_device_heat_gains_file[index]
+                                high_activity = high_activity_file[index]
+                                low_activity = low_activity_file[index]
+                                flexibility = flexibility_file[index]
+                                car_states = car_states_file[index]
+                                car_locations = car_locations_file[index]
+                                driving_distances = driving_distances_file[index]
+
+                                (
+                                    electricity_consumption,
+                                    heating_by_devices,
+                                    water_consumption,
+                                    heating_by_residents,
+                                    number_of_residents,
+                                ) = self.load_result_files_and_transform_to_lists(
+                                    electricity=electricity,
+                                    warm_water=warm_water,
+                                    inner_device_heat_gains=inner_device_heat_gains,
+                                    high_activity=high_activity,
+                                    low_activity=low_activity,
+                                    data_acquisition_mode=self.utsp_config.data_acquisition_mode,
+                                )
+                                list_of_flexibility_and_car_data = self.load_results_and_transform_string_to_data(
+                                    list_of_result_files=[flexibility, car_states, car_locations, driving_distances]
+                                )
+
+                                # write lists to dict
+                                value_dict["electricity_consumption"].append(electricity_consumption)
+                                value_dict["heating_by_devices"].append(heating_by_devices)
+                                value_dict["heating_by_residents"].append(heating_by_residents)
+                                value_dict["water_consumption"].append(water_consumption)
+                                value_dict["number_of_residents"].append(number_of_residents)
+                                self.flexibility_data_dict["flexibility"].append(list_of_flexibility_and_car_data[0])
+                                self.car_data_dict["car_states"].append(list_of_flexibility_and_car_data[1])
+                                self.car_data_dict["car_locations"].append(list_of_flexibility_and_car_data[2])
+                                self.car_data_dict["driving_distances"].append(list_of_flexibility_and_car_data[3])
+
+                            # get sum of all household profiles
+                            (
+                                self.electricity_consumption,
+                                self.heating_by_residents,
+                                self.water_consumption,
+                                self.heating_by_devices,
+                                self.number_of_residents,
+                            ) = self.get_result_lists_by_summing_over_value_dict(value_dict=value_dict)
+
+                            self.max_hot_water_demand = max(self.water_consumption)
+
+                            # cache for multiple results at a time
+                            self.cache_results(
+                                cache_filepath=cache_filepath,
+                                number_of_residents=self.number_of_residents,
+                                heating_by_residents=self.heating_by_residents,
+                                water_consumption=self.water_consumption,
+                                heating_by_devices=self.heating_by_devices,
+                                electricity_consumption=self.electricity_consumption,
+                                flexibility=list_of_flexibility_and_car_data[0],
+                                car_states=list_of_flexibility_and_car_data[1],
+                                car_locations=list_of_flexibility_and_car_data[2],
+                                driving_distances=list_of_flexibility_and_car_data[3],
                             )
-                            attempt += 1
 
-                        finally:
-                            if result_folder is not None:
-                                folders_to_process: List[str] = []
-                                if isinstance(result_folder, list):
-                                    folders_to_process = result_folder
-                                elif isinstance(result_folder, str):
-                                    folders_to_process = [result_folder]
+                    except Exception:
+                        # Unwrapped on purpose: the original exception and its traceback reach the
+                        # caller untouched, with the guidance printed beside it rather than instead
+                        # of it. Narrowing or re-wrapping here would only mistranslate failures that
+                        # nobody has observed yet.
+                        log.error(self.describe_unreachable_profile_source())
+                        raise
 
-                                for folder in folders_to_process:
-                                    folder_to_delete = os.path.dirname(folder)
-                                    try:
-                                        if folder_to_delete and os.path.exists(folder_to_delete):
-                                            shutil.rmtree(folder_to_delete)
-                                            log.information(
-                                                f"Folder with local lpg result '{os.path.basename(folder_to_delete)}' deleted.")
-                                        else:
-                                            log.warning(
-                                                f"Error: Folder '{folder_to_delete}' does not exist and cannot be deleted.")
-                                    except (OSError, TypeError) as e:
-                                        log.warning(f"Error during folder cleanup: {e}")
-                            else:
-                                log.warning("LPG result folder was None; cleanup skipped.")
+                    finally:
+                        if result_folder is not None:
+                            folders_to_process: List[str] = []
+                            if isinstance(result_folder, list):
+                                folders_to_process = result_folder
+                            elif isinstance(result_folder, str):
+                                folders_to_process = [result_folder]
+
+                            for folder in folders_to_process:
+                                folder_to_delete = os.path.dirname(folder)
+                                try:
+                                    if folder_to_delete and os.path.exists(folder_to_delete):
+                                        shutil.rmtree(folder_to_delete)
+                                        log.information(
+                                            f"Folder with local lpg result '{os.path.basename(folder_to_delete)}' deleted.")
+                                    else:
+                                        log.warning(
+                                            f"Error: Folder '{folder_to_delete}' does not exist and cannot be deleted.")
+                                except (OSError, TypeError) as e:
+                                    log.warning(f"Error during folder cleanup: {e}")
+                        else:
+                            log.warning("LPG result folder was None; cleanup skipped.")
 
                 if self.utsp_config.data_acquisition_mode == LpgDataAcquisitionMode.USE_PREDEFINED_PROFILE:
                     log.information(

--- a/hisim/components/pylpg_workspace.py
+++ b/hisim/components/pylpg_workspace.py
@@ -10,18 +10,22 @@ first deleted the directory the other was still using.
 
 This module owns the index arithmetic and the directory lifecycle instead, so the connector does not
 have to. The default index comes from the process, which removes the shared constant; the directory
-is claimed before it is created, and claiming one that already exists fails immediately with a message
-naming the index, because the alternative is two runs silently interleaving in one folder. See
-``roadmap/pylpg_flakiness.md`` F3.
+is claimed before it is created and released once the attempt ends, whether it succeeded or not; and
+claiming one that already exists fails immediately with a message naming the index, because the
+alternative is two runs silently interleaving in one folder. See ``roadmap/pylpg_flakiness.md`` F3
+and F4.
 """
 
 # clean
 
 import os
 import pathlib
-from typing import ClassVar
+import shutil
+from typing import ClassVar, List
 
 from pylpg import lpg_execution
+
+from hisim import log
 
 __authors__ = "Noah Pflugradt"
 __copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
@@ -161,3 +165,31 @@ class PylpgWorkspace:
                 f"{cls.INDEX_ENVIRONMENT_VARIABLE} to a free index for this process."
             )
         return directory
+
+    @classmethod
+    def release(cls, calculation_indices: List[int]) -> None:
+        """Deletes the working directories of the given calculation indices, ignoring what is gone.
+
+        Cleanup used to be driven by the result folder the calculation returned, which only exists
+        once the calculation has produced one. A run that failed earlier than that -- an unavailable
+        binary, a killed process, a collision -- logged that the result folder was ``None``, skipped
+        the cleanup and left its directory on disk, so the next run failed on ``Directory not empty``
+        before it started and one failure poisoned the next. The calculation index is known before the
+        attempt begins, so resolving the path from it lets the cleanup run either way.
+
+        Failures to delete are logged rather than raised. This runs in a ``finally`` block, where an
+        exception would replace whatever the run was already failing with, and a directory that could
+        not be removed is reported by the next :meth:`claim` anyway.
+
+        Args:
+            calculation_indices: the indices this run claimed; ones whose directory is already gone
+                are skipped silently.
+        """
+        for calculation_index in calculation_indices:
+            directory = cls.working_directory(calculation_index)
+            try:
+                if directory.exists():
+                    shutil.rmtree(directory)
+                    log.information(f"Local LPG working directory '{directory.name}' deleted.")
+            except OSError as error:
+                log.warning(f"Could not delete the local LPG working directory '{directory}': {error}")

--- a/hisim/components/pylpg_workspace.py
+++ b/hisim/components/pylpg_workspace.py
@@ -1,0 +1,163 @@
+"""Allocates and reclaims the working directory that a local LoadProfileGenerator run computes in.
+
+``pylpg`` does not let a caller choose where it works. ``LPGExecutor.__init__`` hard-codes
+``self.working_directory = pathlib.Path(__file__).parent.absolute()`` and then derives
+``"C" + str(calculation_index)`` beneath it, so the run happens *inside the installed package* and
+the calculation index is the only isolation the library offers. HiSim used to default that index to
+the constant ``1``, which meant every local-LPG process in one virtual environment computed in the
+same ``pylpg/C1`` directory: two at once corrupted each other's sqlite files, and whichever finished
+first deleted the directory the other was still using.
+
+This module owns the index arithmetic and the directory lifecycle instead, so the connector does not
+have to. The default index comes from the process, which removes the shared constant; the directory
+is claimed before it is created, and claiming one that already exists fails immediately with a message
+naming the index, because the alternative is two runs silently interleaving in one folder. See
+``roadmap/pylpg_flakiness.md`` F3.
+"""
+
+# clean
+
+import os
+import pathlib
+from typing import ClassVar
+
+from pylpg import lpg_execution
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+class PylpgWorkingDirectoryInUseError(RuntimeError):
+    """Raised when the ``pylpg/C<index>`` directory a run needs is already on disk.
+
+    It is a distinct type rather than a bare ``RuntimeError`` so that a caller which genuinely wants
+    to wait, retry or pick another index can tell this apart from a failure of the calculation
+    itself. Nothing in HiSim does that today, and deliberately so: the connector lets it propagate
+    like any other failure of the profile source.
+    """
+
+
+class PylpgWorkspace:
+    """Turns a base index into per-household ``pylpg`` working directories and hands them back.
+
+    The class exists because three separate call sites used to invent their own index -- the
+    connector defaulted to ``1``, the multi-household request restarted its own counter at ``1``, and
+    only the scenario regenerator passed anything distinct -- and none of them checked whether the
+    directory they were about to compute in was free. Collecting the rule in one place makes the
+    guarantee statable: distinct processes never derive the same directory, and a directory that is
+    nevertheless occupied stops the run by name instead of being shared.
+
+    The guarantee comes from the stride. A base index is multiplied by
+    :attr:`HOUSEHOLDS_PER_BASE_INDEX` before the household's ordinal is added, so the indices derived
+    from two different base indices cannot overlap. With the default base index -- the process id,
+    which the kernel already keeps unique among running processes -- that makes concurrent runs
+    disjoint without any coordination between them. What remains is a directory left behind by a run
+    that was killed, over a process id the kernel has since recycled; :meth:`claim` reports exactly
+    that case.
+    """
+
+    INDEX_ENVIRONMENT_VARIABLE: ClassVar[str] = "HISIM_LOCAL_LPG_CALC_INDEX"
+    HOUSEHOLDS_PER_BASE_INDEX: ClassVar[int] = 100
+
+    @classmethod
+    def default_base_index(cls) -> int:
+        """Returns the base calculation index for this process, from the environment or the pid.
+
+        The environment variable stays supported because a caller that runs several HiSim processes
+        itself -- the parallel scenario regenerator, for one -- would rather hand out small, readable
+        indices it controls than trust a derivation. Everyone else gets the process id, which needs
+        no coordination and is unique among live processes by construction.
+
+        Returns:
+            int: the base index; multiply it through :meth:`calculation_index` before use.
+
+        Raises:
+            ValueError: if the environment variable is set to something that is not an integer.
+        """
+        configured = os.environ.get(cls.INDEX_ENVIRONMENT_VARIABLE)
+        if configured:
+            return int(configured)
+        return os.getpid()
+
+    @classmethod
+    def calculation_index(cls, base_index: int, household_ordinal: int) -> int:
+        """Derives the calculation index for one household of a request from the run's base index.
+
+        A request for several households needs several directories at once, because the result files
+        of all of them are read after the last calculation finishes. Numbering them consecutively
+        from the base index would be wrong with a process-derived base: process ids are handed out in
+        sequence, so two runs started back to back would overlap immediately. Striding by
+        :attr:`HOUSEHOLDS_PER_BASE_INDEX` keeps each base index's block to itself.
+
+        Args:
+            base_index: the run's base index, normally from :meth:`default_base_index`.
+            household_ordinal: the household's position in this request, counting from zero.
+
+        Returns:
+            int: the calculation index to hand to ``pylpg``.
+
+        Raises:
+            ValueError: if the ordinal does not fit in the stride, which would let this request's
+                indices spill into the next base index's block.
+        """
+        if not 0 <= household_ordinal < cls.HOUSEHOLDS_PER_BASE_INDEX:
+            raise ValueError(
+                f"A single local-LPG request cannot cover more than {cls.HOUSEHOLDS_PER_BASE_INDEX} "
+                f"households, because the calculation indices of one run would then run into those of "
+                f"another; household ordinal {household_ordinal} is out of range."
+            )
+        return base_index * cls.HOUSEHOLDS_PER_BASE_INDEX + household_ordinal
+
+    @staticmethod
+    def working_directory(calculation_index: int) -> pathlib.Path:
+        """Returns the directory ``pylpg`` will compute in for the given calculation index.
+
+        The path is reconstructed the way ``LPGExecutor.__init__`` builds it, from the location of
+        the installed ``pylpg`` package, because the library exposes it nowhere else. That coupling
+        is unpleasant and is the reason the fix is an index scheme rather than a temporary directory:
+        writing into an installed package is the underlying mistake, and the index only rations the
+        damage until ``pylpg`` allows the working directory to be chosen.
+
+        Args:
+            calculation_index: the index a ``pylpg`` calculation will run under.
+
+        Returns:
+            pathlib.Path: the absolute path of that calculation's directory.
+        """
+        pylpg_package_directory = pathlib.Path(lpg_execution.__file__).parent.absolute()
+        return pylpg_package_directory / f"C{calculation_index}"
+
+    @classmethod
+    def claim(cls, calculation_index: int) -> pathlib.Path:
+        """Reserves the working directory for a calculation, failing if something already holds it.
+
+        The check has to happen before ``pylpg`` is invoked, because ``LPGExecutor`` clears whatever
+        it finds and starts writing. If the directory belongs to a run that is still going, clearing
+        it destroys that run; if it belongs to one that died, its debris makes this run fail later
+        and much less clearly, which is how a development box degraded over a session into producing
+        the wrong household on every run.
+
+        Args:
+            calculation_index: the index the calculation will run under.
+
+        Returns:
+            pathlib.Path: the claimed directory, which does not exist yet and which ``pylpg`` will
+                create.
+
+        Raises:
+            PylpgWorkingDirectoryInUseError: if the directory is already on disk.
+        """
+        directory = cls.working_directory(calculation_index)
+        if directory.exists():
+            raise PylpgWorkingDirectoryInUseError(
+                f"The local LPG working directory for calculation index {calculation_index} already "
+                f"exists: {directory}. Either another run is using it right now, or a previous run was "
+                f"killed and left it behind. Delete it if no run is using it, or set "
+                f"{cls.INDEX_ENVIRONMENT_VARIABLE} to a free index for this process."
+            )
+        return directory

--- a/hisim/components/solar_thermal_system.py
+++ b/hisim/components/solar_thermal_system.py
@@ -742,7 +742,9 @@ class SolarThermalSystem(Component):
 
             # Save as a flat CSV, landed atomically so a concurrent reader never sees it half written.
             assert self.cache_filepath is not None
-            with atomic_cache_write(self.cache_filepath) as temporary_cache_filepath:
+            with atomic_cache_write(
+                self.cache_filepath, utils.build_cache_key_string(self.config, self.my_simulation_parameters)
+            ) as temporary_cache_filepath:
                 full_df.to_csv(temporary_cache_filepath, sep=",", decimal=".", index=False)
 
 

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -871,7 +871,9 @@ class Weather(Component):
                     "t_out_daily_average",
                 ],
             )
-            with atomic_cache_write(cache_filepath) as temporary_cache_filepath:
+            with atomic_cache_write(
+                cache_filepath, utils.build_cache_key_string(self.weather_config, self.my_simulation_parameters)
+            ) as temporary_cache_filepath:
                 database.to_csv(temporary_cache_filepath)
 
         # Publish the full-year weather series to the singleton repository unconditionally.

--- a/hisim/utils.py
+++ b/hisim/utils.py
@@ -3,7 +3,6 @@
 # clean
 import datetime as dt
 import gc
-import hashlib
 import inspect
 import itertools
 import json
@@ -22,6 +21,7 @@ import psutil
 import pytz
 
 from hisim import log
+from hisim.caching import CacheEntryMetadata
 from hisim.simulationparameters import SimulationParameters
 
 __authors__ = "Noah Pflugradt, Vitor Hugo Bellotto Zago"
@@ -355,9 +355,14 @@ def get_cache_file(
     wastes work but is harmless, because the contents are a pure function of the key. What is *not*
     harmless is writing the entry straight to the returned path, which lets a concurrent reader see it
     half written -- so every writer must land its entry through
-    :func:`hisim.caching.atomic_cache_write`. This function keeps its own hashing for now and becomes
-    a thin delegating wrapper over ``hisim/caching/`` in a later phase of
-    ``roadmap/cache_service_spec.md`` §4.
+    :func:`hisim.caching.atomic_cache_write`. This function becomes a thin delegating wrapper over
+    ``hisim/caching/`` in a later phase of ``roadmap/cache_service_spec.md`` §4.
+
+    An existing entry only counts as a hit if its companion metadata is present and hashes to the
+    name the entry is filed under. One that fails that check is deleted here and reported as a miss:
+    either it was written before the metadata scheme existed, or its contents came from something
+    other than what its key describes, and there is no way to tell those apart from the file alone.
+    That is also what removes the need for a one-off purge whenever the key scheme changes.
 
     Args:
         component_key: filename prefix for the component type.
@@ -372,34 +377,65 @@ def get_cache_file(
     Raises:
         ValueError: if ``my_simulation_parameters`` is None or the JSON string is too short.
     """
-    parameter_class_copy = copy.deepcopy(parameter_class)
-    component_id = getattr(parameter_class_copy, "component_id", None)
-    if component_id is not None:
-        # The cached data depends on what the component is and how it is parameterized, not on
-        # which building it happens to sit in, so the building is removed from the identity
-        # before the configuration is hashed. The identity is frozen, hence the replacement.
-        setattr(parameter_class_copy, "component_id", dataclasses.replace(component_id, building=None))
-    json_str = parameter_class_copy.to_json()
-    if my_simulation_parameters is None:
-        raise ValueError("Simulation parameters was none.")
+    json_str = build_cache_key_string(parameter_class, my_simulation_parameters)
     if cache_dir_path is None:
         cache_dir_path = my_simulation_parameters.cache_dir_path
-    simulation_parameter_str = my_simulation_parameters.get_unique_key()
-    json_str = json_str + simulation_parameter_str
-    if len(json_str) < 5:
-        raise ValueError("Empty json detected for caching. This is a bug.")
-    json_str_encoded = json_str.encode("utf-8")
-    # Johanna Ganglbauer: python told me "TypeError: openssl_sha256() takes at most 1 argument (2 given)",
-    # I removed the second input argument "usedforsecurity=False" and it works - maybe I need to update the hashlib package?
-    sha_key = hashlib.sha256(json_str_encoded).hexdigest()
+    sha_key = CacheEntryMetadata.hash_of(json_str)
     filename = f"{component_key}_{sha_key}.cache"
 
     cache_absolute_filepath = os.path.join(cache_dir_path, filename)
     if not os.path.isdir(cache_dir_path):
         os.mkdir(cache_dir_path)
     if os.path.isfile(cache_absolute_filepath):
-        return True, cache_absolute_filepath
+        if CacheEntryMetadata.describes(cache_absolute_filepath):
+            return True, cache_absolute_filepath
+        # An entry whose metadata is missing or disagrees with its own filename cannot be shown to
+        # belong to this key: either it predates the metadata scheme, or something other than what
+        # the key describes produced it. Deleting it turns both cases into an ordinary miss, which
+        # is what makes the migration self-executing and a poisoning self-repairing.
+        log.warning(
+            f"Discarding the cache entry {cache_absolute_filepath}: its metadata is missing or does "
+            f"not hash to the name it is filed under, so its contents cannot be shown to belong to "
+            f"this key. It will be recomputed."
+        )
+        CacheEntryMetadata.discard(cache_absolute_filepath)
     return False, cache_absolute_filepath
+
+
+def build_cache_key_string(parameter_class: Any, my_simulation_parameters: SimulationParameters) -> str:
+    """Builds the raw string a cache entry's name is hashed from, and its metadata records verbatim.
+
+    The string is shared by three callers that must agree exactly: the lookup that turns it into a
+    filename, the writer that stores it beside the entry, and the validation that recomputes the hash
+    from the stored copy. Splitting it out of ``get_cache_file`` is what lets a writer record the
+    inputs that actually produced its bytes rather than re-deriving what was asked for.
+
+    The component's building is removed from its identity first. The cached data depends on what the
+    component is and how it is parameterized, not on which building it happens to sit in, and leaving
+    the building in would file the same computation under a different name for every house.
+
+    Args:
+        parameter_class: the configuration dataclass, which must provide ``to_json``.
+        my_simulation_parameters: contributes start, end, resolution, year, timesteps and country.
+
+    Returns:
+        str: the configuration JSON followed by the simulation parameters' unique key.
+
+    Raises:
+        ValueError: if ``my_simulation_parameters`` is None, or the resulting string is too short to
+            be a real configuration, which would mean the caller passed something empty.
+    """
+    if my_simulation_parameters is None:
+        raise ValueError("Simulation parameters was none.")
+    parameter_class_copy = copy.deepcopy(parameter_class)
+    component_id = getattr(parameter_class_copy, "component_id", None)
+    if component_id is not None:
+        # The identity is frozen, hence the replacement rather than an assignment.
+        setattr(parameter_class_copy, "component_id", dataclasses.replace(component_id, building=None))
+    json_str = parameter_class_copy.to_json() + my_simulation_parameters.get_unique_key()
+    if len(json_str) < 5:
+        raise ValueError("Empty json detected for caching. This is a bug.")
+    return str(json_str)
 
 
 def load_export_load_profile_generator(target: str) -> Dict[str, List[str]]:  # noqa

--- a/roadmap/pylpg_flakiness.md
+++ b/roadmap/pylpg_flakiness.md
@@ -1,0 +1,669 @@
+# Why the LPG runs are flaky, and what to do about it
+
+*(The last section widens to every cached component: the worst fault here is a caching pattern, not a pylpg quirk.)*
+
+**Status:** findings, for review · **Date:** 2026-08-31
+**Scope:** `hisim/components/loadprofilegenerator_utsp_connector.py` and the `pylpg` package it drives — and, from §7 onward, every component that caches. Half the faults here turned out not to be about load profiles at all.
+§13 widens to all six components that cache, because the worst fault is a caching pattern rather than a pylpg quirk.
+**Why now:** a golden check that fails on one box and passes in CI, traced to several independent defects.
+
+**Relationship to PR #584 (`cache_service`), read 2026-08-31 — important for anyone comparing the two.**
+That specification predates this document (2026-08-22) and **already contains Faults E and F**, including
+the solar-thermal feedback case in nearly these words. This document did not discover them; it re-derived
+them, and what it adds is evidence that they are live: Fault E is the confirmed cause of a
+`scenario-json-freshness` failure in CI on 2026-08-31, and §13's per-component table checks #584's survey
+against the code as it stands today.
+
+Faults **A to D** — the load-profile fallback chain, the shared `pylpg` working directory, cleanup only on
+success, and the cache filed under a mode that did not run — are **not** in #584 and are this document's own.
+The split matters for ownership: E and F belong to the cache service and should be fixed inside
+`hisim/caching/` as that specification lays out, while A to D are local to the load-profile connector.
+
+---
+
+## 1. The short version
+
+Two separate faults, often mistaken for one:
+
+1. **Any exception in the profile path silently swaps the household.** A transient error — sqlite, IO,
+   timeout, a missing `.env` — makes the connector rewrite its own `data_acquisition_mode` and continue with
+   the shipped `CHR01 Couple both at Work` profile. The simulation finishes, exits zero, and produces a full
+   set of plausible KPIs **for a household nobody asked for**. This needs no concurrency and no shared state;
+   it explains a golden-year job failing for a single household in an isolated runner, and passing on re-run.
+2. **All local LPG runs share one working directory inside `site-packages`.** `pylpg` derives it from the
+   calculation index alone, HiSim defaults that index to `1`, so every process in one virtual environment
+   uses `C1`. Two at once corrupt each other; one that dies leaves the directory dirty and the next fails
+   before it starts. This explains local flakiness and parallel runs; it explains nothing in CI.
+
+3. **The cache is filed under a name the run did not use.** The key is taken from the *requested*
+   configuration before the request; the contents come from whatever actually ran. A downgraded run is
+   therefore filed under the name of the mode it failed to use, and every later run with that configuration
+   gets a cache hit and the wrong household — with no warning at all, because the fallback is never entered.
+   **A transient error becomes permanent and silent.**
+
+4. **Cache entries are written straight to their final path, never atomically.** Two runs computing the same
+   key race: one begins writing, the other sees a file that exists, reads it half-written, and either fails to
+   parse it or silently gets truncated data. This is what broke `default_connections` in CI while its
+   near-twin succeeded beside it, and it affects every cached component (§7).
+
+5. **Cache keys name their owner, not the value's inputs.** Four of the six components cache something
+   derived from a neighbour — PV and the building from the weather, the car from the household — under a key
+   that cannot tell one neighbour from another. And the solar thermal collector caches a series that depends
+   on the storage temperature it is wired to, which no key can ever capture, because that value does not
+   exist until the run produces it (§8).
+
+The third is the worst, and it is a *caching* fault rather than a load-profile one, so §13 widens the
+verification to all six components that cache.
+
+**The decided fix for the first is deletion, not containment** (§9 F1): a run whose configured profile source
+is unavailable fails with an error saying how to configure it differently. That removes the third by
+construction, since a mode that is never rewritten cannot diverge from the key taken before it. It does
+**not** remove the second, and it raises its priority — see F3.
+
+## 2. What was observed
+
+- `scripts/golden_check.py --setup household_heatpump_building_sizer --param one_week_60s` fails on the
+  development box with **67 diverged KPIs**, while the **same commit passes in CI** (`golden-check.yml` on
+  `main` at `79020a2a`, success). The failure reproduces on `main` itself, so it belongs to no feature branch.
+- The divergences are not noise. `Residents' electricity consumption from grid` moves **35 %**, warm water
+  **6 %**, theoretical heating demand **0.5 %**. Every value is physically plausible.
+- The run log says why, in a warning nobody reads:
+
+  ```
+  WRN: Error while LpgDataAcquisitionMode.USE_LOCAL_LPG request:
+       [Errno 39] Directory not empty: '…/site-packages/pylpg/C1/results'
+  WRN: LPG data acquisition mode will be set to: USE_PREDEFINED_PROFILE!
+  WRN: LPG result folder was None; cleanup skipped.
+  ```
+- Independently reported by the maintainer: pylpg "randomly produces sqlite errors", and **re-running the
+  same test usually works**.
+- `site-packages/pylpg/C1/results/` currently holds `Results.HH1.sqlite`, `…-shm` and `…-wal`. The WAL
+  sidecars mean a writer exited without checkpointing.
+
+## 3. Fault A — the silent downgrade
+
+### What the code does
+
+`loadprofilegenerator_utsp_connector.py`, four sites rewrite the component's own configured mode:
+
+| Line | From → to | Trigger |
+|---|---|---|
+| `:891` | `USE_UTSP` → `USE_LOCAL_LPG` | `.env` has no `UTSP_URL` / `UTSP_API_KEY` |
+| `:904` | `USE_LOCAL_LPG` → `USE_PREDEFINED_PROFILE` | a `try:` whose body is `pass` and a `# todo` |
+| `:1086` | `USE_UTSP` → `USE_LOCAL_LPG` | **any** exception |
+| `:1089` | `USE_LOCAL_LPG` → `USE_PREDEFINED_PROFILE` | **any** exception |
+
+The last two sit in `except Exception as e:` inside a two-attempt loop (`:908-911`). The handler logs a
+warning, changes the mode, resets `attempt = 1`, and loops. When the chain reaches the predefined profile it
+succeeds, because reading a shipped CSV nearly always succeeds.
+
+### Why it produces wrong results rather than errors
+
+The predefined profile is **a different household**. Occupancy drives electricity demand, warm-water draw and
+internal heat gains, so every downstream number moves: heat pump duty, storage losses, battery cycling, grid
+import, costs, emissions. Nothing is missing and nothing is malformed, so no check downstream can tell.
+The only signal is a `WRN` line in a log nobody diffs.
+
+This is the same failure shape as two defects found during P3 — a meter fed twice, and an energy manager
+pairing a battery with the wrong control signal. In each case the system kept running and produced numbers
+that looked right. A silent fallback is a machine for manufacturing exactly that.
+
+### Why it explains the CI symptom
+
+It needs no shared directory, no concurrency and no second process. One transient error inside one isolated
+matrix job is enough:
+
+- *fails sometimes* — whenever a transient error occurs anywhere in the LPG path;
+- *passes on re-run* — the transient error does not recur;
+- *one household is enough* — one exception is enough;
+- *shows up as a KPI mismatch, not a crash* — because the run genuinely completed.
+
+### A second consequence, already known
+
+The component **mutates its own configuration** at run time. The P4 survey recorded this separately as a
+recording defect: a realized record written after such a run states `USE_PREDEFINED_PROFILE` even though the
+author asked for `USE_LOCAL_LPG`. The same line is therefore both a reproducibility bug and a flakiness bug.
+
+### The committed twins were audited, and they are clean
+
+`data_acquisition_mode` is already an ordinary configuration field (`:71`), so every recorded energy-system
+file states the mode it ran with — which makes the defect above **auditable after the fact**. Checked across
+all twins in `energy_systems/` on 2026-08-31:
+
+| Twins | Setup asks for | Twin records | Verdict |
+|---|---|---|---|
+| 11 | `USE_LOCAL_LPG` (set explicitly by the sizer setups) | `USE_LOCAL_LPG` | honest |
+| 6 | factory default `USE_PREDEFINED_PROFILE` | `USE_PREDEFINED_PROFILE` | honest |
+
+**No twin captured a downgrade**, so none needs re-recording when F1 lands, and local LPG evidently worked
+throughout the recording runs.
+
+This also gives a cheap standing check, worth keeping once F1 makes it rare: *a twin recording
+`USE_PREDEFINED_PROFILE` for a setup whose source requests `USE_LOCAL_LPG` is a downgrade frozen into a
+committed file.* One grep over `energy_systems/` against `system_setups/` finds it, and the freshness job is
+the natural place for it.
+
+### Setting the mode from a file needs no new work
+
+For the avoidance of doubt, since F1 removes the automatic path and leaves configuration as the only route:
+the field is already settable from an energy-system file today, and round-trips as an enum by name —
+
+```yaml
+config:
+  data_acquisition_mode: USE_PREDEFINED_PROFILE
+```
+
+The `for_household` constructor takes it as an argument too, though that route is blocked for a different
+reason: `configure.py::_call_builder` passes constructor arguments without running them through the codec, so
+a file-supplied enum arrives as a bare string. That is P4 gate R2.3 and is out of scope here; the `config:`
+route is unaffected.
+
+## 4. Fault B — one working directory for every process
+
+`pylpg/lpg_execution.py` builds its working directory from the calculation index alone (`"C" + str(index)`,
+`:195`, `:259`), and that directory lives **inside the installed package**. HiSim picks the index at
+`loadprofilegenerator_utsp_connector.py:339`:
+
+```python
+self.calculation_index_for_local_lpg = int(os.environ.get("HISIM_LOCAL_LPG_CALC_INDEX", "1"))
+```
+
+The environment variable exists precisely so parallel runs can be separated — the comment above it says so —
+but **the default is a constant**, and nothing in the test suite, the scripts or the workflows sets it. So
+every concurrent run in one virtual environment shares `C1`:
+
+- both write `C1/results/Results.HH1.sqlite`, in WAL mode → "database is locked", "disk I/O error", and the
+  other sqlite failures reported;
+- the cleanup at `:1097-1116` does `shutil.rmtree(os.path.dirname(result_folder))`, so a finishing run
+  **deletes the directory a running one is still using**;
+- whichever loses the race fails, and fails differently every time.
+
+## 5. Fault C — cleanup only after success
+
+The `finally` block at `:1097` cleans up only `if result_folder is not None`. A run that fails before that
+variable is set logs `LPG result folder was None; cleanup skipped` and **leaves the directory dirty**, so the
+next run hits `[Errno 39] Directory not empty` before it starts. One failure therefore poisons the next.
+This is why the box degraded over a session rather than failing from the beginning, and why a single
+successful run repairs it — its own `rmtree` clears the debris.
+
+## 6. Fault D — the cache is filed under a name the run did not use *(the worst one)*
+
+Promoted from an open question once the ordering was checked. `hisim/utils.py:get_cache_file` builds the key
+as `sha256(config.to_json() + simulation_parameters.get_unique_key())`, and `data_acquisition_mode` **is** a
+field of that config (`:71`), so the mode is part of the key. The problem is *when* the key is taken:
+
+```
+build()  ->  get_list_of_file_exists_bools_and_cache_file_paths()   # :779  key computed HERE
+                 |  hash contains the mode as REQUESTED
+             ...cache miss...
+             self.utsp_config.data_acquisition_mode = ...PREDEFINED  # :891 / :904 / :1086 / :1089
+                 |  the mode changes AFTER the key is fixed
+             self.cache_results(cache_filepath=cache_filepath, ...)  # :988 / :1056  writes to the OLD key
+```
+
+The file is **named after the mode that was asked for** and **filled with the output of the mode that
+actually ran**. A run that requested `USE_LOCAL_LPG`, hit a transient error and fell back therefore writes
+the predefined household's profile into the file keyed for `USE_LOCAL_LPG`.
+
+Every later run with that configuration then takes a **cache hit** and loads the wrong household — without
+entering the fallback, without the warning of §3, without any trace at all. **One transient error becomes a
+permanent, silent wrong result.**
+
+This inverts the reassuring evidence. "Re-running usually works" holds only while the cache is cold or was
+never written; once a downgraded result is filed, re-running makes the wrong answer *consistent* rather than
+correcting it. It also explains why this box drifted from passing golden checks to failing them within one
+session, and why the failure then reproduced stably rather than intermittently.
+
+Only this component rewrites its own configuration — the other five cache users were checked and do not — so
+the key/contents divergence is unique to it. The *pattern* is not: any component whose cache key is taken
+from intent while its contents come from behaviour has the same hole.
+
+## 7. Fault E — cache writes are not atomic, so concurrent runs read half a file
+
+Found 2026-08-31 while diagnosing a CI failure, and it is the one that explains that failure. General to
+**all six** cached components, not to load profiles.
+
+`hisim/utils.py:get_cache_file` decides whether an entry exists with `os.path.isfile(path)` and returns the
+final path. Every writer then writes **straight to that path** — `to_csv(cache_filepath)` in `weather.py:873`,
+`generic_pv_system.py:790`, `solar_thermal_system.py:743`, `generic_car.py:570`; `open(cache_filepath, "w")`
+in `loadprofilegenerator_utsp_connector.py:2012` — and every reader reads it directly. Nothing is written to
+a temporary name first, and nothing is renamed into place.
+
+So two processes computing the same key race:
+
+```
+worker A:  exists = False  ->  computes  ->  begins writing weather_<hash>.csv
+worker B:  exists = True   ->  pd.read_csv(...)  ->  reads a half-written file
+```
+
+The reader sees a file that exists and is incomplete. Depending on where the writer had got to, it raises a
+parse error or — worse — parses successfully and returns truncated data.
+
+**The observed failure.** `scripts/regenerate_scenario_jsons.py` runs setups in parallel (`-j 4` on the CI
+runner). Of twenty-one setups, exactly one failed: `default_connections`, immediately after
+`automatic_default_connections` succeeded. Those two are near-identical, share their weather and building
+configuration, and therefore **share cache keys**. The same command run sequentially on a development box
+reports `21 OK, 0 FAILED`.
+
+Note what this is *not*. The regenerator already hands every worker its own `pylpg/C<index>` (`:117-120`), so
+Fault B is excluded — that script is the one place that got the working-directory problem right. This is a
+second, independent shared resource: `hisim/inputs/cache/`, which no mechanism protects.
+
+**Consequence for the protocol of §8:** any `--jobs > 1` run is unsafe today for setups that share a key, and
+weather is shared by almost everything. Parallel regeneration and parallel test runs are both exposed.
+
+## 8. Fault F — cache keys describe their owner, not the value's inputs
+
+Audited 2026-08-31, prompted by the owner's question: *can a component cache a result that varies between
+households while filing it under one key?* Yes — four of the six do, and one of them caches something that
+must not be cached at all.
+
+`get_cache_file(component_key, parameter_class, my_simulation_parameters)` builds the key from **the
+component's own configuration** plus the simulation parameters (start, end, resolution, year, timesteps,
+country). It contains nothing about any other component. So any cached value derived from a *neighbour's*
+output is filed under a key that cannot distinguish one neighbour from another.
+
+| Component | Cached value | The key covers | Missing |
+|---|---|---|---|
+| `generic_pv_system` | a year of AC power ratios | `PVSystemConfig`, incl. a `location` **string** | the weather's `data_source` and `source_path`: one location under NSRDB / DWD / TRY, or a different file, gives different arrays under one key |
+| `solar_thermal_system` | per-timestep `flat_plate_precalc` output | `coordinates`, `azimuth`, `tilt` | the whole weather — **and see below, it is worse than a narrow key** |
+| `building/building` | `solar_heat_gain_through_windows` | `BuildingConfig` | the irradiance series it is computed from |
+| `generic_car` | `car_location`, `meters_driven` | `CarConfig`: `source_weight`, `fuel`, `consumption_per_km`, costs | **the household.** The driving profile comes from the occupancy's data and *nothing* household-specific is in the key. Two households with identical car hardware share one entry |
+| `weather` | its own series | own config, incl. `source_path` and `data_source` | — sound |
+| `loadprofilegenerator_utsp_connector` | the profile | own config, incl. household and mode | — sound in principle; broken by Fault D instead |
+
+The PV case is the mildest only by accident: setups copy one `weather_location` variable into both configs by
+convention, so the strings tend to move together. That is a habit, not an invariant, and nothing enforces it.
+The car case has no such accident — `CarConfig` contains nothing that varies with the household.
+
+### The solar thermal collector must not be cached at all
+
+`flat_plate_precalc` is called with `temp_collector_inlet=temperature_collector_inlet_deg_c`
+(`solar_thermal_system.py:677`), and that value is read from a wired input:
+
+```python
+temperature_collector_inlet_deg_c = stsv.get_input_value(self.water_temperature_input_channel)   # :649
+```
+
+The inlet temperature comes from the **storage**, and collector efficiency depends on it — that is what the
+loss parameters `a_1` and `a_2` are for. The component also declares a `ControlSignal` input beside it. So
+the cached series is a function of the simulation's own state, not of the weather: change the storage volume,
+the controller, the draw profile or the heat generator, and the cached values are wrong.
+
+No key can fix this. The inlet temperature does not exist until the run produces it, so there is nothing to
+hash. The cache-hit branch checks only that the number of values matches the number of timesteps, which the
+right count of entirely wrong values passes silently.
+
+### The rule this yields
+
+Not "the key must contain every input" — some inputs **cannot** be keyed, because they are outputs of the
+same run.
+
+> **A precomputed series may be cached only if every input is known before the simulation starts.** A wired
+> `ComponentInput` read through `get_input_value` and folded into a cached value is proof that it is not.
+
+Measured against that rule: `generic_pv_system`, `generic_car` and `weather` make **no** `get_input_value`
+calls at all, so their payloads are decided before the run and are legitimately cacheable — they need wider
+keys. `building/building` makes twelve such calls, but the cached quantity uses only the six weather-derived
+ones (azimuth, DNI, DHI, GHI, DNI-extra, apparent zenith) and not the feedback inputs beside them, so it is
+also a key problem rather than a caching one. `solar_thermal_system` makes ten, and the cached value depends
+on one of them.
+
+### Fixes
+
+**F7 — widen the keys of PV, building and car** `[decided 2026-08-31, owner]`
+
+**This fix is deliberately temporary and should be deleted, not defended.** PR #584 §3 answers the problem
+properly: a per-calculation DTO plus an automatic code fingerprint, which requires producers to be extracted
+into standalone modules first. That extraction is its own phase and lands after the local tier
+`[decided 2026-08-31]`. Between now and then, four caches can serve one household's results to another, so
+the keys are widened by hand in the meantime and removed when the DTO scheme arrives. Say so in the code, or
+someone will maintain it.
+
+- **PV and building** take the weather configuration's hash. Both derive their artifact from weather series
+  while keying on their own config; PV's `location` string only tends to track the weather because setups
+  copy one variable into both, which is a habit and not an invariant.
+- **The car takes a hash of the occupancy's configuration** `[decided 2026-08-31]`, not merely the household
+  name. The profile is a function of the whole occupancy setup — household, energy intensity, travel route
+  set, transportation device set — and any of those changes the driving pattern. Putting the household name
+  into `CarConfig` was rejected: it duplicates state that belongs to the occupancy, and two sources of truth
+  drift.
+  *How it reaches the car:* the occupancy already publishes the per-car profile into the simulation
+  repository, so it publishes the hash of its own configuration alongside, under the same identity. The car
+  reads both — the data it consumes and the fingerprint of what produced it — which is the same shape the DTO
+  scheme will formalise later, so this stopgap points in the right direction rather than away from it.
+- **Solar thermal is not in this list.** F8 restricts its artifact to the solar position, whose inputs are
+  already exactly its key, so it needs no widening at all.
+
+**What this does not fix**, and must not be claimed to: a widened key still describes *inputs the component
+knows about*. It cannot notice a change in code, in a library version, or in an input nobody thought to add.
+Those are what #584's `code_fingerprint` and `third_party_fingerprint` are for, and they are the reason this
+is a stopgap rather than a solution.
+
+**F8 — cache the sun position, and nothing else** `[specified 2026-08-31, owner]`
+
+`flat_plate_precalc` (oemof.thermal) computes in three stages, and the boundary falls in a convenient place:
+
+```python
+solposition = pvlib.solarposition.get_solarposition(time=data.index, latitude=lat, longitude=long)   # (1)
+dni = pvlib.irradiance.dni(ghi=…, dhi=…, zenith=solposition["apparent_zenith"])                      # (2)
+total_irradiation = pvlib.irradiance.get_total_irradiance(surface_tilt=…, surface_azimuth=…, …)      # (2)
+eta_c = calc_eta_c_flate_plate(eta_0, a_1, a_2, temp_collector_inlet, delta_temp_n, temp_amb, …)     # (3)
+data["collectors_heat"] = data["col_ira"] * eta_c
+```
+
+| Stage | Depends on | Known before the run? | Cache |
+|---|---|---|---|
+| (1) solar position — `apparent_zenith`, `azimuth` | latitude, longitude, timestamps | **yes** | **yes** |
+| (2) plane-of-array irradiance | (1) + `ghi`, `dhi` from the weather | only if the weather is | no |
+| (3) efficiency and collector heat | (2) + **`temp_collector_inlet` from the storage** | **never** | never |
+
+**Cache stage (1) only.** Its inputs are latitude, longitude and the timestamp series, and the timestamps
+follow from `start_date`, `end_date` and `seconds_per_timestep`. Every one of those is already in the key:
+`coordinates` comes from `SolarThermalSystemConfig`, the rest from the simulation parameters. So this is the
+one place in the audit where **restricting what is cached makes the existing key exactly correct**, with no
+widening required and no upstream identity to thread through.
+
+What that costs and buys, to be measured rather than assumed: stage (1) is the pvlib call, which is the
+expensive part per timestep; stages (2) and (3) are arithmetic on scalars. The cache should therefore keep
+most of its value while becoming sound. If the measurement says otherwise, removing the cache entirely is
+still preferable to keeping a wrong one.
+
+Concretely:
+
+- Replace the per-timestep `flat_plate_precalc` call with a call whose solar-position part is looked up.
+  Either precompute `get_solarposition` for the whole period in `i_prepare_simulation` and pass the row for
+  the timestep into the remaining stages, or vectorise the whole of stage (1) once — the second is closer to
+  what the PV system already does after its own vectorisation.
+- The cached artefact becomes two columns, `apparent_zenith` and `azimuth`, indexed by timestep. It replaces
+  the current dump of the full `precalc_data` frame.
+- **Delete the length check** at the cache-hit branch. It currently accepts any file with the right number of
+  rows, which is precisely how a wrong cache passes unnoticed; with a key that genuinely determines the
+  contents, a length mismatch means corruption and should raise rather than warn.
+- Stage (2) still consumes weather through wired inputs and stage (3) the storage temperature, so neither is
+  cached and neither needs a key.
+
+This also removes `solar_thermal_system` from F7's list: with only stage (1) cached, there is no upstream
+weather identity to add.
+
+**F9 — enforce the rule.** A test that fails when a value folded into a cache is derived from
+`get_input_value`, so the next precompute cannot quietly acquire a feedback dependency. Without it this
+audit is a snapshot, and the audit is the expensive part.
+
+## 9. Fixes
+
+Ordered by value. Each stands alone.
+
+### F1 — delete the fallback chain; fail with an error that says what to do *(the important one)*
+
+**Implemented** on `lpg_flakiness_fix`. All four downgrade sites and the retry loop around the
+request are gone; an exception propagates unwrapped with the guidance below printed beside it.
+
+`[decided 2026-08-31, owner]` **All four downgrade sites go.** An earlier draft of this document proposed
+keeping the chain behind an opt-in flag; that was the weaker answer and is superseded here, because the
+argument for keeping it does not survive examination.
+
+The fallback's only benefit is saving a one-line configuration edit: `data_acquisition_mode` is already an
+explicit field with three valid values, so anyone who wants the shipped profile can ask for it. Against that
+benefit it converts a misconfiguration into a wrong result that passes every check the project has. An
+opt-in does not repair this either — a flag set once and forgotten produces the same silent substitution
+later, when nobody remembers setting it.
+
+So: an exception in the UTSP or local-LPG path **propagates**, and the message must be worth reading. It
+should name the mode that was configured, quote the underlying failure, and say what to change:
+
+```
+Occupancy profile could not be obtained in USE_UTSP mode: <underlying error>.
+
+USE_UTSP needs UTSP_URL and UTSP_API_KEY in a .env file at the repository root.
+If you do not have UTSP access, set data_acquisition_mode on UtspLpgConnectorConfig to one of
+  USE_LOCAL_LPG          - generate the profile locally with pylpg (slower)
+  USE_PREDEFINED_PROFILE - use a shipped profile; NOTE this is a DIFFERENT household
+                           and results are not comparable with the other two modes.
+```
+
+The last clause matters: the predefined profile is not a degraded version of the requested household, it is
+another household. Anyone choosing it should choose it knowing that.
+
+Also in this fix:
+
+- `[decided 2026-08-31]` **Raise everything, unwrapped.** No narrowing, no re-wrapping, no retry: the original
+  exception and its traceback reach the caller untouched. Anticipating the failure set before observing it
+  would only mistranslate it, and an `AttributeError` dressed up as advice about configuring a profile source
+  is worse than the plain traceback. The guidance above is printed alongside, not instead. If a specific
+  failure turns out to deserve a retry, that is added then, for that failure, on evidence.
+- Delete the `:904` site outright — its `try:` body is `pass` with a `# todo`, so it can only ever have been
+  a no-op that made the code look defensive.
+
+**This removes Fault D as a side effect**, which is the strongest argument for it. The cache key is only
+dishonest because the mode is rewritten after the key has been taken; if nothing rewrites it, requested and
+effective are identical by construction. F2 and F5 below shrink to almost nothing as a result.
+
+### F2 — stop the component rewriting its own configuration *(mostly delivered by F1)*
+
+**Implemented** on `lpg_flakiness_fix`, as the check this section asks for: `tests/test_lpg_utsp_connector_no_downgrade.py`
+plus assertions in the two UTSP-marked tests that used to skip themselves on a downgrade.
+
+With the chain gone, the four assignments to `self.utsp_config.data_acquisition_mode` go with it, and the
+component no longer edits the object it was configured with. That also closes the recording defect the P4
+survey filed separately: a realized record written after such a run stated `USE_PREDEFINED_PROFILE` even
+though its author had asked for `USE_LOCAL_LPG`.
+
+What remains is a check rather than a feature: assert in the tests that the configured mode is the mode the
+run used. No effective-versus-requested bookkeeping is needed once they cannot diverge.
+
+### F3 — give every process its own pylpg working directory *(more urgent after F1, not less)*
+
+**Implemented** on `lpg_flakiness_fix` in `hisim/components/pylpg_workspace.py`. The base index
+defaults to the process id and a multi-household request strides by a hundred, so two base indices
+cannot derive the same directory; each calculation claims its directory before pylpg is invoked.
+
+`[decided 2026-08-31]` **Index by process, and fail hard if the directory already exists.** The temporary
+directory this document first proposed is not available: `LPGExecutor.__init__` hard-codes
+`self.working_directory = pathlib.Path(__file__).parent.absolute()` and derives `"C" + str(index)` beneath
+it, so the index is the only isolation the library offers. Deriving it from the process removes the shared
+default, and checking the directory first turns the residual collision from silent corruption into an
+immediate, named failure — the right trade when the alternative is two runs interleaving in one folder.
+
+**Two callers must change with the default, not just the default.** `scripts/regenerate_scenario_jsons.py`
+already hands each worker a distinct index (`:115`) and is the one place that got this right.
+`scripts/record_all_setups.py` does the opposite deliberately: it pins `LPG_INDEX = "1"` with the reasoning
+that its runs are sequential, so one index serves them all, set explicitly *"so that a machine with a stale
+setting records the same thing as a clean one"*. That reasoning is sound about determinism and wrong about
+isolation — it makes the recorder safe against itself and defenceless against anything else on the machine,
+which is exactly how this box was poisoned while several runs went on at once. The fix must keep the
+explicitness (do not fall back to an inherited value) while making the value process-unique.
+
+Independently reproduced 2026-08-31 by an unrelated agent on this box: concurrent runs at index 1 delete each
+other's directory mid-calculation and the .NET binary dies inside `Interop.Sys.GetCwd()`; setting
+`HISIM_LOCAL_LPG_CALC_INDEX` to a free value made every run deterministic. That is Fault B observed from a
+second direction, and — through Fault A — a plausible cause of the sixty-seven diverged indicators of §2:
+a collision raises, the fallback swaps the household, and the golden comparison reports physics.
+
+The message must say which index collided and what it means: another run holds it, or a previous one was
+killed and left it behind. With F4 in place an ordinary failure cleans up after itself, so a leftover
+directory is genuinely exceptional. Disk stays bounded by concurrency rather than by the modulus, since each
+directory exists only for the run that made it.
+
+Note the interaction before reading the rest. Today a `C1` collision raises, the fallback swallows it, and the
+run continues with the wrong household — wrong, but it finishes. **After F1 that same collision is a hard
+failure.** Parallel local runs, and any concurrent use in CI, would begin failing outright instead of lying.
+That is the correct behaviour and also a usability regression if F3 does not land with it, so **F1 and F3
+should ship together.**
+
+- Default the calculation index to something process-unique (the PID, modulo a sensible range) rather than
+  to `1`; keep `HISIM_LOCAL_LPG_CALC_INDEX` as an explicit override.
+- Better, if `pylpg` allows it: copy the calculation directory into a temporary location per run and point
+  the executor at that, so nothing is ever written inside `site-packages`. Writing into an installed package
+  is the underlying mistake; the index only rations the damage.
+
+### F4 — clean up after failure too
+
+**Implemented** on `lpg_flakiness_fix`. The connector records every calculation index it claimed a
+directory for and the `finally` releases those, so the cleanup no longer depends on a result folder
+that a failing run never produced.
+
+Move the cleanup so it runs whether or not `result_folder` was set: resolve the directory from the
+calculation index, which is known before the attempt starts. A failure must not poison the next run.
+
+### F5 — the cache key becomes honest by construction *(delivered by F1)*
+
+**Implemented** on `lpg_flakiness_fix`. The companion metadata lives in `hisim/caching/local.py`
+beside the atomic write; the metadata lands before the data, and an entry that is missing metadata or
+whose metadata disagrees with its filename is deleted on lookup and recomputed.
+
+Fault D exists only because the mode is rewritten between the key being taken and the results being written.
+F1 removes every rewrite, so requested and effective can no longer differ and the key always describes the
+contents. No separate mechanism is required.
+
+**A companion metadata file makes the cache self-describing** `[owner proposal 2026-08-31, adopted with one
+change]`. Beside every `X.cache`, write `X.cache.meta` holding the raw string that was hashed. Three things
+follow: an entry can be read and understood; an entry whose metadata is missing is unvalidatable and is
+deleted; and when the key scheme changes, only entries whose metadata does not match the new scheme need to
+go, instead of the whole directory.
+
+**The change: write the metadata from the *effective* inputs, not the requested ones.** As first proposed it
+records what was hashed, which is exactly what Fault D gets wrong — the downgraded run hashed
+`USE_LOCAL_LPG` and stored a different household's data, so the metadata would agree with the filename and
+the poisoned entry would look sound. Recording what actually produced the bytes makes validation a
+comparison: **recompute the hash from the metadata and check it against the filename**. Agreement proves the
+contents belong to the key; disagreement *is* a poisoning, found automatically instead of by clearing
+everything. It is also tamper-evident: the metadata cannot be edited into agreement without recomputing the
+hash.
+
+Two constraints on the implementation:
+
+- **The data file lands last.** `get_cache_file` decides existence by the data file, so metadata is renamed
+  into place first and data second. A crash then leaves an orphan metadata file — harmless and ignorable —
+  rather than a data file nobody can validate, which is the very state the deletion rule exists to clean up.
+  This composes with F6: both go to temporaries and are renamed, data last.
+- **It does not fix an incomplete key.** If the key omits the weather, so does the metadata, and the two
+  agree happily. It makes migration systematic and auditing possible; F7 is still required.
+
+Worth raising with #584 before the cache is shared: the hashed string is configuration JSON and contains
+absolute paths (`source_path`, `cache_dir_path`). Locally that is only noise; in a shared cache the metadata
+would carry machine-specific paths between environments.
+
+With this in place the one-off purge becomes unnecessary — entries written before the fix have no metadata
+and are deleted on sight by the same rule that handles every later scheme change. The **guard** of F9 still
+stands beside it: a test that fails if a component rewrites its own configuration between the key being
+computed and the cache being written.
+
+### F6 — write cache entries atomically *(fixes Fault E, all six components)*
+
+**Implemented** on `atomic_cache_writes`, in `hisim/caching/local.py`.
+
+Write to a temporary file in the same directory and `os.replace()` it into position. `os.replace` is atomic
+on POSIX and on Windows, so a reader sees either the previous entry or the complete new one and never a
+partial file. The natural home is `hisim/utils.py` beside `get_cache_file` — a small `write_cache_atomically`
+helper that the six writers call instead of writing to the path themselves.
+
+Two details worth getting right. The temporary file must be in the **same directory** as the target, or the
+rename crosses a filesystem and stops being atomic. And `get_cache_file`'s `exists` result stays advisory:
+two processes may still both compute the same entry, which wastes work but is harmless once the write is
+atomic — whereas locking to prevent it would add a failure mode of its own.
+
+This is independent of F1 and of everything pylpg. It should ship on its own merits, because it is the only
+fault here that corrupts data for components that have nothing to do with load profiles.
+
+## 10. How to verify a fix
+
+**This protocol applies to every cached component, not only to load profiles — see §13.** It is what
+distinguishes a cold computation from a cached one:
+
+1. wipe the cache;
+2. run once;
+3. record the result;
+4. run again;
+5. compare run 1 against run 2 — they must be identical.
+
+Add to that:
+
+- **Fault A:** force an exception in the local-LPG path (rename the pylpg directory) and assert the run
+  **fails** with the default configuration, and that with the opt-in it completes *and* reports the
+  substitution.
+- **Fault B:** start two runs concurrently in one virtual environment and assert both succeed with identical
+  results. Today this reproduces the sqlite errors.
+- **Fault C:** kill a run mid-request, then start another; the second must succeed.
+- **Fault D:** cause a downgrade with a cold cache, then run again *without* the fault present. The second
+  run must not silently reuse the first run's entry. Today it does.
+- **Regression:** `household_heatpump_building_sizer / one_week_60s` must pass `golden_check.py` on a
+  development box, not only in CI.
+- **Every cached component:** the same five steps, per §11's table. PV is expected to fail today.
+
+## 11. What not to do
+
+- **Do not re-bless the golden references** to match a downgraded run. The references are right; the run was
+  wrong. Blessing them would make the substituted household the new definition of correct.
+- **Do not add retries** around the sqlite errors. Retrying hides Fault B rather than fixing it, and the
+  existing two-attempt loop is what turns one transient error into a silent household swap.
+- ~~Do not delete the fallback outright.~~ **Superseded 2026-08-31.** This document first argued the
+  fallback was worth keeping behind an opt-in. The owner's objection is better: if UTSP is configured and
+  unavailable, the useful response is an error telling you to configure it differently, not a different
+  household and a warning. Wanting the shipped profile is already expressible — it is one field — so the
+  fallback buys a saved keystroke at the price of results nobody can trust. It goes (F1).
+
+## 12. Immediate mitigation
+
+Until the fixes land, a poisoned box needs **both** directories cleared — the pylpg working directory *and*
+the HiSim cache, because §6 means wrong profiles may already be filed there under the right name:
+
+```bash
+rm -rf <venv>/lib/python3.*/site-packages/pylpg/C*/results
+rm -rf <repo>/hisim/inputs/cache/UTSPConnector_*.cache
+```
+
+Clearing only the first leaves the poisoned entries in place and the box keeps producing the wrong household
+with no warning whatsoever.
+
+and parallel local runs should set `HISIM_LOCAL_LPG_CALC_INDEX` to a distinct value per process.
+
+## 13. Every component that caches, not just this one
+
+The worst fault here (§6) is a **caching pattern**: a key taken from what the caller asked for, contents
+produced by what the code actually did. Nothing about it is specific to load profiles, so the verification
+protocol of §8 belongs to every cached component, and each needs its own answer to one question — *can this
+cache ever be filled with something other than what its key describes?*
+
+Six components use the shared helper `hisim.utils.get_cache_file`:
+
+| Component | Cached | Notes |
+|---|---|---|
+| `loadprofilegenerator_utsp_connector.py` | occupancy profiles | Faults A–D above. The only one that rewrites its own configuration. |
+| `generic_pv_system.py` | a year of AC power ratios | **Second confirmed defect — see below.** |
+| `weather.py` | weather series | Feeds nearly every setup; a wrong entry here moves everything. |
+| `building/building.py` | building physics | |
+| `solar_thermal_system.py` | collector output | |
+| `generic_car.py` | car profiles | Its data originates from the occupancy, so Fault D can reach it second-hand. |
+
+### The PV cache does not round-trip exactly
+
+`generic_pv_system.py` writes its cache with `database.to_csv(...)` (`:790`) and reads it back with
+`pd.read_csv(...)` (`:669`) — a **text** round trip of float64 data. The P3 parity work already ran into
+this: giving both sides of a comparison one cache directory let the second run read the first run's PV
+output back out of the CSV, which both masked a real configuration difference **and invented a false one,
+because the round trip is not bit-exact**. That was worked around there by giving each side its own empty
+cache; it is not fixed.
+
+So a cached PV run and an uncached one are not the same run. Under the §8 protocol, PV is expected to
+**fail** today — which makes it the first thing to measure rather than a surprise to discover.
+
+### What the sweep should produce
+
+For each of the six, in the order above: run the protocol, and record whether run 1 and run 2 agree bit for
+bit. Where they differ, establish which of the two is right — the cached or the computed value — because
+that decides whether the fix is in the writer or the reader. Then answer, per component, whether every input
+that changes the result is part of the key. A cache whose key omits a relevant input is Fault D wearing a
+different hat.
+
+## 14. Open questions
+
+1. ~~Does the LPG cache key include the effective acquisition mode?~~ **Answered: it includes the requested
+   mode, and the contents come from the effective one — promoted to Fault D, §6.**
+2. Do the CI runners hit Fault A through an unavailable UTSP, or through something else? The warning text is
+   in the job logs and would say which.
+3. ~~Should `USE_UTSP` → `USE_LOCAL_LPG` remain automatic?~~ **Answered: no.** It looks safer than the
+   second hop because the household is nominally the same, but the two paths run different LPG builds and
+   there is no evidence they agree bit for bit — so it is still a silent change of results. If that
+   equivalence is ever demonstrated, the hop could be reconsidered on the evidence; until then it is the
+   same defect wearing a friendlier face.

--- a/scripts/regenerate_scenario_jsons.py
+++ b/scripts/regenerate_scenario_jsons.py
@@ -13,11 +13,14 @@ restrict the run to setups that already have a committed ``.scenario.json``.
 
 Parallelism
 -----------
-``--jobs/-j N`` runs up to ``N`` setups at once. Local-LPG occupancy setups use
-a shared ``pylpg/C<index>`` working directory that defaults to ``C1`` and would
-collide under concurrency, so every worker slot is handed a distinct index via
-the ``HISIM_LOCAL_LPG_CALC_INDEX`` environment variable (honoured by
-``UtspLpgConnector``). With ``--jobs 1`` (the default) behaviour is unchanged.
+``--jobs/-j N`` runs up to ``N`` setups at once. Local-LPG occupancy setups
+compute in a ``pylpg/C<index>`` working directory derived from a base index, so
+every worker slot is handed a distinct one via the ``HISIM_LOCAL_LPG_CALC_INDEX``
+environment variable (honoured by ``UtspLpgConnector``). The connector now
+derives that base index from the process when nothing sets it, so the variable
+is no longer what stands between the workers and a shared ``C1``; it is kept
+because small, allocated indices are easier to follow in a log than process ids.
+With ``--jobs 1`` (the default) behaviour is unchanged.
 
 The converter also emits a per-setup ``<setup>.simulation.json``; the repo only
 tracks grouped ``2021_*.simulation.json`` files, so these strays are removed

--- a/tests/test_caching_local.py
+++ b/tests/test_caching_local.py
@@ -7,17 +7,24 @@ final path can, and used to be, which is what broke a parallel scenario regenera
 
 The first test is the control: it pins the old behaviour so the second test cannot quietly stop
 proving anything if the harness ever loses its grip on the timing.
+
+The second half of the module covers the companion metadata written beside every entry. It is what
+makes an entry validatable at all: recomputing the hash of the recorded inputs and comparing it with
+the name the entry is filed under proves the contents belong to the key, and any disagreement -- or
+any missing metadata -- deletes the entry rather than serving it.
 """
 
 # clean
 
 import pathlib
 import threading
-from typing import Any, Callable, ClassVar, List
+from typing import Any, Callable, ClassVar, List, Optional, Tuple
 
 import pytest
 
-from hisim.caching import atomic_cache_write
+from hisim import utils
+from hisim.caching import CacheEntryMetadata, atomic_cache_write
+from hisim.simulationparameters import SimulationParameters
 
 
 class CacheRaceHarness:
@@ -37,6 +44,8 @@ class CacheRaceHarness:
     CHUNK_COUNT: ClassVar[int] = 8
     LINES_PER_CHUNK: ClassVar[int] = 512
     HANDSHAKE_TIMEOUT_SECONDS: ClassVar[float] = 10.0
+    # Both writers describe the same inputs, because they are computing the same key.
+    CACHE_KEY_STRING: ClassVar[str] = '{"location": "Aachen"}2021-01-01|2021-12-31|60'
 
     def __init__(self, target_path: str) -> None:
         """Builds the payload and the events that sequence the writers against the reader."""
@@ -68,7 +77,7 @@ class CacheRaceHarness:
 
     def write_atomically(self, writer_index: int) -> None:
         """Writes through :func:`hisim.caching.atomic_cache_write`, the pattern the fix introduces."""
-        with atomic_cache_write(self.target_path) as temporary_path:
+        with atomic_cache_write(self.target_path, self.CACHE_KEY_STRING) as temporary_path:
             with open(temporary_path, "w", encoding="utf-8") as handle:
                 self._emit(handle, writer_index)
 
@@ -144,7 +153,10 @@ def test_atomic_cache_write_never_exposes_a_partial_file(tmp_path: pathlib.Path)
     assert observations, "the reader never managed to read the entry at all"
     assert all(seen == harness.expected_content for seen in observations)
     assert pathlib.Path(harness.target_path).read_text(encoding="utf-8") == harness.expected_content
-    assert sorted(path.name for path in tmp_path.iterdir()) == ["Weather_deadbeef.cache"]
+    assert sorted(path.name for path in tmp_path.iterdir()) == [
+        "Weather_deadbeef.cache",
+        "Weather_deadbeef.cache" + CacheEntryMetadata.SUFFIX,
+    ]
 
 
 @pytest.mark.base
@@ -160,9 +172,152 @@ def test_atomic_cache_write_leaves_no_debris_when_the_write_fails(tmp_path: path
     target_path.write_text("the previous entry\n", encoding="utf-8")
 
     with pytest.raises(RuntimeError, match="computation blew up"):
-        with atomic_cache_write(str(target_path)) as temporary_path:
+        with atomic_cache_write(str(target_path), "the inputs of the new entry") as temporary_path:
             pathlib.Path(temporary_path).write_text("half of the new entry", encoding="utf-8")
             raise RuntimeError("computation blew up")
 
     assert target_path.read_text(encoding="utf-8") == "the previous entry\n"
     assert sorted(path.name for path in tmp_path.iterdir()) == ["Weather_deadbeef.cache"]
+
+
+class CacheKeyFixture:
+    """A minimal configuration plus the simulation parameters a cache key is built from.
+
+    ``get_cache_file`` needs something with ``to_json`` and a ``SimulationParameters``; building a
+    real component configuration would drag half the component layer into a test about file naming.
+    Keeping the pair in one object lets each test derive the entry path, write an entry, tamper with
+    its metadata and look it up again without repeating six lines of setup.
+    """
+
+    def __init__(self, cache_directory: pathlib.Path) -> None:
+        """Points the simulation parameters at a scratch cache directory.
+
+        Args:
+            cache_directory: the temporary directory the entry is written into.
+        """
+        self.simulation_parameters = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=3600)
+        self.simulation_parameters.cache_dir_path = str(cache_directory)
+
+    class Configuration:
+        """Stands in for a component configuration; only ``to_json`` matters to the key."""
+
+        @staticmethod
+        def to_json() -> str:
+            """Returns the configuration JSON that the cache key is built from.
+
+            Returns:
+                str: a fixed JSON document, so the key is stable across the test's two lookups.
+            """
+            return '{"name": "metadata-demo"}'
+
+    def lookup(self) -> Tuple[bool, str]:
+        """Asks ``get_cache_file`` whether this key has an entry, and where it would live.
+
+        Returns:
+            Tuple[bool, str]: the advisory ``exists`` flag and the absolute entry path.
+        """
+        return utils.get_cache_file(
+            component_key="MetadataDemo",
+            parameter_class=self.Configuration(),
+            my_simulation_parameters=self.simulation_parameters,
+        )
+
+    def write_entry(self, contents: str, effective_cache_key_string: Optional[str] = None) -> str:
+        """Writes an entry for this key, optionally lying about the inputs that produced it.
+
+        Args:
+            contents: the payload to store.
+            effective_cache_key_string: what to record as the effective inputs; defaults to the
+                honest value, so that passing something else simulates a poisoned entry.
+
+        Returns:
+            str: the path the entry was written to.
+        """
+        _, cache_filepath = self.lookup()
+        honest = utils.build_cache_key_string(self.Configuration(), self.simulation_parameters)
+        with atomic_cache_write(cache_filepath, effective_cache_key_string or honest) as temporary_path:
+            pathlib.Path(temporary_path).write_text(contents, encoding="utf-8")
+        return cache_filepath
+
+
+@pytest.mark.base
+def test_a_written_entry_is_found_again_with_its_metadata(tmp_path: pathlib.Path) -> None:
+    """The ordinary path: an entry written honestly validates and is served on the next lookup.
+
+    This is the control for the two tests below. Without it a bug that rejected every entry would
+    still pass them, and the cache would have quietly stopped being a cache.
+    """
+    fixture = CacheKeyFixture(tmp_path)
+    cache_filepath = fixture.write_entry("the profile\n")
+
+    exists, found_path = fixture.lookup()
+
+    assert exists is True
+    assert found_path == cache_filepath
+    metadata_path = pathlib.Path(CacheEntryMetadata.metadata_filepath(cache_filepath))
+    assert metadata_path.is_file()
+    assert CacheEntryMetadata.hash_of(metadata_path.read_text(encoding="utf-8")) in cache_filepath
+
+
+@pytest.mark.base
+def test_an_entry_without_metadata_is_discarded_and_recomputed(tmp_path: pathlib.Path) -> None:
+    """An entry nothing describes is deleted on sight and reported as a miss.
+
+    Every entry written before the metadata scheme existed is in exactly this state, which is what
+    makes the migration self-executing: there is no purge to run and no directory to wipe, because
+    the first lookup of an undescribed entry removes it. The same rule covers a metadata file lost to
+    a partial copy or a botched manual edit.
+    """
+    fixture = CacheKeyFixture(tmp_path)
+    cache_filepath = fixture.write_entry("the profile\n")
+    pathlib.Path(CacheEntryMetadata.metadata_filepath(cache_filepath)).unlink()
+
+    exists, _ = fixture.lookup()
+
+    assert exists is False
+    assert not pathlib.Path(cache_filepath).exists()
+
+
+@pytest.mark.base
+def test_an_entry_whose_metadata_disagrees_with_its_name_is_discarded(tmp_path: pathlib.Path) -> None:
+    """A poisoned entry -- contents from inputs the key does not describe -- is found and deleted.
+
+    This is the case the metadata exists for. Recording what was *requested* would make such an entry
+    look sound, because the request is what the filename was hashed from; recording what actually
+    produced the bytes turns validation into a comparison, and the comparison fails exactly when the
+    two diverged. It is also tamper-evident: the metadata cannot be edited into agreement without
+    recomputing the digest in the name.
+    """
+    fixture = CacheKeyFixture(tmp_path)
+    cache_filepath = fixture.write_entry(
+        "a different household's profile\n", effective_cache_key_string='{"name": "something-else"}'
+    )
+
+    exists, _ = fixture.lookup()
+
+    assert exists is False
+    assert not pathlib.Path(cache_filepath).exists()
+    assert not pathlib.Path(CacheEntryMetadata.metadata_filepath(cache_filepath)).exists()
+
+
+@pytest.mark.base
+def test_the_metadata_lands_before_the_data(tmp_path: pathlib.Path) -> None:
+    """The data file is the last thing to appear, so no observer can see an unvalidatable entry.
+
+    ``get_cache_file`` decides an entry exists by looking at the data file. If the data landed first,
+    a crash or a concurrent reader in the gap would find an entry with no metadata -- which the rules
+    above then delete, throwing away a perfectly good computation. The reverse order can only leave
+    an orphan metadata file, which nothing looks at.
+    """
+    fixture = CacheKeyFixture(tmp_path)
+    _, cache_filepath = fixture.lookup()
+    metadata_filepath = CacheEntryMetadata.metadata_filepath(cache_filepath)
+    honest = utils.build_cache_key_string(fixture.Configuration(), fixture.simulation_parameters)
+
+    with atomic_cache_write(cache_filepath, honest) as temporary_path:
+        pathlib.Path(temporary_path).write_text("the profile\n", encoding="utf-8")
+        assert not pathlib.Path(cache_filepath).exists()
+        assert not pathlib.Path(metadata_filepath).exists()
+
+    assert pathlib.Path(metadata_filepath).is_file()
+    assert pathlib.Path(cache_filepath).is_file()

--- a/tests/test_lpg_utsp_connector_local_lpg.py
+++ b/tests/test_lpg_utsp_connector_local_lpg.py
@@ -38,14 +38,15 @@ def test_occupancy_scaling_with_utsp() -> None:
         data_acquisition_mode_after_initialization,
     ) = initialize_lpg_utsp_connector_and_return_results(households=household)
 
-    if (
+    # An unusable local LPG now fails the run instead of quietly becoming the predefined profile
+    # (roadmap/pylpg_flakiness.md F1), so this test can no longer be skipped into passing on a box
+    # where pylpg is broken -- it would already have raised above. The assertion states the
+    # invariant that replaces the skip: the profiles just measured came from the configured mode,
+    # which is the only reason the doubling comparison below means anything.
+    assert (
         data_acquisition_mode_after_initialization
-        == loadprofilegenerator_utsp_connector.LpgDataAcquisitionMode.USE_PREDEFINED_PROFILE
-    ):
-        pytest.skip(
-            "This test makes only sense if the local LPG can be used for data acquisition. "
-            "Here the use of the Local LPG was not possible. Therefore this test will be ignored."
-        )
+        == loadprofilegenerator_utsp_connector.LpgDataAcquisitionMode.USE_LOCAL_LPG
+    ), "the connector must run the configured mode, never substitute another profile source"
 
     log.information("number of residents in 1 household " + str(number_of_residents_one))
 
@@ -99,8 +100,9 @@ def initialize_lpg_utsp_connector_and_return_results(
             electricity_consumption: Total electricity consumption.
             water_consumption: Total water consumption.
             data_acquisition_mode_after_initialization: The `LpgDataAcquisitionMode`
-                after connector initialization (may differ from the requested mode
-                if the local LPG was unavailable).
+                the connector holds after initialization. It is always the configured
+                mode, because an unreachable profile source raises rather than
+                substituting a different one.
     """
     # Set Simu Params
     year = 2021

--- a/tests/test_lpg_utsp_connector_no_downgrade.py
+++ b/tests/test_lpg_utsp_connector_no_downgrade.py
@@ -1,0 +1,135 @@
+"""The occupancy connector must run the mode it was configured with, or fail saying why.
+
+Until roadmap/pylpg_flakiness.md F1 landed, any exception in the UTSP or local-LPG path made the
+connector rewrite its own ``data_acquisition_mode`` and continue with the shipped predefined
+profile -- a different household. The run then finished, exited zero and produced a full set of
+plausible indicators that no downstream check could distinguish from the requested household's.
+These tests pin the replacement behaviour from both ends: the exception has to reach the caller,
+and the configuration object has to come back holding exactly what its author put in it.
+
+They are deliberately cheap and marked ``base``. Neither needs a UTSP server, a network or a
+working pylpg installation, because both make the profile source fail on purpose; what they check
+is the connector's reaction to that failure, which is the part that used to be wrong.
+"""
+
+# clean
+
+import os
+from typing import Any
+
+import pytest
+
+from hisim import utils
+from hisim.components import loadprofilegenerator_utsp_connector as lpg_connector
+from hisim.simulationparameters import SimulationParameters
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+class UnreachableProfileSourceError(RuntimeError):
+    """Marks the failure these tests inject, so the assertion can prove the original one propagated.
+
+    A generic exception type would let a re-wrapped or a narrowed exception pass the test, which is
+    precisely what F1 forbids: the original exception and its traceback must reach the caller
+    untouched. A dedicated type makes ``pytest.raises`` check identity rather than plausibility.
+    """
+
+
+def build_connector_config(
+    mode: lpg_connector.LpgDataAcquisitionMode, cache_directory: str
+) -> lpg_connector.UtspLpgConnectorConfig:
+    """Builds a connector configuration in the given acquisition mode, cached in a scratch directory.
+
+    The cache directory is redirected into the test's own temporary path because a hit in the real
+    ``hisim/inputs/cache`` would satisfy the request before the profile source is ever consulted,
+    and these tests are entirely about what happens when it is consulted and fails.
+
+    Args:
+        mode: the acquisition mode to configure; the test then asserts it survives the run.
+        cache_directory: a writable scratch directory to use as the connector's cache.
+
+    Returns:
+        UtspLpgConnectorConfig: the default configuration with the mode and cache path applied.
+    """
+    config = lpg_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
+    config.data_acquisition_mode = mode
+    config.cache_dir_path = cache_directory
+    config.result_dir_path = os.path.join(cache_directory, "results")
+    return config
+
+
+@pytest.mark.base
+def test_local_lpg_failure_propagates_instead_of_swapping_the_household(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A local-LPG failure raises the original exception and leaves the configured mode alone.
+
+    The LPG executor is replaced with one that always raises, which is what an absent or broken
+    pylpg installation looks like from the connector's side. The old code caught that, logged a
+    warning, set ``USE_PREDEFINED_PROFILE`` and finished successfully; the new code must let the
+    exception through with the mode untouched.
+    """
+
+    def raise_instead_of_executing(*_args: Any, **_kwargs: Any) -> Any:
+        raise UnreachableProfileSourceError("pylpg is not available in this test")
+
+    monkeypatch.setattr(lpg_connector.lpg_execution, "LPGExecutor", raise_instead_of_executing)
+    config = build_connector_config(lpg_connector.LpgDataAcquisitionMode.USE_LOCAL_LPG, str(tmp_path))
+    simulation_parameters = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+
+    with pytest.raises(UnreachableProfileSourceError):
+        lpg_connector.UtspLpgConnector(config=config, my_simulation_parameters=simulation_parameters)
+
+    assert config.data_acquisition_mode is lpg_connector.LpgDataAcquisitionMode.USE_LOCAL_LPG
+
+
+@pytest.mark.base
+def test_missing_utsp_credentials_fail_the_run_rather_than_choosing_another_source(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unconfigured UTSP is an error, not a reason to run the local LPG instead.
+
+    ``UTSP_URL`` and ``UTSP_API_KEY`` are made unreadable, which is the state of any checkout
+    without a ``.env``. The connector used to answer that by switching to the local LPG and, if
+    that failed too, to the predefined profile; both hops changed the household without saying so
+    anywhere a check could see.
+    """
+
+    def raise_for_any_variable(key: str, default: Any = None) -> str:
+        raise UnreachableProfileSourceError(f"no .env in this test, {key} is unset (default {default})")
+
+    monkeypatch.setattr(utils, "get_environment_variable", raise_for_any_variable)
+    config = build_connector_config(lpg_connector.LpgDataAcquisitionMode.USE_UTSP, str(tmp_path))
+    simulation_parameters = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+
+    with pytest.raises(UnreachableProfileSourceError):
+        lpg_connector.UtspLpgConnector(config=config, my_simulation_parameters=simulation_parameters)
+
+    assert config.data_acquisition_mode is lpg_connector.LpgDataAcquisitionMode.USE_UTSP
+
+
+@pytest.mark.base
+def test_the_guidance_names_the_configured_mode_and_the_way_out() -> None:
+    """The message printed beside the traceback has to be worth reading, so its content is pinned.
+
+    It exists because the failure it accompanies is a configuration failure: the reader needs the
+    mode that was asked for, the credentials that mode needs, and the two alternatives. The warning
+    that the predefined profile is a *different* household is the clause most easily lost in a
+    later edit, and the one whose absence caused the original defect to go unnoticed for so long.
+    """
+    config = build_connector_config(lpg_connector.LpgDataAcquisitionMode.USE_LOCAL_LPG, os.devnull)
+    connector = lpg_connector.UtspLpgConnector.__new__(lpg_connector.UtspLpgConnector)
+    connector.utsp_config = config
+
+    guidance = connector.describe_unreachable_profile_source()
+
+    assert "USE_LOCAL_LPG" in guidance
+    assert "UTSP_URL" in guidance and "UTSP_API_KEY" in guidance
+    assert "DIFFERENT household" in guidance
+    assert "not comparable" in guidance

--- a/tests/test_lpg_utsp_connector_scaling.py
+++ b/tests/test_lpg_utsp_connector_scaling.py
@@ -41,61 +41,59 @@ def test_occupancy_scaling_with_utsp():
         water_consumption_one,
     ) = simulate_and_read_occupancy_outputs(my_occupancy)
 
-    if (
+    # The connector no longer rewrites its own acquisition mode when a source is unreachable
+    # (roadmap/pylpg_flakiness.md F1), so reaching this line at all means UTSP answered. The
+    # assertion pins that: a mode other than the configured one would mean the profiles above
+    # came from a different household and every scaling ratio below would be meaningless.
+    assert (
         data_acquisition_mode_after_initialization
-        == loadprofilegenerator_utsp_connector.LpgDataAcquisitionMode.USE_PREDEFINED_PROFILE
-    ):
-        pytest.skip(
-            "UTSP not available for data acquisition; scaling test requires UTSP"
-        )
+        == loadprofilegenerator_utsp_connector.LpgDataAcquisitionMode.USE_UTSP
+    ), "the connector must run the configured mode, never substitute another profile source"
 
-    else:
+    # Guard against a vacuously-satisfied scaling test: if any
+    # single-household baseline were zero, every assert_allclose(N * 0, 0)
+    # below would pass even if the connector ignored the household count
+    # entirely, giving false confidence that scaling works (issue #1788).
+    # The baselines are summed over the first 24 hours (see
+    # simulate_and_read_occupancy_outputs) to avoid timestep-0 zeros, but
+    # these guards provide an explicit fail-loud check. They run before the
+    # second UTSP call so a zero baseline short-circuits without wasting a
+    # network round-trip.
+    assert number_of_residents_one > 0, "baseline residents must be non-zero for scaling test to be meaningful"
+    assert heating_by_residents_one > 0, "baseline heating-by-residents must be non-zero"
+    assert heating_by_devices_one > 0, "baseline heating-by-devices must be non-zero"
+    assert electricity_consumption_one > 0, "baseline electricity must be non-zero"
+    assert water_consumption_one > 0, "baseline water must be non-zero"
 
-        # Guard against a vacuously-satisfied scaling test: if any
-        # single-household baseline were zero, every assert_allclose(N * 0, 0)
-        # below would pass even if the connector ignored the household count
-        # entirely, giving false confidence that scaling works (issue #1788).
-        # The baselines are summed over the first 24 hours (see
-        # simulate_and_read_occupancy_outputs) to avoid timestep-0 zeros, but
-        # these guards provide an explicit fail-loud check. They run before the
-        # second UTSP call so a zero baseline short-circuits without wasting a
-        # network round-trip.
-        assert number_of_residents_one > 0, "baseline residents must be non-zero for scaling test to be meaningful"
-        assert heating_by_residents_one > 0, "baseline heating-by-residents must be non-zero"
-        assert heating_by_devices_one > 0, "baseline heating-by-devices must be non-zero"
-        assert electricity_consumption_one > 0, "baseline electricity must be non-zero"
-        assert water_consumption_one > 0, "baseline water must be non-zero"
+    log.information(f"number of residents in 1 household {number_of_residents_one}")
 
-        log.information(f"number of residents in 1 household {number_of_residents_one}")
+    # run occupancy for two identical households
+    household_list = [
+        Households.CHR02_Couple_30_64_age_with_work,
+        Households.CHR02_Couple_30_64_age_with_work,
+        # Households.CHR02_Couple_30_64_age_with_work,
+        # Households.CHR02_Couple_30_64_age_with_work,
+    ]
+    my_occupancy, _ = build_lpg_utsp_connector(households=household_list)
+    fft.add_global_index_of_components([my_occupancy])
+    (
+        number_of_residents_two,
+        heating_by_residents_two,
+        heating_by_devices_two,
+        electricity_consumption_two,
+        water_consumption_two,
+    ) = simulate_and_read_occupancy_outputs(my_occupancy)
 
-        # run occupancy for two identical households
-        household_list = [
-            Households.CHR02_Couple_30_64_age_with_work,
-            Households.CHR02_Couple_30_64_age_with_work,
-            # Households.CHR02_Couple_30_64_age_with_work,
-            # Households.CHR02_Couple_30_64_age_with_work,
-        ]
-        my_occupancy, _ = build_lpg_utsp_connector(households=household_list)
-        fft.add_global_index_of_components([my_occupancy])
-        (
-            number_of_residents_two,
-            heating_by_residents_two,
-            heating_by_devices_two,
-            electricity_consumption_two,
-            water_consumption_two,
-        ) = simulate_and_read_occupancy_outputs(my_occupancy)
+    log.information(f"number of residents in {len(household_list)} households {number_of_residents_two}")
 
-        log.information(f"number of residents in {len(household_list)} households {number_of_residents_two}")
-
-        # now test if results are doubled when occupancy is initialzed with 2 households
-        np.testing.assert_allclose(number_of_residents_two, len(household_list) * number_of_residents_one, rtol=0.01)
-        np.testing.assert_allclose(heating_by_residents_two, len(household_list) * heating_by_residents_one, rtol=0.01)
-        np.testing.assert_allclose(heating_by_devices_two, len(household_list) * heating_by_devices_one, rtol=0.01)
-        np.testing.assert_allclose(
-            electricity_consumption_two, len(household_list) * electricity_consumption_one, rtol=0.01
-        )
-        np.testing.assert_allclose(water_consumption_two, len(household_list) * water_consumption_one, rtol=0.01)
-
+    # now test if results are doubled when occupancy is initialzed with 2 households
+    np.testing.assert_allclose(number_of_residents_two, len(household_list) * number_of_residents_one, rtol=0.01)
+    np.testing.assert_allclose(heating_by_residents_two, len(household_list) * heating_by_residents_one, rtol=0.01)
+    np.testing.assert_allclose(heating_by_devices_two, len(household_list) * heating_by_devices_one, rtol=0.01)
+    np.testing.assert_allclose(
+        electricity_consumption_two, len(household_list) * electricity_consumption_one, rtol=0.01
+    )
+    np.testing.assert_allclose(water_consumption_two, len(household_list) * water_consumption_one, rtol=0.01)
 
 def build_lpg_utsp_connector(
     households: JsonReference | List[JsonReference]
@@ -120,9 +118,10 @@ def build_lpg_utsp_connector(
         - The constructed ``UtspLpgConnector`` instance (outputs not yet
           globally indexed).
         - data_acquisition_mode_after_initialization: The
-          ``LpgDataAcquisitionMode`` resolved after initialization (may differ
-          from the requested mode when UTSP is unavailable, e.g. falling back
-          to ``USE_PREDEFINED_PROFILE``).
+          ``LpgDataAcquisitionMode`` the connector holds after initialization.
+          It is always the configured mode: an unreachable source now fails the
+          run instead of substituting another one, so the caller asserts on it
+          rather than branching on it.
     """
     # Set Simu Params
     year = 2021

--- a/tests/test_lpg_utsp_connector_scaling.py
+++ b/tests/test_lpg_utsp_connector_scaling.py
@@ -95,6 +95,7 @@ def test_occupancy_scaling_with_utsp():
     )
     np.testing.assert_allclose(water_consumption_two, len(household_list) * water_consumption_one, rtol=0.01)
 
+
 def build_lpg_utsp_connector(
     households: JsonReference | List[JsonReference]
 ) -> Tuple[

--- a/tests/test_pylpg_workspace.py
+++ b/tests/test_pylpg_workspace.py
@@ -1,0 +1,121 @@
+"""The index scheme that keeps two local-LPG runs out of each other's working directory.
+
+``pylpg`` computes inside its own installed package, in a directory named after the calculation
+index, so the index is the only isolation available. HiSim defaulted it to ``1`` and the
+multi-household request restarted its own counter at ``1``, which put every concurrent run in
+``pylpg/C1``: sqlite files corrupted each other and a finishing run deleted the folder a running one
+was still using. These tests pin the replacement rule -- distinct base indices give disjoint blocks
+of directories, and an occupied directory stops the run by name.
+
+None of them touch pylpg or start a calculation; they exercise arithmetic and one filesystem check,
+which is why they are ``base`` rather than ``utsp``.
+"""
+
+# clean
+
+import pathlib
+from typing import Any
+
+import pytest
+
+from hisim.components.pylpg_workspace import PylpgWorkingDirectoryInUseError, PylpgWorkspace
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+@pytest.mark.base
+def test_the_default_base_index_is_the_process_when_nothing_is_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no override the base index is the process id, which no two live runs share.
+
+    The point of the change is that the default is no longer a constant. Any process-derived value
+    would do; the process id is chosen because the kernel already guarantees it is unique among
+    running processes, so concurrent runs separate without coordinating.
+    """
+    monkeypatch.delenv(PylpgWorkspace.INDEX_ENVIRONMENT_VARIABLE, raising=False)
+    assert PylpgWorkspace.default_base_index() > 0
+
+
+@pytest.mark.base
+def test_an_explicit_base_index_overrides_the_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A caller that allocates indices itself keeps control of them.
+
+    The parallel scenario regenerator hands each of its workers a small index of its own, which is
+    the one place in the repository that got the working-directory problem right. That has to keep
+    working, so the environment variable still wins over the derivation.
+    """
+    monkeypatch.setenv(PylpgWorkspace.INDEX_ENVIRONMENT_VARIABLE, "17")
+    assert PylpgWorkspace.default_base_index() == 17
+
+
+@pytest.mark.base
+def test_two_base_indices_never_derive_the_same_calculation_index() -> None:
+    """Blocks derived from different base indices are disjoint, which is the whole guarantee.
+
+    Numbering a multi-household request consecutively from the base would collide immediately with a
+    process-derived base, because process ids are handed out in sequence and two runs started back
+    to back would differ by one. The stride is what prevents that, so the disjointness is asserted
+    across the full width of a block rather than on a couple of examples.
+    """
+    first_block = {
+        PylpgWorkspace.calculation_index(4242, ordinal) for ordinal in range(PylpgWorkspace.HOUSEHOLDS_PER_BASE_INDEX)
+    }
+    second_block = {
+        PylpgWorkspace.calculation_index(4243, ordinal) for ordinal in range(PylpgWorkspace.HOUSEHOLDS_PER_BASE_INDEX)
+    }
+    assert len(first_block) == PylpgWorkspace.HOUSEHOLDS_PER_BASE_INDEX
+    assert first_block.isdisjoint(second_block)
+
+
+@pytest.mark.base
+def test_a_request_wider_than_the_stride_is_refused() -> None:
+    """A request that would spill out of its block fails rather than quietly overlapping the next.
+
+    The stride bounds how many households one request can hold. Exceeding it silently would restore
+    exactly the defect the stride exists to prevent, so the arithmetic refuses instead.
+    """
+    with pytest.raises(ValueError):
+        PylpgWorkspace.calculation_index(1, PylpgWorkspace.HOUSEHOLDS_PER_BASE_INDEX)
+
+
+@pytest.mark.base
+def test_claiming_a_free_directory_returns_a_path_that_does_not_exist_yet() -> None:
+    """A claim on a free index yields the path pylpg will create, and creates nothing itself.
+
+    The claim is a check, not a reservation: ``pylpg`` makes the directory when it starts, and
+    creating it here would make the very next claim of the same index fail.
+    """
+    directory = PylpgWorkspace.claim(PylpgWorkspace.calculation_index(987654321, 0))
+    assert not directory.exists()
+    assert directory.name.startswith("C")
+
+
+@pytest.mark.base
+def test_claiming_an_occupied_directory_fails_and_names_the_index(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    """An occupied directory stops the run immediately with a message a reader can act on.
+
+    Letting the calculation start would either destroy a run that is still going -- ``LPGExecutor``
+    clears whatever it finds -- or fail much later with ``Directory not empty``, which is how a
+    development box degraded over a session. The message therefore has to say which index collided
+    and what the two possible causes are.
+    """
+    occupied_index = PylpgWorkspace.calculation_index(555, 0)
+
+    def working_directory_in_tmp(calculation_index: int) -> pathlib.Path:
+        return pathlib.Path(tmp_path) / f"C{calculation_index}"
+
+    monkeypatch.setattr(PylpgWorkspace, "working_directory", staticmethod(working_directory_in_tmp))
+    working_directory_in_tmp(occupied_index).mkdir()
+
+    with pytest.raises(PylpgWorkingDirectoryInUseError) as failure:
+        PylpgWorkspace.claim(occupied_index)
+
+    assert str(occupied_index) in str(failure.value)
+    assert PylpgWorkspace.INDEX_ENVIRONMENT_VARIABLE in str(failure.value)

--- a/tests/test_pylpg_workspace.py
+++ b/tests/test_pylpg_workspace.py
@@ -5,7 +5,8 @@ index, so the index is the only isolation available. HiSim defaulted it to ``1``
 multi-household request restarted its own counter at ``1``, which put every concurrent run in
 ``pylpg/C1``: sqlite files corrupted each other and a finishing run deleted the folder a running one
 was still using. These tests pin the replacement rule -- distinct base indices give disjoint blocks
-of directories, and an occupied directory stops the run by name.
+of directories, an occupied directory stops the run by name, and a run releases what it claimed
+whether it succeeded or failed.
 
 None of them touch pylpg or start a calculation; they exercise arithmetic and one filesystem check,
 which is why they are ``base`` rather than ``utsp``.
@@ -119,3 +120,29 @@ def test_claiming_an_occupied_directory_fails_and_names_the_index(monkeypatch: p
 
     assert str(occupied_index) in str(failure.value)
     assert PylpgWorkspace.INDEX_ENVIRONMENT_VARIABLE in str(failure.value)
+
+
+@pytest.mark.base
+def test_release_removes_the_directories_a_run_claimed(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    """Cleanup is driven by the claimed indices, so it works for a run that never got a result folder.
+
+    The old cleanup deleted the parent of the result folder the calculation returned, and skipped
+    itself entirely when the run failed before producing one. That left the directory on disk and the
+    next run failed on ``Directory not empty`` before it started, which is how one failure poisoned
+    the next. Indices are known before the attempt begins, so releasing by index covers both
+    outcomes; an index whose directory is already gone is skipped rather than raising, because this
+    runs in a ``finally`` where an exception would mask the real failure.
+    """
+
+    def working_directory_in_tmp(calculation_index: int) -> pathlib.Path:
+        return pathlib.Path(tmp_path) / f"C{calculation_index}"
+
+    monkeypatch.setattr(PylpgWorkspace, "working_directory", staticmethod(working_directory_in_tmp))
+    claimed = [PylpgWorkspace.calculation_index(31, ordinal) for ordinal in range(2)]
+    working_directory_in_tmp(claimed[0]).mkdir()
+    (working_directory_in_tmp(claimed[0]) / "results").mkdir()
+
+    PylpgWorkspace.release(claimed)
+
+    assert not working_directory_in_tmp(claimed[0]).exists()
+    assert not working_directory_in_tmp(claimed[1]).exists()

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -12,6 +12,7 @@ import pytest
 from hisim import sim_repository
 from hisim import component
 from hisim import utils
+from hisim.caching import atomic_cache_write
 from hisim.components import weather
 from hisim.simulationparameters import SimulationParameters
 from hisim.config import DisplayConfig
@@ -135,6 +136,13 @@ def _build_weather_with_cache(
     ``i_prepare_simulation`` takes the cached-file branch instead of
     re-processing the raw weather data.  When *include_pressure* is ``True``
     a ``Pressure`` column is added; otherwise it is omitted.
+
+    The entry goes in through ``atomic_cache_write`` rather than straight to the
+    path, because ``get_cache_file`` only counts an entry as present when the
+    companion metadata beside it hashes to the name it is filed under.  Writing
+    the CSV alone would leave an entry nothing describes, which the lookup
+    deletes on sight, and the cached-file branch this fixture exists to reach
+    would never be taken.
     """
     mysim = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=3600)
     mysim.cache_dir_path = str(tmp_path)
@@ -153,7 +161,10 @@ def _build_weather_with_cache(
     if include_pressure:
         columns.append("Pressure")
     data = {col: [float(i) * 10 for i in range(5)] for col in columns}
-    pd.DataFrame(data).to_csv(cache_filepath, index=False)
+    with atomic_cache_write(
+        cache_filepath, utils.build_cache_key_string(my_config, mysim)
+    ) as temporary_cache_filepath:
+        pd.DataFrame(data).to_csv(temporary_cache_filepath, index=False)
     return my_weather
 
 


### PR DESCRIPTION
Implements F1–F5 of `roadmap/pylpg_flakiness.md`, which ships on this branch. Targets `main` directly; F6 (atomic cache writes) is already there via #602.

> **This is #603 recovered.** #603 was merged — but into `atomic_cache_writes`, at 08:01 on 2026-09-01, *after* #602 had already taken that branch to `main`. The six commits therefore never reached `main` and are stranded on a merged branch, while `main` still carries all four silent-downgrade sites at `loadprofilegenerator_utsp_connector.py:892`, `:905`, `:1087` and `:1090`. They are replayed here with `git rebase --onto main atomic_cache_writes`, unchanged. #604 hitting the LPG flake in a golden job is this gap showing.

A transient error in the profile path used to make the connector rewrite its own `data_acquisition_mode` and continue with a shipped profile for **a different household**. The run finished, exited zero, and produced a full set of plausible indicators for a household nobody asked for — the only trace a warning in a log nobody diffs. That is why a golden-year job can fail for one household in an isolated runner and pass when re-run.

## What changes

**F1 — the fallback chain is deleted.** All four sites that rewrote the acquisition mode are gone, along with the retry loop whose only purpose was to re-enter the chain. An exception now propagates **unwrapped** — original exception, original traceback — with guidance printed alongside:

```
ERR:Occupancy profile could not be obtained in USE_LOCAL_LPG mode; the underlying error follows this message.

USE_UTSP needs UTSP_URL and UTSP_API_KEY in a .env file at the repository root.
If you do not have UTSP access, set data_acquisition_mode on UtspLpgConnectorConfig to one of
  USE_LOCAL_LPG          - generate the profile locally with pylpg (slower)
  USE_PREDEFINED_PROFILE - use a shipped profile; NOTE this is a DIFFERENT household
                           and results are not comparable with the other two modes.
```

Wanting the shipped profile is already expressible — it is one field — so the fallback bought a saved keystroke at the price of results nobody can trust. **Behaviour change to note:** configuring `USE_UTSP` with no `.env` is now an error rather than a silent switch to local generation.

**F2 — the component no longer edits the object it was configured with.** This also closes a recording defect filed separately: a realized record written after such a run stated `USE_PREDEFINED_PROFILE` even though its author asked for `USE_LOCAL_LPG`.

**F3 — one working directory per process.** `pylpg` derives its working directory from the calculation index alone, inside `site-packages`, and the index defaulted to a constant — so every concurrent run in one environment shared `C1`, corrupting each other's sqlite files and deleting each other's directories mid-calculation. The base index is now the process id, strided by 100 so a multi-household request keeps its block to itself. A directory that already exists is a hard, named failure:

```
PylpgWorkingDirectoryInUseError: The local LPG working directory for calculation index 700
already exists: .../pylpg/C700. Either another run is using it right now, or a previous run
was killed and left it behind. Delete it if no run is using it, or set
HISIM_LOCAL_LPG_CALC_INDEX to a free index for this process.
```

`HISIM_LOCAL_LPG_CALC_INDEX` still overrides the base, for callers that hand out indices themselves.

**F4 — cleanup runs after a failure too.** It is driven by the claimed indices rather than by a result folder a failing run never produced, so one failure no longer poisons the next.

**F5 — every cache entry describes itself.** `X.cache.meta` holds the raw string that was hashed, written from the **effective** inputs. A hit requires the metadata to hash to the digest in the filename; otherwise both files are deleted and the lookup reports a miss. Metadata is renamed into place first and data second, so a crash leaves a harmless orphan rather than an unvalidatable entry. This replaces the one-off purge: pre-existing entries have no metadata and clear themselves.

## Evidence

Each fix was demonstrated failing before and behaving after — the full outputs are in the commits. Two concurrent runs claim `C311249000` and `C311249100` and both finish; a planted directory produces the error above; an interrupted run cleans up and a second run reclaims the index.

**Two tests were silently opting out.** `test_lpg_utsp_connector_local_lpg.py` and `test_lpg_utsp_connector_scaling.py` inspected the post-init mode and **skipped themselves** when they found `USE_PREDEFINED_PROFILE` — so whenever the fallback fired, the tests that would have caught it stood down. That branch is now unreachable and each asserts the configured mode instead; otherwise their scaling comparisons would be comparing a substituted household.

Green: base 4495 passed / 1 skipped · extendedbase 13 · mypy 280/183/23 clean · pylint 10.00/10 · prospector 0/0/0 · `golden_check.py --setup household_gas_building_sizer --param one_week_60s` **OK**, with `grep "data acquisition mode will be set to"` returning zero matches, as F1 requires.

## Still outstanding

`scripts/record_all_setups.py` pins `LPG_INDEX = "1"` deliberately, which is safe against itself and defenceless against anything else on the machine. That script lives on the P3 branch, not on `main`, so the change belongs there and is **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
