### PR TITLE
Let a component that models no device answer for itself, and ask the setup tests for KPIs

### DIFF
--- a/hisim/component.py
+++ b/hisim/component.py
@@ -17,7 +17,7 @@ import os
 import dataclasses as dc
 import typing
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 import json
 import pandas as pd
 
@@ -449,13 +449,34 @@ class Component:
             raise ValueError("Error: Component " + self.component_name + " has no outputs defined")
         return self.outputs
 
+    #: Set on a component that models no physical device -- a signal generator, a summation
+    #: node, a demonstration transformer. Such a component has nothing to buy, nothing to run
+    #: and no indicators of its own, so the three methods below answer for it instead of
+    #: refusing. Never set it on a component whose cost or KPI model has simply not been
+    #: written: the default is to refuse, so a real device that nobody has modelled stops the
+    #: run rather than being summed into the totals as zero and read as an answer.
+    #: That distinction is the whole point of the flag. The default below still raises, so a device
+    #: with real costs that nobody has modelled fails the run loudly instead of being summed into
+    #: the system total as zero, which would understate it silently and look like an answer.
+    MODELS_NO_DEVICE: ClassVar[bool] = False
+
     def get_cost_opex(
         self,
         all_outputs: List,
         postprocessing_results: pd.DataFrame,
     ) -> OpexCostDataClass:
         # pylint: disable=unused-argument
-        """Calculates operational cost, operational co2 footprint and consumption in kWh (for Diesel in l) during simulation time frame."""
+        """Calculates operational cost, operational co2 footprint and consumption in kWh (for Diesel in l) during simulation time frame.
+
+        Raises unless the component has declared :attr:`MODELS_NO_DEVICE`. Half the component
+        library does not implement this method, so enabling COMPUTE_OPEX used to be safe only for a
+        system built entirely from the half that does -- and the failure named the component without
+        saying whether its costs were nil or merely unwritten. A component that has none now says so
+        and returns zeros; everything else still stops the run, which is the right outcome for a
+        cost that exists and is missing.
+        """
+        if self.MODELS_NO_DEVICE:
+            return OpexCostDataClass.get_default_opex_cost_data_class()
         raise NotImplementedError(f"{self.component_name} has no opex costs implemented.")
 
     @staticmethod
@@ -469,16 +490,49 @@ class Component:
         all_outputs: List,  # pylint: disable=unused-argument
         postprocessing_results: pd.DataFrame,  # pylint: disable=unused-argument
     ) -> List[KpiEntry]:
-        """Calculates KPIs for the respective component and return all KPI entries as list."""
-        # if the method is not implemented in the component return an empty list
+        """Calculates KPIs for the respective component and return all KPI entries as list.
+
+        Refuses unless the component has declared :attr:`MODELS_NO_DEVICE`, in which case it has no
+        indicators of its own and contributes none. The comment this replaces said the empty list
+        was the intent for an unimplemented method, and the code beneath it raised -- the two had
+        disagreed long enough that setups built from indicator-less components could not compute
+        KPIs at all.
+        """
+        if self.MODELS_NO_DEVICE:
+            return []
         raise NotImplementedError(f"{self.component_name} has no kpis implemented.")
+
+    def capital_cost_data(
+        self, simulation_parameters: Optional[SimulationParameters] = None
+    ) -> CapexCostDataClass:
+        """Return this component's capital cost, or zeros when it models no device.
+
+        Callers use this rather than :meth:`get_cost_capex` directly, because the flag that says a
+        component has no costs cannot be read from inside that method: it is a ``staticmethod`` that
+        receives only the configuration, and some thirty components override it as one. Changing
+        that signature to let the base class see the class attribute would mean touching every one
+        of those overrides for the sake of the handful that declare no costs, so the check lives
+        here, on the instance, where the flag is in scope.
+
+        Args:
+            simulation_parameters: the parameters to cost against; the component's own when omitted.
+
+        Returns:
+            CapexCostDataClass: the component's capital cost, or a zeroed instance.
+        """
+        if self.MODELS_NO_DEVICE:
+            return CapexCostDataClass.get_default_capex_cost_data_class()
+        return self.get_cost_capex(
+            config=self.config,
+            simulation_parameters=simulation_parameters or self.my_simulation_parameters,
+        )
 
     def calc_maintenance_cost(self) -> float:
         """Calc maintenance_cost per simulated period as share of capex of component."""
 
