### PR TITLE
Finish the cache round-trip sweep: the car was reading its own cache inexactly

### DIFF
--- a/hisim/components/generic_car.py
+++ b/hisim/components/generic_car.py
@@ -499,7 +499,14 @@ class Car(cp.Component):
         if file_exists:
             # load from cache
             log.information("Generic car data is taken from cache.")
-            dataframe = pd.read_csv(cache_filepath, sep=",", decimal=".", encoding="cp1252")
+            # float_precision="round_trip" is what makes a cached run and an uncached one the same
+            # run. pandas' default CSV reader uses a fast, inexact float parser and loses the last
+            # bit of a fifth of the distances in this file -- measured on a committed year-long
+            # entry: 334 of the 1789 non-zero values of meters_driven come back different from
+            # what was written, and none do with this argument.
+            dataframe = pd.read_csv(
+                cache_filepath, sep=",", decimal=".", encoding="cp1252", float_precision="round_trip"
+            )
             self.car_location = dataframe["car_location"].tolist()
             self.meters_driven = dataframe["meters_driven"].tolist()
 

--- a/tests/test_cache_round_trip.py
+++ b/tests/test_cache_round_trip.py
@@ -30,10 +30,9 @@ class CacheReaders:
     Listed explicitly rather than discovered, because a new cache reader should have to be added
     here deliberately -- which is the moment to ask whether it parses exactly.
 
-    The solar thermal collector is absent on purpose: its cache is rebuilt on a separate branch
-    (roadmap/pylpg_flakiness.md F8) and its own test asserts the same guarantee behaviourally, by
-    comparing a computed run against a cached one. Whichever of the two lands second should add it
-    here, so that this list is once again every reader rather than most of them.
+    The list is now all six of them. Four arrived with the argument; the solar thermal collector
+    was rebuilt on its own branch (roadmap/pylpg_flakiness.md F8) and was added once both had
+    landed; the car was simply missed, and had been reading its cache inexactly the whole time.
     """
 
     SITES: Tuple[Tuple[str, str], ...] = (
@@ -41,6 +40,8 @@ class CacheReaders:
         ("hisim/components/building/building.py", "if not self.is_in_cache:  #"),
         ("hisim/components/weather.py", "my_weather = pd.read_csv("),
         ("hisim/components/loadprofilegenerator_utsp_connector.py", "dataframe = pd.read_csv("),
+        ("hisim/components/solar_thermal_system.py", "Get solar position from cache."),
+        ("hisim/components/generic_car.py", "Generic car data is taken from cache."),
     )
 
     EXACT = 'float_precision="round_trip"'


### PR DESCRIPTION
## Problem

#619 and #620 added `float_precision="round_trip"` to the cache readers, and the guarding test asked whichever landed second to add the solar-thermal reader to its list. Both landed; neither did. Adding it turned up a sixth reader nobody had counted: `generic_car.py:502` reads its cache with `encoding="cp1252"` and no float precision, and has since the cache existed. pandas' default parser is inexact — measured on a committed year-long car entry, **334 of the 1789 non-zero `meters_driven` values come back different from what was written** (about a fifth of every distance the car drives). A warm run of any setup with a car has been a slightly different simulation from a cold one, in the component that decides when the car can charge.

## What was done

- `float_precision="round_trip"` on the car's cache read, with the measurement in the comment.
- `tests/test_cache_round_trip.py`: `CacheReaders.SITES` now lists all six readers (solar thermal and car added); docstring updated to say the car was missed, not deferred.

## Result

Cold and warm runs agree for every cache reader. No golden value moves: the eight golden setups are all heating variants and none owns a car. Verified: the round-trip test fails with the car read reverted and passes with it; 44 car/cache tests pass; mypy, pylint 10.00, prospector 0.