### PR TITLE
Let an undefined ratio be undefined, so a household with no electricity can report

### DIFF
--- a/hisim/postprocessing/kpi_computation/kpi_preparation.py
+++ b/hisim/postprocessing/kpi_computation/kpi_preparation.py
@@ -556,8 +556,21 @@ class KpiPreparation:
         """Compute the ratio of two values.
 
         ratio = denominator / numerator * 100 [%].
+
+        Every caller divides by a total consumption, and a system can legitimately consume nothing:
+        the simple air-conditioner household has no occupancy and no generation at all, so it
+        reported a total of zero and the division ended the KPI run with ZeroDivisionError. The ratio
+        there is not zero, it is undefined -- there is nothing for the numerator to be a proportion
+        of -- and the entry is emitted with no value, which is what this module already does for a
+        self-consumption rate when there is no production
+        (:meth:`compute_self_consumption_rate_according_to_solar_htw_berlin`). Substituting zero
+        would state a measurement nobody made.
         """
-        ratio_in_percent = denominator_value / numerator_value * 100
+        ratio_in_percent: Optional[float]
+        if numerator_value == 0:
+            ratio_in_percent = None
+        else:
+            ratio_in_percent = denominator_value / numerator_value * 100
         # make kpi entry
         ratio_in_percent_entry = KpiEntry(
             name=kpi_name,
@@ -573,16 +586,29 @@ class KpiPreparation:
 
     def get_total_energy_self_sufficiency(
         self,
-        self_sufficency_rate_for_electricity_in_percent: float,
+        self_sufficency_rate_for_electricity_in_percent: Optional[float],
         total_electricity_consumption_in_kwh: float,
         gas_demand_from_grid_in_kwh: float,
         total_gas_consumption_in_kwh: float,
         other_fuel_consumption_in_kwh: float,
-    ):
+    ) -> Optional[float]:
         """Calculate self-sufficiency including all energy consumptions for all loadtypes.
 
         Please note that the fuel meter has a self-sufficiency of 0% (all energy is pruchased).
+
+        Two of the three inputs can legitimately be absent, and this used to assume neither was.
+        The electricity rate is ``None`` for a system with no electricity meter, because the grid
+        exchange is then unknown -- the two functions that produce it say so deliberately -- and
+        multiplying that ``None`` was the TypeError that stopped every meterless setup in
+        post-processing. The total consumption is zero for a system that consumes no energy at all,
+        and dividing by it is the ZeroDivisionError beside it.
+
+        Both cases mean the same thing: the figure is undefined rather than zero, and the entry is
+        emitted without a value. A system whose electricity balance is unknown does not have a
+        known total-energy self-sufficiency, and reporting one would be inventing it.
         """
+        if self_sufficency_rate_for_electricity_in_percent is None:
+            return None
         total_energy_consumption_in_kwh = (
             total_electricity_consumption_in_kwh + total_gas_consumption_in_kwh + other_fuel_consumption_in_kwh
         )
@@ -597,6 +623,8 @@ class KpiPreparation:
             + self_sufficiency_gas_in_percent * total_gas_consumption_in_kwh
             + self_suffciency_other_fuels_in_percent * other_fuel_consumption_in_kwh
         )
+        if total_energy_consumption_in_kwh == 0:
+            return None
         total_energy_self_sufficiency_in_percent = (
             total_self_sufficient_energy_consumption_in_kwh / total_energy_consumption_in_kwh
         )

--- a/tests/test_simple_air_conditioner_household_building_sizer.py
+++ b/tests/test_simple_air_conditioner_household_building_sizer.py
@@ -31,6 +31,9 @@ from hisim.components.simple_air_conditioner import (
     SimpleAirConditioner,
     SimpleAirConditionerController,
 )
+from hisim import hisim_main
+from hisim import utils
+from hisim.postprocessingoptions import PostProcessingOptions
 from hisim.simulationparameters import SimulationParameters
 from tests.functions_for_testing import add_global_index_of_components, get_number_of_outputs
 
