### PR TITLE
Give the parallel drivers one place to borrow local-LPG calculation indices from

### DIFF
--- a/hisim/components/pylpg_workspace.py
+++ b/hisim/components/pylpg_workspace.py
@@ -14,6 +14,12 @@ is claimed before it is created and released once the attempt ends, whether it s
 claiming one that already exists fails immediately with a message naming the index, because the
 alternative is two runs silently interleaving in one folder. See ``roadmap/pylpg_flakiness.md`` F3
 and F4.
+
+A driver that runs several HiSim processes at once needs one more thing: a way to give each of its
+worker slots an index of its own and take it back when the slot is reused. That is
+:class:`LpgBaseIndexPool`, which lives here rather than in any one driver so that the two scripts
+which need it -- the scenario-JSON regenerator and the energy-system recorder -- cannot drift apart
+on how indices are handed out or on what the environment variable is called.
 """
 
 # clean
@@ -21,10 +27,11 @@ and F4.
 import contextlib
 import os
 import pathlib
+import queue
 import shutil
 import sys
 import time
-from typing import ClassVar, Iterator, List, Optional, Sequence, Tuple
+from typing import ClassVar, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple
 
 from pylpg import lpg_execution
 
@@ -471,3 +478,80 @@ class PylpgWorkspace:
                     log.information(f"Local LPG working directory '{directory.name}' deleted.")
             except OSError as error:
                 log.warning(f"Could not delete the local LPG working directory '{directory}': {error}")
+
+
+class LpgBaseIndexPool:
+    """Hands out distinct local-LoadProfileGenerator base indices to the slots of a parallel driver.
+
+    A driver that runs several HiSim processes at once has to give each of them a base index of its
+    own, or their calculation directories collide in the way this module's header describes. It
+    cannot simply number the processes, because there are usually far more setups to run than slots
+    to run them in, and a slot is reused as soon as the process occupying it finishes. What it needs
+    is a pool the size of the slot count, borrowed from for the length of one child and returned
+    afterwards, which is what this class is.
+
+    Small allocated indices are preferred over the process-derived default of
+    :meth:`PylpgWorkspace.default_base_index` for exactly one reason: they are readable. A log line
+    naming ``C1`` through ``C4`` can be followed by eye, and one naming the pids of four children
+    cannot. Correctness comes from the indices being distinct while they are lent out, not from
+    their being small.
+
+    The pool is safe to share between threads because it is a queue and nothing more; it is not safe
+    to share between processes, and a driver that forks rather than threads should build one pool per
+    process instead.
+    """
+
+    def __init__(self, slots: int) -> None:
+        """Fills the pool with one index per slot, counting from one.
+
+        Args:
+            slots: how many children the driver will run at once.
+
+        Raises:
+            ValueError: if asked for fewer than one slot, which would produce a pool that no
+                borrower can ever be served from and so a driver that hangs on its first child.
+        """
+        if slots < 1:
+            raise ValueError(f"A pool needs at least one slot to lend from; {slots} were asked for.")
+        self.slots = slots
+        self._available: "queue.Queue[int]" = queue.Queue()
+        for index in range(1, slots + 1):
+            self._available.put(index)
+
+    @contextlib.contextmanager
+    def borrowed(self) -> Iterator[int]:
+        """Lends one base index for the duration of the block, and takes it back afterwards.
+
+        The index is returned in a ``finally``, so a child that raised, timed out or was killed
+        still frees its slot. Without that, one failed setup would shrink the pool for the rest of
+        the run and a run with as many failures as slots would stop making progress altogether.
+
+        Yields:
+            int: a base index no other borrower holds while this block runs.
+        """
+        base_index = self._available.get()
+        try:
+            yield base_index
+        finally:
+            self._available.put(base_index)
+
+    @staticmethod
+    def announced_in(environment: Mapping[str, str], base_index: int) -> Dict[str, str]:
+        """Returns a copy of an environment that tells a child which base index to use.
+
+        Kept here rather than at each call site so that the drivers and
+        :meth:`PylpgWorkspace.default_base_index` cannot disagree about the variable's name, which
+        is a disagreement nothing would report: a child reading a name nobody sets falls back to its
+        process id and works, right up to the point where two children fall back to indices that
+        happen to collide.
+
+        Args:
+            environment: the environment to base the child's on; not modified.
+            base_index: the index to announce, normally from :meth:`borrowed`.
+
+        Returns:
+            Dict[str, str]: the child's environment.
+        """
+        announced = dict(environment)
+        announced[PylpgWorkspace.INDEX_ENVIRONMENT_VARIABLE] = str(base_index)
+        return announced

--- a/hisim/components/pylpg_workspace.py
+++ b/hisim/components/pylpg_workspace.py
@@ -494,14 +494,19 @@ class LpgBaseIndexPool:
 
         pool = LpgBaseIndexPool(slots=4)
         with pool.borrowed() as base_index:
-            env = LpgBaseIndexPool.child_environment(base_index)
+            env = pool.child_environment(base_index)
             subprocess.run([...], env=env)
 
     Why small numbers instead of the process-id default of :meth:`PylpgWorkspace.default_base_index`:
-    they are easier to read in a log. ``C1`` to ``C4`` can be followed by eye; four process ids cannot.
+    they are easier to read in a log. The directories they lead to are easy to tell apart -- base
+    index 1 computes in ``C100``, 2 in ``C200`` and so on, because a base index is strided through
+    :meth:`PylpgWorkspace.calculation_index` before it names a directory -- where the directories of
+    four process ids cannot be told apart at a glance.
 
-    The pool is thread-safe (it is a ``queue.Queue``). It is not shared between processes; a script
-    that forks must create one pool per process.
+    The pool is thread-safe (it is a ``queue.Queue``). It is not shared between processes: a script
+    that forks must create one pool per process, and two independent drivers that each own a pool on
+    one machine hand out the same indices ``1`` to ``slots`` and collide. Runs that cannot coordinate
+    with each other must stay with the process-id default instead of using a pool.
     """
 
     def __init__(self, slots: int) -> None:
@@ -516,7 +521,6 @@ class LpgBaseIndexPool:
         """
         if slots < 1:
             raise ValueError(f"A pool needs at least one slot to lend from; {slots} were asked for.")
-        self.slots = slots
         self._available: "queue.Queue[int]" = queue.Queue()
         for index in range(1, slots + 1):
             self._available.put(index)

--- a/hisim/components/pylpg_workspace.py
+++ b/hisim/components/pylpg_workspace.py
@@ -15,11 +15,10 @@ claiming one that already exists fails immediately with a message naming the ind
 alternative is two runs silently interleaving in one folder. See ``roadmap/pylpg_flakiness.md`` F3
 and F4.
 
-A driver that runs several HiSim processes at once needs one more thing: a way to give each of its
-worker slots an index of its own and take it back when the slot is reused. That is
-:class:`LpgBaseIndexPool`, which lives here rather than in any one driver so that the two scripts
-which need it -- the scenario-JSON regenerator and the energy-system recorder -- cannot drift apart
-on how indices are handed out or on what the environment variable is called.
+A script that runs several HiSim processes in parallel must give each process a different base index,
+otherwise two of them compute in the same ``pylpg/C<index>`` directory. :class:`LpgBaseIndexPool` hands
+those indices out and takes them back. It lives in this module so that the pool and
+:meth:`PylpgWorkspace.default_base_index` share one definition of the environment variable's name.
 """
 
 # clean
@@ -481,35 +480,39 @@ class PylpgWorkspace:
 
 
 class LpgBaseIndexPool:
-    """Hands out distinct local-LoadProfileGenerator base indices to the slots of a parallel driver.
+    """A fixed set of local-LPG base indices that parallel workers borrow one at a time.
 
-    A driver that runs several HiSim processes at once has to give each of them a base index of its
-    own, or their calculation directories collide in the way this module's header describes. It
-    cannot simply number the processes, because there are usually far more setups to run than slots
-    to run them in, and a slot is reused as soon as the process occupying it finishes. What it needs
-    is a pool the size of the slot count, borrowed from for the length of one child and returned
-    afterwards, which is what this class is.
+    Background: pylpg computes each LoadProfileGenerator request inside a directory named
+    ``pylpg/C<index>``. The *base index* is the number a HiSim process derives that name from
+    (see :meth:`PylpgWorkspace.calculation_index`). Two processes with the same base index write
+    into the same directory and corrupt each other's results.
 
-    Small allocated indices are preferred over the process-derived default of
-    :meth:`PylpgWorkspace.default_base_index` for exactly one reason: they are readable. A log line
-    naming ``C1`` through ``C4`` can be followed by eye, and one naming the pids of four children
-    cannot. Correctness comes from the indices being distinct while they are lent out, not from
-    their being small.
+    A script such as ``scripts/regenerate_scenario_jsons.py`` runs N worker threads, each of which
+    starts one HiSim subprocess after another. Numbering the subprocesses would not work, because
+    there are more of them than workers and the numbers would grow without bound. Instead the script
+    creates a pool of N indices and each worker borrows one for the duration of a subprocess::
 