-        maintenance_cost_per_simulated_period_in_euro = self.get_cost_capex(
-            config=self.config, simulation_parameters=self.my_simulation_parameters
-        ).maintenance_cost_per_simulated_period_in_euro
+        maintenance_cost_per_simulated_period_in_euro = (
+            self.capital_cost_data().maintenance_cost_per_simulated_period_in_euro
+        )
 
         return maintenance_cost_per_simulated_period_in_euro
 

--- a/hisim/components/example_transformer.py
+++ b/hisim/components/example_transformer.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 # Import packages from standard library or the environment e.g. pandas, numpy etc.
 from dataclasses import dataclass
-from typing import Optional
+from typing import ClassVar, Optional
 from dataclasses_json import dataclass_json
 
 # Import modules from HiSim
@@ -97,6 +97,11 @@ class ExampleTransformer(Component):
         Defaults to an empty :py:class:`~hisim.config.DisplayConfig`.
 
     """
+
+    # A demonstration component that scales one signal by a constant. It models no device, so
+    # it has no operating cost -- as opposed to one whose cost model is merely unwritten.
+    # See Component.MODELS_NO_DEVICE.
+    MODELS_NO_DEVICE: ClassVar[bool] = True
 
     TransformerInput1: str = "Input1"
     TransformerInput2: str = "Optional Input1"

--- a/hisim/components/random_numbers.py
+++ b/hisim/components/random_numbers.py
@@ -57,6 +57,11 @@ class RandomNumbers(Component):
         - i_simulate: Outputs the pre-generated random value for the current timestep
     """
 
