### PR TITLE
Regenerate every scenario JSON against the checkout the driver was started from

### DIFF
--- a/scripts/regenerate_scenario_jsons.py
+++ b/scripts/regenerate_scenario_jsons.py
@@ -109,6 +109,17 @@ def regenerate_one(
 
     Borrows a unique local-LPG calc index from ``index_pool`` for the duration
     of the run so concurrent workers never share a ``pylpg/C<index>`` dir.
+
+    The child is handed an explicit ``PYTHONPATH`` naming this checkout, because
+    the converter is started as a script path rather than with ``-m``. For a
+    script invocation Python puts the *script's own directory* on ``sys.path``,
+    which is ``scripts/`` and holds no ``hisim`` package, so ``cwd`` never gets a
+    say; the editable install's finder then answers the import from whichever
+    checkout was installed. In a second checkout -- a git worktree, a release
+    clone -- that silently regenerates every setup with the *other* tree's HiSim
+    and reports no drift, which is a false all-clear rather than a failure. The
+    variable is prepended to any inherited value so a caller's own entries still
+    apply.
     """
     stem = setup_path.stem
     log_path = log_dir / f"{stem}.log"
@@ -116,6 +127,9 @@ def regenerate_one(
     try:
         env = dict(os.environ)
         env["HISIM_LOCAL_LPG_CALC_INDEX"] = str(calc_index)
+        env["PYTHONPATH"] = os.pathsep.join(
+            [str(REPO_ROOT), *([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])]
+        )
         rel = setup_path.relative_to(REPO_ROOT).as_posix()
         with open(log_path, "w", encoding="utf-8") as logf:
             proc = subprocess.run(

--- a/scripts/regenerate_scenario_jsons.py
+++ b/scripts/regenerate_scenario_jsons.py
@@ -105,21 +105,16 @@ def regenerate_one(
     log_dir: Path,
     keep_simulation_json: bool,
 ) -> SetupResult:
-    """Regenerate a single setup's scenario JSON in a subprocess.
+    """Regenerate one setup's scenario JSON in a subprocess.
 
-    Borrows a unique local-LPG calc index from ``index_pool`` for the duration
-    of the run so concurrent workers never share a ``pylpg/C<index>`` dir.
+    Borrows a unique local-LPG calculation index from ``index_pool`` for the duration of the run, so
+    concurrent workers never share a ``pylpg/C<index>`` directory.
 
-    The child is handed an explicit ``PYTHONPATH`` naming this checkout, because
-    the converter is started as a script path rather than with ``-m``. For a
-    script invocation Python puts the *script's own directory* on ``sys.path``,
-    which is ``scripts/`` and holds no ``hisim`` package, so ``cwd`` never gets a
-    say; the editable install's finder then answers the import from whichever
-    checkout was installed. In a second checkout -- a git worktree, a release
-    clone -- that silently regenerates every setup with the *other* tree's HiSim
-    and reports no drift, which is a false all-clear rather than a failure. The
-    variable is prepended to any inherited value so a caller's own entries still
-    apply.
+    The child gets ``PYTHONPATH`` set to this checkout. The converter is started as a script path, and for
+    a script Python puts the *script's* directory on ``sys.path``, not the working directory; without the
+    variable, ``import hisim`` in the child resolves to the installed package, which in a git worktree is a
+    different checkout, and the regeneration silently reports no drift against the wrong code. The
+    variable is prepended, so a caller's own ``PYTHONPATH`` entries still apply.
     """
     stem = setup_path.stem
     log_path = log_dir / f"{stem}.log"

--- a/scripts/regenerate_scenario_jsons.py
+++ b/scripts/regenerate_scenario_jsons.py
@@ -114,7 +114,9 @@ def regenerate_one(
     a script Python puts the *script's* directory on ``sys.path``, not the working directory; without the
     variable, ``import hisim`` in the child resolves to the installed package, which in a git worktree is a
     different checkout, and the regeneration silently reports no drift against the wrong code. The
-    variable is prepended, so a caller's own ``PYTHONPATH`` entries still apply.
+    variable is prepended, so a caller's own ``PYTHONPATH`` entries stay -- but for any name both
+    provide, above all ``hisim`` itself, the checkout wins. That shadowing is deliberate: the report
+    is about *this* checkout, so no caller may point the children at another one.
     """
     stem = setup_path.stem
     log_path = log_dir / f"{stem}.log"

--- a/tests/test_regeneration_environment.py
+++ b/tests/test_regeneration_environment.py
@@ -1,0 +1,174 @@
+"""Tests for the environment the scenario-JSON regeneration hands its children.
+
+The regeneration driver rebuilds every ``system_setups/*.py`` in a subprocess and then reports
+whether the committed ``.scenario.json`` files still match. That report is only worth having if
+each child ran *this* checkout's HiSim, and nothing about the way the child is started makes that
+true by itself: the converter is invoked as a script path, so Python seeds ``sys.path`` with the
+script's own directory (``scripts/``) rather than with the working directory, and the editable
+install's finder is then free to answer ``import hisim`` from whichever checkout happens to be
+installed. In a second checkout the driver would regenerate everything against the wrong tree and
+announce no drift -- a false all-clear, which is worse than a failure because nobody investigates
+it.
+
+The first test pins the mechanism, so that the reasoning above stays checkable rather than being a
+comment nobody can verify. The second pins the fix. Each test states the failure mode it catches.
+"""
+
+# clean
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import ClassVar, Dict, List
+
+import pytest
+
+from scripts.regenerate_scenario_jsons import REPO_ROOT, regenerate_one
+
+
+class PathProbe:
+    """A throwaway two-directory tree used to observe how Python seeds ``sys.path``.
+
+    The tree mimics the shape the driver runs in: a root holding an importable package and a
+    ``scripts/`` subdirectory holding the program that imports it. The package name is deliberate
+    nonsense so that the probe can never accidentally succeed by finding something real, which
+    makes a successful import proof that the root was on the path and an ``ImportError`` proof that
+    it was not.
+    """
+
+    #: The package the probe tries to import. Nothing by this name exists on any real path.
+    PACKAGE: ClassVar[str] = "sentinel_package_for_the_path_probe"
+
+    #: What the probe prints when the import worked.
+    FOUND: ClassVar[str] = "found"
+
+    @classmethod
+    def build(cls, root: Path) -> Path:
+        """Lay out the probe tree and return the path of the program to run.
+
+        Args:
+            root: An empty directory to build in.
+
+        Returns:
+            The path of the probe script, inside ``root / "scripts"``.
+        """
+        (root / cls.PACKAGE).mkdir()
+        (root / cls.PACKAGE / "__init__.py").write_text("", encoding="utf-8")
+        scripts = root / "scripts"
+        scripts.mkdir()
+        probe = scripts / "probe.py"
+        probe.write_text(
+            f"import {cls.PACKAGE}\nprint({cls.FOUND!r})\n",
+            encoding="utf-8",
+        )
+        return probe
+
+    @classmethod
+    def run(cls, probe: Path, root: Path, on_the_path: bool) -> subprocess.CompletedProcess:
+        """Run the probe the way the driver runs the converter, with or without the fix.
+
+        Args:
+            probe: The probe script, as returned by :meth:`build`.
+            root: The directory that is both the working directory and the package's home.
+            on_the_path: Whether to name ``root`` in ``PYTHONPATH``.
+
+        Returns:
+            The finished process, whose return code says whether the import succeeded.
+        """
+        environment = dict(os.environ)
+        environment.pop("PYTHONPATH", None)
+        if on_the_path:
+            environment["PYTHONPATH"] = str(root)
+        return subprocess.run(  # nosec B603 - fixed argument vector, no shell
+            [sys.executable, str(probe)],
+            cwd=str(root),
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+@pytest.mark.base
+def test_a_script_started_by_path_cannot_import_from_its_working_directory(tmp_path: Path) -> None:
+    """The premise: ``cwd`` is not what a script invocation puts on ``sys.path``.
+
+    This is the whole reason the driver has to name ``PYTHONPATH`` explicitly. If a future Python
+    ever did seed ``sys.path`` with the working directory for a script path, this test fails, the
+    argument above stops applying, and the extra variable can go.
+
+    Catches: somebody deleting the ``PYTHONPATH`` line on the grounds that ``cwd=REPO_ROOT``
+    already covers it.
+    """
+    probe = PathProbe.build(tmp_path)
+
+    without_the_fix = PathProbe.run(probe, tmp_path, on_the_path=False)
+    with_the_fix = PathProbe.run(probe, tmp_path, on_the_path=True)
+
+    assert without_the_fix.returncode != 0, (
+        "a script started by path imported a package from its working directory, so the working "
+        "directory is on sys.path after all and this script's PYTHONPATH handling is redundant"
+    )
+    assert PathProbe.PACKAGE in without_the_fix.stderr
+    assert with_the_fix.returncode == 0, with_the_fix.stderr
+    assert PathProbe.FOUND in with_the_fix.stdout
+
+
+class RecordedChild:
+    """A stand-in for :func:`subprocess.run` that keeps the environment it was handed.
+
+    The driver's contract with its children is entirely in that environment, so capturing it is
+    enough to test the contract, and it means the test never pays for a simulation.
+    """
+
+    def __init__(self) -> None:
+        """Start out having seen nothing."""
+        self.environments: List[Dict[str, str]] = []
+
+    def __call__(self, *args, **kwargs) -> subprocess.CompletedProcess:
+        """Record the environment and report success without running anything.
+
+        Args:
+            *args: The argument vector the driver built; ignored.
+            **kwargs: The keyword arguments, of which ``env`` is what this test is about.
+
+        Returns:
+            A finished process with return code zero.
+        """
+        self.environments.append(dict(kwargs["env"]))
+        return subprocess.CompletedProcess(args=args[0] if args else [], returncode=0)
+
+
+@pytest.mark.base
+def test_the_child_is_told_to_import_hisim_from_this_checkout(tmp_path: Path, monkeypatch) -> None:
+    """Every child's ``PYTHONPATH`` must begin with the checkout the driver was started from.
+
+    Prepending rather than replacing matters too: a caller who set ``PYTHONPATH`` for reasons of
+    their own keeps it, they just stop outranking this checkout.
+
+    Catches: a regeneration run in a git worktree quietly rebuilding every setup against the
+    installed checkout instead, and reporting that nothing drifted.
+    """
+    recorded = RecordedChild()
+    monkeypatch.setattr("scripts.regenerate_scenario_jsons.subprocess.run", recorded)
+    monkeypatch.setenv("PYTHONPATH", "/somewhere/the/caller/cares/about")
+    import queue
+
+    indices: "queue.Queue[int]" = queue.Queue()
+    indices.put(1)
+
+    regenerate_one(
+        setup_path=REPO_ROOT / "system_setups" / "simple_system_setup_one.py",
+        python=sys.executable,
+        index_pool=indices,
+        log_dir=tmp_path,
+        keep_simulation_json=True,
+    )
+
+    assert len(recorded.environments) == 1
+    entries = recorded.environments[0]["PYTHONPATH"].split(os.pathsep)
+    assert entries[0] == str(REPO_ROOT), f"PYTHONPATH does not lead with the checkout: {entries}"
+    assert "/somewhere/the/caller/cares/about" in entries, f"the caller's own entry was dropped: {entries}"

--- a/tests/test_regeneration_environment.py
+++ b/tests/test_regeneration_environment.py
@@ -1,17 +1,9 @@
-"""Tests for the environment the scenario-JSON regeneration hands its children.
+"""Tests for the environment the scenario-JSON regeneration passes to its subprocesses.
 
-The regeneration driver rebuilds every ``system_setups/*.py`` in a subprocess and then reports
-whether the committed ``.scenario.json`` files still match. That report is only worth having if
-each child ran *this* checkout's HiSim, and nothing about the way the child is started makes that
-true by itself: the converter is invoked as a script path, so Python seeds ``sys.path`` with the
-script's own directory (``scripts/``) rather than with the working directory, and the editable
-install's finder is then free to answer ``import hisim`` from whichever checkout happens to be
-installed. In a second checkout the driver would regenerate everything against the wrong tree and
-announce no drift -- a false all-clear, which is worse than a failure because nobody investigates
-it.
-
-The first test pins the mechanism, so that the reasoning above stays checkable rather than being a
-comment nobody can verify. The second pins the fix. Each test states the failure mode it catches.
+The converter runs as a script, and for a script Python puts the script's directory on ``sys.path``,
+not the working directory. So ``import hisim`` in the child resolves to the installed package unless
+``PYTHONPATH`` names this checkout; in a git worktree that is a different checkout, and the regeneration
+then reports no drift against the wrong code. The first test pins the mechanism, the second the fix.
 """
 
 # clean
@@ -30,13 +22,10 @@ from scripts.regenerate_scenario_jsons import REPO_ROOT, regenerate_one
 
 
 class PathProbe:
-    """A throwaway two-directory tree used to observe how Python seeds ``sys.path``.
+    """A throwaway package plus a throwaway script, used to observe what Python puts on ``sys.path``.
 
-    The tree mimics the shape the driver runs in: a root holding an importable package and a
-    ``scripts/`` subdirectory holding the program that imports it. The package name is deliberate
-    nonsense so that the probe can never accidentally succeed by finding something real, which
-    makes a successful import proof that the root was on the path and an ``ImportError`` proof that
-    it was not.
+    The package name is nonsense so the probe cannot succeed by finding something real: a successful
+    import proves the package's directory was on the path, an ``ImportError`` proves it was not.
     """
 
     #: The package the probe tries to import. Nothing by this name exists on any real path.
@@ -68,15 +57,15 @@ class PathProbe:
 
     @classmethod
     def run(cls, probe: Path, root: Path, on_the_path: bool) -> subprocess.CompletedProcess:
-        """Run the probe the way the driver runs the converter, with or without the fix.
+        """Run the probe the way the driver runs the converter, with or without ``PYTHONPATH``.
 
         Args:
-            probe: The probe script, as returned by :meth:`build`.
-            root: The directory that is both the working directory and the package's home.
-            on_the_path: Whether to name ``root`` in ``PYTHONPATH``.
+            probe: the probe script from :meth:`build`.
+            root: the working directory, which is also the package's parent.
+            on_the_path: whether to set ``PYTHONPATH`` to ``root``.
 
         Returns:
-            The finished process, whose return code says whether the import succeeded.
+            subprocess.CompletedProcess: the finished process; its return code says whether the import worked.
         """
         environment = dict(os.environ)
         environment.pop("PYTHONPATH", None)
@@ -94,14 +83,10 @@ class PathProbe:
 
 @pytest.mark.base
 def test_a_script_started_by_path_cannot_import_from_its_working_directory(tmp_path: Path) -> None:
-    """The premise: ``cwd`` is not what a script invocation puts on ``sys.path``.
+    """A script run by path cannot import a package from its working directory unless ``PYTHONPATH`` names it.
 
-    This is the whole reason the driver has to name ``PYTHONPATH`` explicitly. If a future Python
-    ever did seed ``sys.path`` with the working directory for a script path, this test fails, the
-    argument above stops applying, and the extra variable can go.
-
-    Catches: somebody deleting the ``PYTHONPATH`` line on the grounds that ``cwd=REPO_ROOT``
-    already covers it.
+    This is the reason the driver sets the variable. If a future Python put the working directory on
+    ``sys.path`` for scripts, this test would fail and the variable could go.
     """
     probe = PathProbe.build(tmp_path)
 
@@ -144,14 +129,7 @@ class RecordedChild:
 
 @pytest.mark.base
 def test_the_child_is_told_to_import_hisim_from_this_checkout(tmp_path: Path, monkeypatch) -> None:
-    """Every child's ``PYTHONPATH`` must begin with the checkout the driver was started from.
-
-    Prepending rather than replacing matters too: a caller who set ``PYTHONPATH`` for reasons of
-    their own keeps it, they just stop outranking this checkout.
-
-    Catches: a regeneration run in a git worktree quietly rebuilding every setup against the
-    installed checkout instead, and reporting that nothing drifted.
-    """
+    """Every child's ``PYTHONPATH`` starts with this checkout and keeps the caller's own entries after it."""
     recorded = RecordedChild()
     monkeypatch.setattr("scripts.regenerate_scenario_jsons.subprocess.run", recorded)
     monkeypatch.setenv("PYTHONPATH", "/somewhere/the/caller/cares/about")

--- a/tests/test_regeneration_environment.py
+++ b/tests/test_regeneration_environment.py
@@ -105,8 +105,9 @@ def test_a_script_started_by_path_cannot_import_from_its_working_directory(tmp_p
 class RecordedChild:
     """A stand-in for :func:`subprocess.run` that keeps the environment it was handed.
 
-    The driver's contract with its children is entirely in that environment, so capturing it is
-    enough to test the contract, and it means the test never pays for a simulation.
+    The environment is the part of the driver's contract with its children that this test file is
+    about (the argument vector, working directory and log routing are the rest), and it is captured
+    whole -- so recording it is enough here, and the test never pays for a simulation.
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
## Problem

`scripts/regenerate_scenario_jsons.py` starts the converter as a script path. For a script invocation Python seeds `sys.path` with the *script's directory* (`scripts/`), which holds no `hisim` package, so the `cwd=REPO_ROOT` the driver passes never gets a say — the editable install's finder answers `import hisim` from whichever checkout was installed. Run from a git worktree or a second clone, the driver rebuilt all 22 setups with the *other* tree's HiSim and reported "22 OK, no drift". That false all-clear happened twice in three days and blessed a regeneration that had to be thrown away (`roadmap/p4_random_findings.md` F-2). CI is unaffected, because there the single checkout and the installed package are the same files.

## What was done

- `regenerate_one` hands each child an explicit `PYTHONPATH` naming the checkout the driver itself was loaded from, prepended to any inherited value.
- Two tests: one builds a throwaway package next to a throwaway script and shows that a script run by path cannot import from its working directory until `PYTHONPATH` says so (so the fix can be dropped if a future Python makes it redundant); one captures the environment handed to a child and asserts it leads with this checkout.

## Result

A regeneration run in a worktree now means what it says. Verified: the two tests, a real single-setup regeneration with zero drift, pylint 10.00, prospector 0.

_Follow-up commit on this branch: the docstrings and comments this PR added were rewritten in plain language after review feedback (what → how it is used → short why). No code changes._