-    The pool is safe to share between threads because it is a queue and nothing more; it is not safe
-    to share between processes, and a driver that forks rather than threads should build one pool per
-    process instead.
+        pool = LpgBaseIndexPool(slots=4)
+        with pool.borrowed() as base_index:
+            env = LpgBaseIndexPool.child_environment(base_index)
+            subprocess.run([...], env=env)
+
+    Why small numbers instead of the process-id default of :meth:`PylpgWorkspace.default_base_index`:
+    they are easier to read in a log. ``C1`` to ``C4`` can be followed by eye; four process ids cannot.
+
+    The pool is thread-safe (it is a ``queue.Queue``). It is not shared between processes; a script
+    that forks must create one pool per process.
     """
 
     def __init__(self, slots: int) -> None:
-        """Fills the pool with one index per slot, counting from one.
+        """Create a pool holding the indices ``1`` to ``slots``.
 
         Args:
-            slots: how many children the driver will run at once.
+            slots: the number of workers that will borrow at the same time.
 
         Raises:
-            ValueError: if asked for fewer than one slot, which would produce a pool that no
-                borrower can ever be served from and so a driver that hangs on its first child.
+            ValueError: if ``slots`` is less than one. An empty pool would make the first
+                :meth:`borrowed` call wait forever.
         """
         if slots < 1:
             raise ValueError(f"A pool needs at least one slot to lend from; {slots} were asked for.")
@@ -520,14 +523,13 @@ class LpgBaseIndexPool:
 
     @contextlib.contextmanager
     def borrowed(self) -> Iterator[int]:
-        """Lends one base index for the duration of the block, and takes it back afterwards.
+        """Take one index for the duration of a ``with`` block and return it afterwards.
 
-        The index is returned in a ``finally``, so a child that raised, timed out or was killed
-        still frees its slot. Without that, one failed setup would shrink the pool for the rest of
-        the run and a run with as many failures as slots would stop making progress altogether.
+        If all indices are out, the call blocks until one is returned. The index is returned in a
+        ``finally`` clause, so it comes back even when the block raises.
 
         Yields:
-            int: a base index no other borrower holds while this block runs.
+            int: a base index that no other ``with`` block holds at the same time.
         """
         base_index = self._available.get()
         try:
@@ -536,22 +538,20 @@ class LpgBaseIndexPool:
             self._available.put(base_index)
 
     @staticmethod
-    def announced_in(environment: Mapping[str, str], base_index: int) -> Dict[str, str]:
-        """Returns a copy of an environment that tells a child which base index to use.
+    def child_environment(base_index: int, environment: Optional[Mapping[str, str]] = None) -> Dict[str, str]:
+        """Return a copy of an environment with the base index set for a child process.
 
-        Kept here rather than at each call site so that the drivers and
-        :meth:`PylpgWorkspace.default_base_index` cannot disagree about the variable's name, which
-        is a disagreement nothing would report: a child reading a name nobody sets falls back to its
-        process id and works, right up to the point where two children fall back to indices that
-        happen to collide.
+        The variable written is :attr:`PylpgWorkspace.INDEX_ENVIRONMENT_VARIABLE`, which
+        :meth:`PylpgWorkspace.default_base_index` reads in the child. Both sides use the same
+        constant, so they cannot disagree about the variable's name.
 
         Args:
-            environment: the environment to base the child's on; not modified.
-            base_index: the index to announce, normally from :meth:`borrowed`.
+            base_index: the index to pass on, normally the one from :meth:`borrowed`.
+            environment: the environment to copy; ``os.environ`` when omitted. It is not modified.
 
         Returns:
-            Dict[str, str]: the child's environment.
+            Dict[str, str]: the environment for the child, with the variable set.
         """
-        announced = dict(environment)
-        announced[PylpgWorkspace.INDEX_ENVIRONMENT_VARIABLE] = str(base_index)
-        return announced
+        child = dict(os.environ if environment is None else environment)
+        child[PylpgWorkspace.INDEX_ENVIRONMENT_VARIABLE] = str(base_index)
+        return child

--- a/scripts/regenerate_scenario_jsons.py
+++ b/scripts/regenerate_scenario_jsons.py
@@ -50,16 +50,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SYSTEM_SETUPS_DIR = REPO_ROOT / "system_setups"
 CONVERTER = REPO_ROOT / "hisim" / "hisim_convert_to_json.py"
 
