### PR TITLE
Check that a calculation produced the files it was asked for, not merely something

### DIFF
--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -1385,7 +1385,20 @@ class UtspLpgConnector(cp.Component):
                 # code, so a failed calculation is indistinguishable from a successful one until
                 # somebody opens a file that was never written -- and the FileNotFoundError that
                 # results names one arbitrary json and never mentions the LoadProfileGenerator.
-                PylpgWorkspace.verify_results_were_produced(calculation_index, str(path_to_result_folder))
+                # The names, not merely the count: a calculation that dies partway leaves some of
+                # its outputs behind, and a directory that is non-empty tells the reader nothing
+                # about whether what it needs is in it. Which files are indispensable is already
+                # recorded against each name, so it is read from there rather than from a position
+                # in the returned tuple, which would go wrong silently if that tuple ever changed.
+                declared_result_files = self.define_required_result_files()[0]
+                required_result_files = [
+                    file_name
+                    for file_name, requirement in declared_result_files.items()
+                    if requirement == datastructures.ResultFileRequirement.REQUIRED
+                ]
+                PylpgWorkspace.verify_results_were_produced(
+                    calculation_index, str(path_to_result_folder), required_files=required_result_files
+                )
 
         return str(path_to_result_folder)
 

--- a/hisim/components/pylpg_workspace.py
+++ b/hisim/components/pylpg_workspace.py
@@ -23,7 +23,7 @@ import os
 import pathlib
 import shutil
 import sys
-from typing import ClassVar, Iterator, List
+from typing import ClassVar, Iterator, List, Optional, Sequence
 
 from pylpg import lpg_execution
 
@@ -210,7 +210,9 @@ class PylpgWorkspace:
     LOG_LINES_TO_QUOTE: ClassVar[int] = 30
 
     @classmethod
-    def verify_results_were_produced(cls, calculation_index: int, result_folder: str) -> None:
+    def verify_results_were_produced(
+        cls, calculation_index: int, result_folder: str, required_files: Optional[Sequence[str]] = None
+    ) -> None:
         """Checks that a finished calculation actually left results, and explains it if not.
 
         Called immediately after the binary returns, because that is the last moment at which the
@@ -223,18 +225,39 @@ class PylpgWorkspace:
         the directory is deleted with the workspace, and on a developer box it is deleted by the
         cleanup in :meth:`release` moments later.
 
+        Checking that the directory merely holds *something* is not enough, and the first version of
+        this check made that mistake. A calculation can die partway and leave some of its outputs
+        behind: a run that produced eleven of the fourteen files it was asked for satisfied the
+        emptiness test, and the absence resurfaced later as ``FileNotFoundError`` on whichever file
+        the reader happened to open first -- ``SumProfiles.HH1.Warm Water.csv``, in the case that
+        prompted this -- naming neither the calculation nor the generator, three layers from the
+        cause. The caller knows which files it is about to read, so it says so and they are checked
+        by name.
+
         Args:
             calculation_index: the index the calculation ran under, for the message.
             result_folder: the directory the caller is about to read results from.
+            required_files: the result files this run must have produced. When omitted, only the
+                presence of any output at all is checked, which is the weaker test described above.
 
         Raises:
-            LocalLpgCalculationFailedError: if the directory is missing or holds no files.
+            LocalLpgCalculationFailedError: if the directory is missing, holds no files, or is
+                missing any of ``required_files``.
         """
         results = pathlib.Path(result_folder)
-        if results.is_dir() and any(results.iterdir()):
+        missing = [name for name in (required_files or []) if not (results / name).is_file()]
+        if results.is_dir() and any(results.iterdir()) and not missing:
             return
 