+    # A generator of random values is not a device: it has nothing to buy and nothing to run.
+    # Declaring that is what lets a setup built from it ask for costs at all;
+    # see Component.MODELS_NO_DEVICE.
+    MODELS_NO_DEVICE: ClassVar[bool] = True
+
     RandomOutput: ClassVar[str] = "Random Numbers"
 
     def __init__(

--- a/hisim/components/sumbuilder.py
+++ b/hisim/components/sumbuilder.py
@@ -2,7 +2,7 @@
 
 # clean
 from dataclasses import dataclass
-from typing import Any, List
+from typing import Any, ClassVar, List
 
 from dataclasses_json import dataclass_json
 
@@ -45,6 +45,10 @@ class SumBuilderConfig(ConfigBase):
 
 class CalculateOperation(cp.Component):
     """Arbitrary mathematical operations."""
+
+    # Arithmetic over other components' outputs: it owns no device, so there is nothing to
+    # buy and nothing to run. See Component.MODELS_NO_DEVICE.
+    MODELS_NO_DEVICE: ClassVar[bool] = True
 
     operations_available: List[str] = ["Sum", "Subtract", "Multiply", "Divide"]
     Output: str = "Output"
@@ -151,6 +155,10 @@ class SumBuilderForTwoInputs(Component):
     time step, and writes the result to one output channel.
     """
 
+    # Arithmetic over other components' outputs: it owns no device, so there is nothing to
+    # buy and nothing to run. See Component.MODELS_NO_DEVICE.
+    MODELS_NO_DEVICE: ClassVar[bool] = True
+
     SumInput1: str = "Input 1"
     SumInput2: str = "Input 2"
     SumOutput: str = "Sum"
@@ -231,6 +239,10 @@ class SumBuilderForTwoInputs(Component):
 
 class SumBuilderForThreeInputs(Component):
     """Sum builder for three inputs."""
+
+    # Arithmetic over other components' outputs: it owns no device, so there is nothing to
+    # buy and nothing to run. See Component.MODELS_NO_DEVICE.
+    MODELS_NO_DEVICE: ClassVar[bool] = True
 
     SumInput1: str = "Input 1"
     SumInput2: str = "Input 2"

--- a/hisim/postprocessing/cost_and_emission_computation/opex_and_capex_cost_calculation.py
+++ b/hisim/postprocessing/cost_and_emission_computation/opex_and_capex_cost_calculation.py
@@ -332,8 +332,8 @@ def capex_calculation(
             # The building a component belongs to is read from its structured identity instead of
             # being guessed from a substring of its runtime name.
             if building_object == component_unwrapped.component_id.building_label:
-                capex: CapexCostDataClass = component_unwrapped.get_cost_capex(
-                    config=component_unwrapped.config, simulation_parameters=simulation_parameters
+                capex: CapexCostDataClass = component_unwrapped.capital_cost_data(
+                    simulation_parameters=simulation_parameters
                 )
                 # filter out none type values
                 if any(v is None for v in asdict(capex).values()):

--- a/tests/functions_for_testing.py
+++ b/tests/functions_for_testing.py
@@ -1,6 +1,46 @@
 """Helper functions for testing."""
 # clean
+from typing import ClassVar, Tuple
+
 from hisim.component import ComponentOutput
+from hisim.postprocessingoptions import PostProcessingOptions
+from hisim.simulationparameters import SimulationParameters
+
+
+class SetupTestParameters:
+    """Simulation parameters for a system-setup test, with the KPI machinery switched on.
+
+    ``SimulationParameters.one_day_only`` enables no post-processing at all, and every setup test
+    in this suite used it as-is. A setup could therefore run every timestep, write finished.flag,
+    satisfy its test, and still fail the instant anyone asked it for KPIs -- which is precisely
+    what four of them did, each discovered only when something else went looking. The failures
+    lived entirely in post-processing and nothing in the tests reached it.
+
+    Building the parameters here rather than in each test means a new setup test exercises that
+    path by default instead of by remembering to.
+    """
+
+    OPTIONS: ClassVar[Tuple[PostProcessingOptions, ...]] = (
+        PostProcessingOptions.COMPUTE_KPIS,
+        PostProcessingOptions.WRITE_KPIS_TO_JSON,
+        PostProcessingOptions.COMPUTE_CAPEX,
+        PostProcessingOptions.COMPUTE_OPEX,
+    )
+
+    @classmethod
+    def one_day_with_kpis(cls, year: int = 2021, seconds_per_timestep: int = 60) -> SimulationParameters:
+        """Return one-day parameters that compute KPIs and costs.
+
+        Args:
+            year: the simulation year.
+            seconds_per_timestep: the resolution.
+
+        Returns:
+            SimulationParameters: one day, with the KPI and cost options enabled.
+        """
+        parameters = SimulationParameters.one_day_only(year=year, seconds_per_timestep=seconds_per_timestep)
+        parameters.post_processing_options.extend(cls.OPTIONS)
+        return parameters
 
 
 def get_number_of_outputs(list_of_components: list) -> int:

--- a/tests/test_system_setups_automatic_default_connections.py
+++ b/tests/test_system_setups_automatic_default_connections.py
@@ -4,8 +4,8 @@ import os
 from pathlib import Path
 
 import pytest
+from tests import functions_for_testing as fft
 from hisim import hisim_main
-from hisim.simulationparameters import SimulationParameters
 from hisim import log
 from hisim import utils
 
@@ -24,7 +24,7 @@ def test_basic_household_with_default_connections() -> None:
     """
     path = "../system_setups/automatic_default_connections.py"
 
-    simulation_parameters = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    simulation_parameters = fft.SetupTestParameters.one_day_with_kpis()
     hisim_main.main(path, simulation_parameters)
     log.information(os.getcwd())
 

--- a/tests/test_system_setups_basic_household.py
+++ b/tests/test_system_setups_basic_household.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from tests import functions_for_testing as fft
 from hisim import hisim_main
-from hisim.simulationparameters import SimulationParameters
 from hisim import log
 from hisim import utils
 
@@ -22,7 +22,7 @@ def test_basic_household() -> None:
     run.
     """
     path = "../system_setups/basic_household.py"
-    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    mysimpar = fft.SetupTestParameters.one_day_with_kpis()
     hisim_main.main(path, mysimpar)
     log.information(str(Path.cwd()))
 

--- a/tests/test_system_setups_default_connections.py
+++ b/tests/test_system_setups_default_connections.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import pytest
 
+from tests import functions_for_testing as fft
 from hisim import hisim_main
 from hisim import utils
 from hisim.postprocessingoptions import PostProcessingOptions
-from hisim.simulationparameters import SimulationParameters
 
 
 @pytest.mark.system_setups
@@ -27,11 +27,10 @@ def test_basic_household_with_default_connections() -> None:
     """
     path = "../system_setups/default_connections.py"
 
-    simulation_parameters = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    # ``one_day_only`` enables no post-processing options by default, so no result artifacts
-    # (CSV/JSON/PDF) would be written. Enable CSV export (combined into a single file) so the
-    # test can assert that the simulation actually emitted result data, not just a
-    # ``finished.flag`` marker.
+    # The shared helper switches on the KPI and cost options, so this exercises post-processing
+    # rather than only the timestep loop. CSV export is added on top because this test also asserts
+    # that result data was actually emitted, not just a ``finished.flag`` marker.
+    simulation_parameters = fft.SetupTestParameters.one_day_with_kpis()
     simulation_parameters.post_processing_options.extend(
         [
             PostProcessingOptions.EXPORT_TO_CSV,

--- a/tests/test_system_setups_dynamic_components.py
+++ b/tests/test_system_setups_dynamic_components.py
@@ -9,6 +9,13 @@ from hisim import utils
 from hisim.result_path_provider import ResultPathProviderSingleton
 
 
+# This setup cannot yet be run with the KPI and cost options that
+# tests.functions_for_testing.SetupTestParameters switches on, and the omission is recorded here
+# rather than left as an absence. The CHP refuses to report operating costs, and refusing is
+# correct: the cost exists and has not been modelled, so answering zero would understate the system
+# total silently. Component.MODELS_NO_DEVICE is only for components that genuinely have none.
+# Switch this test over once that cost model is written -- see the family-A entry in the setup
+# sweep.
 @pytest.mark.extendedbase
 @utils.measure_execution_time
 def test_dynamic_components_system_setup() -> None:

--- a/tests/test_system_setups_electrolyzer_with_renewables.py
+++ b/tests/test_system_setups_electrolyzer_with_renewables.py
@@ -55,6 +55,13 @@ def fixture_isolated_result_directory() -> Iterator[str]:
             shutil.rmtree(directory)
 
 
+# This setup cannot yet be run with the KPI and cost options that
+# tests.functions_for_testing.SetupTestParameters switches on, and the omission is recorded here
+# rather than left as an absence. The transformer and rectifier unit refuses to report operating costs, and refusing is
+# correct: the cost exists and has not been modelled, so answering zero would understate the system
+# total silently. Component.MODELS_NO_DEVICE is only for components that genuinely have none.
+# Switch this test over once that cost model is written -- see the family-A entry in the setup
+# sweep.
 @pytest.mark.system_setups
 @utils.measure_execution_time
 def test_electrolyzer_with_renewables(isolated_result_directory: str) -> None:


### PR DESCRIPTION
Half the component library does not implement get_cost_opex, so enabling COMPUTE_OPEX was safe only for a system built entirely from the half that does -- and the refusal named the component without saying whether its
  costs were nil or merely unwritten. MODELS_NO_DEVICE is how a component says which. A signal generator, a summation node and a demonstration transformer own no device: nothing to buy, nothing to run, no indicators of their own.
  Everything else still refuses, which is right for a cost that exists and has not been modelled. The setup tests now build their parameters through functions_for_testing.SetupTestParameters, which switches the KPI and cost options
  on -- one_day_only enables no post-processing at all, which is how four setups this week ran every timestep, wrote finished.flag, passed their tests and still failed the moment anyone asked for KPIs. Two tests are deliberately not
  converted and say so in a comment: the CHP and the transformer-rectifier refuse their operating costs, correctly, because those costs exist and are unmodelled. **Merge after the undefined-ratio PR** -- simple_system_setup_one and
  _two then reach ZeroDivisionError at kpi_preparation.py:560, which that PR fixes; verified together, all three pass.