-# Put this checkout on sys.path before importing from it. Run as a script path, this file's own
-# directory is what Python seeds sys.path with, and scripts/ holds no hisim package -- so without
-# this the import below is answered by the editable install, from whichever checkout was installed
-# rather than from the one being regenerated. That is the same defect as the child's PYTHONPATH in
-# regenerate_one(), one process further up. Imported as scripts.regenerate_scenario_jsons instead,
-# the root is already there and this is a no-op.
+# When this file runs as a script, Python puts scripts/ on sys.path, not the repository root, so
+# "import hisim" would resolve to the installed package instead of this checkout. Add the root
+# first. When the module is imported as scripts.regenerate_scenario_jsons the root is already on
+# the path and this does nothing.
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-# The import has to follow that repair, so it cannot sit with the others at the top.
+# This import must come after the sys.path change above.
 # pylint: disable=wrong-import-position
 from hisim.components.pylpg_workspace import LpgBaseIndexPool  # noqa: E402
 
@@ -133,7 +131,7 @@ def regenerate_one(
     stem = setup_path.stem
     log_path = log_dir / f"{stem}.log"
     with index_pool.borrowed() as calc_index:
-        env = LpgBaseIndexPool.announced_in(os.environ, calc_index)
+        env = LpgBaseIndexPool.child_environment(calc_index)
         env["PYTHONPATH"] = os.pathsep.join(
             [str(REPO_ROOT), *([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])]
         )

--- a/scripts/regenerate_scenario_jsons.py
+++ b/scripts/regenerate_scenario_jsons.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import queue
 import subprocess
 import sys
 import threading
@@ -50,6 +49,19 @@ from typing import Optional
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SYSTEM_SETUPS_DIR = REPO_ROOT / "system_setups"
 CONVERTER = REPO_ROOT / "hisim" / "hisim_convert_to_json.py"
+
+# Put this checkout on sys.path before importing from it. Run as a script path, this file's own
+# directory is what Python seeds sys.path with, and scripts/ holds no hisim package -- so without
+# this the import below is answered by the editable install, from whichever checkout was installed
+# rather than from the one being regenerated. That is the same defect as the child's PYTHONPATH in
+# regenerate_one(), one process further up. Imported as scripts.regenerate_scenario_jsons instead,
+# the root is already there and this is a no-op.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# The import has to follow that repair, so it cannot sit with the others at the top.
+# pylint: disable=wrong-import-position
+from hisim.components.pylpg_workspace import LpgBaseIndexPool  # noqa: E402
 
 
 @dataclass
@@ -101,7 +113,7 @@ def discover_setups(only: Optional[list[str]], only_existing: bool, exclude: Opt
 def regenerate_one(
     setup_path: Path,
     python: str,
-    index_pool: "queue.Queue[int]",
+    index_pool: LpgBaseIndexPool,
     log_dir: Path,
     keep_simulation_json: bool,
 ) -> SetupResult:
@@ -120,10 +132,8 @@ def regenerate_one(
     """
     stem = setup_path.stem
     log_path = log_dir / f"{stem}.log"
-    calc_index = index_pool.get()
-    try:
-        env = dict(os.environ)
-        env["HISIM_LOCAL_LPG_CALC_INDEX"] = str(calc_index)
+    with index_pool.borrowed() as calc_index:
+        env = LpgBaseIndexPool.announced_in(os.environ, calc_index)
         env["PYTHONPATH"] = os.pathsep.join(
             [str(REPO_ROOT), *([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])]
         )
@@ -137,8 +147,6 @@ def regenerate_one(
                 stderr=subprocess.STDOUT,
                 check=False,
             )
-    finally:
-        index_pool.put(calc_index)
 
     scenario_path = setup_path.with_suffix(".scenario.json")
     if not keep_simulation_json:
@@ -202,10 +210,8 @@ def main(argv: Optional[list[str]] = None) -> int:
     print(f"\nUsing interpreter: {args.python}")
     print(f"Parallel jobs: {jobs}   Logs: {args.log_dir}\n")
 
-    # Pool of distinct local-LPG calc indices, one per concurrent worker slot.
-    index_pool: "queue.Queue[int]" = queue.Queue()
-    for i in range(1, jobs + 1):
-        index_pool.put(i)
+    # Pool of distinct local-LPG base indices, one per concurrent worker slot.
+    index_pool = LpgBaseIndexPool(jobs)
 
     results: list[SetupResult] = []
     print_lock = threading.Lock()

--- a/scripts/regenerate_scenario_jsons.py
+++ b/scripts/regenerate_scenario_jsons.py
@@ -44,7 +44,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SYSTEM_SETUPS_DIR = REPO_ROOT / "system_setups"
@@ -52,14 +52,18 @@ CONVERTER = REPO_ROOT / "hisim" / "hisim_convert_to_json.py"
 
 # When this file runs as a script, Python puts scripts/ on sys.path, not the repository root, so
 # "import hisim" would resolve to the installed package instead of this checkout. Add the root
-# first. When the module is imported as scripts.regenerate_scenario_jsons the root is already on
-# the path and this does nothing.
+# first, before anything imports hisim. When the module is imported as
+# scripts.regenerate_scenario_jsons the root is usually importable already; the insert is then
+# redundant but harmless.
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-# This import must come after the sys.path change above.
-# pylint: disable=wrong-import-position
-from hisim.components.pylpg_workspace import LpgBaseIndexPool  # noqa: E402
+# hisim.components.pylpg_workspace imports pylpg at module level, and pylpg is an optional
+# dependency that no requirements file declares. Importing it here would make even --help and
+# --dry-run fail in an environment without pylpg, so the runtime import is deferred to main();
+# this block never executes and exists only for the type checker.
+if TYPE_CHECKING:
+    from hisim.components.pylpg_workspace import LpgBaseIndexPool
 
 
 @dataclass
@@ -131,7 +135,7 @@ def regenerate_one(
     stem = setup_path.stem
     log_path = log_dir / f"{stem}.log"
     with index_pool.borrowed() as calc_index:
-        env = LpgBaseIndexPool.child_environment(calc_index)
+        env = index_pool.child_environment(calc_index)
         env["PYTHONPATH"] = os.pathsep.join(
             [str(REPO_ROOT), *([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])]
         )
@@ -207,6 +211,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     jobs = min(args.jobs, len(setups))
     print(f"\nUsing interpreter: {args.python}")
     print(f"Parallel jobs: {jobs}   Logs: {args.log_dir}\n")
+
+    # Deferred so that --help and --dry-run work without pylpg; see the TYPE_CHECKING note at the top.
+    from hisim.components.pylpg_workspace import LpgBaseIndexPool  # pylint: disable=import-outside-toplevel
 
     # Pool of distinct local-LPG base indices, one per concurrent worker slot.
     index_pool = LpgBaseIndexPool(jobs)

--- a/tests/test_pylpg_workspace.py
+++ b/tests/test_pylpg_workspace.py
@@ -472,10 +472,12 @@ def test_the_real_check_recognises_the_locked_database_in_the_log_and_the_retry_
 
 
 @pytest.mark.base
-def test_two_slots_borrowing_at_once_get_different_base_indices() -> None:
-    """Two concurrent borrowers never hold the same index.
+def test_two_borrows_held_at_the_same_time_get_different_base_indices() -> None:
+    """Two borrows held at the same time never share an index.
 
-    If they did, two HiSim processes would compute in the same ``pylpg/C<index>`` directory.
+    If they did, two HiSim processes would compute in the same ``pylpg/C<index>`` directory. Both
+    borrows happen on this one thread; that a second *thread* borrowing sees the same distinctness
+    is the standard library's ``queue.Queue`` guarantee, which a test here could not add to.
     """
     pool = LpgBaseIndexPool(slots=2)
 

--- a/tests/test_pylpg_workspace.py
+++ b/tests/test_pylpg_workspace.py
@@ -6,7 +6,7 @@ multi-household request restarted its own counter at ``1``, which put every conc
 ``pylpg/C1``: sqlite files corrupted each other and a finishing run deleted the folder a running one
 was still using. These tests pin the replacement rule -- distinct base indices give disjoint blocks
 of directories, an occupied directory stops the run by name, and a run releases what it claimed
-whether it succeeded or failed.
+whether it succeeded or failed -- and the pool a parallel driver hands those base indices out from.
 
 None of them touch pylpg or start a calculation; they exercise arithmetic and one filesystem check,
 which is why they are ``base`` rather than ``utsp``.
@@ -21,6 +21,7 @@ import pytest
 
 from hisim.components.pylpg_workspace import (
     LocalLpgCalculationFailedError,
+    LpgBaseIndexPool,
     PylpgWorkingDirectoryInUseError,
     PylpgWorkspace,
 )
@@ -468,3 +469,98 @@ def test_the_real_check_recognises_the_locked_database_in_the_log_and_the_retry_
     assert generator.runs == 2
     assert generator.files_present_at_start == [[], []], "the second run must start without the first one's a.json"
     assert (result_folder / "b.json").is_file()
+
+
+@pytest.mark.base
+def test_two_slots_borrowing_at_once_get_different_base_indices() -> None:
+    """The pool's whole purpose: no two live borrowers hold the same index.
+
+    Catches: a pool that lends the same index twice, which puts two concurrent HiSim processes back
+    into one ``pylpg/C<index>`` directory and restores the corruption the index scheme exists to
+    prevent.
+    """
+    pool = LpgBaseIndexPool(slots=2)
+
+    with pool.borrowed() as first, pool.borrowed() as second:
+        assert first != second
+        assert {first, second} == {1, 2}
+
+
+@pytest.mark.base
+def test_an_index_is_lent_again_once_its_slot_is_free() -> None:
+    """A slot is reused as soon as the child occupying it finishes.
+
+    A driver runs far more setups than it has slots, so the pool has to be reusable; a pool that
+    only ever lent each index once would serve the first ``slots`` children and then hang.
+
+    Catches: an index that is taken out of circulation after one use.
+    """
+    pool = LpgBaseIndexPool(slots=1)
+
+    with pool.borrowed() as first:
+        assert first == 1
+    with pool.borrowed() as second:
+        assert second == 1
+
+
+@pytest.mark.base
+def test_a_borrower_that_raises_still_returns_its_index() -> None:
+    """A failed child must not shrink the pool.
+
+    Catches: a run in which as many setups fail as there are slots quietly stopping dead, with no
+    error of its own, because every index has been lost to an exception.
+    """
+    pool = LpgBaseIndexPool(slots=1)
+
+    with pytest.raises(RuntimeError):
+        with pool.borrowed():
+            raise RuntimeError("the child failed")
+
+    with pool.borrowed() as reused:
+        assert reused == 1
+
+
+@pytest.mark.base
+def test_a_pool_with_no_slots_is_refused() -> None:
+    """A pool nothing can be borrowed from is a driver that hangs, so it is rejected on sight.
+
+    Catches: a caller computing its slot count and passing zero, which would block on the first
+    child forever rather than reporting anything.
+    """
+    with pytest.raises(ValueError, match="at least one slot"):
+        LpgBaseIndexPool(slots=0)
+
+
+@pytest.mark.base
+def test_the_announced_environment_is_read_back_as_the_default_base_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """What the pool writes is what a child reads, with no name agreed twice.
+
+    The two halves of this contract live apart -- the driver announces the index, the connector in
+    the child asks for it -- so the test puts them together and checks the round trip rather than
+    checking either against a literal.
+
+    Catches: a driver setting a variable the connector does not read, in which case every child
+    falls back to its process id and the collisions come back without anything reporting them.
+    """
+    announced = LpgBaseIndexPool.announced_in({"UNRELATED": "kept"}, base_index=7)
+
+    assert announced["UNRELATED"] == "kept"
+    for name, value in announced.items():
+        monkeypatch.setenv(name, value)
+    assert PylpgWorkspace.default_base_index() == 7
+
+
+@pytest.mark.base
+def test_announcing_does_not_change_the_environment_it_was_given() -> None:
+    """The caller's environment is a template, not something to write through.
+
+    Catches: a driver whose first child mutates ``os.environ`` for the whole process, so that a
+    later child inheriting it computes under an index the pool believes is free.
+    """
+    original = {"HOME": "/somewhere"}
+
+    LpgBaseIndexPool.announced_in(original, base_index=3)
+
+    assert original == {"HOME": "/somewhere"}

--- a/tests/test_pylpg_workspace.py
+++ b/tests/test_pylpg_workspace.py
@@ -473,11 +473,9 @@ def test_the_real_check_recognises_the_locked_database_in_the_log_and_the_retry_
 
 @pytest.mark.base
 def test_two_slots_borrowing_at_once_get_different_base_indices() -> None:
-    """The pool's whole purpose: no two live borrowers hold the same index.
+    """Two concurrent borrowers never hold the same index.
 
-    Catches: a pool that lends the same index twice, which puts two concurrent HiSim processes back
-    into one ``pylpg/C<index>`` directory and restores the corruption the index scheme exists to
-    prevent.
+    If they did, two HiSim processes would compute in the same ``pylpg/C<index>`` directory.
     """
     pool = LpgBaseIndexPool(slots=2)
 
@@ -488,12 +486,9 @@ def test_two_slots_borrowing_at_once_get_different_base_indices() -> None:
 
 @pytest.mark.base
 def test_an_index_is_lent_again_once_its_slot_is_free() -> None:
-    """A slot is reused as soon as the child occupying it finishes.
+    """A returned index can be borrowed again.
 
-    A driver runs far more setups than it has slots, so the pool has to be reusable; a pool that
-    only ever lent each index once would serve the first ``slots`` children and then hang.
-
-    Catches: an index that is taken out of circulation after one use.
+    A script runs more subprocesses than it has workers, so each index is used many times.
     """
     pool = LpgBaseIndexPool(slots=1)
 
@@ -505,10 +500,10 @@ def test_an_index_is_lent_again_once_its_slot_is_free() -> None:
 
 @pytest.mark.base
 def test_a_borrower_that_raises_still_returns_its_index() -> None:
-    """A failed child must not shrink the pool.
+    """An exception inside the ``with`` block does not lose the index.
 
-    Catches: a run in which as many setups fail as there are slots quietly stopping dead, with no
-    error of its own, because every index has been lost to an exception.
+    Otherwise every failed subprocess would shrink the pool, and after ``slots`` failures the script
+    would block forever.
     """
     pool = LpgBaseIndexPool(slots=1)
 
@@ -522,45 +517,33 @@ def test_a_borrower_that_raises_still_returns_its_index() -> None:
 
 @pytest.mark.base
 def test_a_pool_with_no_slots_is_refused() -> None:
-    """A pool nothing can be borrowed from is a driver that hangs, so it is rejected on sight.
-
-    Catches: a caller computing its slot count and passing zero, which would block on the first
-    child forever rather than reporting anything.
-    """
+    """``slots=0`` is rejected at construction instead of blocking on the first borrow."""
     with pytest.raises(ValueError, match="at least one slot"):
         LpgBaseIndexPool(slots=0)
 
 
 @pytest.mark.base
-def test_the_announced_environment_is_read_back_as_the_default_base_index(
+def test_the_child_environment_is_read_back_as_the_default_base_index(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """What the pool writes is what a child reads, with no name agreed twice.
+    """The variable the pool writes is the one the child reads.
 
-    The two halves of this contract live apart -- the driver announces the index, the connector in
-    the child asks for it -- so the test puts them together and checks the round trip rather than
-    checking either against a literal.
-
-    Catches: a driver setting a variable the connector does not read, in which case every child
-    falls back to its process id and the collisions come back without anything reporting them.
+    Checked as a round trip through ``PylpgWorkspace.default_base_index`` rather than against the
+    variable's literal name, so the two sides cannot drift apart unnoticed.
     """
-    announced = LpgBaseIndexPool.announced_in({"UNRELATED": "kept"}, base_index=7)
+    child = LpgBaseIndexPool.child_environment(7, {"UNRELATED": "kept"})
 
-    assert announced["UNRELATED"] == "kept"
-    for name, value in announced.items():
+    assert child["UNRELATED"] == "kept"
+    for name, value in child.items():
         monkeypatch.setenv(name, value)
     assert PylpgWorkspace.default_base_index() == 7
 
 
 @pytest.mark.base
-def test_announcing_does_not_change_the_environment_it_was_given() -> None:
-    """The caller's environment is a template, not something to write through.
-
-    Catches: a driver whose first child mutates ``os.environ`` for the whole process, so that a
-    later child inheriting it computes under an index the pool believes is free.
-    """
+def test_the_child_environment_is_a_copy() -> None:
+    """The environment passed in is not modified."""
     original = {"HOME": "/somewhere"}
 
-    LpgBaseIndexPool.announced_in(original, base_index=3)
+    LpgBaseIndexPool.child_environment(3, original)
 
     assert original == {"HOME": "/somewhere"}

--- a/tests/test_regeneration_environment.py
+++ b/tests/test_regeneration_environment.py
@@ -1,9 +1,18 @@
 """Tests for the environment the scenario-JSON regeneration passes to its subprocesses.
 
-The converter runs as a script, and for a script Python puts the script's directory on ``sys.path``,
-not the working directory. So ``import hisim`` in the child resolves to the installed package unless
-``PYTHONPATH`` names this checkout; in a git worktree that is a different checkout, and the regeneration
-then reports no drift against the wrong code. The first test pins the mechanism, the second the fix.
+The regeneration driver rebuilds every ``system_setups/*.py`` in a subprocess and then reports
+whether the committed ``.scenario.json`` files still match. That report is only worth having if
+each child ran *this* checkout's HiSim, and nothing about the way the child is started makes that
+true by itself: the converter is invoked as a script path, so Python seeds ``sys.path`` with the
+script's own directory (``scripts/``) rather than with the working directory, and the editable
+install's finder is then free to answer ``import hisim`` from whichever checkout happens to be
+installed. In a second checkout the driver would regenerate everything against the wrong tree and
+announce no drift -- a false all-clear, which is worse than a failure because nobody investigates
+it.
+
+The first test pins the mechanism, so that the reasoning above stays checkable rather than being a
+comment nobody can verify. The second pins the fix. The third pins the other half of the child's
+contract, the borrowed local-LPG base index. Each test states the failure mode it catches.
 """
 
 # clean
@@ -18,7 +27,7 @@ from typing import ClassVar, Dict, List
 
 import pytest
 
-from hisim.components.pylpg_workspace import LpgBaseIndexPool
+from hisim.components.pylpg_workspace import LpgBaseIndexPool, PylpgWorkspace
 from scripts.regenerate_scenario_jsons import REPO_ROOT, regenerate_one
 
 
@@ -148,3 +157,30 @@ def test_the_child_is_told_to_import_hisim_from_this_checkout(tmp_path: Path, mo
     entries = recorded.environments[0]["PYTHONPATH"].split(os.pathsep)
     assert entries[0] == str(REPO_ROOT), f"PYTHONPATH does not lead with the checkout: {entries}"
     assert "/somewhere/the/caller/cares/about" in entries, f"the caller's own entry was dropped: {entries}"
+
+
+@pytest.mark.base
+def test_the_child_is_handed_the_borrowed_base_index(tmp_path: Path, monkeypatch) -> None:
+    """The base index borrowed from the pool must arrive in the child's environment.
+
+    The pool and its ``child_environment`` are unit-tested on their own, but ``regenerate_one`` is
+    the only place that composes them, and only this test observes that composition: without it the
+    driver could stop borrowing, or hand every child the same constant, and no test would fail until
+    concurrent workers corrupted each other's ``pylpg/C<index>`` directories again.
+
+    Catches: a refactor of ``regenerate_one`` that drops or bypasses the borrow.
+    """
+    recorded = RecordedChild()
+    monkeypatch.setattr("scripts.regenerate_scenario_jsons.subprocess.run", recorded)
+
+    regenerate_one(
+        setup_path=REPO_ROOT / "system_setups" / "simple_system_setup_one.py",
+        python=sys.executable,
+        index_pool=LpgBaseIndexPool(slots=1),
+        log_dir=tmp_path,
+        keep_simulation_json=True,
+    )
+
+    assert len(recorded.environments) == 1
+    handed = recorded.environments[0].get(PylpgWorkspace.INDEX_ENVIRONMENT_VARIABLE)
+    assert handed == "1", f"the borrowed base index did not reach the child: {handed!r}"

--- a/tests/test_regeneration_environment.py
+++ b/tests/test_regeneration_environment.py
@@ -18,6 +18,7 @@ from typing import ClassVar, Dict, List
 
 import pytest
 
+from hisim.components.pylpg_workspace import LpgBaseIndexPool
 from scripts.regenerate_scenario_jsons import REPO_ROOT, regenerate_one
 
 
@@ -134,15 +135,11 @@ def test_the_child_is_told_to_import_hisim_from_this_checkout(tmp_path: Path, mo
     recorded = RecordedChild()
     monkeypatch.setattr("scripts.regenerate_scenario_jsons.subprocess.run", recorded)
     monkeypatch.setenv("PYTHONPATH", "/somewhere/the/caller/cares/about")
-    import queue
-
-    indices: "queue.Queue[int]" = queue.Queue()
-    indices.put(1)
 
     regenerate_one(
         setup_path=REPO_ROOT / "system_setups" / "simple_system_setup_one.py",
         python=sys.executable,
-        index_pool=indices,
+        index_pool=LpgBaseIndexPool(slots=1),
         log_dir=tmp_path,
         keep_simulation_json=True,
     )


### PR DESCRIPTION
## Problem

pylpg computes inside its installed package in a directory named after the calculation index, so a driver running several HiSim processes must hand each worker slot its own index or they corrupt each other's sqlite files. `regenerate_scenario_jsons.py` grew an inline queue for this. The P3 recorder was expected to need the same, and the environment variable's name was spelled independently in each driver — a disagreement nothing would report, since a child reading a name nobody sets falls back to its pid and works until two collide.

## What was done

- `LpgBaseIndexPool` in `hisim/components/pylpg_workspace.py`, next to the index arithmetic it belongs to: lends an index for the length of a block, returns it in a `finally` (a child that raised or was killed still frees its slot), refuses a zero-slot pool, and `child_environment()` builds a child's environment with the variable set, so the name lives in one place.
- The regenerator borrows from it instead of its inline queue. Reaching the module from the driver needs the checkout on `sys.path` first (same defect as #621, one process further up) — demonstrated, not asserted.
- Six tests, including a round trip through `PylpgWorkspace.default_base_index()` so the two halves of the contract cannot drift.

## Result

One implementation of index lending, shared name, tested. Second commit: docstrings rewritten in plain language after review feedback (what → example → short why), `announced_in` renamed `child_environment`. **Honest caveat:** the P3 recorder turned out not to need it — it is sequential by design (two setups needing the same new parameters file must share it), and #598 un-pins its index instead. So this PR is a clean-up with tests rather than a prerequisite; merge or close on that basis. Based on #621 (both edit `regenerate_one`); GitHub retargets to `main` when #621 merges.