-        reason = "did not exist" if not results.is_dir() else "was empty"
+        if not results.is_dir():
+            reason = "did not exist"
+        elif not any(results.iterdir()):
+            reason = "was empty"
+        else:
+            reason = (
+                f"is missing {len(missing)} of the {len(required_files or [])} files the run needs: "
+                + ", ".join(f"'{name}'" for name in missing)
+            )
         message = [
             f"The local LoadProfileGenerator calculation for index {calculation_index} produced no "
             f"results: '{results}' {reason}.",

--- a/tests/test_pylpg_workspace.py
+++ b/tests/test_pylpg_workspace.py
@@ -234,3 +234,57 @@ def test_the_generator_lock_admits_one_process_at_a_time() -> None:
         assert not (first[0] == "enter" and second[0] == "enter"), (
             f"two processes were inside the install lock at once: {recorded}"
         )
+
+
+@pytest.mark.base
+def test_a_partial_result_set_is_a_calculation_failure(tmp_path: Any) -> None:
+    """Some of the outputs is not enough, and the first version of this check thought it was.
+
+    A calculation can die partway and leave part of its work behind. The directory then exists and
+    holds files, which satisfied the emptiness test, and the absence surfaced much later as
+    ``FileNotFoundError`` on whichever file the reader opened first -- three layers from the cause
+    and naming neither the calculation nor the generator. This is the case that got past it: eleven
+    files present, one missing, reported as a missing CSV rather than as a dead calculation.
+    """
+    results = tmp_path / "results" / "Results"
+    results.mkdir(parents=True)
+    (results / "SumProfiles.HH1.Electricity.csv").write_text("x", encoding="utf-8")
+
+    with pytest.raises(LocalLpgCalculationFailedError) as failure:
+        PylpgWorkspace.verify_results_were_produced(
+            500,
+            str(results),
+            required_files=["SumProfiles.HH1.Electricity.csv", "SumProfiles.HH1.Warm Water.csv"],
+        )
+
+    message = str(failure.value)
+    assert "Warm Water" in message, "the message must name the file that is missing"
+    assert "SumProfiles.HH1.Electricity.csv" not in message.rsplit("needs:", maxsplit=1)[-1], (
+        "only the missing files belong in the list, not the ones that are there"
+    )
+
+
+@pytest.mark.base
+def test_a_complete_result_set_passes(tmp_path: Any) -> None:
+    """Every required file present is the ordinary case and must stay silent."""
+    results = tmp_path / "results" / "Results"
+    results.mkdir(parents=True)
+    for name in ("a.csv", "b.csv"):
+        (results / name).write_text("x", encoding="utf-8")
+
+    PylpgWorkspace.verify_results_were_produced(600, str(results), required_files=["a.csv", "b.csv"])
+
+
+@pytest.mark.base
+def test_optional_files_are_not_required(tmp_path: Any) -> None:
+    """Only the files the run declared indispensable are checked.
+
+    The generator emits flexibility events and per-car series only for systems that have them, and
+    the connector marks those OPTIONAL. Treating them as required would turn every household
+    without a car into a failed calculation.
+    """
+    results = tmp_path / "results" / "Results"
+    results.mkdir(parents=True)
+    (results / "required.csv").write_text("x", encoding="utf-8")
+
+    PylpgWorkspace.verify_results_were_produced(700, str(results), required_files=["required.csv"])


### PR DESCRIPTION
The check added with the local-LPG guard (#611) asked whether the results directory held anything at all, and a calculation that dies partway leaves part of its work behind. Such a run satisfied the
  test, and the absence resurfaced three layers later as FileNotFoundError on whichever file the reader opened first -- naming neither the calculation nor the generator. CI hit exactly that on 2026-09-02:
  'SumProfiles.HH1.Warm Water.csv' missing from an otherwise populated directory, reported as a missing CSV rather than a dead calculation. The gap was known when the guard was written and left open; this closes
  it. The caller knows which files it is about to read, and which are indispensable is already recorded against each name by define_required_result_files -- so the list is read from the requirement rather than
  from a position in the returned tuple, which would go wrong silently if that tuple changed. Optional outputs stay optional: flexibility events and per-car series exist only for systems that have them. The risk
  in such a check is being wrong about the names and failing every run instead of the broken ones, so it was measured: two cold local-LPG golden pairs, single- and multi-household, both still pass.