@@ -134,8 +137,6 @@ def test_setup_function_builds_correct_component_graph(tmp_path: Any) -> None:
     - ``prepare_calculation`` and ``connect_all_components`` succeed (all
       mandatory inputs resolve).
     """
-    from hisim import hisim_main
-
     # Use a one-day simulation so prepare_calculation (weather data loading) is
     # fast.  Set a concrete result_directory so the setup function does not try
     # to configure the ResultPathProviderSingleton and so connect_input can write
@@ -267,3 +268,75 @@ def test_scenario_json_structure() -> None:
     )
     assert ctrl_config["setpoint_temperature_c"] == 24.0
     assert ctrl_config["deadband_k"] == 0.5
+
+
+class UndefinedForThisHousehold:
+    """The KPIs that cannot exist for a household with no electricity at all.
+
+    This setup builds a weather, a building and an air conditioner: no occupancy, no generation, no
+    meter. Its total electricity consumption is genuinely zero, so every figure expressed as a
+    proportion of it has no value -- not zero, which would be a measurement, but nothing. The KPI
+    layer used to divide by that total and end the run with ``ZeroDivisionError``; it now emits the
+    entries without values, the way it already did for a self-consumption rate with no production.
+
+    Pinning the names keeps the distinction from being quietly "fixed" into zeros later, which would
+    make a household that consumes nothing indistinguishable from one that consumes plenty and
+    self-supplies none of it.
+    """
+
+    NAMES = (
+        "Ratio between total production and total consumption",
+        "Ratio between PV production and total consumption",
+        "Relative electricity demand from grid",
+        "Self-sufficiency rate according to solar htw berlin",
+        "Total energy self-suffiency rate",
+    )
+
+
+@pytest.mark.system_setups
+@utils.measure_execution_time
+def test_the_setup_completes_a_kpi_run_with_its_undefined_ratios_empty() -> None:
+    """Run the setup for one day with KPI and cost post-processing on.
+
+    The three tests above build the component graph and inspect it; none of them runs the setup to
+    completion, and none asks for KPIs -- the default post-processing options leave them off. So the
+    setup could pass this suite while dying in post-processing, which is exactly what it did.
+
+    Asserting that the undefined ratios carry no value, rather than only that the run finished,
+    is what makes this a test of the convention instead of a test that nothing raised.
+    """
+    path = Path("../system_setups/simple_air_conditioner_household_building_sizer.py")
+
+    sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    sim_params.post_processing_options = [
+        PostProcessingOptions.COMPUTE_KPIS,
+        PostProcessingOptions.WRITE_KPIS_TO_JSON,
+        PostProcessingOptions.COMPUTE_CAPEX,
+        PostProcessingOptions.COMPUTE_OPEX,
+    ]
+    result_directory = hisim_main.main(str(path), sim_params)
+
+    result_path = Path(result_directory)
+    assert (result_path / "finished.flag").is_file(), f"the run did not finish: {result_directory}"
+    kpi_path = result_path / "all_kpis.json"
+    assert kpi_path.is_file(), f"all_kpis.json not found in {result_directory}"
+
+    values_by_name: dict = {}
+
+    def collect(node: object) -> None:
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            if isinstance(value, dict) and "value" in value and "unit" in value:
+                values_by_name[key] = value["value"]
+            else:
+                collect(value)
+
+    collect(json.loads(kpi_path.read_text(encoding="utf-8")))
+
+    for name in UndefinedForThisHousehold.NAMES:
+        assert name in values_by_name, f"KPI '{name}' is missing from {kpi_path}"
+        assert values_by_name[name] is None, (
+            f"KPI '{name}' carries {values_by_name[name]!r}, but this household consumes no "
+            "electricity at all, so a proportion of its consumption is undefined rather than zero."
+        )


### PR DESCRIPTION
simple_air_conditioner_household_building_sizer builds a weather, a building and an air conditioner: no occupancy, no generation, no meter. Its total electricity
  consumption is genuinely zero, and the KPI layer divided by it (ZeroDivisionError at kpi_preparation.py:560), then multiplied a self-sufficiency rate that is None for want of a
  meter (TypeError at :596) -- the same line that stopped the two setups before it, which were fixed by giving them meters. This one cannot be: there is no electricity to meter.
  Both places now emit the entry without a value, which is what the same module already does for a self-consumption rate with no production. A ratio of something to nothing is
  undefined, not zero. Eight of the setup's 68 KPIs are now empty, all of them proportions of a consumption that does not exist, and the new test names five and asserts they stay
  empty -- the failure mode of this fix is somebody later deciding the blanks look untidy. The file's three existing tests build the component graph and never run the setup or
  ask for KPIs, which is why it passed its own suite while broken.