### PR TITLE
Refuse to feed one dynamic component the same source output twice

### DIFF
--- a/hisim/dynamic_component.py
+++ b/hisim/dynamic_component.py
@@ -88,6 +88,23 @@ def tags_search_and_compare(
     return True
 
 
+class DuplicateComponentFeedError(ValueError):
+    """Raised when one source output is wired into one dynamic component more than once.
+
+    A dynamic component sums the inputs that carry a given tag, so feeding it the same output twice
+    makes it count that flow twice. Nothing about the result looks wrong: the simulation completes
+    and every series is plausible. ``household_gas_solar_thermal`` did exactly this -- the occupancy
+    was wired to the electricity meter by hand *and* by the meter's own default connection -- and
+    reported a grid import of 21.72 kWh against a total consumption of 10.9. The only thing that
+    ever noticed was a derived percentage going above 100, and the setup sat broken for months
+    filed as a bug in the KPI layer.
+
+    It is a distinct type rather than a bare ``ValueError`` so a caller that genuinely wants to
+    detect and skip the second feed can tell it from the other ways a connection can be rejected.
+    Nothing in HiSim does that today.
+    """
+
+
 class DynamicComponent(Component):
 
     """Class for components with a dynamic number of inputs and outputs.
@@ -337,7 +354,32 @@ class DynamicComponent(Component):
         source_weight: int,
         allow_unconnected_mandatory: bool = False,
     ) -> None:
-        """Adds a component input and connects it at once."""
+        """Adds a component input and connects it at once.
+
+        Raises:
+            DuplicateComponentFeedError: if this component is already fed by that source output.
+        """
+        # Refuse a second feed of the same source output before creating anything. The two ways of
+        # wiring a dynamic component -- by hand here, and through the default connections that
+        # connect_automatically applies -- do not know about each other, so a setup that uses both
+        # for one source silently doubles it. Checking the inputs rather than my_component_inputs is
+        # deliberate: these are the objects connection resolution actually reads.
+        for existing_input in self.inputs:
+            if (
+                existing_input.src_object_name == source_object_name
+                and existing_input.src_field_name == str(source_component_output)
+            ):
+                raise DuplicateComponentFeedError(
+                    f"'{self.component_name}' is already fed by "
+                    f"'{source_object_name}.{source_component_output}' through input "
+                    f"'{existing_input.field_name}', and something is adding it a second time. A "
+                    f"dynamic component sums what it is given, so the second feed would count that "
+                    f"flow twice and every total derived from it would be wrong without looking "
+                    f"wrong. The usual cause is a setup wiring a source by hand and also passing "
+                    f"connect_automatically=True, which applies the component's own default "
+                    f"connection for the same source: do one or the other, not both."
+                )
+
         # Label Input and generate variable
         num_inputs = len(self.inputs)
         label = f"Input_{source_object_name}_{source_component_output}_{num_inputs}"

--- a/system_setups/household_gas_solar_thermal.py
+++ b/system_setups/household_gas_solar_thermal.py
@@ -24,7 +24,7 @@ from hisim.components import (
 from hisim.components import weather
 from hisim.components import building
 from hisim.components import electricity_meter
-from hisim import loadtypes, log
+from hisim import log
 
 
 __authors__ = "Kristina Dabrock"
@@ -230,14 +230,11 @@ def setup_function(
     # =================================================================================================================================
     # Connect Component Inputs with Outputs
 
-    my_electricity_meter.add_component_input_and_connect(
-        source_object_name=my_occupancy.component_name,
-        source_component_output=my_occupancy.ElectricalPowerConsumption,
-        source_load_type=loadtypes.LoadTypes.ELECTRICITY,
-        source_unit=loadtypes.Units.WATT,
-        source_tags=[loadtypes.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
-        source_weight=999,
-    )
+    # The occupancy is not fed to the electricity meter here. The meter declares that exact
+    # connection itself (electricity_meter.py, get_default_connections_from_utsp_occupancy) and is
+    # registered with connect_automatically below, so wiring it by hand as well fed one source into
+    # one meter twice -- and hisim/simulator.py does not de-duplicate, so the sum really was taken
+    # twice. That is what made the relative electricity demand exceed 100 % and stopped the KPI run.
 
     my_dhw_storage.connect_input(
         my_dhw_storage.WaterConsumption,

--- a/system_setups/household_gas_solar_thermal.scenario.json
+++ b/system_setups/household_gas_solar_thermal.scenario.json
@@ -229,17 +229,6 @@
                 },
                 {
                     "dynamic": true,
-                    "source_component_output": "ElectricalPowerConsumption",
-                    "source_object_name": "UTSPConnector",
-                    "source_load_type": "Electricity",
-                    "source_unit": "W",
-                    "source_tags": [
-                        "Consumption without any EMS control"
-                    ],
-                    "source_weight": 999
-                },
-                {
-                    "dynamic": true,
                     "source_component_output": "ElectricityConsumptionOutput",
                     "source_object_name": "SolarThermalSystem",
                     "source_load_type": "Electricity",
@@ -460,22 +449,12 @@
         },
         {
             "source": {
-                "component_name": "UTSPConnector",
-                "field_name": "ElectricalPowerConsumption"
-            },
-            "target": {
-                "component_name": "ElectricityMeter",
-                "field_name": "Input_UTSPConnector_ElectricalPowerConsumption_1"
-            }
-        },
-        {
-            "source": {
                 "component_name": "SolarThermalSystem",
                 "field_name": "ElectricityConsumptionOutput"
             },
             "target": {
                 "component_name": "ElectricityMeter",
-                "field_name": "Input_SolarThermalSystem_ElectricityConsumptionOutput_2"
+                "field_name": "Input_SolarThermalSystem_ElectricityConsumptionOutput_1"
             }
         },
         {

--- a/tests/test_duplicate_component_feeds.py
+++ b/tests/test_duplicate_component_feeds.py
@@ -1,0 +1,111 @@
+"""The rule that one source output may feed one dynamic component only once.
+
+A dynamic component sums the inputs carrying a given tag, so a source wired into it twice is
+counted twice, and nothing about the result looks wrong -- the simulation completes and every
+series is plausible. ``household_gas_solar_thermal`` reported a grid import of 21.72 kWh against a
+total consumption of 10.9 for exactly this reason, and sat broken for months filed as a bug in the
+KPI layer, because the only thing that ever noticed was a derived percentage exceeding 100.
+
+These tests pin the refusal and, as importantly, pin what it must *not* refuse: two different
+outputs of one source, and one output going to two different components, are both ordinary.
+"""
+
+# clean
+
+import dataclasses
+
+import pytest
+
+from hisim import loadtypes as lt
+from hisim.component import ComponentInput
+from hisim.config import ComponentID
+from hisim.dynamic_component import DuplicateComponentFeedError
+from hisim.components.electricity_meter import ElectricityMeter, ElectricityMeterConfig
+from hisim.simulationparameters import SimulationParameters
+
+
+def make_meter(name: str = "ElectricityMeter") -> ElectricityMeter:
+    """Build an electricity meter to wire things into."""
+    config = dataclasses.replace(
+        ElectricityMeterConfig.get_electricity_meter_default_config(),
+        component_id=ComponentID(name=name),
+    )
+    return ElectricityMeter(
+        my_simulation_parameters=SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60),
+        config=config,
+    )
+
+
+def feed(meter: ElectricityMeter, source: str, output: str) -> None:
+    """Wire one source output into the meter as uncontrolled consumption."""
+    meter.add_component_input_and_connect(
+        source_object_name=source,
+        source_component_output=output,
+        source_load_type=lt.LoadTypes.ELECTRICITY,
+        source_unit=lt.Units.WATT,
+        source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
+        source_weight=999,
+    )
+
+
+@pytest.mark.base
+def test_the_same_output_cannot_feed_one_component_twice() -> None:
+    """The second feed is refused, by name, at the point of wiring."""
+    meter = make_meter()
+    feed(meter, "UTSPConnector", "ElectricalPowerConsumption")
+
+    with pytest.raises(DuplicateComponentFeedError) as refusal:
+        feed(meter, "UTSPConnector", "ElectricalPowerConsumption")
+
+    message = str(refusal.value)
+    assert "UTSPConnector" in message and "ElectricalPowerConsumption" in message, (
+        "the refusal must name the source and output, so the reader can find the second wiring"
+    )
+    assert "connect_automatically" in message, (
+        "the usual cause is wiring by hand as well as by default connection; the message says so"
+    )
+
+
+@pytest.mark.base
+def test_the_refusal_happens_before_anything_is_added() -> None:
+    """A refused feed leaves the component exactly as it was.
+
+    The check runs before the input object is built and appended, so a caller that catches the
+    error is not left with a half-added input that connection resolution would later trip over.
+    """
+    meter = make_meter()
+    feed(meter, "UTSPConnector", "ElectricalPowerConsumption")
+    inputs_after_first = len(meter.inputs)
+
+    with pytest.raises(DuplicateComponentFeedError):
+        feed(meter, "UTSPConnector", "ElectricalPowerConsumption")
+
+    assert len(meter.inputs) == inputs_after_first, "the refused feed must add no input"
+
+
+@pytest.mark.base
+def test_two_different_outputs_of_one_source_are_allowed() -> None:
+    """Distinct outputs are distinct flows, however they are tagged."""
+    meter = make_meter()
+    feed(meter, "UTSPConnector", "ElectricalPowerConsumption")
+    feed(meter, "UTSPConnector", "WaterConsumption")
+
+    sources = {(one.src_object_name, one.src_field_name) for one in meter.inputs if one.src_object_name}
+    assert ("UTSPConnector", "ElectricalPowerConsumption") in sources
+    assert ("UTSPConnector", "WaterConsumption") in sources
+
+
+@pytest.mark.base
+def test_one_output_may_feed_two_different_components() -> None:
+    """The rule is per component, not global: a meter and an energy manager may both read a source."""
+    first = make_meter("FirstMeter")
+    second = make_meter("SecondMeter")
+
+    feed(first, "UTSPConnector", "ElectricalPowerConsumption")
+    feed(second, "UTSPConnector", "ElectricalPowerConsumption")
+
+    for meter in (first, second):
+        assert any(
+            isinstance(one, ComponentInput) and one.src_field_name == "ElectricalPowerConsumption"
+            for one in meter.inputs
+        ), f"{meter.component_name} should have been fed"

--- a/tests/test_system_setups_household_gas_solar_thermal.py
+++ b/tests/test_system_setups_household_gas_solar_thermal.py
@@ -1,0 +1,100 @@
+"""Test for the household_gas_solar_thermal system setup.
+
+This module contains a single integration test that loads the setup, runs it for one day with the
+KPI and cost post-processing switched on, and checks that its electricity balance adds up.
+"""
+
+import json
+from pathlib import Path
+import pytest
+from hisim import hisim_main
+from hisim.postprocessingoptions import PostProcessingOptions
+from hisim.simulationparameters import SimulationParameters
+from hisim import utils
+
+
+class ElectricityBalance:
+    """What the meter must report, and the one figure that cannot exist.
+
+    The household has an occupancy and no electrical generation -- the solar collector is thermal --
+    so everything it consumes comes from the grid, nothing goes back, and its self-sufficiency is
+    zero. The self-consumption rate is the share of its own production that it uses, and with no
+    production that is undefined rather than zero.
+
+    ``RELATIVE_DEMAND_CEILING`` is the assertion that matters. This setup fed the occupancy into the
+    electricity meter by hand *and* registered the meter with ``connect_automatically``, which
+    applies the meter's own default connection for the same source; the simulator does not
+    de-duplicate, so one source was summed into one meter twice and the grid import came out at
+    roughly double the total consumption. The KPI layer noticed only because a demand above 100 %
+    is impossible, and refused to continue. Pinning the ceiling keeps that shape of wiring mistake
+    detectable here rather than as an opaque post-processing failure.
+    """
+
+    RELATIVE_DEMAND_CEILING = 100.0
+    REQUIRED = (
+        "Total electricity consumption",
+        "Total energy from grid",
+        "Relative electricity demand from grid",
+        "Self-sufficiency rate according to solar htw berlin",
+    )
+    NOT_COMPUTABLE = ("Self-consumption rate according to solar htw berlin",)
+
+
+@pytest.mark.system_setups
+@utils.measure_execution_time
+def test_household_gas_solar_thermal() -> None:
+    """Run the setup for one day and check the electricity balance is possible.
+
+    There was no test for this setup at all, and it had been failing in post-processing for long
+    enough to be parked as an unexplained KPI-layer bug. It is not one: the wiring counted the
+    occupancy twice, and the KPI layer was the only thing that noticed.
+    """
+    path = Path("../system_setups/household_gas_solar_thermal.py")
+
+    sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    sim_params.post_processing_options = [
+        PostProcessingOptions.COMPUTE_KPIS,
+        PostProcessingOptions.WRITE_KPIS_TO_JSON,
+        PostProcessingOptions.COMPUTE_CAPEX,
+        PostProcessingOptions.COMPUTE_OPEX,
+    ]
+    result_directory = hisim_main.main(str(path), sim_params)
+
+    result_path = Path(result_directory)
+    assert (result_path / "finished.flag").is_file(), f"the run did not finish: {result_directory}"
+    kpi_path = result_path / "all_kpis.json"
+    assert kpi_path.is_file(), f"all_kpis.json not found in {result_directory}"
+
+    values_by_name: dict = {}
+
+    def collect(node: object) -> None:
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            if isinstance(value, dict) and "value" in value and "unit" in value:
+                values_by_name[key] = value["value"]
+            else:
+                collect(value)
+
+    collect(json.loads(kpi_path.read_text(encoding="utf-8")))
+
+    for name in ElectricityBalance.REQUIRED:
+        assert name in values_by_name, f"KPI '{name}' is missing from {kpi_path}"
+        assert values_by_name[name] is not None, f"KPI '{name}' has no value"
+
+    for name in ElectricityBalance.NOT_COMPUTABLE:
+        assert values_by_name.get(name) is None, (
+            f"KPI '{name}' carries a value, but this household generates no electricity, so the "
+            "share of its own production that it consumes is undefined."
+        )
+
+    relative_demand = values_by_name["Relative electricity demand from grid"]
+    assert relative_demand <= ElectricityBalance.RELATIVE_DEMAND_CEILING, (
+        f"the grid supplied {relative_demand} % of a consumption it cannot exceed -- a source is "
+        "very likely fed into the electricity meter twice, by hand and by default connection both."
+    )
+
+    assert values_by_name["Total energy from grid"] <= values_by_name["Total electricity consumption"], (
+        "grid import exceeds total consumption, which is the same double-counting seen from the "
+        "other side."
+    )


### PR DESCRIPTION
The second half of F-4 (roadmap/p3_random_findings.md), per the 2026-08-30 decision: fix the setup *and* make the simulator refuse duplicate feeds. A dynamic component sums the inputs carrying a given tag, so a source
  wired into it twice is counted twice -- and nothing about the result looks wrong. household_gas_solar_thermal reported a grid import of 21.72 kWh against a total consumption of 10.9 for exactly this reason and sat broken for
  months, filed as a bug in the KPI layer, which had been right all along. The two ways of wiring a dynamic component do not know about each other: a setup can call add_component_input_and_connect by hand and also pass
  connect_automatically=True, which applies the component's own default connection for the same source. Both funnel through add_component_input_and_connect, so one guard there covers both. **Measured before enforcing**: with the
  guard active the whole setup fleet was run, and exactly one setup trips it -- the known case. No other setup and no test wires a duplicate. The rule refuses a second feed of the same source output whatever its tags, deliberately
  not narrower, and the tests pin what it must *not* refuse: two different outputs of one source, and one output feeding two components. **Merge after #615**, which removes that setup's hand-wiring; verified together, it passes.