### PR TITLE
Stop household_gas_solar_thermal counting its occupancy's electricity twice

### DIFF
--- a/system_setups/household_gas_solar_thermal.py
+++ b/system_setups/household_gas_solar_thermal.py
@@ -24,7 +24,7 @@ from hisim.components import (
 from hisim.components import weather
 from hisim.components import building
 from hisim.components import electricity_meter
-from hisim import loadtypes, log
+from hisim import log
 
 
 __authors__ = "Kristina Dabrock"
@@ -230,14 +230,11 @@ def setup_function(
     # =================================================================================================================================
     # Connect Component Inputs with Outputs
 
-    my_electricity_meter.add_component_input_and_connect(
-        source_object_name=my_occupancy.component_name,
-        source_component_output=my_occupancy.ElectricalPowerConsumption,
-        source_load_type=loadtypes.LoadTypes.ELECTRICITY,
-        source_unit=loadtypes.Units.WATT,
-        source_tags=[loadtypes.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
-        source_weight=999,
-    )
+    # The occupancy is not fed to the electricity meter here. The meter declares that exact
+    # connection itself (electricity_meter.py, get_default_connections_from_utsp_occupancy) and is
+    # registered with connect_automatically below, so wiring it by hand as well fed one source into
+    # one meter twice -- and hisim/simulator.py does not de-duplicate, so the sum really was taken
+    # twice. That is what made the relative electricity demand exceed 100 % and stopped the KPI run.
 
     my_dhw_storage.connect_input(
         my_dhw_storage.WaterConsumption,

--- a/system_setups/household_gas_solar_thermal.scenario.json
+++ b/system_setups/household_gas_solar_thermal.scenario.json
@@ -229,17 +229,6 @@
                 },
                 {
                     "dynamic": true,
-                    "source_component_output": "ElectricalPowerConsumption",
-                    "source_object_name": "UTSPConnector",
-                    "source_load_type": "Electricity",
-                    "source_unit": "W",
-                    "source_tags": [
-                        "Consumption without any EMS control"
-                    ],
-                    "source_weight": 999
-                },
-                {
-                    "dynamic": true,
                     "source_component_output": "ElectricityConsumptionOutput",
                     "source_object_name": "SolarThermalSystem",
                     "source_load_type": "Electricity",
@@ -460,22 +449,12 @@
         },
         {
             "source": {
-                "component_name": "UTSPConnector",
-                "field_name": "ElectricalPowerConsumption"
-            },
-            "target": {
-                "component_name": "ElectricityMeter",
-                "field_name": "Input_UTSPConnector_ElectricalPowerConsumption_1"
-            }
-        },
-        {
-            "source": {
                 "component_name": "SolarThermalSystem",
                 "field_name": "ElectricityConsumptionOutput"
             },
             "target": {
                 "component_name": "ElectricityMeter",
-                "field_name": "Input_SolarThermalSystem_ElectricityConsumptionOutput_2"
+                "field_name": "Input_SolarThermalSystem_ElectricityConsumptionOutput_1"
             }
         },
         {

--- a/tests/test_system_setups_household_gas_solar_thermal.py
+++ b/tests/test_system_setups_household_gas_solar_thermal.py
@@ -1,0 +1,100 @@
+"""Test for the household_gas_solar_thermal system setup.
+
+This module contains a single integration test that loads the setup, runs it for one day with the
+KPI and cost post-processing switched on, and checks that its electricity balance adds up.
+"""
+
+import json
+from pathlib import Path
+import pytest
+from hisim import hisim_main
+from hisim.postprocessingoptions import PostProcessingOptions
+from hisim.simulationparameters import SimulationParameters
+from hisim import utils
+
+
+class ElectricityBalance:
+    """What the meter must report, and the one figure that cannot exist.
+
+    The household has an occupancy and no electrical generation -- the solar collector is thermal --
+    so everything it consumes comes from the grid, nothing goes back, and its self-sufficiency is
+    zero. The self-consumption rate is the share of its own production that it uses, and with no
+    production that is undefined rather than zero.
+
+    ``RELATIVE_DEMAND_CEILING`` is the assertion that matters. This setup fed the occupancy into the
+    electricity meter by hand *and* registered the meter with ``connect_automatically``, which
+    applies the meter's own default connection for the same source; the simulator does not
+    de-duplicate, so one source was summed into one meter twice and the grid import came out at
+    roughly double the total consumption. The KPI layer noticed only because a demand above 100 %
+    is impossible, and refused to continue. Pinning the ceiling keeps that shape of wiring mistake
+    detectable here rather than as an opaque post-processing failure.
+    """
+
+    RELATIVE_DEMAND_CEILING = 100.0
+    REQUIRED = (
+        "Total electricity consumption",
+        "Total energy from grid",
+        "Relative electricity demand from grid",
+        "Self-sufficiency rate according to solar htw berlin",
+    )
+    NOT_COMPUTABLE = ("Self-consumption rate according to solar htw berlin",)
+
+
+@pytest.mark.system_setups
+@utils.measure_execution_time
+def test_household_gas_solar_thermal() -> None:
+    """Run the setup for one day and check the electricity balance is possible.
+
+    There was no test for this setup at all, and it had been failing in post-processing for long
+    enough to be parked as an unexplained KPI-layer bug. It is not one: the wiring counted the
+    occupancy twice, and the KPI layer was the only thing that noticed.
+    """
+    path = Path("../system_setups/household_gas_solar_thermal.py")
+
+    sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    sim_params.post_processing_options = [
+        PostProcessingOptions.COMPUTE_KPIS,
+        PostProcessingOptions.WRITE_KPIS_TO_JSON,
+        PostProcessingOptions.COMPUTE_CAPEX,
+        PostProcessingOptions.COMPUTE_OPEX,
+    ]
+    result_directory = hisim_main.main(str(path), sim_params)
+
+    result_path = Path(result_directory)
+    assert (result_path / "finished.flag").is_file(), f"the run did not finish: {result_directory}"
+    kpi_path = result_path / "all_kpis.json"
+    assert kpi_path.is_file(), f"all_kpis.json not found in {result_directory}"
+
+    values_by_name: dict = {}
+
+    def collect(node: object) -> None:
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            if isinstance(value, dict) and "value" in value and "unit" in value:
+                values_by_name[key] = value["value"]
+            else:
+                collect(value)
+
+    collect(json.loads(kpi_path.read_text(encoding="utf-8")))
+
+    for name in ElectricityBalance.REQUIRED:
+        assert name in values_by_name, f"KPI '{name}' is missing from {kpi_path}"
+        assert values_by_name[name] is not None, f"KPI '{name}' has no value"
+
+    for name in ElectricityBalance.NOT_COMPUTABLE:
+        assert values_by_name.get(name) is None, (
+            f"KPI '{name}' carries a value, but this household generates no electricity, so the "
+            "share of its own production that it consumes is undefined."
+        )
+
+    relative_demand = values_by_name["Relative electricity demand from grid"]
+    assert relative_demand <= ElectricityBalance.RELATIVE_DEMAND_CEILING, (
+        f"the grid supplied {relative_demand} % of a consumption it cannot exceed -- a source is "
+        "very likely fed into the electricity meter twice, by hand and by default connection both."
+    )
+
+    assert values_by_name["Total energy from grid"] <= values_by_name["Total electricity consumption"], (
+        "grid import exceeds total consumption, which is the same double-counting seen from the "
+        "other side."
+    )


### PR DESCRIPTION
The setup fed the occupancy into the electricity meter by hand and also registered the meter with connect_automatically, which applies the meter's own default connection for that same source. hisim/simulator.py does not
  de-duplicate two feeds of one source, so the sum really was taken twice: grid import 21.72 kWh against a total consumption of 10.9, and the KPI layer refused to continue because a relative demand above 100 percent is impossible.
  This had been parked as an unexplained KPI-layer bug -- it is not one; the KPI layer was the only thing that noticed, and it was right. The hand-wiring goes, the default connection stays. Grid import is now 10.86 against 10.9
  consumed, self-sufficiency 0 percent because a solar *thermal* collector generates no electricity, and the self-consumption rate empty for the same reason. There was no test; the new one asserts the balance is *possible* -- grid
  import at most total consumption, relative demand at most 100 percent -- because the wiring mistake was invisible until a derived percentage went impossible. Found as F-4 of roadmap/p3_random_findings.md, by the recorder refusing
  a wiring the imperative path accepted in silence. The companion simulator change, refusing duplicate feeds outright, is deliberately not here: it touches connect_automatically for every component and deserves its own run through
  the gates.