### PR TITLE
Cache client, phase 1: settings, the key scheme, and one client every component reaches

### DIFF
--- a/hisim/caching/__init__.py
+++ b/hisim/caching/__init__.py
@@ -12,7 +12,7 @@ interpreter.
 
 # clean
 
-from hisim.caching.client import CacheClient, CacheEntry, default_client
+from hisim.caching.client import CacheClient, CacheEntry
 from hisim.caching.keys import (
     CacheKey,
     CacheKeyError,
@@ -42,5 +42,4 @@ __all__ = [
     "ProducerLayering",
     "ProducerLayeringError",
     "atomic_cache_write",
-    "default_client",
 ]

--- a/hisim/caching/__init__.py
+++ b/hisim/caching/__init__.py
@@ -2,18 +2,48 @@
 
 The package is the home of everything the simulation knows about caching, as laid out in
 ``roadmap/cache_service_spec.md`` §4: local paths and atomic writes, key construction, the remote
-HTTP tier, curated-dataset retrieval and the client that orchestrates them. Only the local tier of
-§10 phase 1 has been built, so the public surface is deliberately one context manager and the metadata
-rule it enforces; the remaining modules arrive with the later phases and this file is where they will
-be re-exported from.
+HTTP tier, curated-dataset retrieval and the client that orchestrates them. Phase 1 of §10 is what
+exists: the local tier, the settings, the key scheme and a client with one tier behind it. The remote
+and shared-directory tiers and the dataset retrieval arrive with the later phases and are re-exported
+from here when they do.
 
 Importing this package must stay cheap and free of side effects, because it sits at the same layer as
 ``hisim/config/`` and is imported by both components and ``hisim/utils.py``. It therefore imports the
-standard library only -- never a component, the simulator or the singleton repository.
+standard library and ``hisim.log`` only -- never a component, the simulator, the simulation parameters
+or the singleton repository. A test pins that rule.
 """
 
 # clean
 
+from hisim.caching.client import CacheClient, CacheEntry, default_client
+from hisim.caching.keys import (
+    CacheKey,
+    CacheKeyError,
+    CanonicalJson,
+    Fingerprints,
+    ImportClosure,
+    KeyMaterial,
+    ProducerLayering,
+    ProducerLayeringError,
+)
 from hisim.caching.local import CacheEntryMetadata, atomic_cache_write
+from hisim.caching.settings import CacheNetworkMode, CacheSettings, CacheSettingsError
 
-__all__ = ["CacheEntryMetadata", "atomic_cache_write"]
+__all__ = [
+    "CacheClient",
+    "CacheEntry",
+    "CacheEntryMetadata",
+    "CacheKey",
+    "CacheKeyError",
+    "CacheNetworkMode",
+    "CacheSettings",
+    "CacheSettingsError",
+    "CanonicalJson",
+    "Fingerprints",
+    "ImportClosure",
+    "KeyMaterial",
+    "ProducerLayering",
+    "ProducerLayeringError",
+    "atomic_cache_write",
+    "default_client",
+]

--- a/hisim/caching/__init__.py
+++ b/hisim/caching/__init__.py
@@ -1,16 +1,13 @@
-"""Public API of the HiSim cache service client.
+"""Public API of the HiSim cache client (``roadmap/cache_service_spec.md`` §4).
 
-The package is the home of everything the simulation knows about caching, as laid out in
-``roadmap/cache_service_spec.md`` §4: local paths and atomic writes, key construction, the remote
-HTTP tier, curated-dataset retrieval and the client that orchestrates them. Phase 1 of §10 is what
-exists: the local tier, the settings, the key scheme and a client with one tier behind it. The remote
-and shared-directory tiers and the dataset retrieval arrive with the later phases and are re-exported
-from here when they do.
+Phase 1 of §10 is implemented: the local tier (``local``), the settings (``settings``), the key scheme
+(``keys``) and a client with one tier behind it (``client``). The remote and shared-directory tiers and
+the dataset retrieval come with later phases and will be re-exported from here.
 
-Importing this package must stay cheap and free of side effects, because it sits at the same layer as
-``hisim/config/`` and is imported by both components and ``hisim/utils.py``. It therefore imports the
-standard library and ``hisim.log`` only -- never a component, the simulator, the simulation parameters
-or the singleton repository. A test pins that rule.
+This package sits at the same layer as ``hisim/config/`` and is imported by components and by
+``hisim/utils.py``. It therefore imports only the standard library and ``hisim.log`` -- never a component,
+the simulator, the simulation parameters or the singleton repository. A test checks this in a fresh
+interpreter.
 """
 
 # clean

--- a/hisim/caching/client.py
+++ b/hisim/caching/client.py
@@ -19,7 +19,7 @@ This module imports the standard library, ``hisim.log`` and its own package only
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import ClassVar, Iterator, Optional
+from typing import ClassVar, Iterator
 
 from hisim import log
 from hisim.caching.local import CacheEntryMetadata, atomic_cache_write
@@ -73,8 +73,12 @@ class CacheClient:
     :meth:`lookup` in later phases.
     """
 
-    #: The extension every local entry carries.
-    SUFFIX: ClassVar[str] = ".cache"
+    #: The extension every local entry carries. Defined once, on the metadata class that parses it back.
+    SUFFIX: ClassVar[str] = CacheEntryMetadata.DATA_SUFFIX
+
+    #: Whether the ``HISIM_CACHE_DIR`` redirect has been announced in the log this process. One line
+    #: is enough; the override applies to every lookup identically.
+    _override_announced: ClassVar[bool] = False
 
     def __init__(self, settings: CacheSettings) -> None:
         """Bind the client to one set of settings.
@@ -103,24 +107,34 @@ class CacheClient:
 
         Returns:
             str: the filename.
+
+        Raises:
+            ValueError: if the component key contains a path separator. The key becomes part of a
+                filename; a separator would file the entry outside the cache directory.
         """
+        if "/" in component_key or "\\" in component_key:
+            raise ValueError(
+                f"The component key {component_key!r} contains a path separator and cannot name a cache "
+                "entry; rename the component so its cache files stay inside the cache directory."
+            )
         return f"{component_key}_{digest}{cls.SUFFIX}"
 
-    def lookup(self, component_key: str, key_material: str, default_directory: str) -> CacheEntry:
-        """Look an entry up in the local directory.
+    def lookup(self, component_key: str, key_material: str, directory: str) -> CacheEntry:
+        """Look an entry up in the given directory.
 
         Creates the directory if needed. An existing file counts as a hit only if its ``.meta`` companion
-        hashes to the filename; otherwise it is deleted and the lookup is a miss.
+        hashes to the filename; otherwise it is deleted and the lookup is a miss. The caller resolves
+        which directory applies (see :meth:`CacheSettings.resolve_local_directory` for the
+        ``HISIM_CACHE_DIR`` override); the lookup itself takes the decision as given.
 
         Args:
             component_key: the filename prefix.
             key_material: the string that identifies the entry's inputs; its hash is the filename's digest.
-            default_directory: the directory to use unless ``HISIM_CACHE_DIR`` overrides it.
+            directory: the directory to look in.
 
         Returns:
             CacheEntry: with ``exists`` True only for a validated hit.
         """
-        directory = self.settings.resolve_local_directory(default_directory)
         os.makedirs(directory, exist_ok=True)
         path = os.path.join(directory, self.entry_filename(component_key, CacheEntryMetadata.hash_of(key_material)))
         return CacheEntry(path=path, exists=self._validated_local_hit(path), key_material=key_material)
@@ -163,14 +177,20 @@ class CacheClient:
         parts.append(f"network {self.settings.network.value} (not yet active in this phase)")
         return ", ".join(parts)
 
+    def announce_environment_override(self, directory: str) -> None:
+        """Log, once per process, that ``HISIM_CACHE_DIR`` is redirecting the cache.
 
-def default_client(settings: Optional[CacheSettings] = None) -> CacheClient:
-    """Return a client for the given settings, or for the environment when none are given.
+        The override silently relocates every component's cache away from the simulation's own
+        directory -- existing entries elsewhere are ignored and recomputed -- so the first redirected
+        lookup says so in the log. One line is enough: the override applies to every lookup the same
+        way, and a line per lookup would only bury it.
 
-    Args:
-        settings: settings to use; ``None`` reads the environment now.
-
-    Returns:
-        CacheClient: the client.
-    """
-    return CacheClient(settings) if settings is not None else CacheClient.from_environment()
+        Args:
+            directory: the directory the override points at.
+        """
+        if CacheClient._override_announced:
+            return
+        CacheClient._override_announced = True
+        log.information(
+            f"{CacheSettings.Variables.DIRECTORY} redirects the cache to {directory} ({self.describe()})."
+        )

--- a/hisim/caching/client.py
+++ b/hisim/caching/client.py
@@ -1,21 +1,17 @@
-"""The client that decides whether a cache entry exists, where it lives, and how a new one lands.
+"""The cache client: looks an entry up, says where it lives, and lands a new one atomically.
 
-``roadmap/cache_service_spec.md`` §4 describes ``CacheClient`` as the orchestrator of the tiers:
-local directory, then server, then shared directory, then compute. This phase ships the first tier
-only, and it ships it as the client rather than as a helper for one reason -- every component already
-talks to the cache through ``hisim.utils.get_cache_file``, and the way to make the later tiers reach
-every component at once is to have that function delegate here now, while there is only one tier to
-delegate to. When the remote tier arrives it slots in behind :meth:`CacheClient.lookup` and no
-component changes.
+``roadmap/cache_service_spec.md`` §4 describes ``CacheClient`` as the object that walks the tiers --
+local directory, server, shared directory -- and falls back to computing. This phase implements the
+local tier only. It is already shaped as the client, and ``hisim.utils.get_cache_file`` already
+delegates to it, so that the later tiers can be added behind :meth:`CacheClient.lookup` without any
+component changing.
 
-What the local tier does is exactly what ``get_cache_file`` used to do inline: derive the filename from
-the component key and the digest of the key material, create the directory, and count an existing file
-as a hit only if its companion metadata hashes to the name it is filed under -- otherwise discard it and
-report a miss, which is what makes a scheme change or a poisoning self-repairing. The behaviour moved;
-it did not change.
+The local tier does what ``get_cache_file`` used to do inline: derive the filename from the component
+key and the hash of the key material, create the directory, and count an existing file as a hit only if
+its ``.meta`` companion hashes to the filename. A file that fails that check is deleted and reported as
+a miss, which is how entries from an older key scheme clean themselves up.
 
-This module imports the standard library, ``hisim.log`` and its own package, never a component or the
-simulation, so the client stays at the layer of ``hisim/config/``.
+This module imports the standard library, ``hisim.log`` and its own package only.
 """
 
 # clean
@@ -40,12 +36,11 @@ __status__ = "development"
 
 @dataclass(frozen=True)
 class CacheEntry:
-    """One looked-up entry: whether it exists, where it is, and what identifies it.
+    """The result of one lookup: where the entry is, whether it exists, and what identifies it.
 
-    ``exists`` is advisory, as it always was: two processes may both miss the same key and both compute
-    the entry, which wastes work and nothing more, because the contents are a pure function of the key
-    and the landing is atomic. Writing straight to :attr:`path` is the one thing a caller must never
-    do; :meth:`writing` is how an entry lands.
+    Use :meth:`writing` to create the entry; never write to :attr:`path` directly, because a reader may
+    see a half-written file. ``exists`` is advisory: two processes can both miss the same key and both
+    compute the entry, which wastes work but is harmless, since the result is a pure function of the key.
     """
 
     #: The absolute path the entry is, or will be, filed at.
@@ -59,10 +54,10 @@ class CacheEntry:
 
     @contextmanager
     def writing(self) -> Iterator[str]:
-        """Yields a temporary path to write the entry to, then moves it and its metadata into place.
+        """Yield a temporary path to write into; on exit, move it and its ``.meta`` file into place atomically.
 
-        Thin wrapper over :func:`hisim.caching.atomic_cache_write` that supplies this entry's own path
-        and key material, so a caller cannot pair the wrong two.
+        A wrapper around :func:`hisim.caching.atomic_cache_write` that fills in this entry's own path and
+        key material.
 
         Yields:
             str: the temporary path to write to.
@@ -72,26 +67,26 @@ class CacheEntry:
 
 
 class CacheClient:
-    """Looks entries up across the configured tiers and hands back where to read or write them.
+    """Looks cache entries up in the configured tiers.
 
-    One tier today. The class is built so that the second and third are additions to
-    :meth:`lookup`, not changes to its callers.
+    One tier exists today (the local directory). The remote and shared-directory tiers are added behind
+    :meth:`lookup` in later phases.
     """
 
     #: The extension every local entry carries.
     SUFFIX: ClassVar[str] = ".cache"
 
     def __init__(self, settings: CacheSettings) -> None:
-        """Binds the client to one set of settings.
+        """Bind the client to one set of settings.
 
         Args:
-            settings: what the environment said, read once by the caller.
+            settings: the settings to use, normally from :meth:`CacheSettings.from_environment`.
         """
         self.settings = settings
 
     @classmethod
     def from_environment(cls) -> "CacheClient":
-        """Builds a client from the process environment.
+        """Create a client from the process environment.
 
         Returns:
             CacheClient: the client.
@@ -100,7 +95,7 @@ class CacheClient:
 
     @classmethod
     def entry_filename(cls, component_key: str, digest: str) -> str:
-        """Names an entry the way every reader and writer expects: ``<component_key>_<digest>.cache``.
+        """Return the filename of an entry: ``<component_key>_<digest>.cache``.
 
         Args:
             component_key: the filename prefix, today the component's instance name.
@@ -112,13 +107,15 @@ class CacheClient:
         return f"{component_key}_{digest}{cls.SUFFIX}"
 
     def lookup(self, component_key: str, key_material: str, default_directory: str) -> CacheEntry:
-        """Finds an entry in the local tier, creating the directory and discarding what cannot be trusted.
+        """Look an entry up in the local directory.
+
+        Creates the directory if needed. An existing file counts as a hit only if its ``.meta`` companion
+        hashes to the filename; otherwise it is deleted and the lookup is a miss.
 
         Args:
             component_key: the filename prefix.
-            key_material: the raw string identifying the entry's inputs.
-            default_directory: the directory to use unless the environment overrides it, normally the
-                simulation's ``cache_dir_path``.
+            key_material: the string that identifies the entry's inputs; its hash is the filename's digest.
+            default_directory: the directory to use unless ``HISIM_CACHE_DIR`` overrides it.
 
         Returns:
             CacheEntry: with ``exists`` True only for a validated hit.
@@ -130,11 +127,10 @@ class CacheClient:
 
     @staticmethod
     def _validated_local_hit(path: str) -> bool:
-        """Says whether a file at ``path`` is an entry that can be shown to belong to its key.
+        """Return True if ``path`` is a file whose ``.meta`` companion hashes to its own name.
 
-        An entry whose metadata is missing or disagrees with its own filename either predates the
-        metadata scheme or was produced by something other than what the key describes; the file alone
-        cannot tell the two apart, so both are deleted and reported as a miss.
+        A file that fails the check is deleted and a warning is logged. It either predates the metadata
+        scheme or was written under a different key scheme; in both cases recomputing is the right answer.
 
         Args:
             path: the entry's path.
@@ -154,7 +150,7 @@ class CacheClient:
         return False
 
     def describe(self) -> str:
-        """One line saying which tiers this client will use, for logs and diagnostics.
+        """Return one line naming the tiers this client uses, for logs.
 
         Returns:
             str: the description.
@@ -169,12 +165,10 @@ class CacheClient:
 
 
 def default_client(settings: Optional[CacheSettings] = None) -> CacheClient:
-    """Returns a client for the given settings, or for the environment when none are given.
-
-    Exists so that ``hisim.utils.get_cache_file`` has one obvious thing to call.
+    """Return a client for the given settings, or for the environment when none are given.
 
     Args:
-        settings: pre-read settings, or ``None`` to read the environment now.
+        settings: settings to use; ``None`` reads the environment now.
 
     Returns:
         CacheClient: the client.

--- a/hisim/caching/client.py
+++ b/hisim/caching/client.py
@@ -1,0 +1,182 @@
+"""The client that decides whether a cache entry exists, where it lives, and how a new one lands.
+
+``roadmap/cache_service_spec.md`` §4 describes ``CacheClient`` as the orchestrator of the tiers:
+local directory, then server, then shared directory, then compute. This phase ships the first tier
+only, and it ships it as the client rather than as a helper for one reason -- every component already
+talks to the cache through ``hisim.utils.get_cache_file``, and the way to make the later tiers reach
+every component at once is to have that function delegate here now, while there is only one tier to
+delegate to. When the remote tier arrives it slots in behind :meth:`CacheClient.lookup` and no
+component changes.
+
+What the local tier does is exactly what ``get_cache_file`` used to do inline: derive the filename from
+the component key and the digest of the key material, create the directory, and count an existing file
+as a hit only if its companion metadata hashes to the name it is filed under -- otherwise discard it and
+report a miss, which is what makes a scheme change or a poisoning self-repairing. The behaviour moved;
+it did not change.
+
+This module imports the standard library, ``hisim.log`` and its own package, never a component or the
+simulation, so the client stays at the layer of ``hisim/config/``.
+"""
+
+# clean
+
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import ClassVar, Iterator, Optional
+
+from hisim import log
+from hisim.caching.local import CacheEntryMetadata, atomic_cache_write
+from hisim.caching.settings import CacheSettings
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    """One looked-up entry: whether it exists, where it is, and what identifies it.
+
+    ``exists`` is advisory, as it always was: two processes may both miss the same key and both compute
+    the entry, which wastes work and nothing more, because the contents are a pure function of the key
+    and the landing is atomic. Writing straight to :attr:`path` is the one thing a caller must never
+    do; :meth:`writing` is how an entry lands.
+    """
+
+    #: The absolute path the entry is, or will be, filed at.
+    path: str
+
+    #: Whether a validated entry was found at :attr:`path`.
+    exists: bool
+
+    #: The raw string the entry's name is hashed from; recorded beside the entry when it is written.
+    key_material: str
+
+    @contextmanager
+    def writing(self) -> Iterator[str]:
+        """Yields a temporary path to write the entry to, then moves it and its metadata into place.
+
+        Thin wrapper over :func:`hisim.caching.atomic_cache_write` that supplies this entry's own path
+        and key material, so a caller cannot pair the wrong two.
+
+        Yields:
+            str: the temporary path to write to.
+        """
+        with atomic_cache_write(self.path, self.key_material) as temporary_path:
+            yield temporary_path
+
+
+class CacheClient:
+    """Looks entries up across the configured tiers and hands back where to read or write them.
+
+    One tier today. The class is built so that the second and third are additions to
+    :meth:`lookup`, not changes to its callers.
+    """
+
+    #: The extension every local entry carries.
+    SUFFIX: ClassVar[str] = ".cache"
+
+    def __init__(self, settings: CacheSettings) -> None:
+        """Binds the client to one set of settings.
+
+        Args:
+            settings: what the environment said, read once by the caller.
+        """
+        self.settings = settings
+
+    @classmethod
+    def from_environment(cls) -> "CacheClient":
+        """Builds a client from the process environment.
+
+        Returns:
+            CacheClient: the client.
+        """
+        return cls(CacheSettings.from_environment())
+
+    @classmethod
+    def entry_filename(cls, component_key: str, digest: str) -> str:
+        """Names an entry the way every reader and writer expects: ``<component_key>_<digest>.cache``.
+
+        Args:
+            component_key: the filename prefix, today the component's instance name.
+            digest: the sha256 hex digest of the key material.
+
+        Returns:
+            str: the filename.
+        """
+        return f"{component_key}_{digest}{cls.SUFFIX}"
+
+    def lookup(self, component_key: str, key_material: str, default_directory: str) -> CacheEntry:
+        """Finds an entry in the local tier, creating the directory and discarding what cannot be trusted.
+
+        Args:
+            component_key: the filename prefix.
+            key_material: the raw string identifying the entry's inputs.
+            default_directory: the directory to use unless the environment overrides it, normally the
+                simulation's ``cache_dir_path``.
+
+        Returns:
+            CacheEntry: with ``exists`` True only for a validated hit.
+        """
+        directory = self.settings.resolve_local_directory(default_directory)
+        os.makedirs(directory, exist_ok=True)
+        path = os.path.join(directory, self.entry_filename(component_key, CacheEntryMetadata.hash_of(key_material)))
+        return CacheEntry(path=path, exists=self._validated_local_hit(path), key_material=key_material)
+
+    @staticmethod
+    def _validated_local_hit(path: str) -> bool:
+        """Says whether a file at ``path`` is an entry that can be shown to belong to its key.
+
+        An entry whose metadata is missing or disagrees with its own filename either predates the
+        metadata scheme or was produced by something other than what the key describes; the file alone
+        cannot tell the two apart, so both are deleted and reported as a miss.
+
+        Args:
+            path: the entry's path.
+
+        Returns:
+            bool: True for a validated hit.
+        """
+        if not os.path.isfile(path):
+            return False
+        if CacheEntryMetadata.describes(path):
+            return True
+        log.warning(
+            f"Discarding the cache entry {path}: its metadata is missing or does not hash to the name it is "
+            f"filed under, so its contents cannot be shown to belong to this key. It will be recomputed."
+        )
+        CacheEntryMetadata.discard(path)
+        return False
+
+    def describe(self) -> str:
+        """One line saying which tiers this client will use, for logs and diagnostics.
+
+        Returns:
+            str: the description.
+        """
+        if self.settings.is_standalone:
+            return "local cache directory only"
+        parts = ["local cache directory"]
+        if self.settings.shared_directory is not None:
+            parts.append(f"shared directory {self.settings.shared_directory}")
+        parts.append(f"network {self.settings.network.value} (not yet active in this phase)")
+        return ", ".join(parts)
+
+
+def default_client(settings: Optional[CacheSettings] = None) -> CacheClient:
+    """Returns a client for the given settings, or for the environment when none are given.
+
+    Exists so that ``hisim.utils.get_cache_file`` has one obvious thing to call.
+
+    Args:
+        settings: pre-read settings, or ``None`` to read the environment now.
+
+    Returns:
+        CacheClient: the client.
+    """
+    return CacheClient(settings) if settings is not None else CacheClient.from_environment()

--- a/hisim/caching/keys.py
+++ b/hisim/caching/keys.py
@@ -1,0 +1,554 @@
+"""What goes into a cache key, and how it is derived from a producer and its inputs without anyone declaring it.
+
+``roadmap/cache_service_spec.md`` §3 extends the key from ``sha256(config_json + simulation_key)`` to
+
+    sha256( artifact_kind : code_fingerprint : third_party_fingerprint : dto_json )
+
+so that a key describes the *inputs* of a calculation rather than the *owner* of its result. The
+first part names the producer. The second changes whenever code that can influence the calculation
+changes and stays put when only component plumbing does. The third pins the third-party packages
+the calculation runs on, by version. The last is the canonical JSON of the calculation's own inputs,
+the DTO of §3.1. Two calculations with the same key are the same calculation, on the same code, on
+the same libraries, from the same inputs -- which is what lets a cache be shared between a laptop,
+a cluster and a container without anyone worrying about whose entry they are reading.
+
+The two fingerprints are **fully automatic**: nothing is declared, they are read off the producer
+module's import statements. That is only sound because producer modules live under the layering rule
+:class:`ProducerLayering` enforces -- no dynamic imports, which an AST walk cannot see, and no imports
+of the component or simulator machinery, which would drag most of the package into the closure and turn
+the fingerprint into a commit hash. The rule and the fingerprint are two uses of the same
+:class:`ImportClosure`, so they cannot disagree about what a producer depends on.
+
+The legacy key scheme is not here. ``hisim.utils.build_cache_key_string`` keeps producing it for
+components that have not yet been given a producer, and the two coexist until the last extraction lands.
+This module imports the standard library only, so that it stays importable from anywhere in HiSim
+without pulling in the simulation.
+"""
+
+# clean
+
+import ast
+import dataclasses
+import enum
+import hashlib
+import importlib.metadata
+import importlib.util
+import json
+import pathlib
+import re
+import sys
+from types import ModuleType
+from typing import Any, ClassVar, Dict, FrozenSet, Iterator, List, Mapping, Optional, Set, Tuple
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+class CacheKeyError(ValueError):
+    """Raised when a cache key cannot be built from what was given.
+
+    Every message names the thing that was wrong -- the artifact kind, the DTO field, the module -- so
+    the producer author can fix it without reading this module.
+    """
+
+
+class ProducerLayeringError(CacheKeyError):
+    """Raised when a producer module imports something the producer layer bans.
+
+    A producer is meant to be a pure calculation callable without a ``Simulator``. Importing the
+    component machinery is how it stops being one, and it is also what would make its fingerprint
+    swallow the package, so the two concerns share one refusal.
+    """
+
+
+class KeyMaterial:
+    """The marker that says whether a DTO field is part of the key or merely travels with it.
+
+    Spec §3.1: a producer that needs an upstream artifact gets its *key* as a plain string field and
+    the loaded payload in a second field that is excluded from hashing. Both are ordinary dataclass
+    fields; the only difference is this marker in the field's metadata, which :class:`CanonicalJson`
+    reads. A payload field is declared exactly as the spec writes it::
+
+        weather_artifact_key: str
+        weather_frame: pd.DataFrame = dataclasses.field(default=None, metadata=KeyMaterial.PAYLOAD)
+
+    The invariant that every payload field is paired with a key field identifying it is the producer
+    author's to keep; nothing here can check that the pairing is right, only that a payload stays out
+    of the key.
+    """
+
+    #: The metadata key under which a field says whether it is key material.
+    FLAG: ClassVar[str] = "key_material"
+
+    #: The metadata mapping that declares a payload field. Pass it as ``metadata=`` to
+    #: :func:`dataclasses.field`; unmarked fields are key material by default.
+    PAYLOAD: ClassVar[Mapping[str, bool]] = {"key_material": False}
+
+    @classmethod
+    def is_key_material(cls, field: "dataclasses.Field[Any]") -> bool:
+        """Says whether a field participates in the key. Unmarked fields do, by default.
+
+        Args:
+            field: the dataclass field to inspect.
+
+        Returns:
+            bool: False only for fields declared with :attr:`PAYLOAD` in their metadata.
+        """
+        return bool(field.metadata.get(cls.FLAG, True))
+
+
+class CanonicalJson:
+    """Turns a DTO into the one JSON string that stands for it, so equal inputs give equal keys.
+
+    The rules are the spec's: sorted keys, enums by value, and payload fields left out. Two things are
+    added because they were needed to make real DTOs serialisable at all: nested dataclasses are
+    rendered recursively under the same rules, and paths are rendered as strings. Anything else that
+    ``json`` cannot render is refused by name, because silently stringifying an unknown object would
+    let two different inputs share a key.
+    """
+
+    #: The ``json.dumps`` separators, spelled out so that the canonical form is fixed rather than
+    #: whatever the library's default happens to be.
+    SEPARATORS: ClassVar[Tuple[str, str]] = (",", ":")
+
+    @classmethod
+    def dumps(cls, dto: Any) -> str:
+        """Renders a DTO canonically.
+
+        Args:
+            dto: a dataclass instance -- the single parameter of a producer function.
+
+        Returns:
+            str: the canonical JSON.
+
+        Raises:
+            CacheKeyError: if the DTO is not a dataclass instance, or a field holds a value that has
+                no canonical rendering.
+        """
+        if not dataclasses.is_dataclass(dto) or isinstance(dto, type):
+            raise CacheKeyError(
+                f"A calculation DTO must be a dataclass instance; got {type(dto).__name__}. "
+                "Spec §3.1: every producer takes exactly one frozen dataclass."
+            )
+        return json.dumps(cls._render_dataclass(dto, ""), sort_keys=True, separators=cls.SEPARATORS)
+
+    @classmethod
+    def _render_dataclass(cls, dto: Any, path: str) -> Dict[str, Any]:
+        """Renders one dataclass instance, skipping payload fields.
+
+        Args:
+            dto: the instance.
+            path: the dotted path to it, for error messages.
+
+        Returns:
+            Dict[str, Any]: the rendered mapping.
+        """
+        rendered: Dict[str, Any] = {}
+        for field in dataclasses.fields(dto):
+            if not KeyMaterial.is_key_material(field):
+                continue
+            rendered[field.name] = cls._render(getattr(dto, field.name), f"{path}.{field.name}".lstrip("."))
+        return rendered
+
+    @classmethod
+    def _render(cls, value: Any, path: str) -> Any:
+        """Renders one value under the canonical rules.
+
+        Args:
+            value: the value.
+            path: the dotted path to it, for error messages.
+
+        Returns:
+            Any: something ``json.dumps`` can render deterministically.
+
+        Raises:
+            CacheKeyError: for a value with no canonical rendering.
+        """
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        if isinstance(value, enum.Enum):
+            return value.value
+        if isinstance(value, pathlib.PurePath):
+            return str(value)
+        if dataclasses.is_dataclass(value) and not isinstance(value, type):
+            return cls._render_dataclass(value, path)
+        if isinstance(value, (list, tuple)):
+            return [cls._render(item, f"{path}[{index}]") for index, item in enumerate(value)]
+        if isinstance(value, Mapping):
+            return {str(key): cls._render(item, f"{path}[{key!r}]") for key, item in value.items()}
+        raise CacheKeyError(
+            f"DTO field {path!r} holds a {type(value).__name__}, which has no canonical JSON form. "
+            "Spec §3.1: DTO fields are primitives, enums, lists, mappings, nested DTOs and artifact keys; "
+            "a payload that only travels with the key is declared with metadata=KeyMaterial.PAYLOAD."
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class ImportClosure:
+    """Everything a module imports, transitively within one package, found by reading source, not running it.
+
+    This is the object both fingerprints and the layering rule are computed from. It is built by
+    parsing each module's ``import`` statements and following the ones that stay inside the root
+    package; imports of anything else are recorded by their top-level name and not followed, because
+    a third-party package is identified by its version, not its source.
+
+    Modules are *located* with :func:`importlib.util.find_spec`, which imports parent packages to find
+    a child but never executes the child itself. That is as close to a purely static walk as Python
+    allows, and it is why the root package's ``__init__`` must stay cheap.
+    """
+
+    #: The package whose modules are followed, e.g. ``"hisim"``.
+    root_package: str
+
+    #: Every module of the root package in the closure, the starting module included, sorted.
+    package_modules: Tuple[str, ...]
+
+    #: The file each package module was read from, keyed by module name.
+    module_files: Mapping[str, str]
+
+    #: Top-level names of every import that leaves the root package, standard library excluded.
+    third_party_top_levels: Tuple[str, ...]
+
+    #: Descriptions of every dynamic-import call site found, empty for a well-behaved producer.
+    dynamic_import_sites: Tuple[str, ...]
+
+    class Calls:
+        """The dynamic-import spellings the walk looks for, which a static analysis cannot see through."""
+
+        NAMES: ClassVar[FrozenSet[str]] = frozenset({"__import__", "import_module"})
+
+    @classmethod
+    def of(cls, module: ModuleType, root_package: Optional[str] = None) -> "ImportClosure":
+        """Computes the closure of a module.
+
+        Args:
+            module: the starting module; it must have been loaded from a file.
+            root_package: the package whose modules are followed. Defaults to the top-level package of
+                ``module`` itself, which is ``hisim`` for every real producer; tests pass their own.
+
+        Returns:
+            ImportClosure: the closure.
+
+        Raises:
+            CacheKeyError: if the module has no source file to read.
+        """
+        name = module.__name__
+        root = root_package if root_package is not None else name.split(".")[0]
+        module_files: Dict[str, str] = {}
+        third_party: Set[str] = set()
+        dynamic: List[str] = []
+        pending = [name]
+        while pending:
+            current = pending.pop()
+            if current in module_files:
+                continue
+            source_path = cls._source_file(current)
+            module_files[current] = source_path
+            tree = ast.parse(pathlib.Path(source_path).read_text(encoding="utf-8"), filename=source_path)
+            for imported in cls._imported_names(tree, current):
+                if imported == root or imported.startswith(root + "."):
+                    pending.append(cls._module_or_owner(imported))
+                else:
+                    top_level = imported.split(".")[0]
+                    if top_level not in sys.stdlib_module_names:
+                        third_party.add(top_level)
+            dynamic.extend(cls._dynamic_import_sites(tree, current))
+        return cls(
+            root_package=root,
+            package_modules=tuple(sorted(module_files)),
+            module_files=dict(sorted(module_files.items())),
+            third_party_top_levels=tuple(sorted(third_party)),
+            dynamic_import_sites=tuple(dynamic),
+        )
+
+    @staticmethod
+    def _source_file(module_name: str) -> str:
+        """Locates a module's source file without executing the module.
+
+        Args:
+            module_name: the fully qualified name.
+
+        Returns:
+            str: the path of its ``.py`` file.
+
+        Raises:
+            CacheKeyError: if the module cannot be found or has no source file.
+        """
+        try:
+            spec = importlib.util.find_spec(module_name)
+        except (ImportError, ValueError) as error:
+            raise CacheKeyError(f"Cannot locate module {module_name!r} to fingerprint it: {error}") from error
+        if spec is None or not spec.origin or not spec.origin.endswith(".py"):
+            raise CacheKeyError(
+                f"Module {module_name!r} has no Python source file to fingerprint; a producer and everything "
+                "it imports from its own package must be ordinary .py modules."
+            )
+        return spec.origin
+
+    @classmethod
+    def _module_or_owner(cls, imported: str) -> str:
+        """Resolves ``from pkg import name`` where ``name`` may be a submodule or an attribute.
+
+        Args:
+            imported: the fully qualified name as the import statement spells it.
+
+        Returns:
+            str: ``imported`` if it is a module, otherwise the package it is an attribute of.
+        """
+        try:
+            if importlib.util.find_spec(imported) is not None:
+                return imported
+        except (ImportError, ValueError):
+            pass
+        return imported.rsplit(".", 1)[0] if "." in imported else imported
+
+    @staticmethod
+    def _imported_names(tree: ast.AST, module_name: str) -> Iterator[str]:
+        """Yields the fully qualified name of every import statement in a module.
+
+        Relative imports are resolved against the importing module's package, so a producer may use
+        ``from . import helpers`` and still be followed.
+
+        Args:
+            tree: the parsed module.
+            module_name: the importing module, for resolving relative imports.
+
+        Yields:
+            str: one fully qualified name per imported module or attribute.
+        """
+        package_parts = module_name.split(".")[:-1]
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    yield alias.name
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:
+                    base_parts = package_parts[: len(package_parts) - (node.level - 1)] if node.level > 1 else package_parts
+                    base = ".".join(base_parts)
+                    base = f"{base}.{node.module}" if node.module else base
+                else:
+                    base = node.module or ""
+                for alias in node.names:
+                    yield f"{base}.{alias.name}" if base else alias.name
+
+    @classmethod
+    def _dynamic_import_sites(cls, tree: ast.AST, module_name: str) -> Iterator[str]:
+        """Yields a description of every call that imports by name at run time.
+
+        Args:
+            tree: the parsed module.
+            module_name: the module, for the description.
+
+        Yields:
+            str: ``module:line`` for each ``__import__`` or ``import_module`` call.
+        """
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            callee = node.func
+            called = callee.id if isinstance(callee, ast.Name) else callee.attr if isinstance(callee, ast.Attribute) else ""
+            if called in cls.Calls.NAMES:
+                yield f"{module_name}:{node.lineno}"
+
+
+class ProducerLayering:
+    """The rule a producer module and its closure must obey, and the check that enforces it.
+
+    A producer is a pure calculation: callable without a ``Simulator``, importing numpy, pandas,
+    pvlib and config dataclasses, never the component base class, the simulator or a repository. The
+    rule has a cache cost as well as a design reason -- every module in the closure is fingerprinted, so
+    importing a frequently edited module invalidates all of a producer's artifacts on every edit to it.
+    Dynamic imports are banned outright because the closure walk cannot see through them, and a
+    dependency it cannot see is a stale entry it cannot prevent.
+    """
+
+    #: Module prefixes a producer's closure may not contain.
+    FORBIDDEN_PREFIXES: ClassVar[Tuple[str, ...]] = (
+        "hisim.component",
+        "hisim.dynamic_component",
+        "hisim.simulator",
+        "hisim.sim_repository",
+        "hisim.sim_repository_singleton",
+        "hisim.postprocessing",
+    )
+
+    @classmethod
+    def violations(cls, closure: ImportClosure) -> Tuple[str, ...]:
+        """Lists every way a closure breaks the rule, empty for a compliant producer.
+
+        Args:
+            closure: the producer's import closure.
+
+        Returns:
+            Tuple[str, ...]: one sentence per violation.
+        """
+        found: List[str] = []
+        for module_name in closure.package_modules:
+            if any(module_name == prefix or module_name.startswith(prefix + ".") for prefix in cls.FORBIDDEN_PREFIXES):
+                found.append(f"imports {module_name}, which is component or simulator machinery")
+        for site in closure.dynamic_import_sites:
+            found.append(f"imports dynamically at {site}, which the closure walk cannot follow")
+        return tuple(found)
+
+    @classmethod
+    def check(cls, closure: ImportClosure) -> None:
+        """Raises if the closure breaks the rule.
+
+        Args:
+            closure: the producer's import closure.
+
+        Raises:
+            ProducerLayeringError: naming every violation at once, so they are fixed in one pass.
+        """
+        violations = cls.violations(closure)
+        if violations:
+            listed = "\n  - ".join(violations)
+            raise ProducerLayeringError(
+                f"The producer {closure.package_modules[0] if closure.package_modules else '?'} breaks the producer "
+                f"layering rule:\n  - {listed}\nA producer is a pure calculation; pass plain values through its DTO instead."
+            )
+
+
+class Fingerprints:
+    """The two automatic fingerprints of spec §3, computed from an :class:`ImportClosure`.
+
+    Both are deterministic functions of the closure alone. Neither includes the repository commit,
+    deliberately: a commit changes on every edit anywhere, and keying on it would make every cache
+    entry disposable on every push. The commit travels as metadata beside the entry instead.
+    """
+
+    #: What the standard library contributes to the third-party fingerprint: the interpreter's
+    #: major.minor, because that is what decides its behaviour, and nothing finer.
+    PYTHON_LABEL: ClassVar[str] = "python"
+
+    @staticmethod
+    def code(closure: ImportClosure) -> str:
+        """Hashes the source of every package module in the closure.
+
+        Args:
+            closure: the producer's import closure.
+
+        Returns:
+            str: a sha256 hex digest over the sorted (module name, source) pairs.
+        """
+        digest = hashlib.sha256()
+        for module_name in closure.package_modules:
+            digest.update(module_name.encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(pathlib.Path(closure.module_files[module_name]).read_bytes())
+            digest.update(b"\0")
+        return digest.hexdigest()
+
+    @classmethod
+    def third_party(cls, closure: ImportClosure) -> str:
+        """Lists ``name==version`` for every third-party distribution the closure imports.
+
+        Deliberately not a hash of the whole installed environment: the cluster, the CI container and
+        the RenoVisor image never have identical dependency sets, and hashing all of them would reduce
+        cross-environment cache hits to zero. Only what the calculation imports counts.
+
+        Args:
+            closure: the producer's import closure.
+
+        Returns:
+            str: the sorted, semicolon-separated pins, led by the interpreter version.
+        """
+        distributions = importlib.metadata.packages_distributions()
+        pins: Set[str] = {f"{cls.PYTHON_LABEL}=={sys.version_info.major}.{sys.version_info.minor}"}
+        for top_level in closure.third_party_top_levels:
+            for distribution_name in distributions.get(top_level, [top_level]):
+                try:
+                    pins.add(f"{distribution_name}=={importlib.metadata.version(distribution_name)}")
+                except importlib.metadata.PackageNotFoundError:
+                    pins.add(f"{distribution_name}==unknown")
+        return ";".join(sorted(pins))
+
+
+@dataclasses.dataclass(frozen=True)
+class CacheKey:
+    """A cache key under the spec §3 scheme: four parts, one digest.
+
+    The parts are kept rather than only the digest because the metadata file beside each entry
+    records the raw material, and a person reading it should be able to see which producer, which
+    code, which libraries and which inputs an entry came from.
+    """
+
+    #: A short name for the producer, e.g. ``"pv_series"``. Also the filename prefix.
+    artifact_kind: str
+
+    #: :meth:`Fingerprints.code` of the producer's closure.
+    code_fingerprint: str
+
+    #: :meth:`Fingerprints.third_party` of the producer's closure.
+    third_party_fingerprint: str
+
+    #: :meth:`CanonicalJson.dumps` of the calculation's DTO.
+    dto_json: str
+
+    #: What an artifact kind may look like: a filename and URL segment with no surprises.
+    KIND_PATTERN: ClassVar["re.Pattern[str]"] = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+    #: The separator between the four parts of the material.
+    SEPARATOR: ClassVar[str] = ":"
+
+    def __post_init__(self) -> None:
+        """Refuses an artifact kind that could not serve as a path segment.
+
+        Raises:
+            CacheKeyError: if the kind is empty or contains characters outside the pattern.
+        """
+        if not self.KIND_PATTERN.match(self.artifact_kind):
+            raise CacheKeyError(
+                f"Artifact kind {self.artifact_kind!r} is not usable as a filename and URL segment; use letters, "
+                "digits, underscores and hyphens, starting with a letter or digit."
+            )
+
+    @classmethod
+    def for_producer(cls, artifact_kind: str, producer_module: ModuleType, dto: Any) -> "CacheKey":
+        """Builds the key for one calculation, checking the producer's layering on the way.
+
+        Args:
+            artifact_kind: the producer's short name.
+            producer_module: the module holding the producer function and its DTO class.
+            dto: the calculation's inputs.
+
+        Returns:
+            CacheKey: the key.
+
+        Raises:
+            ProducerLayeringError: if the producer module imports what a producer may not.
+            CacheKeyError: if the DTO or the kind cannot be rendered.
+        """
+        closure = ImportClosure.of(producer_module)
+        ProducerLayering.check(closure)
+        return cls(
+            artifact_kind=artifact_kind,
+            code_fingerprint=Fingerprints.code(closure),
+            third_party_fingerprint=Fingerprints.third_party(closure),
+            dto_json=CanonicalJson.dumps(dto),
+        )
+
+    @property
+    def material(self) -> str:
+        """The string the digest is taken from, and what the entry's metadata file records verbatim.
+
+        Returns:
+            str: the four parts joined by :attr:`SEPARATOR`.
+        """
+        return self.SEPARATOR.join(
+            (self.artifact_kind, self.code_fingerprint, self.third_party_fingerprint, self.dto_json)
+        )
+
+    @property
+    def digest(self) -> str:
+        """The sha256 hex digest of :attr:`material`; the ``{sha}`` of the remote key and the local filename.
+
+        Returns:
+            str: the digest.
+        """
+        return hashlib.sha256(self.material.encode("utf-8")).hexdigest()

--- a/hisim/caching/keys.py
+++ b/hisim/caching/keys.py
@@ -1,28 +1,23 @@
-"""What goes into a cache key, and how it is derived from a producer and its inputs without anyone declaring it.
+"""Cache keys under the cache-service scheme: what goes into one and how it is derived.
 
-``roadmap/cache_service_spec.md`` §3 extends the key from ``sha256(config_json + simulation_key)`` to
+``roadmap/cache_service_spec.md`` §3 defines the key as
 
     sha256( artifact_kind : code_fingerprint : third_party_fingerprint : dto_json )
 
-so that a key describes the *inputs* of a calculation rather than the *owner* of its result. The
-first part names the producer. The second changes whenever code that can influence the calculation
-changes and stays put when only component plumbing does. The third pins the third-party packages
-the calculation runs on, by version. The last is the canonical JSON of the calculation's own inputs,
-the DTO of §3.1. Two calculations with the same key are the same calculation, on the same code, on
-the same libraries, from the same inputs -- which is what lets a cache be shared between a laptop,
-a cluster and a container without anyone worrying about whose entry they are reading.
+``artifact_kind`` names the producer (for example ``pv_series``). ``code_fingerprint`` is a hash of the
+producer module's source and of every HiSim module it imports, so a change to code that can affect the
+result changes the key. ``third_party_fingerprint`` pins the third-party packages the producer imports,
+by version. ``dto_json`` is the canonical JSON of the calculation's inputs (the DTO). Two calculations with
+the same key ran the same code on the same libraries with the same inputs, which is what allows one
+cache to be shared between a laptop, a cluster and a container.
 
-The two fingerprints are **fully automatic**: nothing is declared, they are read off the producer
-module's import statements. That is only sound because producer modules live under the layering rule
-:class:`ProducerLayering` enforces -- no dynamic imports, which an AST walk cannot see, and no imports
-of the component or simulator machinery, which would drag most of the package into the closure and turn
-the fingerprint into a commit hash. The rule and the fingerprint are two uses of the same
-:class:`ImportClosure`, so they cannot disagree about what a producer depends on.
+The fingerprints need no declarations: they are read from the module's ``import`` statements
+(:class:`ImportClosure`). That works only if producer modules follow :class:`ProducerLayering` -- no
+dynamic imports, and no imports of the component or simulator machinery, which would pull most of the
+package into the closure.
 
-The legacy key scheme is not here. ``hisim.utils.build_cache_key_string`` keeps producing it for
-components that have not yet been given a producer, and the two coexist until the last extraction lands.
-This module imports the standard library only, so that it stays importable from anywhere in HiSim
-without pulling in the simulation.
+No component uses this scheme yet. ``hisim.utils.build_cache_key_string`` produces the legacy key until
+each producer is extracted. This module imports the standard library only.
 """
 
 # clean
@@ -50,36 +45,27 @@ __status__ = "development"
 
 
 class CacheKeyError(ValueError):
-    """Raised when a cache key cannot be built from what was given.
-
-    Every message names the thing that was wrong -- the artifact kind, the DTO field, the module -- so
-    the producer author can fix it without reading this module.
-    """
+    """Raised when a cache key cannot be built. The message names the offending kind, field or module."""
 
 
 class ProducerLayeringError(CacheKeyError):
-    """Raised when a producer module imports something the producer layer bans.
+    """Raised when a producer module imports something the producer layer forbids.
 
-    A producer is meant to be a pure calculation callable without a ``Simulator``. Importing the
-    component machinery is how it stops being one, and it is also what would make its fingerprint
-    swallow the package, so the two concerns share one refusal.
+    See :class:`ProducerLayering` for the rule and the reason.
     """
 
 
 class KeyMaterial:
-    """The marker that says whether a DTO field is part of the key or merely travels with it.
+    """Marks a DTO field as a payload that travels with the key but is not part of it.
 
-    Spec §3.1: a producer that needs an upstream artifact gets its *key* as a plain string field and
-    the loaded payload in a second field that is excluded from hashing. Both are ordinary dataclass
-    fields; the only difference is this marker in the field's metadata, which :class:`CanonicalJson`
-    reads. A payload field is declared exactly as the spec writes it::
+    A producer that needs an upstream artifact takes its key as a string field and the loaded data as a
+    second field excluded from hashing (spec §3.1). Declare the second field like this::
 
         weather_artifact_key: str
         weather_frame: pd.DataFrame = dataclasses.field(default=None, metadata=KeyMaterial.PAYLOAD)
 
-    The invariant that every payload field is paired with a key field identifying it is the producer
-    author's to keep; nothing here can check that the pairing is right, only that a payload stays out
-    of the key.
+    :class:`CanonicalJson` skips fields marked this way. Pairing every payload field with a key field is
+    the author's responsibility.
     """
 
     #: The metadata key under which a field says whether it is key material.
@@ -91,25 +77,23 @@ class KeyMaterial:
 
     @classmethod
     def is_key_material(cls, field: "dataclasses.Field[Any]") -> bool:
-        """Says whether a field participates in the key. Unmarked fields do, by default.
+        """Return True unless the field is marked as payload.
 
         Args:
-            field: the dataclass field to inspect.
+            field: the dataclass field.
 
         Returns:
-            bool: False only for fields declared with :attr:`PAYLOAD` in their metadata.
+            bool: False only for fields declared with :attr:`PAYLOAD`.
         """
         return bool(field.metadata.get(cls.FLAG, True))
 
 
 class CanonicalJson:
-    """Turns a DTO into the one JSON string that stands for it, so equal inputs give equal keys.
+    """Renders a DTO as the one JSON string that represents it, so equal inputs give equal keys.
 
-    The rules are the spec's: sorted keys, enums by value, and payload fields left out. Two things are
-    added because they were needed to make real DTOs serialisable at all: nested dataclasses are
-    rendered recursively under the same rules, and paths are rendered as strings. Anything else that
-    ``json`` cannot render is refused by name, because silently stringifying an unknown object would
-    let two different inputs share a key.
+    Rules: keys sorted, enums by value, payload fields omitted, nested dataclasses rendered recursively,
+    paths as strings. Any other value is refused with the field's name, because stringifying an unknown
+    object could give two different inputs the same key.
     """
 
     #: The ``json.dumps`` separators, spelled out so that the canonical form is fixed rather than
@@ -118,17 +102,16 @@ class CanonicalJson:
 
     @classmethod
     def dumps(cls, dto: Any) -> str:
-        """Renders a DTO canonically.
+        """Render a DTO canonically.
 
         Args:
-            dto: a dataclass instance -- the single parameter of a producer function.
+            dto: a dataclass instance, the single argument of a producer function.
 
         Returns:
             str: the canonical JSON.
 
         Raises:
-            CacheKeyError: if the DTO is not a dataclass instance, or a field holds a value that has
-                no canonical rendering.
+            CacheKeyError: if ``dto`` is not a dataclass instance, or a field holds a value with no canonical form.
         """
         if not dataclasses.is_dataclass(dto) or isinstance(dto, type):
             raise CacheKeyError(
@@ -139,11 +122,11 @@ class CanonicalJson:
 
     @classmethod
     def _render_dataclass(cls, dto: Any, path: str) -> Dict[str, Any]:
-        """Renders one dataclass instance, skipping payload fields.
+        """Render one dataclass instance, skipping payload fields.
 
         Args:
             dto: the instance.
-            path: the dotted path to it, for error messages.
+            path: dotted path to it, for error messages.
 
         Returns:
             Dict[str, Any]: the rendered mapping.
@@ -157,17 +140,17 @@ class CanonicalJson:
 
     @classmethod
     def _render(cls, value: Any, path: str) -> Any:
-        """Renders one value under the canonical rules.
+        """Render one value under the canonical rules.
 
         Args:
             value: the value.
-            path: the dotted path to it, for error messages.
+            path: dotted path to it, for error messages.
 
         Returns:
-            Any: something ``json.dumps`` can render deterministically.
+            Any: a value ``json.dumps`` renders deterministically.
 
         Raises:
-            CacheKeyError: for a value with no canonical rendering.
+            CacheKeyError: for a value with no canonical form.
         """
         if value is None or isinstance(value, (bool, int, float, str)):
             return value
@@ -190,16 +173,12 @@ class CanonicalJson:
 
 @dataclasses.dataclass(frozen=True)
 class ImportClosure:
-    """Everything a module imports, transitively within one package, found by reading source, not running it.
+    """Everything a module imports, followed transitively within one package, found by reading source.
 
-    This is the object both fingerprints and the layering rule are computed from. It is built by
-    parsing each module's ``import`` statements and following the ones that stay inside the root
-    package; imports of anything else are recorded by their top-level name and not followed, because
-    a third-party package is identified by its version, not its source.
-
-    Modules are *located* with :func:`importlib.util.find_spec`, which imports parent packages to find
-    a child but never executes the child itself. That is as close to a purely static walk as Python
-    allows, and it is why the root package's ``__init__`` must stay cheap.
+    Both fingerprints and the layering check are computed from this. Modules of the root package are
+    followed and their files recorded; imports of anything else are recorded by top-level name only,
+    since a third-party package is identified by its version, not its source. Modules are located with
+    :func:`importlib.util.find_spec`, which imports parent packages but not the module itself.
     """
 
     #: The package whose modules are followed, e.g. ``"hisim"``.
@@ -218,24 +197,24 @@ class ImportClosure:
     dynamic_import_sites: Tuple[str, ...]
 
     class Calls:
-        """The dynamic-import spellings the walk looks for, which a static analysis cannot see through."""
+        """Function names that import a module at run time. A static walk cannot see through them."""
 
         NAMES: ClassVar[FrozenSet[str]] = frozenset({"__import__", "import_module"})
 
     @classmethod
     def of(cls, module: ModuleType, root_package: Optional[str] = None) -> "ImportClosure":
-        """Computes the closure of a module.
+        """Compute the closure of a module.
 
         Args:
-            module: the starting module; it must have been loaded from a file.
-            root_package: the package whose modules are followed. Defaults to the top-level package of
-                ``module`` itself, which is ``hisim`` for every real producer; tests pass their own.
+            module: the starting module; it must have been loaded from a ``.py`` file.
+            root_package: the package whose modules are followed. Defaults to the module's top-level package
+                (``hisim`` for every real producer); tests pass their own.
 
         Returns:
             ImportClosure: the closure.
 
         Raises:
-            CacheKeyError: if the module has no source file to read.
+            CacheKeyError: if a module in the closure has no source file.
         """
         name = module.__name__
         root = root_package if root_package is not None else name.split(".")[0]
@@ -268,7 +247,7 @@ class ImportClosure:
 
     @staticmethod
     def _source_file(module_name: str) -> str:
-        """Locates a module's source file without executing the module.
+        """Locate a module's source file without executing the module.
 
         Args:
             module_name: the fully qualified name.
@@ -292,10 +271,10 @@ class ImportClosure:
 
     @classmethod
     def _module_or_owner(cls, imported: str) -> str:
-        """Resolves ``from pkg import name`` where ``name`` may be a submodule or an attribute.
+        """Resolve ``from pkg import name``, where ``name`` may be a submodule or an attribute.
 
         Args:
-            imported: the fully qualified name as the import statement spells it.
+            imported: the fully qualified name as written in the import.
 
         Returns:
             str: ``imported`` if it is a module, otherwise the package it is an attribute of.
@@ -309,17 +288,14 @@ class ImportClosure:
 
     @staticmethod
     def _imported_names(tree: ast.AST, module_name: str) -> Iterator[str]:
-        """Yields the fully qualified name of every import statement in a module.
-
-        Relative imports are resolved against the importing module's package, so a producer may use
-        ``from . import helpers`` and still be followed.
+        """Yield the fully qualified name of every import in a module, relative imports resolved.
 
         Args:
             tree: the parsed module.
-            module_name: the importing module, for resolving relative imports.
+            module_name: the importing module, used to resolve relative imports.
 
         Yields:
-            str: one fully qualified name per imported module or attribute.
+            str: one name per imported module or attribute.
         """
         package_parts = module_name.split(".")[:-1]
         for node in ast.walk(tree):
@@ -338,14 +314,14 @@ class ImportClosure:
 
     @classmethod
     def _dynamic_import_sites(cls, tree: ast.AST, module_name: str) -> Iterator[str]:
-        """Yields a description of every call that imports by name at run time.
+        """Yield ``module:line`` for every ``__import__`` or ``import_module`` call.
 
         Args:
             tree: the parsed module.
-            module_name: the module, for the description.
+            module_name: the module name, for the description.
 
         Yields:
-            str: ``module:line`` for each ``__import__`` or ``import_module`` call.
+            str: one entry per call site.
         """
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
@@ -357,14 +333,13 @@ class ImportClosure:
 
 
 class ProducerLayering:
-    """The rule a producer module and its closure must obey, and the check that enforces it.
+    """The import rule for producer modules, and the check that enforces it.
 
-    A producer is a pure calculation: callable without a ``Simulator``, importing numpy, pandas,
-    pvlib and config dataclasses, never the component base class, the simulator or a repository. The
-    rule has a cache cost as well as a design reason -- every module in the closure is fingerprinted, so
-    importing a frequently edited module invalidates all of a producer's artifacts on every edit to it.
-    Dynamic imports are banned outright because the closure walk cannot see through them, and a
-    dependency it cannot see is a stale entry it cannot prevent.
+    A producer is a pure calculation. It may import numpy, pandas, pvlib and config dataclasses; it may
+    not import the component base class, the simulator or a repository, and it may not import dynamically.
+    Two reasons: a producer must stay callable without a ``Simulator``, and every module in its closure is
+    fingerprinted, so importing a frequently edited module would invalidate all of its cache entries on
+    every edit. Dynamic imports are forbidden because the closure walk cannot see them.
     """
 
     #: Module prefixes a producer's closure may not contain.
@@ -379,13 +354,13 @@ class ProducerLayering:
 
     @classmethod
     def violations(cls, closure: ImportClosure) -> Tuple[str, ...]:
-        """Lists every way a closure breaks the rule, empty for a compliant producer.
+        """Return one sentence per rule violation; empty for a compliant producer.
 
         Args:
             closure: the producer's import closure.
 
         Returns:
-            Tuple[str, ...]: one sentence per violation.
+            Tuple[str, ...]: the violations.
         """
         found: List[str] = []
         for module_name in closure.package_modules:
@@ -397,13 +372,13 @@ class ProducerLayering:
 
     @classmethod
     def check(cls, closure: ImportClosure) -> None:
-        """Raises if the closure breaks the rule.
+        """Raise if the closure violates the rule.
 
         Args:
             closure: the producer's import closure.
 
         Raises:
-            ProducerLayeringError: naming every violation at once, so they are fixed in one pass.
+            ProducerLayeringError: listing every violation at once.
         """
         violations = cls.violations(closure)
         if violations:
@@ -417,9 +392,8 @@ class ProducerLayering:
 class Fingerprints:
     """The two automatic fingerprints of spec §3, computed from an :class:`ImportClosure`.
 
-    Both are deterministic functions of the closure alone. Neither includes the repository commit,
-    deliberately: a commit changes on every edit anywhere, and keying on it would make every cache
-    entry disposable on every push. The commit travels as metadata beside the entry instead.
+    Neither includes the repository commit: a commit changes on every edit anywhere and would make every
+    entry disposable on every push. The commit is stored as metadata beside the entry instead.
     """
 
     #: What the standard library contributes to the third-party fingerprint: the interpreter's
@@ -428,7 +402,7 @@ class Fingerprints:
 
     @staticmethod
     def code(closure: ImportClosure) -> str:
-        """Hashes the source of every package module in the closure.
+        """Hash the source of every package module in the closure.
 
         Args:
             closure: the producer's import closure.
@@ -446,17 +420,17 @@ class Fingerprints:
 
     @classmethod
     def third_party(cls, closure: ImportClosure) -> str:
-        """Lists ``name==version`` for every third-party distribution the closure imports.
+        """List ``name==version`` for every third-party distribution in the closure, plus the Python version.
 
-        Deliberately not a hash of the whole installed environment: the cluster, the CI container and
-        the RenoVisor image never have identical dependency sets, and hashing all of them would reduce
-        cross-environment cache hits to zero. Only what the calculation imports counts.
+        Only what the producer imports is pinned, not the whole environment: the cluster, the CI container and
+        the RenoVisor image never have identical dependency sets, and pinning everything would prevent any
+        cross-environment cache hit.
 
         Args:
             closure: the producer's import closure.
 
         Returns:
-            str: the sorted, semicolon-separated pins, led by the interpreter version.
+            str: the sorted pins, separated by semicolons.
         """
         distributions = importlib.metadata.packages_distributions()
         pins: Set[str] = {f"{cls.PYTHON_LABEL}=={sys.version_info.major}.{sys.version_info.minor}"}
@@ -471,11 +445,10 @@ class Fingerprints:
 
 @dataclasses.dataclass(frozen=True)
 class CacheKey:
-    """A cache key under the spec §3 scheme: four parts, one digest.
+    """A cache key under spec §3: four parts and their digest.
 
-    The parts are kept rather than only the digest because the metadata file beside each entry
-    records the raw material, and a person reading it should be able to see which producer, which
-    code, which libraries and which inputs an entry came from.
+    The parts are kept, not only the digest, because the ``.meta`` file beside an entry records the raw
+    material and a reader should be able to see which producer, code, libraries and inputs it came from.
     """
 
     #: A short name for the producer, e.g. ``"pv_series"``. Also the filename prefix.
@@ -497,10 +470,10 @@ class CacheKey:
     SEPARATOR: ClassVar[str] = ":"
 
     def __post_init__(self) -> None:
-        """Refuses an artifact kind that could not serve as a path segment.
+        """Refuse an artifact kind that cannot serve as a filename and URL segment.
 
         Raises:
-            CacheKeyError: if the kind is empty or contains characters outside the pattern.
+            CacheKeyError: if the kind is empty or contains other characters than letters, digits, ``_`` and ``-``.
         """
         if not self.KIND_PATTERN.match(self.artifact_kind):
             raise CacheKeyError(
@@ -510,10 +483,10 @@ class CacheKey:
 
     @classmethod
     def for_producer(cls, artifact_kind: str, producer_module: ModuleType, dto: Any) -> "CacheKey":
-        """Builds the key for one calculation, checking the producer's layering on the way.
+        """Build the key for one calculation, checking the producer's layering first.
 
         Args:
-            artifact_kind: the producer's short name.
+            artifact_kind: the producer's short name, for example ``pv_series``.
             producer_module: the module holding the producer function and its DTO class.
             dto: the calculation's inputs.
 
@@ -521,8 +494,8 @@ class CacheKey:
             CacheKey: the key.
 
         Raises:
-            ProducerLayeringError: if the producer module imports what a producer may not.
-            CacheKeyError: if the DTO or the kind cannot be rendered.
+            ProducerLayeringError: if the producer module violates the layering rule.
+            CacheKeyError: if the kind or the DTO cannot be rendered.
         """
         closure = ImportClosure.of(producer_module)
         ProducerLayering.check(closure)
@@ -535,7 +508,7 @@ class CacheKey:
 
     @property
     def material(self) -> str:
-        """The string the digest is taken from, and what the entry's metadata file records verbatim.
+        """The string the digest is computed from; also what the entry's ``.meta`` file records.
 
         Returns:
             str: the four parts joined by :attr:`SEPARATOR`.
@@ -546,7 +519,7 @@ class CacheKey:
 
     @property
     def digest(self) -> str:
-        """The sha256 hex digest of :attr:`material`; the ``{sha}`` of the remote key and the local filename.
+        """The sha256 hex digest of :attr:`material`: the ``{sha}`` in the remote key and the local filename.
 
         Returns:
             str: the digest.

--- a/hisim/caching/keys.py
+++ b/hisim/caching/keys.py
@@ -29,6 +29,7 @@ import hashlib
 import importlib.metadata
 import importlib.util
 import json
+import math
 import pathlib
 import re
 import sys
@@ -93,7 +94,9 @@ class CanonicalJson:
 
     Rules: keys sorted, enums by value, payload fields omitted, nested dataclasses rendered recursively,
     paths as strings. Any other value is refused with the field's name, because stringifying an unknown
-    object could give two different inputs the same key.
+    object could give two different inputs the same key. For the same reason mapping keys must be
+    strings (coercing them would collapse ``1`` and ``"1"`` into one key) and floats must be finite
+    (every NaN would render as the same ``NaN``, which is not JSON either).
     """
 
     #: The ``json.dumps`` separators, spelled out so that the canonical form is fixed rather than
@@ -152,6 +155,11 @@ class CanonicalJson:
         Raises:
             CacheKeyError: for a value with no canonical form.
         """
+        if isinstance(value, float) and not math.isfinite(value):
+            raise CacheKeyError(
+                f"DTO field {path!r} holds the non-finite float {value!r}, which has no canonical JSON form: "
+                "every NaN would render identically and give different inputs the same key."
+            )
         if value is None or isinstance(value, (bool, int, float, str)):
             return value
         if isinstance(value, enum.Enum):
@@ -163,7 +171,14 @@ class CanonicalJson:
         if isinstance(value, (list, tuple)):
             return [cls._render(item, f"{path}[{index}]") for index, item in enumerate(value)]
         if isinstance(value, Mapping):
-            return {str(key): cls._render(item, f"{path}[{key!r}]") for key, item in value.items()}
+            for key in value:
+                if not isinstance(key, str):
+                    raise CacheKeyError(
+                        f"DTO field {path!r} holds a mapping with the non-string key {key!r}; coercing it to "
+                        "a string would let two different inputs (say the int 1 and the string '1') share "
+                        "one cache key, so mapping keys must be strings."
+                    )
+            return {key: cls._render(item, f"{path}[{key!r}]") for key, item in value.items()}
         raise CacheKeyError(
             f"DTO field {path!r} holds a {type(value).__name__}, which has no canonical JSON form. "
             "Spec §3.1: DTO fields are primitives, enums, lists, mappings, nested DTOs and artifact keys; "
@@ -183,6 +198,9 @@ class ImportClosure:
 
     #: The package whose modules are followed, e.g. ``"hisim"``.
     root_package: str
+
+    #: The module the walk started from -- the producer itself, named in error messages.
+    entry_module: str
 
     #: Every module of the root package in the closure, the starting module included, sorted.
     package_modules: Tuple[str, ...]
@@ -229,7 +247,8 @@ class ImportClosure:
             source_path = cls._source_file(current)
             module_files[current] = source_path
             tree = ast.parse(pathlib.Path(source_path).read_text(encoding="utf-8"), filename=source_path)
-            for imported in cls._imported_names(tree, current):
+            is_package = pathlib.Path(source_path).name == "__init__.py"
+            for imported in cls._imported_names(tree, current, is_package):
                 if imported == root or imported.startswith(root + "."):
                     pending.append(cls._module_or_owner(imported))
                 else:
@@ -239,6 +258,7 @@ class ImportClosure:
             dynamic.extend(cls._dynamic_import_sites(tree, current))
         return cls(
             root_package=root,
+            entry_module=name,
             package_modules=tuple(sorted(module_files)),
             module_files=dict(sorted(module_files.items())),
             third_party_top_levels=tuple(sorted(third_party)),
@@ -287,17 +307,21 @@ class ImportClosure:
         return imported.rsplit(".", 1)[0] if "." in imported else imported
 
     @staticmethod
-    def _imported_names(tree: ast.AST, module_name: str) -> Iterator[str]:
+    def _imported_names(tree: ast.AST, module_name: str, is_package: bool) -> Iterator[str]:
         """Yield the fully qualified name of every import in a module, relative imports resolved.
 
         Args:
             tree: the parsed module.
             module_name: the importing module, used to resolve relative imports.
+            is_package: whether the module is a package's ``__init__``. A relative import in a package
+                resolves against the package itself; in a plain module it resolves against the parent
+                package. Without this distinction, ``from . import sub`` in the root ``__init__`` would
+                lose the root prefix and misfile ``sub`` as a third-party name.
 
         Yields:
             str: one name per imported module or attribute.
         """
-        package_parts = module_name.split(".")[:-1]
+        package_parts = module_name.split(".") if is_package else module_name.split(".")[:-1]
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for alias in node.names:
@@ -316,6 +340,10 @@ class ImportClosure:
     def _dynamic_import_sites(cls, tree: ast.AST, module_name: str) -> Iterator[str]:
         """Yield ``module:line`` for every ``__import__`` or ``import_module`` call.
 
+        A bare name matches either spelling (``import_module`` may arrive via ``from importlib
+        import import_module``). The attribute form counts only on the ``importlib`` module itself,
+        so an unrelated object that happens to have an ``import_module`` method is not a violation.
+
         Args:
             tree: the parsed module.
             module_name: the module name, for the description.
@@ -327,7 +355,16 @@ class ImportClosure:
             if not isinstance(node, ast.Call):
                 continue
             callee = node.func
-            called = callee.id if isinstance(callee, ast.Name) else callee.attr if isinstance(callee, ast.Attribute) else ""
+            if isinstance(callee, ast.Name):
+                called = callee.id
+            elif (
+                isinstance(callee, ast.Attribute)
+                and isinstance(callee.value, ast.Name)
+                and callee.value.id == "importlib"
+            ):
+                called = callee.attr
+            else:
+                called = ""
             if called in cls.Calls.NAMES:
                 yield f"{module_name}:{node.lineno}"
 
@@ -384,7 +421,7 @@ class ProducerLayering:
         if violations:
             listed = "\n  - ".join(violations)
             raise ProducerLayeringError(
-                f"The producer {closure.package_modules[0] if closure.package_modules else '?'} breaks the producer "
+                f"The producer {closure.entry_module} breaks the producer "
                 f"layering rule:\n  - {listed}\nA producer is a pure calculation; pass plain values through its DTO instead."
             )
 
@@ -431,6 +468,11 @@ class Fingerprints:
 
         Returns:
             str: the sorted pins, separated by semicolons.
+
+        Raises:
+            CacheKeyError: if a dependency's version cannot be resolved. A pin like ``name==unknown``
+                would let two environments running different code for that package share cache
+                entries, which is the failure the fingerprint exists to prevent.
         """
         distributions = importlib.metadata.packages_distributions()
         pins: Set[str] = {f"{cls.PYTHON_LABEL}=={sys.version_info.major}.{sys.version_info.minor}"}
@@ -438,8 +480,13 @@ class Fingerprints:
             for distribution_name in distributions.get(top_level, [top_level]):
                 try:
                     pins.add(f"{distribution_name}=={importlib.metadata.version(distribution_name)}")
-                except importlib.metadata.PackageNotFoundError:
-                    pins.add(f"{distribution_name}==unknown")
+                except importlib.metadata.PackageNotFoundError as error:
+                    raise CacheKeyError(
+                        f"The producer {closure.entry_module} imports {top_level!r}, but no version can be "
+                        f"resolved for the distribution {distribution_name!r}, so the third-party fingerprint "
+                        "cannot vouch for the code that runs. Install the package with metadata, or drop the "
+                        "import from the producer."
+                    ) from error
         return ";".join(sorted(pins))
 
 
@@ -520,6 +567,11 @@ class CacheKey:
     @property
     def digest(self) -> str:
         """The sha256 hex digest of :attr:`material`: the ``{sha}`` in the remote key and the local filename.
+
+        The expression is the same as :meth:`hisim.caching.local.CacheEntryMetadata.hash_of` and must
+        stay the same, or a new-scheme key would not match the filename the local tier derives for it.
+        It is spelled out here rather than imported because this module deliberately imports the
+        standard library only.
 
         Returns:
             str: the digest.

--- a/hisim/caching/local.py
+++ b/hisim/caching/local.py
@@ -61,12 +61,18 @@ class CacheEntryMetadata:
 
     SUFFIX: ClassVar[str] = ".meta"
 
+    #: The extension of the data file beside the metadata. The one definition; the client's filenames
+    #: and the parsing below both use it.
+    DATA_SUFFIX: ClassVar[str] = ".cache"
+
     @staticmethod
     def hash_of(cache_key_string: str) -> str:
         """Hashes the string a cache entry is named after, in the one place that defines the scheme.
 
         Both the writer of an entry's name and the validator of an existing entry have to agree on
         the digest exactly, so the algorithm lives here rather than being spelled out at each site.
+        :meth:`hisim.caching.keys.CacheKey.digest` repeats the expression (that module imports the
+        standard library only); the two must stay identical.
 
         Args:
             cache_key_string: the raw string that identifies the entry's inputs.
@@ -104,9 +110,9 @@ class CacheEntryMetadata:
                 that shape -- which is itself a reason to treat the entry as unvalidatable.
         """
         filename = os.path.basename(cache_filepath)
-        if not filename.endswith(".cache") or "_" not in filename:
+        if not filename.endswith(CacheEntryMetadata.DATA_SUFFIX) or "_" not in filename:
             return ""
-        return filename[: -len(".cache")].rsplit("_", 1)[1]
+        return filename[: -len(CacheEntryMetadata.DATA_SUFFIX)].rsplit("_", 1)[1]
 
     @classmethod
     def describes(cls, cache_filepath: str) -> bool:

--- a/hisim/caching/settings.py
+++ b/hisim/caching/settings.py
@@ -1,20 +1,12 @@
-"""Where the cache client learns how it is configured, and the one place that reads those variables.
+"""Cache settings: the six environment variables the cache client reads, read in one place.
 
-``roadmap/cache_service_spec.md`` §5 configures the cache through six environment variables, following
-the ``UTSP_URL`` / ``UTSP_API_KEY`` precedent of a ``.env`` file at the repository root. All six are
-optional, and that is the load-bearing property: with none of them set the library is local-only and
-HiSim behaves exactly as it did before the library existed. The shared-directory and server tiers are
-strictly additive opt-ins, so a plain ``pip install hisim`` involves no institute infrastructure and a
-user outside it loses nothing by not having any.
+The variables are described in ``roadmap/cache_service_spec.md`` §5 and follow the ``UTSP_URL`` /
+``UTSP_API_KEY`` precedent of a ``.env`` file in the repository root. All of them are optional. With none
+set, HiSim uses only its local cache directory and behaves exactly as it did before the cache client
+existed; the shared-directory and server tiers are opt-ins on top of that.
 
-The spec asks that ``CacheSettings`` read all of this once, in one place, and that nothing else in HiSim
-touch the variables. That is why the class exists at all rather than each tier calling ``os.getenv``
-where it needs a value: a variable read in six places is documented in none of them, and a typo in one
-is a tier that silently stays off.
-
-Only the local half of the settings is acted on in this phase. The network mode and the two endpoint
-URLs are parsed and validated here already, so that a misspelled value fails now rather than the day the
-remote tier arrives, but nothing in this phase opens a connection.
+Only the local settings are used in this phase. The network mode and the endpoint URLs are already
+parsed and validated so that a typo fails now, but no connection is opened yet.
 """
 
 # clean
@@ -34,12 +26,11 @@ __status__ = "development"
 
 
 class CacheNetworkMode(enum.Enum):
-    """How the client chooses between the two server endpoints, or declines to use either.
+    """Which server endpoint the client may use.
 
-    ``AUTO`` probes the internal endpoint once per process and falls back to the external one, then to
-    local-only; ``INTERNAL`` and ``EXTERNAL`` pin one endpoint and skip the probe; ``OFF`` disables all
-    networking and makes the library bit-identical to the pre-service behaviour. The values are the
-    exact spellings accepted in the environment variable, so the enum is also the validation.
+    ``AUTO`` probes the internal endpoint once and falls back to the external one, then to local-only.
+    ``INTERNAL`` and ``EXTERNAL`` pin one endpoint. ``OFF`` disables all network access. The enum values
+    are the exact spellings accepted in ``HISIM_CACHE_NETWORK``.
     """
 
     AUTO = "auto"
@@ -49,29 +40,22 @@ class CacheNetworkMode(enum.Enum):
 
 
 class CacheSettingsError(ValueError):
-    """Raised when an environment variable holds a value the cache cannot act on.
+    """Raised when an environment variable holds a value the cache client cannot use.
 
-    The message names the variable and lists the accepted spellings, because the person who sees it
-    has usually just edited a ``.env`` file and wants to know which line to fix.
+    The message names the variable and lists the accepted values, so the ``.env`` line to fix is clear.
     """
 
 
 @dataclass(frozen=True)
 class CacheSettings:
-    """The cache configuration read from the environment, held as plain typed values.
+    """The cache configuration, read from the environment into plain typed fields.
 
-    Instances are cheap to build and immutable, so there is no process-wide singleton to keep in step
-    with the environment: a caller that wants current settings asks for them. The one thing the spec
-    wants remembered per process -- the result of the network probe -- belongs to the remote tier, not
-    here, because it is an observation and not a setting.
+    Create one with :meth:`from_environment`. Instances are immutable and cheap, so there is no
+    process-wide singleton; code that wants the current settings asks for them.
     """
 
     class Variables:
-        """The names of the six environment variables, stated once so no other module spells them.
-
-        Kept as a nested namespace rather than loose constants so that the variable names are visibly
-        part of the settings contract and a reader can find all six in one screen.
-        """
+        """The names of the six environment variables. No other module spells them."""
 
         URL_INTERNAL: ClassVar[str] = "HISIM_CACHE_URL_INTERNAL"
         URL_EXTERNAL: ClassVar[str] = "HISIM_CACHE_URL_EXTERNAL"
@@ -100,20 +84,19 @@ class CacheSettings:
 
     @classmethod
     def from_environment(cls, environment: Optional[Mapping[str, str]] = None) -> "CacheSettings":
-        """Reads the six variables and returns them as settings, validating what can be validated.
+        """Read the six variables and return them as settings.
 
-        An empty string is treated the same as an unset variable, because that is what a ``.env`` line
-        with nothing after the equals sign produces and nobody means "the URL is the empty string".
+        An empty string counts as unset, because that is what a ``.env`` line with nothing after the
+        equals sign produces.
 
         Args:
-            environment: the mapping to read from; defaults to ``os.environ``. Tests pass their own so
-                that they neither depend on nor disturb the real process environment.
+            environment: the mapping to read; ``os.environ`` when omitted. Tests pass their own.
 
         Returns:
             CacheSettings: the parsed settings.
 
         Raises:
-            CacheSettingsError: if the network mode is not one of the four accepted spellings.
+            CacheSettingsError: if ``HISIM_CACHE_NETWORK`` is not one of the four accepted values.
         """
         source: Mapping[str, str] = os.environ if environment is None else environment
         return cls(
@@ -127,14 +110,13 @@ class CacheSettings:
 
     @property
     def is_standalone(self) -> bool:
-        """Says whether these settings describe the pre-service behaviour: local directory only.
+        """Whether only the local cache directory is in use.
 
-        This is the property the spec's standalone guarantee rests on, so it is spelled out rather than
-        left for callers to infer from three fields. A local-directory override alone does not make the
-        configuration non-standalone; it only moves the directory.
+        True when no server endpoint can be reached (mode ``OFF``, or no URL set) and no shared directory is
+        configured. A local-directory override alone does not change this; it only moves the directory.
 
         Returns:
-            bool: True if no network endpoint can be used and no shared directory is configured.
+            bool: True for local-only operation.
         """
         network_possible = self.network is not CacheNetworkMode.OFF and (
             self.internal_url is not None or self.external_url is not None
@@ -142,24 +124,23 @@ class CacheSettings:
         return not network_possible and self.shared_directory is None
 
     def resolve_local_directory(self, default_directory: str) -> str:
-        """Returns the directory local entries live in, honouring the override if one is set.
+        """Return the local cache directory: the ``HISIM_CACHE_DIR`` override if set, else the default.
 
         Args:
-            default_directory: the directory the simulation would use on its own, normally
-                ``SimulationParameters.cache_dir_path``.
+            default_directory: normally ``SimulationParameters.cache_dir_path``.
 
         Returns:
-            str: the override from the environment if set, otherwise the default.
+            str: the directory to use.
         """
         return self.local_directory if self.local_directory is not None else default_directory
 
     @staticmethod
     def _optional(source: Mapping[str, str], name: str) -> Optional[str]:
-        """Reads one variable, mapping absent and empty to ``None``.
+        """Read one variable; absent and empty both become ``None``.
 
         Args:
             source: the environment mapping.
-            name: the variable to read.
+            name: the variable name.
 
         Returns:
             Optional[str]: the stripped value, or ``None``.
@@ -169,16 +150,16 @@ class CacheSettings:
 
     @classmethod
     def _network_mode(cls, source: Mapping[str, str]) -> CacheNetworkMode:
-        """Parses the network mode, defaulting to ``AUTO`` and refusing anything unrecognised.
+        """Parse ``HISIM_CACHE_NETWORK``; unset means ``AUTO``.
 
         Args:
             source: the environment mapping.
 
         Returns:
-            CacheNetworkMode: the parsed mode.
+            CacheNetworkMode: the mode.
 
         Raises:
-            CacheSettingsError: if the value is set but is not one of the accepted spellings.
+            CacheSettingsError: if the value is set but not one of the accepted spellings.
         """
         raw = cls._optional(source, cls.Variables.NETWORK)
         if raw is None:

--- a/hisim/caching/settings.py
+++ b/hisim/caching/settings.py
@@ -1,0 +1,193 @@
+"""Where the cache client learns how it is configured, and the one place that reads those variables.
+
+``roadmap/cache_service_spec.md`` §5 configures the cache through six environment variables, following
+the ``UTSP_URL`` / ``UTSP_API_KEY`` precedent of a ``.env`` file at the repository root. All six are
+optional, and that is the load-bearing property: with none of them set the library is local-only and
+HiSim behaves exactly as it did before the library existed. The shared-directory and server tiers are
+strictly additive opt-ins, so a plain ``pip install hisim`` involves no institute infrastructure and a
+user outside it loses nothing by not having any.
+
+The spec asks that ``CacheSettings`` read all of this once, in one place, and that nothing else in HiSim
+touch the variables. That is why the class exists at all rather than each tier calling ``os.getenv``
+where it needs a value: a variable read in six places is documented in none of them, and a typo in one
+is a tier that silently stays off.
+
+Only the local half of the settings is acted on in this phase. The network mode and the two endpoint
+URLs are parsed and validated here already, so that a misspelled value fails now rather than the day the
+remote tier arrives, but nothing in this phase opens a connection.
+"""
+
+# clean
+
+import enum
+import os
+from dataclasses import dataclass
+from typing import ClassVar, Mapping, Optional
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+class CacheNetworkMode(enum.Enum):
+    """How the client chooses between the two server endpoints, or declines to use either.
+
+    ``AUTO`` probes the internal endpoint once per process and falls back to the external one, then to
+    local-only; ``INTERNAL`` and ``EXTERNAL`` pin one endpoint and skip the probe; ``OFF`` disables all
+    networking and makes the library bit-identical to the pre-service behaviour. The values are the
+    exact spellings accepted in the environment variable, so the enum is also the validation.
+    """
+
+    AUTO = "auto"
+    INTERNAL = "internal"
+    EXTERNAL = "external"
+    OFF = "off"
+
+
+class CacheSettingsError(ValueError):
+    """Raised when an environment variable holds a value the cache cannot act on.
+
+    The message names the variable and lists the accepted spellings, because the person who sees it
+    has usually just edited a ``.env`` file and wants to know which line to fix.
+    """
+
+
+@dataclass(frozen=True)
+class CacheSettings:
+    """The cache configuration read from the environment, held as plain typed values.
+
+    Instances are cheap to build and immutable, so there is no process-wide singleton to keep in step
+    with the environment: a caller that wants current settings asks for them. The one thing the spec
+    wants remembered per process -- the result of the network probe -- belongs to the remote tier, not
+    here, because it is an observation and not a setting.
+    """
+
+    class Variables:
+        """The names of the six environment variables, stated once so no other module spells them.
+
+        Kept as a nested namespace rather than loose constants so that the variable names are visibly
+        part of the settings contract and a reader can find all six in one screen.
+        """
+
+        URL_INTERNAL: ClassVar[str] = "HISIM_CACHE_URL_INTERNAL"
+        URL_EXTERNAL: ClassVar[str] = "HISIM_CACHE_URL_EXTERNAL"
+        NETWORK: ClassVar[str] = "HISIM_CACHE_NETWORK"
+        API_KEY: ClassVar[str] = "HISIM_CACHE_API_KEY"
+        DIRECTORY: ClassVar[str] = "HISIM_CACHE_DIR"
+        SHARED_DIRECTORY: ClassVar[str] = "HISIM_CACHE_SHARED_DIR"
+
+    #: The institute-network endpoint, tried first under ``AUTO``; ``None`` when unset.
+    internal_url: Optional[str]
+
+    #: The public endpoint, the fallback under ``AUTO``; ``None`` when unset.
+    external_url: Optional[str]
+
+    #: Which endpoint to use, if any. Defaults to ``AUTO`` when the variable is absent.
+    network: CacheNetworkMode
+
+    #: The write token. Reading may not need one; writing to the server always does.
+    api_key: Optional[str]
+
+    #: An override for the local cache directory; ``None`` means the simulation's own default.
+    local_directory: Optional[str]
+
+    #: The shared-filesystem tier of spec §5.1; ``None`` means the tier is off.
+    shared_directory: Optional[str]
+
+    @classmethod
+    def from_environment(cls, environment: Optional[Mapping[str, str]] = None) -> "CacheSettings":
+        """Reads the six variables and returns them as settings, validating what can be validated.
+
+        An empty string is treated the same as an unset variable, because that is what a ``.env`` line
+        with nothing after the equals sign produces and nobody means "the URL is the empty string".
+
+        Args:
+            environment: the mapping to read from; defaults to ``os.environ``. Tests pass their own so
+                that they neither depend on nor disturb the real process environment.
+
+        Returns:
+            CacheSettings: the parsed settings.
+
+        Raises:
+            CacheSettingsError: if the network mode is not one of the four accepted spellings.
+        """
+        source: Mapping[str, str] = os.environ if environment is None else environment
+        return cls(
+            internal_url=cls._optional(source, cls.Variables.URL_INTERNAL),
+            external_url=cls._optional(source, cls.Variables.URL_EXTERNAL),
+            network=cls._network_mode(source),
+            api_key=cls._optional(source, cls.Variables.API_KEY),
+            local_directory=cls._optional(source, cls.Variables.DIRECTORY),
+            shared_directory=cls._optional(source, cls.Variables.SHARED_DIRECTORY),
+        )
+
+    @property
+    def is_standalone(self) -> bool:
+        """Says whether these settings describe the pre-service behaviour: local directory only.
+
+        This is the property the spec's standalone guarantee rests on, so it is spelled out rather than
+        left for callers to infer from three fields. A local-directory override alone does not make the
+        configuration non-standalone; it only moves the directory.
+
+        Returns:
+            bool: True if no network endpoint can be used and no shared directory is configured.
+        """
+        network_possible = self.network is not CacheNetworkMode.OFF and (
+            self.internal_url is not None or self.external_url is not None
+        )
+        return not network_possible and self.shared_directory is None
+
+    def resolve_local_directory(self, default_directory: str) -> str:
+        """Returns the directory local entries live in, honouring the override if one is set.
+
+        Args:
+            default_directory: the directory the simulation would use on its own, normally
+                ``SimulationParameters.cache_dir_path``.
+
+        Returns:
+            str: the override from the environment if set, otherwise the default.
+        """
+        return self.local_directory if self.local_directory is not None else default_directory
+
+    @staticmethod
+    def _optional(source: Mapping[str, str], name: str) -> Optional[str]:
+        """Reads one variable, mapping absent and empty to ``None``.
+
+        Args:
+            source: the environment mapping.
+            name: the variable to read.
+
+        Returns:
+            Optional[str]: the stripped value, or ``None``.
+        """
+        value = source.get(name, "").strip()
+        return value if value else None
+
+    @classmethod
+    def _network_mode(cls, source: Mapping[str, str]) -> CacheNetworkMode:
+        """Parses the network mode, defaulting to ``AUTO`` and refusing anything unrecognised.
+
+        Args:
+            source: the environment mapping.
+
+        Returns:
+            CacheNetworkMode: the parsed mode.
+
+        Raises:
+            CacheSettingsError: if the value is set but is not one of the accepted spellings.
+        """
+        raw = cls._optional(source, cls.Variables.NETWORK)
+        if raw is None:
+            return CacheNetworkMode.AUTO
+        try:
+            return CacheNetworkMode(raw.lower())
+        except ValueError as error:
+            accepted = ", ".join(mode.value for mode in CacheNetworkMode)
+            raise CacheSettingsError(
+                f"{cls.Variables.NETWORK} is set to {raw!r}, which is not a cache network mode; "
+                f"accepted values are: {accepted}."
+            ) from error

--- a/hisim/caching/settings.py
+++ b/hisim/caching/settings.py
@@ -13,6 +13,7 @@ parsed and validated so that a typo fails now, but no connection is opened yet.
 
 import enum
 import os
+import urllib.parse
 from dataclasses import dataclass
 from typing import ClassVar, Mapping, Optional
 
@@ -30,7 +31,8 @@ class CacheNetworkMode(enum.Enum):
 
     ``AUTO`` probes the internal endpoint once and falls back to the external one, then to local-only.
     ``INTERNAL`` and ``EXTERNAL`` pin one endpoint. ``OFF`` disables all network access. The enum values
-    are the exact spellings accepted in ``HISIM_CACHE_NETWORK``.
+    are the exact spellings accepted in ``HISIM_CACHE_NETWORK``. No probing happens in this phase: the
+    mode is parsed and validated, but no connection is opened until the network tier ships.
     """
 
     AUTO = "auto"
@@ -96,17 +98,21 @@ class CacheSettings:
             CacheSettings: the parsed settings.
 
         Raises:
-            CacheSettingsError: if ``HISIM_CACHE_NETWORK`` is not one of the four accepted values.
+            CacheSettingsError: if ``HISIM_CACHE_NETWORK`` is not one of the four accepted values, if a
+                set endpoint URL is not a URL, or if a pinned ``internal``/``external`` mode has no URL
+                to pin to.
         """
         source: Mapping[str, str] = os.environ if environment is None else environment
-        return cls(
-            internal_url=cls._optional(source, cls.Variables.URL_INTERNAL),
-            external_url=cls._optional(source, cls.Variables.URL_EXTERNAL),
+        settings = cls(
+            internal_url=cls._url(source, cls.Variables.URL_INTERNAL),
+            external_url=cls._url(source, cls.Variables.URL_EXTERNAL),
             network=cls._network_mode(source),
             api_key=cls._optional(source, cls.Variables.API_KEY),
             local_directory=cls._optional(source, cls.Variables.DIRECTORY),
             shared_directory=cls._optional(source, cls.Variables.SHARED_DIRECTORY),
         )
+        cls._check_mode_has_its_url(settings)
+        return settings
 
     @property
     def is_standalone(self) -> bool:
@@ -133,6 +139,59 @@ class CacheSettings:
             str: the directory to use.
         """
         return self.local_directory if self.local_directory is not None else default_directory
+
+    @classmethod
+    def _url(cls, source: Mapping[str, str], name: str) -> Optional[str]:
+        """Read one endpoint variable and refuse a value that is not a URL.
+
+        The network tier that would use the URL ships in a later phase, but a typo must fail now, at
+        configuration time, instead of surfacing as a confusing connection error months later.
+
+        Args:
+            source: the environment mapping.
+            name: the variable name.
+
+        Returns:
+            Optional[str]: the URL, or ``None`` when unset.
+
+        Raises:
+            CacheSettingsError: if the value has no scheme or no host, or the scheme is not http/https.
+        """
+        value = cls._optional(source, name)
+        if value is None:
+            return None
+        parsed = urllib.parse.urlparse(value)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise CacheSettingsError(
+                f"{name} is set to {value!r}, which is not an endpoint URL; expected something like "
+                "'https://cache.example.org'."
+            )
+        return value
+
+    @staticmethod
+    def _check_mode_has_its_url(settings: "CacheSettings") -> None:
+        """Refuse a pinned network mode whose endpoint URL is missing.
+
+        ``internal`` or ``external`` without the matching URL cannot ever connect; reporting it as
+        standalone would hide the misconfiguration until the network phase.
+
+        Args:
+            settings: the parsed settings.
+
+        Raises:
+            CacheSettingsError: if the pinned mode's URL is unset.
+        """
+        pins = {
+            CacheNetworkMode.INTERNAL: (settings.internal_url, CacheSettings.Variables.URL_INTERNAL),
+            CacheNetworkMode.EXTERNAL: (settings.external_url, CacheSettings.Variables.URL_EXTERNAL),
+        }
+        if settings.network in pins:
+            url, variable = pins[settings.network]
+            if url is None:
+                raise CacheSettingsError(
+                    f"{CacheSettings.Variables.NETWORK} pins the {settings.network.value} endpoint, but "
+                    f"{variable} is not set, so there is nothing to connect to; set the URL or drop the pin."
+                )
 
     @staticmethod
     def _optional(source: Mapping[str, str], name: str) -> Optional[str]:

--- a/hisim/utils.py
+++ b/hisim/utils.py
@@ -344,38 +344,31 @@ def get_cache_file(
     my_simulation_parameters: SimulationParameters,
     cache_dir_path: Optional[str] = None
 ) -> Tuple[bool, str]:  # noqa
-    """Gets a cache path for a given parameter set.
+    """Return ``(exists, path)`` for the cache entry of a configuration under the given simulation parameters.
 
-    This is the thin delegating wrapper ``roadmap/cache_service_spec.md`` §4 asked for: the key material
-    is built here, because building it needs the configuration's ``to_json`` and the simulation
-    parameters' unique key and the cache package deliberately knows nothing about either; everything
-    after that -- the filename, the directory, the validation of an existing entry and the discarding of
-    one that cannot be trusted -- is :meth:`hisim.caching.CacheClient.lookup`. The signature and the
-    ``(exists, absolute_path)`` return are unchanged so that no component has to move.
+    The key material is built here with :func:`build_cache_key_string`; the lookup itself -- filename,
+    directory, validation of an existing entry -- is :meth:`hisim.caching.CacheClient.lookup`. The
+    signature and return value are unchanged, so no component had to change when the client was introduced.
 
-    The ``exists`` flag is advisory and nothing more. Two processes that miss the same key concurrently
-    will both compute the entry and both write it; that wastes work but is harmless, because the
-    contents are a pure function of the key. What is *not* harmless is writing the entry straight to the
-    returned path, which lets a concurrent reader see it half written -- so every writer must land its
-    entry through :func:`hisim.caching.atomic_cache_write`.
+    ``exists`` is advisory: two processes may both miss the same key and both compute the entry, which
+    wastes work but is harmless. Never write to the returned path directly; use
+    :func:`hisim.caching.atomic_cache_write`, otherwise a concurrent reader can see a half-written file.
 
-    Which directory is used is decided in this order: an explicit ``cache_dir_path`` argument, then the
-    ``HISIM_CACHE_DIR`` environment variable, then ``my_simulation_parameters.cache_dir_path``. The
-    explicit argument wins over the environment so that a test which points at its own directory keeps
-    doing so on a machine where a developer has set the override.
+    The directory is chosen in this order: the ``cache_dir_path`` argument, then ``HISIM_CACHE_DIR``, then
+    ``my_simulation_parameters.cache_dir_path``. The argument wins over the environment so that a test
+    pointing at its own directory keeps working on a machine where the override is set.
 
     Args:
-        component_key: filename prefix for the component type.
-        parameter_class: dataclass with a ``to_json`` method; the building of its
-            ``component_id`` is nulled before hashing.
-        my_simulation_parameters: provides the cache directory and a unique key appended before hashing.
-        cache_dir_path: optional override; see the order above.
+        component_key: filename prefix, today the component's instance name.
+        parameter_class: a dataclass with ``to_json``; its ``component_id.building`` is cleared before hashing.
+        my_simulation_parameters: provides the default directory and the simulation part of the key.
+        cache_dir_path: optional directory override; see the order above.
 
     Returns:
-        Tuple[bool, str]: ``(exists, absolute_path)``. ``exists`` is advisory, see above.
+        Tuple[bool, str]: ``(exists, absolute_path)``.
 
     Raises:
-        ValueError: if ``my_simulation_parameters`` is None or the JSON string is too short.
+        ValueError: if ``my_simulation_parameters`` is None or the key material is implausibly short.
     """
     key_material = build_cache_key_string(parameter_class, my_simulation_parameters)
     client = default_client()

--- a/hisim/utils.py
+++ b/hisim/utils.py
@@ -21,7 +21,7 @@ import psutil
 import pytz
 
 from hisim import log
-from hisim.caching import CacheEntryMetadata
+from hisim.caching import CacheClient, default_client
 from hisim.simulationparameters import SimulationParameters
 
 __authors__ = "Noah Pflugradt, Vitor Hugo Bellotto Zago"
@@ -346,30 +346,30 @@ def get_cache_file(
 ) -> Tuple[bool, str]:  # noqa
     """Gets a cache path for a given parameter set.
 
-    This will generate a file path based on any dataclass_json.
-    It works by turning the class into a json string, hashing the string and then using that as filename.
-    The idea is to have a unique file path for every possible configuration.
+    This is the thin delegating wrapper ``roadmap/cache_service_spec.md`` §4 asked for: the key material
+    is built here, because building it needs the configuration's ``to_json`` and the simulation
+    parameters' unique key and the cache package deliberately knows nothing about either; everything
+    after that -- the filename, the directory, the validation of an existing entry and the discarding of
+    one that cannot be trusted -- is :meth:`hisim.caching.CacheClient.lookup`. The signature and the
+    ``(exists, absolute_path)`` return are unchanged so that no component has to move.
 
-    The ``exists`` flag is advisory and nothing more. It is a plain ``os.path.isfile`` check, so two
-    processes that miss the same key concurrently will both compute the entry and both write it; that
-    wastes work but is harmless, because the contents are a pure function of the key. What is *not*
-    harmless is writing the entry straight to the returned path, which lets a concurrent reader see it
-    half written -- so every writer must land its entry through
-    :func:`hisim.caching.atomic_cache_write`. This function becomes a thin delegating wrapper over
-    ``hisim/caching/`` in a later phase of ``roadmap/cache_service_spec.md`` §4.
+    The ``exists`` flag is advisory and nothing more. Two processes that miss the same key concurrently
+    will both compute the entry and both write it; that wastes work but is harmless, because the
+    contents are a pure function of the key. What is *not* harmless is writing the entry straight to the
+    returned path, which lets a concurrent reader see it half written -- so every writer must land its
+    entry through :func:`hisim.caching.atomic_cache_write`.
 
-    An existing entry only counts as a hit if its companion metadata is present and hashes to the
-    name the entry is filed under. One that fails that check is deleted here and reported as a miss:
-    either it was written before the metadata scheme existed, or its contents came from something
-    other than what its key describes, and there is no way to tell those apart from the file alone.
-    That is also what removes the need for a one-off purge whenever the key scheme changes.
+    Which directory is used is decided in this order: an explicit ``cache_dir_path`` argument, then the
+    ``HISIM_CACHE_DIR`` environment variable, then ``my_simulation_parameters.cache_dir_path``. The
+    explicit argument wins over the environment so that a test which points at its own directory keeps
+    doing so on a machine where a developer has set the override.
 
     Args:
         component_key: filename prefix for the component type.
         parameter_class: dataclass with a ``to_json`` method; the building of its
             ``component_id`` is nulled before hashing.
         my_simulation_parameters: provides the cache directory and a unique key appended before hashing.
-        cache_dir_path: optional override; defaults to ``my_simulation_parameters.cache_dir_path``.
+        cache_dir_path: optional override; see the order above.
 
     Returns:
         Tuple[bool, str]: ``(exists, absolute_path)``. ``exists`` is advisory, see above.
@@ -377,29 +377,17 @@ def get_cache_file(
     Raises:
         ValueError: if ``my_simulation_parameters`` is None or the JSON string is too short.
     """
-    json_str = build_cache_key_string(parameter_class, my_simulation_parameters)
-    if cache_dir_path is None:
-        cache_dir_path = my_simulation_parameters.cache_dir_path
-    sha_key = CacheEntryMetadata.hash_of(json_str)
-    filename = f"{component_key}_{sha_key}.cache"
-
-    cache_absolute_filepath = os.path.join(cache_dir_path, filename)
-    if not os.path.isdir(cache_dir_path):
-        os.mkdir(cache_dir_path)
-    if os.path.isfile(cache_absolute_filepath):
-        if CacheEntryMetadata.describes(cache_absolute_filepath):
-            return True, cache_absolute_filepath
-        # An entry whose metadata is missing or disagrees with its own filename cannot be shown to
-        # belong to this key: either it predates the metadata scheme, or something other than what
-        # the key describes produced it. Deleting it turns both cases into an ordinary miss, which
-        # is what makes the migration self-executing and a poisoning self-repairing.
-        log.warning(
-            f"Discarding the cache entry {cache_absolute_filepath}: its metadata is missing or does "
-            f"not hash to the name it is filed under, so its contents cannot be shown to belong to "
-            f"this key. It will be recomputed."
-        )
-        CacheEntryMetadata.discard(cache_absolute_filepath)
-    return False, cache_absolute_filepath
+    key_material = build_cache_key_string(parameter_class, my_simulation_parameters)
+    client = default_client()
+    if cache_dir_path is not None:
+        # The explicit argument outranks the environment: bypass the override by handing the
+        # argument in as both the default and, effectively, the only option.
+        client = CacheClient(dataclasses.replace(client.settings, local_directory=None))
+        default_directory = cache_dir_path
+    else:
+        default_directory = my_simulation_parameters.cache_dir_path
+    entry = client.lookup(component_key, key_material, default_directory)
+    return entry.exists, entry.path
 
 
 def build_cache_key_string(parameter_class: Any, my_simulation_parameters: SimulationParameters) -> str:

--- a/hisim/utils.py
+++ b/hisim/utils.py
@@ -21,7 +21,7 @@ import psutil
 import pytz
 
 from hisim import log
-from hisim.caching import CacheClient, default_client
+from hisim.caching import CacheClient
 from hisim.simulationparameters import SimulationParameters
 
 __authors__ = "Noah Pflugradt, Vitor Hugo Bellotto Zago"
@@ -371,15 +371,15 @@ def get_cache_file(
         ValueError: if ``my_simulation_parameters`` is None or the key material is implausibly short.
     """
     key_material = build_cache_key_string(parameter_class, my_simulation_parameters)
-    client = default_client()
+    client = CacheClient.from_environment()
     if cache_dir_path is not None:
-        # The explicit argument outranks the environment: bypass the override by handing the
-        # argument in as both the default and, effectively, the only option.
-        client = CacheClient(dataclasses.replace(client.settings, local_directory=None))
-        default_directory = cache_dir_path
+        # The explicit argument outranks the environment; the override is simply not consulted.
+        directory = cache_dir_path
     else:
-        default_directory = my_simulation_parameters.cache_dir_path
-    entry = client.lookup(component_key, key_material, default_directory)
+        directory = client.settings.resolve_local_directory(my_simulation_parameters.cache_dir_path)
+        if client.settings.local_directory is not None:
+            client.announce_environment_override(directory)
+    entry = client.lookup(component_key, key_material, directory)
     return entry.exists, entry.path
 
 

--- a/roadmap/cache_service_spec.md
+++ b/roadmap/cache_service_spec.md
@@ -1,0 +1,466 @@
+# HiSim Cache Service — Specification (v1 draft)
+
+A shared cache service for precomputed HiSim artifacts (LPG occupancy profiles, weather
+preprocessing, PV yields, heat-pump maps, solar gains, …), served over REST by the existing
+RenoVisor C# server, plus a client library inside HiSim that every component uses instead of
+talking to the filesystem directly. Goal: compute each expensive feed-forward artifact **once**
+across all three execution environments — GitHub Actions golden runs, 10 000+-job cluster sweeps,
+and RenoVisor backend containers — and never again.
+
+The service is **strictly an optimization**. Every simulation must produce identical results and
+complete successfully with the server unreachable, misconfigured, or absent. No simulation ever
+fails because of the cache service.
+
+```
+component ──▶ CacheClient.get_or_compute(key, compute_fn)
+                 │
+                 ├─ 1. local file cache (inputs/cache, atomic writes)      hit ▶ return
+                 ├─ 2. remote GET /cache/{key}                             hit ▶ store locally, return
+                 ├─ 3. compute_fn()  ── local atomic write ── best-effort PUT /cache/{key}
+                 ▼
+              result path
+```
+
+---
+
+## 1. Two kinds of server content — keep them separate
+
+| | Opportunistic cache | Curated datasets |
+|---|---|---|
+| Examples | PV yield series, LPG results, preprocessed weather frames, heat-pump maps | Raw weather files (TRY/DWD, currently 121 MB in-repo), pregenerated standard LPG profiles |
+| Key | content hash of (component, code version, config) | human-assigned id + dataset version, e.g. `weather/dwd-try-2015/AACHEN/v2` |
+| Written by | any authorized HiSim client, on cache miss | maintainers only, out-of-band upload |
+| Miss means | normal — client computes locally | client falls back to bundled/offline copy; if none, hard error with clear message |
+| Eviction | LRU by last access | never evicted automatically |
+
+Both live behind the same server and client library, but they have different write policies,
+different miss semantics, and different lifecycles. Conflating them (e.g. letting an
+opportunistic writer overwrite a curated weather file) is the main design error to avoid.
+
+## 2. Server API
+
+All endpoints under a common prefix, e.g. `https://<host>/hisim-cache/api/v1`. Bodies are
+zstd-compressed (`Content-Encoding: zstd`); the payload format inside is whatever the component
+already writes to its `.cache` file today (the server treats it as an opaque blob).
+
+### 2.1 Opportunistic cache
+
+```
+GET  /cache/{component}/{sha}
+     200  blob + headers: ETag, X-Producer-Commit, X-Cache-Version
+     404  miss (server logs the miss — see §9)
+
+PUT  /cache/{component}/{sha}
+     Headers (required): Authorization, X-Producer-Commit, X-Producer-HiSim-Version,
+                         X-Cache-Version, Content-Length
+     201  stored          200  already existed, body identical → no-op
+     409  already existed with *different* content (server keeps the old blob, logs both
+          producers — this indicates a key-schema bug and must be investigated, not overwritten)
+     413  over size limit (per-blob limit, e.g. 256 MB)
+     401/403  auth failure
+```
+
+Design notes:
+- **One round trip.** No separate "is it available?" endpoint; `GET` returns the blob or 404.
+- **Single flat namespace.** Content-complete keys (§3) make branch scoping unnecessary: a
+  code change produces new keys, an unchanged computation produces identical bytes. The 409
+  rule is the tripwire for key-schema bugs; 409 investigations compare blobs within numeric
+  tolerance first, since same-version floats may differ across BLAS/CPU variants.
+- **PUT is idempotent.** Ten cluster jobs racing on the same miss all compute the same bytes and
+  PUT; first write wins, the rest get 200. Identical-content re-PUT is always harmless.
+- Commit id and HiSim version are **metadata, not key material** (§3). They are stored per blob
+  so that entries produced by a commit range later found buggy can be purged server-side.
+
+### 2.2 Curated datasets
+
+```
+GET  /datasets/{kind}/{content_hash}           content-addressed blob fetch; 200 + ETag / 404
+GET  /datasets/{kind}                          index: human-readable name → content hash (JSON),
+                                               e.g. "dwd-try-2015-AACHEN" → "3fa9c2..."
+PUT  /datasets/{kind}/{content_hash}           maintainer token only; server verifies the hash;
+                                               immutable by construction
+```
+
+### 2.3 Operational
+
+```
+GET  /health                                   200, no auth — used by the client's network probe
+GET  /stats                                    hit/miss counters, storage usage (maintainer token)
+GET  /misses?since=...                         top missed keys with counts (maintainer token, §9)
+DELETE /cache?producer_commit={sha}[..{sha}]   purge by producing commit range (maintainer token)
+```
+
+## 3. Cache key schema
+
+The remote key is the local filename stem, unchanged: `{component}/{sha}`. What changes is what
+goes **into** the sha. Today (`utils.get_cache_file`) it is
+`sha256(config_json + simulation_parameter_key)`. For a shared multi-environment cache this is
+extended to:
+
+```
+sha256( artifact_kind                       # e.g. "pv_series" — names the producer
+      + ":" + code_fingerprint              # auto: sha over the producer module's source AND
+                                            #       every hisim module in its transitive import closure
+      + ":" + third_party_fingerprint       # auto: name==version for every third-party package
+                                            #       imported (transitively) by the closure
+      + ":" + dto_json )                    # canonical JSON of the calculation's DTO (§3.1)
+```
+
+Fingerprinting is **fully automatic — no declarations**. This is only possible because
+producers are standalone modules under the strict import lint (§12): their transitive import
+closure is small by construction, so hashing 100% of it neither degenerates into commit-keying
+nor needs an author-maintained `CACHE_CODE_DEPS` list (error-prone, and obsolete here).
+
+- **`code_fingerprint`**: static AST walk over the producer module's `import` statements,
+  recursing into every `hisim.*` module reached; sha over all their source files. Any edit to
+  code that can influence the calculation invalidates exactly the artifacts that depend on
+  it — while edits to component plumbing (KPIs, I/O declarations) invalidate nothing.
+- **`third_party_fingerprint`**: third-party packages found in the closure contribute
+  `name==version` via `importlib.metadata`; the stdlib contributes only the Python
+  major.minor. Deliberately NOT a hash of the whole installed environment — the cluster, the
+  CI container, and the RenoVisor image never have identical full dependency sets, so
+  environment-wide hashing would reduce cross-environment hits to zero.
+- **The lint is what makes this sound**: the producer layer bans dynamic imports (invisible to
+  AST analysis) and imports of component/simulator machinery. Every import has a visible
+  cache cost — importing a frequently-edited registry like `loadtypes` would invalidate all of
+  a producer's artifacts on every enum addition — which is healthy pressure to pass plain
+  values through the DTO instead.
+- **Version-as-proxy caveat**: same package version does not guarantee bit-identical floats
+  across BLAS/CPU variants. A 409 conflict (§2.1) is investigated by first comparing the two
+  blobs within numeric tolerance; only a genuine value difference indicates incomplete keys.
+- The **full repo commit is deliberately NOT key material** for the same reason. It travels as
+  metadata (§2.1) instead, enabling purge-by-commit.
+
+### 3.1 Calculation DTOs
+
+Every producer function takes exactly **one parameter**: a frozen dataclass in the producer's
+own module holding everything the calculation depends on. Its canonical JSON (sorted keys,
+enums by value) is the `dto_json` key material above. Rules:
+
+- **Flat and primitive.** Fields are primitives, enums, lists, and artifact keys — never
+  component references or a `SimulationParameters` object. The component extracts what the
+  calculation needs (`year`, `seconds_per_timestep`, tilt, azimuth, …) when building the DTO;
+  the DTO is the layering firewall between component plumbing and pure calculation.
+- **Only result-relevant fields.** Cost, CO₂, and display fields from the component config
+  never enter the DTO — so tweaking a price no longer invalidates a physics result. This also
+  retires the "null out `component_id.building` before hashing" special case: identity fields
+  simply aren't DTO fields.
+- **Upstream artifacts as references, not payloads.** A producer needing the weather series
+  gets `weather_artifact_key: str` as key material plus the loaded frame in a payload field
+  that is excluded from hashing (dataclass `field(metadata={"key_material": False})`).
+  Invariant: every payload field pairs with a key field identifying it; the component fills
+  both. Keys therefore compose Merkle-style — an upstream weather change propagates into the
+  PV key through the reference.
+- **Input data files by content hash.** A producer that reads a data file (weather CSVs,
+  module databases) references it in the DTO by the file's content hash — which is also how
+  curated datasets are indexed and retrieved (§6). Editing a bundled data file therefore
+  changes every downstream key automatically; no version-bump discipline required.
+- **Nondeterminism must be a field.** Anything random (LPG guid/seed) appears explicitly in
+  the DTO; producers themselves are deterministic functions of their DTO.
+- No separate DTO versioning: the DTO class lives in the producer module, so shape changes
+  are already captured by `code_fingerprint`.
+
+`utils.get_cache_file` keeps its current hashing (config JSON + sim-parameter key) as the
+legacy path for not-yet-migrated components; each producer extraction moves its component to
+the DTO scheme.
+- **Residual staleness risk** — a dynamic import that escapes the AST closure (banned by the
+  producer lint) or nondeterminism not routed through a DTO field — is backstopped twice: the
+  golden tests on main catch changed results, and the server's 409 rule (§2.1) flags any key
+  that two producers computed different bytes for.
+- **Keying is a staleness defense, not a poisoning defense.** No key scheme protects against a
+  client that uploads wrong bytes under a valid key (buggy fork, tampered client, leaked token) —
+  the server cannot recompute values to verify them. Poisoning is handled by the write-auth
+  tiers (§7), main-branch-only CI writes, producer metadata, and purge (§2.3).
+
+## 4. Client library: `hisim/caching/`
+
+A new package at the same layer as `hisim/config/`: imported by components and by `utils.py`,
+imports nothing from components or the simulator. All cache behavior — local paths, atomic
+writes, key construction, remote tiers, dataset retrieval, configuration — lives here.
+`utils.get_cache_file` becomes a thin delegating wrapper (kept for backward compatibility,
+same signature, same `(exists, path)` return).
+
+```
+hisim/caching/
+    __init__.py        # public API re-exports
+    settings.py        # CacheSettings: env resolution, internal/external selection (§5)
+    keys.py            # CacheKey dataclass + sha construction (§3)
+    local.py           # local tier: lookup, atomic write (tmp + os.replace), size accounting
+    remote.py          # HTTP tier: GET/PUT with timeouts, compression, auth, silent failure
+    client.py          # CacheClient: orchestrates local → remote → compute → writeback
+    datasets.py        # curated-dataset retrieval: weather files, standard LPG profiles (§6)
+```
+
+### 4.1 Public API (sketch)
+
+```python
+from hisim.caching import CacheClient, CacheEntry
+
+class MyComponent(Component):
+    # No cache declarations: fingerprints derive automatically from the producer
+    # module's import closure (§3).
+
+    def i_prepare_simulation(self):
+        entry: CacheEntry = self.cache_client.get_or_fetch(
+            component=self,                # names the artifact kind; fingerprints come from the producer module
+            config=self.my_config,         # hashed as today (building nulled)
+            simulation_parameters=self.my_simulation_parameters,
+        )
+        if entry.exists:
+            self.data = pd.read_csv(entry.path)   # component reads its own format, as today
+        else:
+            self.data = self.compute_expensive_thing()
+            self.data.to_csv(entry.path_tmp)      # component writes to the tmp path
+            entry.commit()                         # atomic rename + best-effort remote PUT
+```
+
+`get_or_fetch` behavior, in order:
+1. Local hit → return `exists=True` immediately (no network).
+2. Remote enabled and reachable → `GET`; on 200, decompress, atomic-write locally, return hit.
+3. Shared directory configured (§5.1) → copy in on hit, return.
+4. Miss → return `exists=False` with a **temp path**; `entry.commit()` performs
+   `os.replace(tmp, final)` and then, if the environment is write-authorized, PUTs in a
+   background thread (fire-and-forget with bounded queue; process exit joins with a short cap).
+
+Atomic local writes fix a latent bug that exists independently of this project: today, two
+processes sharing a cache dir (e.g. cluster jobs on a shared filesystem) can read a half-written
+`.cache` file. `local.py` ships first for that reason alone (§10, phase 1).
+
+### 4.2 Failure semantics
+
+- Connect timeout ~2 s, read timeout scaled to blob size; any network/HTTP/auth error → log at
+  debug level, fall through to the next tier. Repeated failures trip a per-process circuit
+  breaker: after N consecutive errors the remote tier is skipped for the rest of the process.
+- Malformed remote blob (decompression error, size mismatch vs Content-Length) → discard,
+  treat as miss, never write it locally.
+- `HISIM_CACHE_NETWORK=off` disables all networking; behavior is bit-identical to today.
+
+## 5. Configuration: internal vs. external endpoints
+
+Follows the existing `.env` precedent (`UTSP_URL` / `UTSP_API_KEY`). All variables optional;
+with none set, the library is local-only and HiSim behaves exactly as before.
+
+```
+HISIM_CACHE_URL_INTERNAL=https://10.x.x.x/hisim-cache        # institute network / cluster
+HISIM_CACHE_URL_EXTERNAL=https://cache.example.fzj.de/hisim-cache
+HISIM_CACHE_NETWORK=auto | internal | external | off          # default: auto
+HISIM_CACHE_API_KEY=...                                        # write token (read may not need one)
+HISIM_CACHE_DIR=...                                            # optional local-dir override
+HISIM_CACHE_SHARED_DIR=...                                     # optional shared-directory tier (§5.1)
+```
+
+**Standalone guarantee:** a plain `pip install hisim` with no environment variables gives
+exactly today's behavior — a local cache directory, no network activity, no FZJ
+infrastructure involved. The shared-dir and server tiers are strictly additive opt-ins; the
+library never requires them, and users outside FZJ lose nothing by not having them.
+
+### 5.1 Shared-directory tier
+
+For groups with a shared filesystem (HPC `$PROJECT` paths, an institute NAS),
+`HISIM_CACHE_SHARED_DIR` enables an additional tier with the same read-through / write-back
+semantics as the REST tier. Same keys, same blob format — an entry is interchangeable
+between a shared directory and the server. All shared-dir writes are atomic (temp file +
+`os.replace`), safe under concurrent writers.
+
+Lookup order when everything is configured: **local dir → server → shared dir → compute.**
+The server ranks above the shared dir because it is readable by everyone — external users
+query the public endpoint anonymously — while writing to it requires a token. The shared dir
+is therefore where clients without write access bank their misses: an external group reads
+the public server for free and accumulates everything the server doesn't have in their own
+shared dir. Write-back on a hit populates the tiers checked before it; a computed result is
+written to every tier the client can write (local always, shared dir if configured, server
+PUT only with a write token).
+
+`auto`: probe `GET {internal}/health` once per process with a 1 s timeout; on success use the
+internal URL, otherwise the external one (if set), otherwise local-only. The result is cached
+for the process lifetime. `internal`/`external` skip probing and pin one endpoint.
+`CacheSettings` reads all of this once, in one place; nothing else in HiSim touches these
+variables.
+
+## 6. Curated-dataset retrieval (`datasets.py`)
+
+Typed retrieval functions, one per dataset kind, used by the weather component and the LPG
+connector instead of hard-coded repo paths:
+
+```python
+get_weather_files(location: str, dataset: WeatherDataset, year: int) -> Path
+get_pregenerated_lpg_profile(household_template: str, year: int, resolution_s: int) -> Path
+```
+
+Resolution order: local dataset directory (`inputs/weather/…` as today) → remote
+`GET /datasets/…` with local write-through → **error** with an actionable message naming the
+dataset id and the prewarm command. Additionally:
+
+- `python -m hisim.caching prewarm [--datasets all|weather|lpg] [--setups ...]` downloads
+  everything a given setup needs, for offline/air-gapped use and for baking warm caches into the
+  RenoVisor container image.
+- Once the remote path is proven in CI, the bulk weather data (121 MB) is removed from the repo;
+  a small default subset (enough to run the example setups and base tests offline after
+  `pip install`) stays bundled. Exact subset decided in phase 3.
+- Datasets are content-addressed (§2.2): the blob's hash is its identity, a human-readable
+  index maps names to hashes, and DTOs reference the hash (§3.1) — so a corrected weather file
+  is a new hash, and it propagates into every downstream cache key automatically.
+- License check for redistributing DWD/TRY data beyond the institute happens before the external
+  endpoint serves weather data.
+
+## 7. Authentication
+
+Reads: anonymous on both endpoints — the public (external) endpoint is explicitly world-readable
+so that users outside FZJ benefit from the cache; the client sends a token on reads only if it
+happens to have one.
+
+Writes are the integrity boundary — a writable endpoint feeds simulation inputs to every user.
+Two mechanisms, chosen per environment:
+
+### 7.1 GitHub runners: OIDC, no stored secrets
+
+GitHub Actions mints short-lived, signed JWTs on request (`permissions: id-token: write`). The
+workflow fetches a token with audience `hisim-cache` and sends it as the bearer token. The C#
+server validates it as a standard JWT (ASP.NET Core `AddJwtBearer`, authority
+`https://token.actions.githubusercontent.com`, GitHub's published JWKS) and then enforces
+claims:
+
+```
+aud   == "hisim-cache"
+repository == "FZJ-IEK3-VSA/HiSim"
+```
+
+Why this over a shared API key in GitHub Secrets: nothing to store, rotate, or leak — tokens
+expire in minutes and are audience-bound. All CI runs of the repository may write, PR branches
+included: with fully automatic fingerprints and content-addressed data files (§3), keys are
+complete by construction, so an unchanged computation writes identical bytes and a changed one
+writes under new keys — a PR's first push computes its new entries once and every later push
+(and the post-merge main run) gets hits. Fork PRs cannot mint OIDC tokens under GitHub's
+rules, so they are automatically read-only — the right trust boundary with zero configuration.
+
+Two limits of this argument, accepted deliberately: fingerprints are client-computed claims,
+so they defend against *accidents*, not a deliberately lying client — the adversary control is
+the token boundary itself, and same-repo PR authors are inside the institute's trust boundary.
+And the 409 rule (§2.1) remains the tripwire for key-schema bugs. Branch-scoped write
+namespaces (the `actions/cache` isolation model) were considered and dropped as unnecessary
+under complete keys; reintroduce them only if the conflict log ever shows real poisoning.
+
+### 7.2 Cluster, RenoVisor containers, developers: static bearer tokens
+
+Long-lived per-environment tokens (`hisim-cluster-2026`, `renovisor-backend`, one per developer
+who needs write), issued and revocable on the server, supplied via `HISIM_CACHE_API_KEY` in
+`.env` — the same handling as `UTSP_API_KEY` today. Tokens are tiered: `write` (opportunistic
+cache PUT), `maintain` (dataset PUT, purge, stats). Compromise recovery = revoke the token +
+purge by that token's producer metadata (§2.3).
+
+## 8. Server-side storage & eviction
+
+- Blobs on disk (or object storage) named by key; a small DB table per blob: key, size,
+  created, last_accessed, producer commit, producer HiSim version, producing token id.
+- Opportunistic tier: quota (e.g. 200 GB) with LRU eviction by `last_accessed`. This replaces
+  any bespoke LRU logic — eviction is a storage policy, not an algorithm HiSim implements.
+- Curated tier: never auto-evicted.
+- Server-side writes are temp-file + rename; a killed upload never leaves a readable partial.
+
+## 9. Miss tracking (and optional prewarming, later)
+
+Every 404 on `/cache/` is logged (key, component, timestamp, client environment from the token /
+User-Agent). `GET /misses` aggregates the top missed keys. If prewarming ever becomes worthwhile,
+it is a scheduled **HiSim client** job (nightly CI or cluster job) that reads the miss report,
+runs the corresponding configs with ordinary HiSim, and lets the normal write-back populate the
+cache. The server never computes anything itself — this keeps the C# server free of any HiSim
+version coupling.
+
+## 10. Rollout phases
+
+1. **`hisim/caching/` local tier** — package skeleton, `CacheKey` with code/helper/dependency
+   fingerprints, atomic writes, `utils.get_cache_file` delegating. Pure refactor,
+   no network, fixes the shared-filesystem race. Golden tests must stay green (all local keys
+   change once due to the new schema — one-time full recompute, coordinated with a golden run).
+2. **Remote read/write tier** — `remote.py`, `client.py`, settings, circuit breaker; the two
+   server endpoints (§2.1) + `/health`; static-token auth; enable on the cluster and in
+   RenoVisor first (highest volume, simplest auth).
+3. **Curated datasets** — `/datasets/` endpoints, `datasets.py`, prewarm CLI, weather component
+   + LPG connector switched to retrieval functions; then shrink the in-repo weather data.
+4. **CI integration** — OIDC validation on the server, `id-token: write` + token fetch in the
+   golden workflows, main-branch-only write policy. (Independently useful regardless of phases
+   2–3: `actions/cache` on `inputs/cache` remains worthwhile for PR-branch runs, which are
+   read-only against the service.)
+
+Each phase is independently shippable and independently reversible (`HISIM_CACHE_NETWORK=off`
+returns to phase-0 behavior at any time).
+
+## 11. Out of scope for v1
+
+- Server-side computation of any kind (see §9 for the client-side alternative).
+- Caching anything inside the convergence loop (coupled components: building thermal model,
+  heat pump interaction, EMS decisions) — only feed-forward `i_prepare_simulation` artifacts.
+- Cross-user result sharing beyond the institute (external endpoint exists, but opening write
+  access to third parties needs a separate review).
+- Branch-scoped write namespaces (dropped: unnecessary under content-complete keys; reintroduce
+  only if the 409 conflict log ever shows real poisoning).
+
+## 12. Survey: the cached computations and their static producer forms
+
+Result of reviewing every cache user (2026-08-22). Goal: each cacheable artifact becomes a
+**static producer function** — pure, callable without a `Simulator`, signature
+`f(dto) -> artifact` with a single calculation DTO per §3.1 — so the prewarm CLI and
+miss-driven prewarming can populate the cache without running simulations.
+
+| Component | Cached artifact | True inputs | Static? |
+|---|---|---|---|
+| `weather` | resampled full-year series | config + sim params + weather files | **already is** — `read_test_reference_year_data` + resampling, only needs extraction |
+| `loadprofilegenerator_utsp_connector` | occupancy/consumption profiles | config + sim params (UTSP or local LPG) | **already is** — external calculation by design |
+| `generic_pv_system` | AC power ratio series | weather series + PV config | **yes** — the predictive branch already computes the full series up front; needs weather passed as an argument instead of `SingletonSimRepository`/stsv |
+| `building` (solar gains) | gains-through-windows series | weather series + window config | **yes** — `get_solar_heat_gain_through_windows` is nearly pure; full-series form exists in the predictive branch |
+| `generic_car` | location / driven-meters series | LPG car data + sim params | **yes**, chained: consumes the LPG artifact |
+| `generic_windturbine` | (today: in-memory memo per operating point) | weather series + turbine config | **yes, and it's an upgrade** — inputs are purely weather-driven, so the memo can become a full-series precompute like PV |
+| `advanced_/more_advanced_heat_pump_hplib` | in-memory memo per rounded operating point | runtime loop state (return temperature) | **no full series** — operating points come from the convergence loop. Option: quantized full-grid map per heat-pump model as a curated dataset. Excluded from v1. |
+| `solar_thermal_system` | per-timestep `flat_plate_precalc` frames | weather + config + **collector inlet temperature from storage (feedback!)** | **no — and the current cache is unsound, see below** |
+
+Producer dependency DAG (what the prewarm CLI walks):
+
+```
+weather ──▶ pv_series
+        ──▶ solar_gains
+        ──▶ windturbine_series
+lpg ──▶ car_series
+```
+
+Findings that fall out of the survey:
+
+- **Solar thermal caching bug (exists today, locally).** The cached precalc frames depend on the
+  collector inlet temperature, which is fed back from the storage — i.e. on the *rest of the
+  system* — but the cache key covers only the collector config and sim params. Two setups sharing
+  a collector config but differing elsewhere (storage size, heating system) share a key while
+  having different correct values. This must be fixed before the shared service ships (either
+  compute the precalc from the nominal inlet temperature `delta_temperature_n_k` implies — a
+  model change — or remove this cache); shared, it would poison across users by design.
+- **Deferred cache writes.** PV (non-predictive), building, and solar thermal fill their cache
+  during `i_simulate` and write the file only at the final timestep — an aborted run populates
+  nothing. Static producers fix this as a side effect: compute → write → simulate.
+- **PV vectorization win.** The miss path calls pvlib once per timestep in a Python loop
+  (525 600 calls for a minutely year). pvlib is natively vectorized over Series; the static
+  producer should pass full series, likely turning the miss cost from minutes into seconds —
+  which also lowers the stakes of every cache miss.
+- **Producers live in their own modules**, next to their component in the same directory
+  (e.g. `generic_pv_calculation.py` beside `generic_pv_system.py`), mirroring the ongoing
+  `building/` split. Component modules stay at their current paths — the scenario JSONs
+  resolve components by fully-qualified class name via `json_executor.py`, so moving them
+  breaks every `.scenario.json`; if a component is ever moved into a subpackage, a re-export
+  shim keeps the old path importable. This placement also tightens the cache key: the
+  `code_fingerprint` hashes the producer module alone, so edits to component plumbing (KPIs,
+  I/O declarations, docstrings) no longer invalidate cached artifacts.
+- Producer modules obey strict one-way layering, like `hisim/config/`: they may import
+  numpy/pandas/pvlib and config dataclasses, never `Component`, the simulator, or the
+  singleton repository. This keeps them callable without starting HiSim and keeps their
+  fingerprints from transitively swallowing the package. Splits land as pure-move PRs
+  (goldens bit-identical); numeric changes such as the PV vectorization follow separately.
+- `hisim/caching/producers.py` only maps artifact kinds to producer functions for the
+  prewarm CLI.
+
+## 13. Open questions
+
+1. Blob size cap and total quota — need measured sizes of the largest current `.cache` files
+   (UTSP full-year minutely results are the likely maximum).
+2. Does the internal endpoint require read auth? (Recommendation: no — friction for zero gain
+   inside the institute network.)
+3. Which weather subset stays bundled in the repo for offline-after-install use?
+4. Should the RenoVisor container prewarm at build time (bigger image, instant start) or first
+   start (small image, slow first request)? Recommendation: build time for weather datasets,
+   first-start for opportunistic entries.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,17 +27,25 @@ REPO_ROOT: Path = Path(__file__).resolve().parent.parent
 
 
 @pytest.fixture(autouse=True)
-def _isolate_cache_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+def _isolate_cache_environment() -> Iterator[None]:
     """Clears every ``HISIM_CACHE_*`` variable, so the suite runs the same on every machine.
 
     ``hisim.utils.get_cache_file`` reads these variables on every call; a developer with
     ``HISIM_CACHE_DIR`` in a ``.env`` or exported shell would otherwise have cache paths land outside
     pytest's ``tmp_path`` and see spurious failures. Tests that exercise an override set the variable
     themselves with ``monkeypatch.setenv``, which applies after this fixture.
+
+    The fixture builds its own ``MonkeyPatch`` instead of requesting the ``monkeypatch`` fixture.
+    Requesting it would instantiate the shared function-scoped instance before every later fixture,
+    and teardown runs in reverse: the stray-file guard's ``git status`` would then execute while a
+    test's own patches -- some of which replace ``subprocess.run`` globally -- are still active.
     """
+    patcher = pytest.MonkeyPatch()
     for attribute in vars(CacheSettings.Variables).values():
         if isinstance(attribute, str) and attribute.startswith("HISIM_CACHE"):
-            monkeypatch.delenv(attribute, raising=False)
+            patcher.delenv(attribute, raising=False)
+    yield
+    patcher.undo()
 
 
 # Make scripts/ importable so tests can ``from hpc_harness import ...`` at the module top.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,9 +20,25 @@ from typing import Set
 
 import pytest
 
+from hisim.caching import CacheSettings
 from hisim.result_path_provider import ResultPathProviderSingleton
 
 REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clears every ``HISIM_CACHE_*`` variable, so the suite runs the same on every machine.
+
+    ``hisim.utils.get_cache_file`` reads these variables on every call; a developer with
+    ``HISIM_CACHE_DIR`` in a ``.env`` or exported shell would otherwise have cache paths land outside
+    pytest's ``tmp_path`` and see spurious failures. Tests that exercise an override set the variable
+    themselves with ``monkeypatch.setenv``, which applies after this fixture.
+    """
+    for attribute in vars(CacheSettings.Variables).values():
+        if isinstance(attribute, str) and attribute.startswith("HISIM_CACHE"):
+            monkeypatch.delenv(attribute, raising=False)
+
 
 # Make scripts/ importable so tests can ``from hpc_harness import ...`` at the module top.
 # The hpc_harness package uses absolute ``hpc_harness.*`` imports internally, so it must be

--- a/tests/test_caching_client.py
+++ b/tests/test_caching_client.py
@@ -17,7 +17,7 @@ from typing import ClassVar
 import pytest
 
 from hisim import utils
-from hisim.caching import CacheClient, CacheEntryMetadata, CacheSettings, atomic_cache_write, default_client
+from hisim.caching import CacheClient, CacheEntryMetadata, CacheSettings, atomic_cache_write
 from hisim.simulationparameters import SimulationParameters
 
 __authors__ = "Noah Pflugradt"
@@ -81,7 +81,9 @@ def test_a_miss_names_the_path_and_creates_the_directory(tmp_path: pathlib.Path)
 
     assert not entry.exists
     assert directory.is_dir()
-    expected_name = CacheClient.entry_filename(Given.COMPONENT_KEY, CacheEntryMetadata.hash_of(Given.KEY_MATERIAL))
+    # The name is spelled out rather than asked of entry_filename, so a change to the naming rule
+    # fails here instead of agreeing with itself.
+    expected_name = f"Weather_{CacheEntryMetadata.hash_of(Given.KEY_MATERIAL)}.cache"
     assert entry.path == str(directory / expected_name)
     assert entry.key_material == Given.KEY_MATERIAL
 
@@ -139,27 +141,37 @@ def test_an_entry_whose_metadata_disagrees_with_its_name_is_discarded(tmp_path: 
 
 
 @pytest.mark.base
-def test_the_environment_override_moves_the_directory(tmp_path: pathlib.Path) -> None:
-    """``HISIM_CACHE_DIR`` replaces the default directory the caller passes.
+def test_lookup_uses_exactly_the_directory_it_is_given(tmp_path: pathlib.Path) -> None:
+    """``lookup`` takes the directory decision as given and does not consult the environment.
 
-    Catches: the override being parsed but not applied.
+    The ``HISIM_CACHE_DIR`` override is applied by the caller through
+    ``CacheSettings.resolve_local_directory`` (pinned in the settings tests and, end to end, in
+    ``test_an_explicit_directory_argument_outranks_the_environment``). A lookup that second-guessed
+    the caller would apply the override even where an explicit argument had already outranked it.
+
+    Catches: the override resolution creeping back into the lookup.
     """
     override = tmp_path / "override"
     client = Given.client(tmp_path, HISIM_CACHE_DIR=str(override))
 
     entry = client.lookup(Given.COMPONENT_KEY, Given.KEY_MATERIAL, str(tmp_path / "default"))
 
-    assert entry.path.startswith(str(override))
-    assert override.is_dir()
+    assert entry.path.startswith(str(tmp_path / "default"))
+    assert not override.exists()
 
 
 @pytest.mark.base
-def test_get_cache_file_returns_exactly_the_path_it_always_did(tmp_path: pathlib.Path) -> None:
+def test_get_cache_file_returns_exactly_the_path_it_always_did(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The delegation to the client changes no cache filename.
 
     The expected path is computed here from the published rule (digest of the legacy key material under the
     component key), not asked of the client, so this test would notice the client changing the rule.
     """
+    # The suite-wide conftest fixture already clears the override; repeated here so this test stays
+    # hermetic on its own -- it asserts the exact default-directory path, which the override would move.
+    monkeypatch.delenv(CacheSettings.Variables.DIRECTORY, raising=False)
 
     @dataclasses.dataclass
     class Config:
@@ -222,15 +234,15 @@ def test_an_explicit_directory_argument_outranks_the_environment(
 
 
 @pytest.mark.base
-def test_default_client_reads_the_environment_or_takes_settings() -> None:
-    """The one-liner ``get_cache_file`` calls works both ways.
+def test_a_component_key_with_a_path_separator_is_refused(tmp_path: pathlib.Path) -> None:
+    """A component key becomes part of a filename, so a separator in it must fail loudly.
 
-    Catches: ``default_client`` ignoring the settings it was handed.
+    Catches: a component named ``a/b`` silently filing its cache entries outside the cache directory.
     """
-    given = CacheSettings.from_environment({CacheSettings.Variables.DIRECTORY: "/given"})
+    client = Given.client(tmp_path)
 
-    assert default_client(given).settings is given
-    assert isinstance(default_client().settings, CacheSettings)
+    with pytest.raises(ValueError, match="path separator"):
+        client.lookup("a/b", Given.KEY_MATERIAL, str(tmp_path))
 
 
 @pytest.mark.base

--- a/tests/test_caching_client.py
+++ b/tests/test_caching_client.py
@@ -1,13 +1,8 @@
 """Tests for :mod:`hisim.caching.client` and for ``hisim.utils.get_cache_file`` delegating to it.
 
-Two things are pinned. First, the client's local tier does exactly what ``get_cache_file`` used to do
-inline -- the same filename, the same directory handling, the same validation and discarding -- because
-the delegation is only safe if nothing moved but the code. Second, the layering rule of spec §4:
-importing the cache package pulls in neither a component, nor the simulator, nor the simulation
-parameters, which is checked in a fresh interpreter so that nothing imported earlier by the test
-session can hide a violation.
-
-Each test states the failure mode it catches.
+Two things are pinned: the client's local tier does exactly what ``get_cache_file`` did inline (same
+filename, directory handling, validation and discarding), and importing the cache package pulls in no
+component, simulator or simulation-parameters module. The second is checked in a fresh interpreter.
 """
 
 # clean
@@ -160,14 +155,10 @@ def test_the_environment_override_moves_the_directory(tmp_path: pathlib.Path) ->
 
 @pytest.mark.base
 def test_get_cache_file_returns_exactly_the_path_it_always_did(tmp_path: pathlib.Path) -> None:
-    """The delegation is invisible: same filename, same directory, same validation, from the same inputs.
+    """The delegation to the client changes no cache filename.
 
-    The expected path is computed by hand from the published rule -- the digest of the legacy key
-    material under the component key -- rather than from the client, so this test would notice the
-    client changing the rule.
-
-    Catches: the move to the client changing a single byte of any cache filename, which would orphan
-    every existing entry on every machine.
+    The expected path is computed here from the published rule (digest of the legacy key material under the
+    component key), not asked of the client, so this test would notice the client changing the rule.
     """
 
     @dataclasses.dataclass
@@ -244,13 +235,9 @@ def test_default_client_reads_the_environment_or_takes_settings() -> None:
 
 @pytest.mark.base
 def test_importing_the_cache_package_imports_no_component_or_simulation_module() -> None:
-    """Spec §4: the package sits at the layer of ``hisim/config/`` and imports nothing above it.
+    """Importing ``hisim.caching`` imports no component, simulator or simulation-parameters module.
 
-    Run in a fresh interpreter, because in the test process those modules are long since imported and
-    ``sys.modules`` would say nothing about who imported them.
-
-    Catches: a convenience import in the package -- ``SimulationParameters`` for a type hint, say --
-    that would make every component import the simulation to reach its cache.
+    Run in a fresh interpreter, because in the test process those modules are already imported.
     """
     forbidden = (
         "hisim.component",

--- a/tests/test_caching_client.py
+++ b/tests/test_caching_client.py
@@ -1,0 +1,278 @@
+"""Tests for :mod:`hisim.caching.client` and for ``hisim.utils.get_cache_file`` delegating to it.
+
+Two things are pinned. First, the client's local tier does exactly what ``get_cache_file`` used to do
+inline -- the same filename, the same directory handling, the same validation and discarding -- because
+the delegation is only safe if nothing moved but the code. Second, the layering rule of spec §4:
+importing the cache package pulls in neither a component, nor the simulator, nor the simulation
+parameters, which is checked in a fresh interpreter so that nothing imported earlier by the test
+session can hide a violation.
+
+Each test states the failure mode it catches.
+"""
+
+# clean
+
+import dataclasses
+import os
+import pathlib
+import subprocess
+import sys
+from typing import ClassVar
+
+import pytest
+
+from hisim import utils
+from hisim.caching import CacheClient, CacheEntryMetadata, CacheSettings, atomic_cache_write, default_client
+from hisim.simulationparameters import SimulationParameters
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+class Given:
+    """The one key and the one payload every test here uses, so the tests read as variations on a theme."""
+
+    KEY_MATERIAL: ClassVar[str] = '{"location": "Aachen"}2021-01-01###2021-12-31###60'
+    COMPONENT_KEY: ClassVar[str] = "Weather"
+    PAYLOAD: ClassVar[str] = "index,value\n0,1.5\n"
+
+    @classmethod
+    def client(cls, tmp_path: pathlib.Path, **environment: str) -> CacheClient:
+        """A client over a settings object read from the given environment mapping.
+
+        Args:
+            tmp_path: unused except to make the signature symmetric with the tests.
+            **environment: the variables to set.
+
+        Returns:
+            CacheClient: the client.
+        """
+        del tmp_path
+        return CacheClient(CacheSettings.from_environment(environment))
+
+    @classmethod
+    def landed_entry(cls, client: CacheClient, directory: pathlib.Path) -> str:
+        """Writes one valid entry through the client and returns its path.
+
+        Args:
+            client: the client to look the entry up through.
+            directory: the cache directory.
+
+        Returns:
+            str: the entry's path.
+        """
+        entry = client.lookup(cls.COMPONENT_KEY, cls.KEY_MATERIAL, str(directory))
+        with entry.writing() as temporary_path:
+            pathlib.Path(temporary_path).write_text(cls.PAYLOAD, encoding="utf-8")
+        return entry.path
+
+
+@pytest.mark.base
+def test_a_miss_names_the_path_and_creates_the_directory(tmp_path: pathlib.Path) -> None:
+    """Looking up an entry that does not exist returns where it would go, in a directory that now exists.
+
+    Catches: a writer having to create the directory itself, which is how a first run on a clean
+    machine used to fail.
+    """
+    directory = tmp_path / "fresh" / "cache"
+    client = Given.client(tmp_path)
+
+    entry = client.lookup(Given.COMPONENT_KEY, Given.KEY_MATERIAL, str(directory))
+
+    assert not entry.exists
+    assert directory.is_dir()
+    expected_name = CacheClient.entry_filename(Given.COMPONENT_KEY, CacheEntryMetadata.hash_of(Given.KEY_MATERIAL))
+    assert entry.path == str(directory / expected_name)
+    assert entry.key_material == Given.KEY_MATERIAL
+
+
+@pytest.mark.base
+def test_an_entry_written_through_the_client_is_a_hit_next_time(tmp_path: pathlib.Path) -> None:
+    """The write path and the read path agree on name and metadata.
+
+    Catches: ``writing()`` landing the entry under a name ``lookup()`` does not look for, or without
+    the metadata that makes it count.
+    """
+    client = Given.client(tmp_path)
+    path = Given.landed_entry(client, tmp_path)
+
+    entry = client.lookup(Given.COMPONENT_KEY, Given.KEY_MATERIAL, str(tmp_path))
+
+    assert entry.exists
+    assert entry.path == path
+    assert pathlib.Path(path).read_text(encoding="utf-8") == Given.PAYLOAD
+    assert CacheEntryMetadata.describes(path)
+
+
+@pytest.mark.base
+def test_an_entry_without_metadata_is_discarded_and_reported_as_a_miss(tmp_path: pathlib.Path) -> None:
+    """A data file that cannot be shown to belong to its key is deleted, not served.
+
+    Catches: the migration rule -- every pre-metadata entry clears itself on first lookup -- being
+    lost in the move from ``get_cache_file`` to the client.
+    """
+    client = Given.client(tmp_path)
+    name = CacheClient.entry_filename(Given.COMPONENT_KEY, CacheEntryMetadata.hash_of(Given.KEY_MATERIAL))
+    stale = tmp_path / name
+    stale.write_text("written before the metadata scheme existed", encoding="utf-8")
+
+    entry = client.lookup(Given.COMPONENT_KEY, Given.KEY_MATERIAL, str(tmp_path))
+
+    assert not entry.exists
+    assert not stale.exists(), "the unvalidatable entry must be deleted, not left to be served later"
+
+
+@pytest.mark.base
+def test_an_entry_whose_metadata_disagrees_with_its_name_is_discarded(tmp_path: pathlib.Path) -> None:
+    """Metadata that hashes to a different name than the file carries is a poisoned entry.
+
+    Catches: validation that only checks the metadata file *exists*.
+    """
+    client = Given.client(tmp_path)
+    path = Given.landed_entry(client, tmp_path)
+    pathlib.Path(CacheEntryMetadata.metadata_filepath(path)).write_text("some other inputs", encoding="utf-8")
+
+    entry = client.lookup(Given.COMPONENT_KEY, Given.KEY_MATERIAL, str(tmp_path))
+
+    assert not entry.exists
+    assert not pathlib.Path(path).exists()
+
+
+@pytest.mark.base
+def test_the_environment_override_moves_the_directory(tmp_path: pathlib.Path) -> None:
+    """``HISIM_CACHE_DIR`` replaces the default directory the caller passes.
+
+    Catches: the override being parsed but not applied.
+    """
+    override = tmp_path / "override"
+    client = Given.client(tmp_path, HISIM_CACHE_DIR=str(override))
+
+    entry = client.lookup(Given.COMPONENT_KEY, Given.KEY_MATERIAL, str(tmp_path / "default"))
+
+    assert entry.path.startswith(str(override))
+    assert override.is_dir()
+
+
+@pytest.mark.base
+def test_get_cache_file_returns_exactly_the_path_it_always_did(tmp_path: pathlib.Path) -> None:
+    """The delegation is invisible: same filename, same directory, same validation, from the same inputs.
+
+    The expected path is computed by hand from the published rule -- the digest of the legacy key
+    material under the component key -- rather than from the client, so this test would notice the
+    client changing the rule.
+
+    Catches: the move to the client changing a single byte of any cache filename, which would orphan
+    every existing entry on every machine.
+    """
+
+    @dataclasses.dataclass
+    class Config:
+        """The smallest thing ``get_cache_file`` accepts: something with ``to_json``."""
+
+        name: str = "demo"
+
+        def to_json(self) -> str:
+            """The configuration's JSON, as ``ConfigBase`` would produce it."""
+            return '{"name": "demo"}'
+
+    parameters = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=3600)
+    parameters.cache_dir_path = str(tmp_path)
+    material = utils.build_cache_key_string(Config(), parameters)
+    expected = tmp_path / f"demo_{CacheEntryMetadata.hash_of(material)}.cache"
+
+    exists, path = utils.get_cache_file("demo", Config(), parameters)
+
+    assert not exists
+    assert path == str(expected)
+
+    with atomic_cache_write(path, material) as temporary_path:
+        pathlib.Path(temporary_path).write_text(Given.PAYLOAD, encoding="utf-8")
+    exists_after, path_after = utils.get_cache_file("demo", Config(), parameters)
+    assert exists_after and path_after == path
+
+
+@pytest.mark.base
+def test_an_explicit_directory_argument_outranks_the_environment(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A caller that names a directory gets that directory, whatever ``HISIM_CACHE_DIR`` says.
+
+    Every test that points ``get_cache_file`` at its own ``tmp_path`` relies on this; without it a
+    developer's override would make those tests write into the developer's cache.
+
+    Catches: the environment override silently redirecting an explicit request.
+    """
+
+    @dataclasses.dataclass
+    class Config:
+        """The smallest thing ``get_cache_file`` accepts: something with ``to_json``."""
+
+        name: str = "demo"
+
+        def to_json(self) -> str:
+            """The configuration's JSON."""
+            return '{"name": "demo"}'
+
+    monkeypatch.setenv(CacheSettings.Variables.DIRECTORY, str(tmp_path / "env"))
+    parameters = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=3600)
+    parameters.cache_dir_path = str(tmp_path / "params")
+    explicit = tmp_path / "explicit"
+
+    _, from_argument = utils.get_cache_file("demo", Config(), parameters, cache_dir_path=str(explicit))
+    _, from_environment = utils.get_cache_file("demo", Config(), parameters)
+
+    assert from_argument.startswith(str(explicit))
+    assert from_environment.startswith(str(tmp_path / "env"))
+
+
+@pytest.mark.base
+def test_default_client_reads_the_environment_or_takes_settings() -> None:
+    """The one-liner ``get_cache_file`` calls works both ways.
+
+    Catches: ``default_client`` ignoring the settings it was handed.
+    """
+    given = CacheSettings.from_environment({CacheSettings.Variables.DIRECTORY: "/given"})
+
+    assert default_client(given).settings is given
+    assert isinstance(default_client().settings, CacheSettings)
+
+
+@pytest.mark.base
+def test_importing_the_cache_package_imports_no_component_or_simulation_module() -> None:
+    """Spec §4: the package sits at the layer of ``hisim/config/`` and imports nothing above it.
+
+    Run in a fresh interpreter, because in the test process those modules are long since imported and
+    ``sys.modules`` would say nothing about who imported them.
+
+    Catches: a convenience import in the package -- ``SimulationParameters`` for a type hint, say --
+    that would make every component import the simulation to reach its cache.
+    """
+    forbidden = (
+        "hisim.component",
+        "hisim.simulator",
+        "hisim.simulationparameters",
+        "hisim.sim_repository",
+        "hisim.sim_repository_singleton",
+        "hisim.utils",
+        "hisim.loadtypes",
+    )
+    program = (
+        "import sys\n"
+        "import hisim.caching\n"
+        f"loaded = [name for name in {forbidden!r} if name in sys.modules]\n"
+        "print(','.join(loaded))\n"
+    )
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(pathlib.Path(__file__).resolve().parents[1])
+
+    completed = subprocess.run(  # nosec B603 - fixed argument vector, no shell
+        [sys.executable, "-c", program], capture_output=True, text=True, check=False, env=environment
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "", f"importing hisim.caching also imported: {completed.stdout.strip()}"

--- a/tests/test_caching_keys.py
+++ b/tests/test_caching_keys.py
@@ -9,11 +9,12 @@ small package written into a temporary directory, so the tests can edit source a
 
 import dataclasses
 import enum
+import hashlib
 import importlib
 import pathlib
 import sys
 from types import ModuleType
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar, Dict
 
 import pytest
 
@@ -212,6 +213,44 @@ def test_a_value_with_no_canonical_form_is_refused_by_field_name() -> None:
 
 
 @pytest.mark.base
+def test_a_mapping_with_a_non_string_key_is_refused() -> None:
+    """A mapping key that is not a string raises, naming the field, instead of being coerced.
+
+    Coercion would let ``{1: ...}`` and ``{"1": ...}`` render identically -- two different inputs,
+    one cache key, which is the exact defect the canonical form exists to prevent.
+    """
+
+    @dataclasses.dataclass(frozen=True)
+    class WithMapping:
+        """A DTO holding a mapping with an integer key."""
+
+        table: Dict[Any, str]
+
+    with pytest.raises(CacheKeyError, match="table"):
+        CanonicalJson.dumps(WithMapping(table={1: "x"}))
+
+
+@pytest.mark.base
+def test_a_non_finite_float_is_refused() -> None:
+    """A NaN or infinity raises, naming the field, instead of rendering as a non-JSON token.
+
+    Every NaN would render as the same ``NaN``, so two different inputs would share a key -- and the
+    ``.meta`` file would not even be parseable JSON.
+    """
+
+    @dataclasses.dataclass(frozen=True)
+    class WithFloat:
+        """A DTO holding one float."""
+
+        value: float
+
+    with pytest.raises(CacheKeyError, match="value"):
+        CanonicalJson.dumps(WithFloat(value=float("nan")))
+    with pytest.raises(CacheKeyError, match="value"):
+        CanonicalJson.dumps(WithFloat(value=float("inf")))
+
+
+@pytest.mark.base
 def test_a_non_dataclass_is_not_a_dto() -> None:
     """Spec §3.1: exactly one frozen dataclass. A dict is refused so the rule stays visible.
 
@@ -250,6 +289,28 @@ def test_the_closure_follows_package_imports_and_records_third_parties(
     assert closure.package_modules == ("acme.producer", "acme.shapes", "acme.sub.helper", "acme.tables")
     assert closure.third_party_top_levels == ("numpy", "pandas")
     assert not closure.dynamic_import_sites
+
+
+@pytest.mark.base
+def test_a_relative_import_in_the_root_init_is_followed(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``from . import helper`` in the root package's ``__init__`` resolves to a package module.
+
+    A package's ``__init__`` resolves relative imports against the package itself, not against a
+    parent. Getting this wrong files ``helper`` as a third-party name, its source is never
+    fingerprinted, and edits to it stop invalidating cache entries.
+    """
+    package = SyntheticPackage(tmp_path, monkeypatch)
+    package.write("helper", "import numpy\nVALUE = 1\n")
+    (tmp_path / SyntheticPackage.ROOT / "__init__.py").write_text("from . import helper\n", encoding="utf-8")
+    package.write("producer", "import acme\n")
+
+    closure = package.closure("producer")
+
+    assert "acme.helper" in closure.package_modules
+    assert "helper" not in closure.third_party_top_levels
+    assert closure.third_party_top_levels == ("numpy",)
 
 
 @pytest.mark.base
@@ -298,6 +359,29 @@ def test_the_third_party_fingerprint_pins_versions_and_the_interpreter(
 
 
 @pytest.mark.base
+def test_an_unresolvable_third_party_version_refuses_the_key(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dependency whose version cannot be resolved raises instead of pinning ``==unknown``.
+
+    An ``unknown`` pin would let two environments running different code for that package share
+    cache entries -- the failure the fingerprint exists to prevent.
+    """
+    del tmp_path, monkeypatch
+    closure = ImportClosure(
+        root_package="acme",
+        entry_module="acme.producer",
+        package_modules=("acme.producer",),
+        module_files={},
+        third_party_top_levels=("package_that_is_not_installed_anywhere",),
+        dynamic_import_sites=(),
+    )
+
+    with pytest.raises(CacheKeyError, match="package_that_is_not_installed_anywhere"):
+        Fingerprints.third_party(closure)
+
+
+@pytest.mark.base
 def test_component_machinery_in_the_closure_is_a_layering_violation(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -308,6 +392,7 @@ def test_component_machinery_in_the_closure_is_a_layering_violation(
     del tmp_path, monkeypatch
     closure = ImportClosure(
         root_package="hisim",
+        entry_module="hisim.components.pv_calculation",
         package_modules=("hisim.component", "hisim.components.pv_calculation"),
         module_files={},
         third_party_top_levels=(),
@@ -319,6 +404,9 @@ def test_component_machinery_in_the_closure_is_a_layering_violation(
     assert len(violations) == 1
     assert "hisim.component" in violations[0]
     with pytest.raises(ProducerLayeringError, match="hisim.component"):
+        ProducerLayering.check(closure)
+    # The error blames the producer the walk started from, not whichever closure module sorts first.
+    with pytest.raises(ProducerLayeringError, match="The producer hisim.components.pv_calculation"):
         ProducerLayering.check(closure)
 
 
@@ -337,6 +425,30 @@ def test_a_dynamic_import_is_a_layering_violation_with_a_line_number(
 
     assert closure.dynamic_import_sites == ("acme.producer:4",)
     assert any("acme.producer:4" in violation for violation in ProducerLayering.violations(closure))
+
+
+@pytest.mark.base
+def test_an_import_module_method_on_another_object_is_not_a_dynamic_import(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only ``importlib.import_module`` and the bare names count; an unrelated object's method does not.
+
+    Catches: the detector rejecting an innocent producer because some object happens to expose a
+    method called ``import_module``.
+    """
+    package = SyntheticPackage(tmp_path, monkeypatch)
+    package.write(
+        "producer",
+        "class Loader:\n"
+        "    def import_module(self, name):\n"
+        "        return name\n"
+        "\n"
+        "RESULT = Loader().import_module('json')\n",
+    )
+
+    closure = package.closure("producer")
+
+    assert not closure.dynamic_import_sites
 
 
 @pytest.mark.base
@@ -364,8 +476,9 @@ def test_a_cache_key_is_the_four_parts_and_its_digest_follows_them(
     assert parts[1] == key.code_fingerprint
     assert parts[2] == key.third_party_fingerprint
     assert parts[3] == key.dto_json
-    assert len(key.digest) == 64
-    assert key.digest == CacheKey(**dataclasses.asdict(key)).digest, "the digest must be a pure function of the parts"
+    assert key.digest == hashlib.sha256(key.material.encode("utf-8")).hexdigest(), (
+        "the digest must be the sha256 of the material -- the same rule CacheEntryMetadata.hash_of applies"
+    )
 
 
 @pytest.mark.base
@@ -388,13 +501,6 @@ def test_for_producer_runs_the_layering_check(tmp_path: pathlib.Path, monkeypatc
     package = SyntheticPackage(tmp_path, monkeypatch)
     package.write("producer", "import importlib\nMODULE = importlib.import_module('json')\n")
     module = package.load("producer")
-
-    def with_acme_root(cls: Any, target: ModuleType, root_package: Optional[str] = None) -> ImportClosure:
-        del cls, root_package
-        return original(target, root_package="acme")
-
-    original = ImportClosure.of
-    monkeypatch.setattr(ImportClosure, "of", classmethod(with_acme_root))
 
     with pytest.raises(ProducerLayeringError, match="dynamically"):
         CacheKey.for_producer("pv_series", module, inputs())

--- a/tests/test_caching_keys.py
+++ b/tests/test_caching_keys.py
@@ -1,13 +1,8 @@
-"""Tests for :mod:`hisim.caching.keys`: the key scheme of spec §3 and the closure walk both fingerprints rest on.
+"""Tests for :mod:`hisim.caching.keys`: the key scheme of spec §3 and the import-closure walk behind it.
 
-The claims under test are the ones the shared cache depends on. A key must change when anything that
-can change the result changes -- the inputs, the producer's code, a module it imports, a library
-version -- and must *not* change for anything else, or a plumbing edit invalidates every artifact and
-the cache is a cache in name only. The closure walk is exercised against a synthetic package written
-into a temporary directory, so the tests can edit "source" and add "imports" freely without touching
-HiSim; the walk takes the root package as a parameter for exactly this reason.
-
-Each test states the failure mode it catches.
+A key must change when anything that can change the result changes -- inputs, producer code, an imported
+module, a library version -- and must not change for anything else. The closure walk is tested against a
+small package written into a temporary directory, so the tests can edit source and add imports freely.
 """
 
 # clean
@@ -69,12 +64,10 @@ class PvInputs:
 
 
 class SyntheticPackage:
-    """Writes a small package into a directory and imports modules from it.
+    """Writes a small package named ``acme`` into a directory and imports modules from it.
 
-    The package is named ``acme`` and the walk is told so, which keeps every test independent of what
-    HiSim itself imports. ``rebuild`` re-imports after editing a file, because the walk reads source
-    from disk but ``find_spec`` consults the import system, and a stale ``sys.modules`` entry would
-    otherwise hide the edit from a test that re-imports.
+    Using a synthetic package keeps the tests independent of what HiSim itself imports. :meth:`load`
+    drops any cached ``acme`` modules first, so a test can edit a file and re-import it.
     """
 
     ROOT: ClassVar[str] = "acme"
@@ -175,13 +168,10 @@ def test_canonical_json_is_sorted_renders_enums_by_value_and_recurses() -> None:
 
 @pytest.mark.base
 def test_a_payload_field_never_reaches_the_key() -> None:
-    """Two DTOs differing only in their payload are the same calculation.
+    """Two DTOs that differ only in a payload field have the same key.
 
-    This is the invariant that lets an upstream frame travel with its key: the frame is identified by
-    the key field beside it, so hashing the frame too would be redundant at best and, for a frame that
-    does not serialise canonically, impossible.
-
-    Catches: the payload marker being ignored, so every producer with a frame field fails to key.
+    A payload field is identified by the key field beside it (for example ``weather_artifact_key``), so
+    hashing the payload too would be redundant, and for a DataFrame impossible.
     """
     with_frame = inputs(weather_frame={"huge": list(range(1000))})
     without_frame = inputs(weather_frame=None)
@@ -206,12 +196,9 @@ def test_every_key_field_moves_the_key() -> None:
 
 @pytest.mark.base
 def test_a_value_with_no_canonical_form_is_refused_by_field_name() -> None:
-    """An object the scheme cannot render is an error naming the field, not a ``str()`` of the object.
+    """A value the scheme cannot render raises an error naming the field, instead of being stringified.
 
-    Silently stringifying would let two different inputs share a key whenever their ``str`` agrees,
-    which for most objects is their type and address.
-
-    Catches: a producer author putting an arbitrary object in a key field and getting a key anyway.
+    Stringifying would let two different inputs share a key whenever their ``str`` is the same.
     """
 
     @dataclasses.dataclass(frozen=True)
@@ -238,14 +225,10 @@ def test_a_non_dataclass_is_not_a_dto() -> None:
 def test_the_closure_follows_package_imports_and_records_third_parties(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The walk finds every module of the package the producer reaches, and names what it reaches outside it.
+    """The walk finds every package module the producer reaches and records third-party imports by name.
 
-    Covers the four import spellings a producer may use: ``import a.b``, ``from a import b`` where
-    ``b`` is a module, ``from a.b import name`` where ``name`` is an attribute, and a relative import.
-    Standard-library imports are neither followed nor recorded.
-
-    Catches: an import spelling the walk does not understand, which would leave a dependency out of
-    the fingerprint and make its edits invisible to the cache.
+    Covers the four spellings: ``import a.b``, ``from a import b`` (module), ``from a.b import name``
+    (attribute) and a relative import. Standard-library imports are neither followed nor recorded.
     """
     package = SyntheticPackage(tmp_path, monkeypatch)
     package.write("sub.helper", "import math\nVALUE = 1\n")
@@ -273,14 +256,10 @@ def test_the_closure_follows_package_imports_and_records_third_parties(
 def test_the_code_fingerprint_moves_with_a_dependency_and_not_with_a_stranger(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Editing a module the producer imports changes the fingerprint; editing one it does not, does not.
+    """Editing an imported module changes the fingerprint; editing an unrelated module does not.
 
-    This is the whole point of fingerprinting the closure rather than the commit: a KPI edit in a
-    component invalidates nothing, a change to the physics the producer imports invalidates exactly
-    the artifacts that depend on it.
-
-    Catches: a fingerprint that is either insensitive to a real dependency or sensitive to the
-    whole package.
+    This is the reason the closure is fingerprinted instead of the commit: a KPI edit in a component
+    invalidates nothing, a change to physics the producer imports invalidates exactly its entries.
     """
     package = SyntheticPackage(tmp_path, monkeypatch)
     package.write("physics", "COEFFICIENT = 0.6\n")
@@ -322,14 +301,9 @@ def test_the_third_party_fingerprint_pins_versions_and_the_interpreter(
 def test_component_machinery_in_the_closure_is_a_layering_violation(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A producer that imports the component base class is refused, naming the module.
+    """A closure containing ``hisim.component`` is reported as a violation naming that module.
 
-    The check runs on the closure, not the producer alone, so an import two hops away is caught too.
-    The forbidden names are HiSim's, so the synthetic package is asked about a closure whose module
-    names are spelled the HiSim way.
-
-    Catches: a producer quietly growing a dependency on the simulator and dragging the package into
-    its fingerprint.
+    The check runs on the whole closure, so an import two hops away is caught as well.
     """
     del tmp_path, monkeypatch
     closure = ImportClosure(

--- a/tests/test_caching_keys.py
+++ b/tests/test_caching_keys.py
@@ -1,0 +1,426 @@
+"""Tests for :mod:`hisim.caching.keys`: the key scheme of spec §3 and the closure walk both fingerprints rest on.
+
+The claims under test are the ones the shared cache depends on. A key must change when anything that
+can change the result changes -- the inputs, the producer's code, a module it imports, a library
+version -- and must *not* change for anything else, or a plumbing edit invalidates every artifact and
+the cache is a cache in name only. The closure walk is exercised against a synthetic package written
+into a temporary directory, so the tests can edit "source" and add "imports" freely without touching
+HiSim; the walk takes the root package as a parameter for exactly this reason.
+
+Each test states the failure mode it catches.
+"""
+
+# clean
+
+import dataclasses
+import enum
+import importlib
+import pathlib
+import sys
+from types import ModuleType
+from typing import Any, ClassVar, Dict, Optional
+
+import pytest
+
+from hisim.caching import (
+    CacheKey,
+    CacheKeyError,
+    CanonicalJson,
+    Fingerprints,
+    ImportClosure,
+    KeyMaterial,
+    ProducerLayering,
+    ProducerLayeringError,
+)
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+class Orientation(enum.Enum):
+    """A stand-in for the enums real DTOs carry."""
+
+    SOUTH = "south"
+    EAST = "east"
+
+
+@dataclasses.dataclass(frozen=True)
+class Location:
+    """A nested DTO, to prove recursion follows the same rules."""
+
+    latitude: float
+    longitude: float
+
+
+@dataclasses.dataclass(frozen=True)
+class PvInputs:
+    """A DTO of the shape spec §3.1 describes: primitives, an enum, a nested DTO, a key, and a payload."""
+
+    peak_power_in_watt: float
+    orientation: Orientation
+    location: Location
+    weather_artifact_key: str
+    weather_frame: Any = dataclasses.field(default=None, metadata=KeyMaterial.PAYLOAD)
+
+
+class SyntheticPackage:
+    """Writes a small package into a directory and imports modules from it.
+
+    The package is named ``acme`` and the walk is told so, which keeps every test independent of what
+    HiSim itself imports. ``rebuild`` re-imports after editing a file, because the walk reads source
+    from disk but ``find_spec`` consults the import system, and a stale ``sys.modules`` entry would
+    otherwise hide the edit from a test that re-imports.
+    """
+
+    ROOT: ClassVar[str] = "acme"
+
+    def __init__(self, directory: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Creates the empty package on the path.
+
+        Args:
+            directory: the directory to write into.
+            monkeypatch: used to put the directory on ``sys.path`` for the test's lifetime.
+        """
+        self.directory = directory
+        (directory / self.ROOT).mkdir()
+        (directory / self.ROOT / "__init__.py").write_text("", encoding="utf-8")
+        monkeypatch.syspath_prepend(str(directory))
+        self._written: Dict[str, str] = {}
+
+    def write(self, module: str, source: str) -> None:
+        """Writes or overwrites one module of the package.
+
+        Args:
+            module: the dotted name below the root, e.g. ``"producer"`` or ``"sub.helper"``.
+            source: the module's source.
+        """
+        parts = module.split(".")
+        folder = self.directory / self.ROOT
+        for part in parts[:-1]:
+            folder = folder / part
+            folder.mkdir(exist_ok=True)
+            init = folder / "__init__.py"
+            if not init.exists():
+                init.write_text("", encoding="utf-8")
+        (folder / f"{parts[-1]}.py").write_text(source, encoding="utf-8")
+        self._written[module] = source
+
+    def load(self, module: str) -> ModuleType:
+        """Imports a module of the package freshly.
+
+        Args:
+            module: the dotted name below the root.
+
+        Returns:
+            ModuleType: the imported module.
+        """
+        qualified = f"{self.ROOT}.{module}"
+        for name in list(sys.modules):
+            if name == self.ROOT or name.startswith(self.ROOT + "."):
+                del sys.modules[name]
+        importlib.invalidate_caches()
+        return importlib.import_module(qualified)
+
+    def closure(self, module: str) -> ImportClosure:
+        """Imports a module and computes its closure within the package.
+
+        Args:
+            module: the dotted name below the root.
+
+        Returns:
+            ImportClosure: the closure.
+        """
+        return ImportClosure.of(self.load(module), root_package=self.ROOT)
+
+
+def inputs(**overrides: Any) -> PvInputs:
+    """A baseline DTO, with any field replaced.
+
+    Args:
+        **overrides: fields to change from the baseline.
+
+    Returns:
+        PvInputs: the DTO.
+    """
+    baseline: Dict[str, Any] = {
+        "peak_power_in_watt": 5000.0,
+        "orientation": Orientation.SOUTH,
+        "location": Location(latitude=50.77, longitude=6.08),
+        "weather_artifact_key": "weather/abc123",
+        "weather_frame": None,
+    }
+    baseline.update(overrides)
+    return PvInputs(**baseline)
+
+
+@pytest.mark.base
+def test_canonical_json_is_sorted_renders_enums_by_value_and_recurses() -> None:
+    """The three rules of spec §3.1, in one string.
+
+    Catches: field order leaking into the key, an enum rendered by name, or a nested DTO rendered by
+    ``repr``.
+    """
+    rendered = CanonicalJson.dumps(inputs())
+
+    assert rendered == (
+        '{"location":{"latitude":50.77,"longitude":6.08},"orientation":"south",'
+        '"peak_power_in_watt":5000.0,"weather_artifact_key":"weather/abc123"}'
+    )
+
+
+@pytest.mark.base
+def test_a_payload_field_never_reaches_the_key() -> None:
+    """Two DTOs differing only in their payload are the same calculation.
+
+    This is the invariant that lets an upstream frame travel with its key: the frame is identified by
+    the key field beside it, so hashing the frame too would be redundant at best and, for a frame that
+    does not serialise canonically, impossible.
+
+    Catches: the payload marker being ignored, so every producer with a frame field fails to key.
+    """
+    with_frame = inputs(weather_frame={"huge": list(range(1000))})
+    without_frame = inputs(weather_frame=None)
+
+    assert CanonicalJson.dumps(with_frame) == CanonicalJson.dumps(without_frame)
+
+
+@pytest.mark.base
+def test_every_key_field_moves_the_key() -> None:
+    """L1 of the cache-testing spec, for the DTO scheme: perturb one input, the key changes.
+
+    Catches: a key that silently drops a field, which is spec ``roadmap/pylpg_flakiness.md`` F7 in
+    its new clothes.
+    """
+    baseline = CanonicalJson.dumps(inputs())
+
+    assert CanonicalJson.dumps(inputs(peak_power_in_watt=5001.0)) != baseline
+    assert CanonicalJson.dumps(inputs(orientation=Orientation.EAST)) != baseline
+    assert CanonicalJson.dumps(inputs(location=Location(latitude=50.78, longitude=6.08))) != baseline
+    assert CanonicalJson.dumps(inputs(weather_artifact_key="weather/def456")) != baseline
+
+
+@pytest.mark.base
+def test_a_value_with_no_canonical_form_is_refused_by_field_name() -> None:
+    """An object the scheme cannot render is an error naming the field, not a ``str()`` of the object.
+
+    Silently stringifying would let two different inputs share a key whenever their ``str`` agrees,
+    which for most objects is their type and address.
+
+    Catches: a producer author putting an arbitrary object in a key field and getting a key anyway.
+    """
+
+    @dataclasses.dataclass(frozen=True)
+    class Bad:
+        """A DTO holding something with no canonical form."""
+
+        handle: object
+
+    with pytest.raises(CacheKeyError, match="handle"):
+        CanonicalJson.dumps(Bad(handle=object()))
+
+
+@pytest.mark.base
+def test_a_non_dataclass_is_not_a_dto() -> None:
+    """Spec §3.1: exactly one frozen dataclass. A dict is refused so the rule stays visible.
+
+    Catches: producers drifting to loose dicts, which have no declared field set to check.
+    """
+    with pytest.raises(CacheKeyError, match="dataclass"):
+        CanonicalJson.dumps({"peak_power_in_watt": 5000.0})
+
+
+@pytest.mark.base
+def test_the_closure_follows_package_imports_and_records_third_parties(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The walk finds every module of the package the producer reaches, and names what it reaches outside it.
+
+    Covers the four import spellings a producer may use: ``import a.b``, ``from a import b`` where
+    ``b`` is a module, ``from a.b import name`` where ``name`` is an attribute, and a relative import.
+    Standard-library imports are neither followed nor recorded.
+
+    Catches: an import spelling the walk does not understand, which would leave a dependency out of
+    the fingerprint and make its edits invisible to the cache.
+    """
+    package = SyntheticPackage(tmp_path, monkeypatch)
+    package.write("sub.helper", "import math\nVALUE = 1\n")
+    package.write("sub.__init__", "")
+    package.write("tables", "import numpy\nTABLE = [1, 2]\n")
+    package.write("shapes", "SHAPE = 'flat'\n")
+    package.write(
+        "producer",
+        "import json\n"
+        "import acme.tables\n"
+        "from acme.sub import helper\n"
+        "from acme.shapes import SHAPE\n"
+        "from . import shapes as again\n"
+        "import pandas as pd\n",
+    )
+
+    closure = package.closure("producer")
+
+    assert closure.package_modules == ("acme.producer", "acme.shapes", "acme.sub.helper", "acme.tables")
+    assert closure.third_party_top_levels == ("numpy", "pandas")
+    assert not closure.dynamic_import_sites
+
+
+@pytest.mark.base
+def test_the_code_fingerprint_moves_with_a_dependency_and_not_with_a_stranger(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Editing a module the producer imports changes the fingerprint; editing one it does not, does not.
+
+    This is the whole point of fingerprinting the closure rather than the commit: a KPI edit in a
+    component invalidates nothing, a change to the physics the producer imports invalidates exactly
+    the artifacts that depend on it.
+
+    Catches: a fingerprint that is either insensitive to a real dependency or sensitive to the
+    whole package.
+    """
+    package = SyntheticPackage(tmp_path, monkeypatch)
+    package.write("physics", "COEFFICIENT = 0.6\n")
+    package.write("plumbing", "KPI_NAME = 'a'\n")
+    package.write("producer", "from acme import physics\n")
+    before = Fingerprints.code(package.closure("producer"))
+
+    package.write("plumbing", "KPI_NAME = 'b'\n")
+    after_stranger = Fingerprints.code(package.closure("producer"))
+    package.write("physics", "COEFFICIENT = 0.7\n")
+    after_dependency = Fingerprints.code(package.closure("producer"))
+
+    assert after_stranger == before, "an unrelated module's edit reached the fingerprint"
+    assert after_dependency != before, "a dependency's edit did not reach the fingerprint"
+
+
+@pytest.mark.base
+def test_the_third_party_fingerprint_pins_versions_and_the_interpreter(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each third-party import contributes ``name==version``; the interpreter contributes its major.minor.
+
+    Catches: a fingerprint that names packages without versions, so a library upgrade that changes
+    results leaves every entry looking current.
+    """
+    package = SyntheticPackage(tmp_path, monkeypatch)
+    package.write("producer", "import numpy\nimport json\n")
+
+    fingerprint = Fingerprints.third_party(package.closure("producer"))
+
+    pins = fingerprint.split(";")
+    assert f"python=={sys.version_info.major}.{sys.version_info.minor}" in pins
+    numpy_pins = [pin for pin in pins if pin.startswith("numpy==")]
+    assert len(numpy_pins) == 1 and numpy_pins[0] != "numpy==unknown"
+    assert not any(pin.startswith("json==") for pin in pins), "the standard library must not be pinned by package"
+
+
+@pytest.mark.base
+def test_component_machinery_in_the_closure_is_a_layering_violation(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A producer that imports the component base class is refused, naming the module.
+
+    The check runs on the closure, not the producer alone, so an import two hops away is caught too.
+    The forbidden names are HiSim's, so the synthetic package is asked about a closure whose module
+    names are spelled the HiSim way.
+
+    Catches: a producer quietly growing a dependency on the simulator and dragging the package into
+    its fingerprint.
+    """
+    del tmp_path, monkeypatch
+    closure = ImportClosure(
+        root_package="hisim",
+        package_modules=("hisim.component", "hisim.components.pv_calculation"),
+        module_files={},
+        third_party_top_levels=(),
+        dynamic_import_sites=(),
+    )
+
+    violations = ProducerLayering.violations(closure)
+
+    assert len(violations) == 1
+    assert "hisim.component" in violations[0]
+    with pytest.raises(ProducerLayeringError, match="hisim.component"):
+        ProducerLayering.check(closure)
+
+
+@pytest.mark.base
+def test_a_dynamic_import_is_a_layering_violation_with_a_line_number(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``importlib.import_module`` and ``__import__`` are found and reported with their location.
+
+    Catches: a dependency the static walk cannot see, which is a stale entry it cannot prevent.
+    """
+    package = SyntheticPackage(tmp_path, monkeypatch)
+    package.write("producer", "import importlib\n\ndef load(name):\n    return importlib.import_module(name)\n")
+
+    closure = package.closure("producer")
+
+    assert closure.dynamic_import_sites == ("acme.producer:4",)
+    assert any("acme.producer:4" in violation for violation in ProducerLayering.violations(closure))
+
+
+@pytest.mark.base
+def test_a_cache_key_is_the_four_parts_and_its_digest_follows_them(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Spec §3 spelled out: material is ``kind:code:third_party:dto`` and the digest is its sha256.
+
+    Catches: the material being assembled in another order or with another separator than the
+    metadata files record.
+    """
+    package = SyntheticPackage(tmp_path, monkeypatch)
+    package.write("producer", "import numpy\n")
+    closure = package.closure("producer")
+
+    key = CacheKey(
+        artifact_kind="pv_series",
+        code_fingerprint=Fingerprints.code(closure),
+        third_party_fingerprint=Fingerprints.third_party(closure),
+        dto_json=CanonicalJson.dumps(inputs()),
+    )
+
+    parts = key.material.split(CacheKey.SEPARATOR, 3)
+    assert parts[0] == "pv_series"
+    assert parts[1] == key.code_fingerprint
+    assert parts[2] == key.third_party_fingerprint
+    assert parts[3] == key.dto_json
+    assert len(key.digest) == 64
+    assert key.digest == CacheKey(**dataclasses.asdict(key)).digest, "the digest must be a pure function of the parts"
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("kind", ["", "pv series", "pv/series", "-pv", "pv.series"])
+def test_an_artifact_kind_that_cannot_be_a_path_segment_is_refused(kind: str) -> None:
+    """The kind is a filename prefix and a URL segment, so it is validated as one.
+
+    Catches: a kind with a slash or a space producing a path that means something else.
+    """
+    with pytest.raises(CacheKeyError, match="Artifact kind"):
+        CacheKey(artifact_kind=kind, code_fingerprint="c", third_party_fingerprint="t", dto_json="{}")
+
+
+@pytest.mark.base
+def test_for_producer_runs_the_layering_check(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Building a key for a non-compliant producer fails at the layering check, before any hashing.
+
+    Catches: a key being issued for a producer whose fingerprint cannot be trusted.
+    """
+    package = SyntheticPackage(tmp_path, monkeypatch)
+    package.write("producer", "import importlib\nMODULE = importlib.import_module('json')\n")
+    module = package.load("producer")
+
+    def with_acme_root(cls: Any, target: ModuleType, root_package: Optional[str] = None) -> ImportClosure:
+        del cls, root_package
+        return original(target, root_package="acme")
+
+    original = ImportClosure.of
+    monkeypatch.setattr(ImportClosure, "of", classmethod(with_acme_root))
+
+    with pytest.raises(ProducerLayeringError, match="dynamically"):
+        CacheKey.for_producer("pv_series", module, inputs())

--- a/tests/test_caching_settings.py
+++ b/tests/test_caching_settings.py
@@ -1,0 +1,153 @@
+"""Tests for :mod:`hisim.caching.settings`: the six variables, and the guarantee that none of them is needed.
+
+The property the whole cache service rests on is the standalone guarantee of spec §5 -- with no
+variables set, HiSim behaves exactly as before. The first test pins it. The rest pin each variable's
+reading and the one validation the settings make, because a misspelled network mode should fail the
+day it is typed rather than the day the remote tier ships. Each test states the failure mode it catches.
+"""
+
+# clean
+
+import pytest
+
+from hisim.caching import CacheNetworkMode, CacheSettings, CacheSettingsError
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+@pytest.mark.base
+def test_no_variables_means_standalone_and_auto() -> None:
+    """The standalone guarantee: an empty environment is local-only, with the network mode at its default.
+
+    Catches: a default that switches a tier on for a user who set nothing.
+    """
+    settings = CacheSettings.from_environment({})
+
+    assert settings.is_standalone
+    assert settings.network is CacheNetworkMode.AUTO
+    assert settings.internal_url is None
+    assert settings.external_url is None
+    assert settings.api_key is None
+    assert settings.local_directory is None
+    assert settings.shared_directory is None
+
+
+@pytest.mark.base
+def test_every_variable_is_read_from_its_documented_name() -> None:
+    """Each of the six variables lands in its field, and nothing else in the environment is read.
+
+    Catches: a field wired to the wrong variable, which would silently ignore a user's setting.
+    """
+    settings = CacheSettings.from_environment(
+        {
+            CacheSettings.Variables.URL_INTERNAL: "https://10.0.0.1/hisim-cache",
+            CacheSettings.Variables.URL_EXTERNAL: "https://cache.example.org/hisim-cache",
+            CacheSettings.Variables.NETWORK: "external",
+            CacheSettings.Variables.API_KEY: "token",
+            CacheSettings.Variables.DIRECTORY: "/somewhere/local",
+            CacheSettings.Variables.SHARED_DIRECTORY: "/somewhere/shared",
+            "UNRELATED": "ignored",
+        }
+    )
+
+    assert settings.internal_url == "https://10.0.0.1/hisim-cache"
+    assert settings.external_url == "https://cache.example.org/hisim-cache"
+    assert settings.network is CacheNetworkMode.EXTERNAL
+    assert settings.api_key == "token"
+    assert settings.local_directory == "/somewhere/local"
+    assert settings.shared_directory == "/somewhere/shared"
+    assert not settings.is_standalone
+
+
+@pytest.mark.base
+def test_an_empty_value_is_the_same_as_an_unset_one() -> None:
+    """A ``.env`` line with nothing after the equals sign does not mean "the URL is the empty string".
+
+    Catches: an empty URL being treated as a configured endpoint and probed.
+    """
+    settings = CacheSettings.from_environment(
+        {CacheSettings.Variables.URL_INTERNAL: "  ", CacheSettings.Variables.DIRECTORY: ""}
+    )
+
+    assert settings.internal_url is None
+    assert settings.local_directory is None
+    assert settings.is_standalone
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("spelling", ["off", "OFF", "Off"])
+def test_the_network_mode_is_case_insensitive(spelling: str) -> None:
+    """``off`` is accepted however it is capitalised, because people do.
+
+    Catches: a mode that is only recognised in one case, which a user would read as the setting not
+    working.
+    """
+    settings = CacheSettings.from_environment({CacheSettings.Variables.NETWORK: spelling})
+
+    assert settings.network is CacheNetworkMode.OFF
+
+
+@pytest.mark.base
+def test_an_unknown_network_mode_is_refused_naming_the_variable_and_the_options() -> None:
+    """A typo in the mode fails at once, with the fix in the message.
+
+    Catches: a misspelled mode silently falling back to a default, so a user who wrote ``offline``
+    to disable the network has it enabled.
+    """
+    with pytest.raises(CacheSettingsError) as raised:
+        CacheSettings.from_environment({CacheSettings.Variables.NETWORK: "offline"})
+
+    message = str(raised.value)
+    assert CacheSettings.Variables.NETWORK in message
+    assert "offline" in message
+    for mode in CacheNetworkMode:
+        assert mode.value in message
+
+
+@pytest.mark.base
+def test_network_off_with_urls_set_is_still_standalone() -> None:
+    """Setting the mode to ``off`` wins over any endpoint that is configured.
+
+    This is the reversibility promise of spec §10: ``HISIM_CACHE_NETWORK=off`` returns to phase-0
+    behaviour at any time, whatever else is set.
+
+    Catches: an endpoint variable overriding the explicit off switch.
+    """
+    settings = CacheSettings.from_environment(
+        {
+            CacheSettings.Variables.URL_INTERNAL: "https://10.0.0.1/hisim-cache",
+            CacheSettings.Variables.NETWORK: "off",
+        }
+    )
+
+    assert settings.is_standalone
+
+
+@pytest.mark.base
+def test_a_shared_directory_alone_makes_the_settings_non_standalone() -> None:
+    """The shared-directory tier counts as infrastructure even with no network configured.
+
+    Catches: ``is_standalone`` only looking at the network and missing the third tier.
+    """
+    settings = CacheSettings.from_environment({CacheSettings.Variables.SHARED_DIRECTORY: "/nas/hisim"})
+
+    assert not settings.is_standalone
+
+
+@pytest.mark.base
+def test_the_local_directory_override_is_honoured_and_absent_means_the_default() -> None:
+    """``HISIM_CACHE_DIR`` replaces the simulation's directory; without it the default is returned unchanged.
+
+    Catches: the override being ignored, or an unset override returning ``None`` instead of the default.
+    """
+    without = CacheSettings.from_environment({})
+    with_override = CacheSettings.from_environment({CacheSettings.Variables.DIRECTORY: "/override"})
+
+    assert without.resolve_local_directory("/default") == "/default"
+    assert with_override.resolve_local_directory("/default") == "/override"

--- a/tests/test_caching_settings.py
+++ b/tests/test_caching_settings.py
@@ -109,6 +109,41 @@ def test_an_unknown_network_mode_is_refused_naming_the_variable_and_the_options(
 
 
 @pytest.mark.base
+@pytest.mark.parametrize("value", ["htp//10.0.0.1/not a real url", "not a url at all", "ftp://cache.example.org"])
+def test_a_malformed_endpoint_url_is_refused_naming_the_variable(value: str) -> None:
+    """A typo in an endpoint URL fails at configuration time, not in the network phase months later.
+
+    Catches: a misspelled URL being stored silently, surfacing as a confusing connection error only
+    once the network tier ships.
+    """
+    with pytest.raises(CacheSettingsError) as raised:
+        CacheSettings.from_environment({CacheSettings.Variables.URL_INTERNAL: value})
+
+    message = str(raised.value)
+    assert CacheSettings.Variables.URL_INTERNAL in message
+    assert value in message
+
+
+@pytest.mark.base
+@pytest.mark.parametrize(
+    ("mode", "variable"),
+    [("internal", CacheSettings.Variables.URL_INTERNAL), ("external", CacheSettings.Variables.URL_EXTERNAL)],
+)
+def test_a_pinned_mode_without_its_url_is_refused(mode: str, variable: str) -> None:
+    """``internal`` or ``external`` with no matching URL cannot ever connect, so it fails now.
+
+    Catches: the misconfiguration being masked as standalone operation, hiding it until the network
+    phase.
+    """
+    with pytest.raises(CacheSettingsError) as raised:
+        CacheSettings.from_environment({CacheSettings.Variables.NETWORK: mode})
+
+    message = str(raised.value)
+    assert variable in message
+    assert mode in message
+
+
+@pytest.mark.base
 def test_network_off_with_urls_set_is_still_standalone() -> None:
     """Setting the mode to ``off`` wins over any endpoint that is configured.
 

--- a/tests/test_caching_settings.py
+++ b/tests/test_caching_settings.py
@@ -1,9 +1,7 @@
-"""Tests for :mod:`hisim.caching.settings`: the six variables, and the guarantee that none of them is needed.
+"""Tests for :mod:`hisim.caching.settings`.
 
-The property the whole cache service rests on is the standalone guarantee of spec §5 -- with no
-variables set, HiSim behaves exactly as before. The first test pins it. The rest pin each variable's
-reading and the one validation the settings make, because a misspelled network mode should fail the
-day it is typed rather than the day the remote tier ships. Each test states the failure mode it catches.
+The first test pins the standalone guarantee of spec §5: with no variables set, HiSim is local-only.
+The others pin how each variable is read and the one validation the settings perform.
 """
 
 # clean

--- a/tests/test_regeneration_environment.py
+++ b/tests/test_regeneration_environment.py
@@ -28,7 +28,7 @@ from typing import ClassVar, Dict, List
 import pytest
 
 from hisim.components.pylpg_workspace import LpgBaseIndexPool, PylpgWorkspace
-from scripts.regenerate_scenario_jsons import REPO_ROOT, regenerate_one
+from scripts.regenerate_scenario_jsons import CONVERTER, REPO_ROOT, regenerate_one
 
 
 class PathProbe:
@@ -113,29 +113,45 @@ def test_a_script_started_by_path_cannot_import_from_its_working_directory(tmp_p
 
 
 class RecordedChild:
-    """A stand-in for :func:`subprocess.run` that keeps the environment it was handed.
+    """A stand-in for :func:`subprocess.run` that keeps the environment the converter was handed.
 
     The environment is the part of the driver's contract with its children that this test file is
     about (the argument vector, working directory and log routing are the rest), and it is captured
     whole -- so recording it is enough here, and the test never pays for a simulation.
+
+    The tests install this by patching ``scripts.regenerate_scenario_jsons.subprocess.run`` -- which
+    is the one global ``subprocess`` module, so the patch catches every ``subprocess.run`` call in
+    the process, not only the driver's. Anything that is not the converter invocation is therefore
+    handed to the real ``subprocess.run``: the stray-file guard, for one, runs ``git status`` at
+    teardown, and depending on fixture ordering that can happen while the patch is still active.
     """
 
     def __init__(self) -> None:
-        """Start out having seen nothing."""
+        """Start out having seen nothing, remembering the real ``subprocess.run`` for passing through.
+
+        Constructed before the patch is installed, so ``subprocess.run`` is still the real one here.
+        """
         self.environments: List[Dict[str, str]] = []
+        self._real_run = subprocess.run
 
     def __call__(self, *args, **kwargs) -> subprocess.CompletedProcess:
-        """Record the environment and report success without running anything.
+        """Record the converter call's environment; hand any other call to the real ``subprocess.run``.
 
         Args:
-            *args: The argument vector the driver built; ignored.
+            *args: The positional arguments; the first is the argument vector, which says whether
+                this is the driver's converter invocation.
             **kwargs: The keyword arguments, of which ``env`` is what this test is about.
 
         Returns:
-            A finished process with return code zero.
+            A finished process with return code zero for the converter, or whatever the real
+            ``subprocess.run`` returns for anything else.
         """
+        vector = args[0] if args else kwargs.get("args", [])
+        if str(CONVERTER) not in [str(part) for part in vector]:
+            # The caller's own kwargs decide check= and everything else; forwarding must not add to them.
+            return self._real_run(*args, **kwargs)  # pylint: disable=subprocess-run-check
         self.environments.append(dict(kwargs["env"]))
-        return subprocess.CompletedProcess(args=args[0] if args else [], returncode=0)
+        return subprocess.CompletedProcess(args=vector, returncode=0)
 
 
 @pytest.mark.base
@@ -184,3 +200,25 @@ def test_the_child_is_handed_the_borrowed_base_index(tmp_path: Path, monkeypatch
     assert len(recorded.environments) == 1
     handed = recorded.environments[0].get(PylpgWorkspace.INDEX_ENVIRONMENT_VARIABLE)
     assert handed == "1", f"the borrowed base index did not reach the child: {handed!r}"
+
+
+@pytest.mark.base
+def test_the_recorded_child_hands_unrelated_calls_to_the_real_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """While the recorder is installed, a call that is not the converter reaches the real ``subprocess.run``.
+
+    The patch replaces ``run`` on the one global ``subprocess`` module, so it catches every caller in
+    the process. Catches: the stray-file guard's ``git status`` at teardown -- which fixture ordering
+    can place inside the patch's lifetime -- being answered by the recorder and failing on the missing
+    ``env`` keyword instead of running.
+    """
+    recorded = RecordedChild()
+    monkeypatch.setattr("scripts.regenerate_scenario_jsons.subprocess.run", recorded)
+
+    completed = subprocess.run(  # nosec B603 - fixed argument vector, no shell
+        [sys.executable, "-c", "print('passed through')"], capture_output=True, text=True, check=False
+    )
+
+    assert completed.stdout.strip() == "passed through"
+    assert not recorded.environments, "an unrelated call must not be recorded as a converter child"


### PR DESCRIPTION
## Problem

`roadmap/cache_service_spec.md` §10 phase 1 is the local tier of the cache service: package skeleton, a `CacheKey` with automatic fingerprints, atomic writes, and `utils.get_cache_file` delegating. #602 shipped the atomic writes and the self-validating metadata. The rest was missing, and every later phase (remote tier, shared directory, datasets) needs one client that every component already talks to — which today is `get_cache_file`, inline.

## What was done

- **`settings.py`** — the six §5 environment variables read in one place. Empty environment → local-only (the standalone guarantee, pinned by test). Network mode validated now, acted on never in this phase.
- **`keys.py`** — the §3 scheme: `CacheKey` = `kind:code_fingerprint:third_party_fingerprint:dto_json`. Fingerprints are automatic from a static walk of the producer module's import closure (`ImportClosure`); `ProducerLayering` enforces the rule that makes that sound, from the same closure; `CanonicalJson` renders enums by value, recurses, leaves payload fields (`metadata=KeyMaterial.PAYLOAD`) out, and refuses anything else *by field name* rather than stringifying it. **No component uses it yet** — the legacy key stays the default, so nothing is invalidated.
- **`client.py`** — one tier behind `CacheClient.lookup`, doing exactly what `get_cache_file` did inline; `get_cache_file` now delegates. An explicit directory argument outranks `HISIM_CACHE_DIR`, so tests pointing at `tmp_path` keep doing so on a machine with the override set.
- Two spec amendments made by contact with code: the §4.1 sketch passed `component=self` into a package that mustn't import components (the client takes a string); payload fields use `dataclasses.field(metadata=KeyMaterial.PAYLOAD)`.

## Result

Byte-identical cache behaviour — a test computes the expected filename by hand from the published rule. A fresh-interpreter test proves importing `hisim.caching` pulls in no component, simulator or `SimulationParameters`. 48 new tests; base suite 4547 passed / 0 failed; **golden OK (16 pairs)**; mypy 284 files, pylint 10.00, prospector 0.

_Follow-up commit on this branch: the docstrings and comments this PR added were rewritten in plain language after review feedback (what → how it is used → short why). No code changes._