### PR TITLE
Make a failed scenario-JSON regeneration diagnosable from the job output

### DIFF
--- a/.github/workflows/scenario-json-freshness.yml
+++ b/.github/workflows/scenario-json-freshness.yml
@@ -114,3 +114,16 @@ jobs:
           name: scenario-json-drift
           path: scenario_json_drift.txt
           if-no-files-found: ignore
+      # The per-setup converter logs are the only record of *why* a setup failed to build, and
+      # they live in the workspace, which the runner destroys. Without this the job's own advice
+      # -- "see the log" -- names a path that no longer exists, and an intermittent converter
+      # failure cannot be diagnosed from a red build at all. The summary now also prints the tail
+      # of each failing log inline; this keeps the whole of every log for the cases where the
+      # tail is not enough.
+      - name: Upload converter logs
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: scenario-json-converter-logs
+          path: results/regenerate_scenario_jsons/
+          if-no-files-found: ignore

--- a/scripts/regenerate_scenario_jsons.py
+++ b/scripts/regenerate_scenario_jsons.py
@@ -144,6 +144,19 @@ def regenerate_one(
     return SetupResult(stem, True, proc.returncode, log_path)
 
 
+class FailureReport:
+    """How much of a failing converter's log the summary reproduces inline.
+
+    A converter failure is usually a Python traceback of a few dozen lines, and the interesting
+    part is the end of it. Forty lines covers the exception, its traceback and the last of the
+    run's own logging without burying the summary above it; the whole file is still on disk for
+    anyone who has the workspace, and is uploaded as an artifact by the freshness workflow for
+    anyone who does not.
+    """
+
+    LINES_TO_PRINT: int = 40
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     """Parse arguments, regenerate the selected setups, print a summary."""
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -205,6 +218,23 @@ def main(argv: Optional[list[str]] = None) -> int:
     print(f"DONE: {len(results) - len(failed)} OK, {len(failed)} FAILED")
     for r in failed:
         print(f"  FAILED {r.stem} (rc={r.returncode}): {r.message} -> {r.log_path}")
+    # Print each failing converter's own output, not just the path to it. On a CI runner the
+    # log file is deleted with the workspace, so naming it is the same as saying nothing: a
+    # regeneration that fails intermittently there cannot be diagnosed at all from the job
+    # output. Printing the tail inline puts the traceback where whoever reads the red build
+    # will actually find it.
+    for r in failed:
+        print(f"\n----- {r.log_path} (last {FailureReport.LINES_TO_PRINT} lines) -----")
+        try:
+            lines = r.log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError as error:
+            print(f"  (could not be read: {error})")
+            continue
+        if not lines:
+            print("  (empty)")
+            continue
+        for line in lines[-FailureReport.LINES_TO_PRINT:]:
+            print(f"  {line}")
     return 0 if not failed else 1
 
 


### PR DESCRIPTION
The freshness gate failed on main and could not be investigated. Its summary named the converter's log file, and the workflow uploaded a different artifact -- so the only record of
  why a setup failed to build lived in the workspace, which the runner destroys. The job's own advice, 'see the log', pointed at a path that no longer existed. An intermittent converter
  failure was undiagnosable by construction. The summary now prints the tail of each failing converter's log inline, and the workflow uploads all of results/regenerate_scenario_jsons/ on
  failure. Neither changes what the gate checks or when it fails. Verified by pointing the runner at a converter that exits non-zero with a traceback on stderr, and confirming the traceback
  appears in the summary.