### PR TITLE
F7: make the PV, building and car cache keys complete — the upstream's identity is a sized field

### DIFF
--- a/hisim/component.py
+++ b/hisim/component.py
@@ -231,7 +231,9 @@ class Component:
                     f"The config of component '{my_config.component_id.key}' "
                     f"({type(my_config).__name__}) still requires sizing in "
                     f"{len(unresolved)} field(s):\n{cfg.describe_auto_fields(my_config)}\n"
-                    "Call .resolve(ctx) with a SizingContext or set the fields explicitly."
+                    "Call .resolve(ctx) with a SizingContext or set the fields explicitly -- for an "
+                    "identity field, from its provider, e.g. "
+                    "config.weather_identity = my_weather_config.identity()."
                 )
             # Subclasses read their concrete config's fields off this base-typed slot; that
             # works for the type checker because ConfigBase carries a checking-only

--- a/hisim/components/building/config.py
+++ b/hisim/components/building/config.py
@@ -77,9 +77,9 @@ class BuildingConfig(ConfigBase):
     # subsidies as percentage of investment costs
     subsidy_as_percentage_of_investment_costs: Optional[float]
 
-    #: Which weather the cached solar gains through the windows were computed against, as the
-    #: weather's own readable identity (see ``WeatherConfig.identity``). Sized from the weather so
-    #: the cache key, which hashes this whole config, is complete. ``roadmap/pylpg_flakiness.md`` F7.
+    #: The weather this building is computed with, as ``WeatherConfig.identity()`` spells it. Sized
+    #: from the weather by the sizing engine, so the solar-gains cache key includes it.
+    #: See ``roadmap/pylpg_flakiness.md`` F7.
     weather_identity: Sizable[str] = sized_field(rule=Size.WEATHER_IDENTITY, value_type=str)
 
     #: Sizing facts this config contributes to the scenario-wide fact pool.

--- a/hisim/components/building/config.py
+++ b/hisim/components/building/config.py
@@ -19,7 +19,7 @@ from typing import ClassVar, Optional
 
 from dataclasses_json import dataclass_json
 
-from hisim.config import ComponentID, ConfigBase, constructor, preset
+from hisim.config import ComponentID, ConfigBase, Sizable, Size, constructor, preset, sized_field
 
 
 @dataclass_json
@@ -76,6 +76,11 @@ class BuildingConfig(ConfigBase):
     maintenance_costs_in_euro_per_year:  Optional[float]
     # subsidies as percentage of investment costs
     subsidy_as_percentage_of_investment_costs: Optional[float]
+
+    #: Which weather the cached solar gains through the windows were computed against, as the
+    #: weather's own readable identity (see ``WeatherConfig.identity``). Sized from the weather so
+    #: the cache key, which hashes this whole config, is complete. ``roadmap/pylpg_flakiness.md`` F7.
+    weather_identity: Sizable[str] = sized_field(rule=Size.WEATHER_IDENTITY, value_type=str)
 
     #: Sizing facts this config contributes to the scenario-wide fact pool.
     #: Computed from the config alone via BuildingInformation, so the TABULA lookup runs

--- a/hisim/components/generic_car.py
+++ b/hisim/components/generic_car.py
@@ -19,7 +19,7 @@ from hisim import loadtypes as lt
 from hisim import utils, log
 from hisim.caching import atomic_cache_write
 from hisim.component import OpexCostDataClass, CapexCostDataClass
-from hisim.config import ConfigBase, ComponentID, DisplayConfig, constructor
+from hisim.config import ConfigBase, ComponentID, DisplayConfig, Sizable, Size, constructor, sized_field
 from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
 from hisim.loadtypes import Units, ComponentType
 
@@ -85,6 +85,12 @@ class CarConfig(ConfigBase):
     maintenance_costs_in_euro_per_year: float
     # subsidies as percentage of investment costs
     subsidy_as_percentage_of_investment_costs: float
+    #: Which occupancy produced the driving profile this car's cached location and distance series
+    #: come from, as the occupancy config's own readable identity (see
+    #: ``UtspLpgConnectorConfig.identity``). The household name alone does not determine the
+    #: profile -- the travel routes, the device set, the energy intensity and the seed all do -- and
+    #: only this field puts them into the cache key. ``roadmap/pylpg_flakiness.md`` F7.
+    occupancy_identity: Sizable[str] = sized_field(rule=Size.OCCUPANCY_IDENTITY, value_type=str)
 
     @classmethod
     def get_main_classname(cls):

--- a/hisim/components/generic_car.py
+++ b/hisim/components/generic_car.py
@@ -85,11 +85,9 @@ class CarConfig(ConfigBase):
     maintenance_costs_in_euro_per_year: float
     # subsidies as percentage of investment costs
     subsidy_as_percentage_of_investment_costs: float
-    #: Which occupancy produced the driving profile this car's cached location and distance series
-    #: come from, as the occupancy config's own readable identity (see
-    #: ``UtspLpgConnectorConfig.identity``). The household name alone does not determine the
-    #: profile -- the travel routes, the device set, the energy intensity and the seed all do -- and
-    #: only this field puts them into the cache key. ``roadmap/pylpg_flakiness.md`` F7.
+    #: The occupancy whose driving profile this car uses, as ``UtspLpgConnectorConfig.identity()``
+    #: spells it. Sized from the occupancy by the sizing engine, so the cache key includes it; the
+    #: household name alone does not determine the profile. See ``roadmap/pylpg_flakiness.md`` F7.
     occupancy_identity: Sizable[str] = sized_field(rule=Size.OCCUPANCY_IDENTITY, value_type=str)
 
     @classmethod

--- a/hisim/components/generic_pv_system.py
+++ b/hisim/components/generic_pv_system.py
@@ -132,10 +132,9 @@ class PVSystemConfig(ConfigBase):
     predictive: bool
     predictive_control: bool
     prediction_horizon: Optional[int]
-    #: Which weather this system's cached power series was computed against, as the weather's own
-    #: readable identity (see ``WeatherConfig.identity``). Sized from the weather rather than copied,
-    #: so the cache key -- which hashes this whole config -- cannot describe a different weather than
-    #: the one the run uses. ``roadmap/pylpg_flakiness.md`` F7.
+    #: The weather this system is computed with, as ``WeatherConfig.identity()`` spells it. Sized from
+    #: the weather by the sizing engine, so the cache key (a hash of this config) includes it.
+    #: See ``roadmap/pylpg_flakiness.md`` F7.
     weather_identity: Sizable[str] = sized_field(rule=Size.WEATHER_IDENTITY, value_type=str)
 
     @classmethod

--- a/hisim/components/generic_pv_system.py
+++ b/hisim/components/generic_pv_system.py
@@ -31,7 +31,7 @@ from hisim import log
 from hisim import utils
 from hisim.caching import atomic_cache_write
 from hisim.component import OpexCostDataClass, CapexCostDataClass
-from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig, Sizable, Size, sized_field
 from hisim.components.weather import Weather
 from hisim.sim_repository_singleton import (
     SingletonSimRepository,
@@ -132,6 +132,11 @@ class PVSystemConfig(ConfigBase):
     predictive: bool
     predictive_control: bool
     prediction_horizon: Optional[int]
+    #: Which weather this system's cached power series was computed against, as the weather's own
+    #: readable identity (see ``WeatherConfig.identity``). Sized from the weather rather than copied,
+    #: so the cache key -- which hashes this whole config -- cannot describe a different weather than
+    #: the one the run uses. ``roadmap/pylpg_flakiness.md`` F7.
+    weather_identity: Sizable[str] = sized_field(rule=Size.WEATHER_IDENTITY, value_type=str)
 
     @classmethod
     def get_default_pv_system(

--- a/hisim/components/heat_distribution_system.py
+++ b/hisim/components/heat_distribution_system.py
@@ -912,7 +912,9 @@ class HeatDistributionControllerConfig(ConfigBase):
         rule=Size.SET_COOLING_TEMPERATURE_IN_CELSIUS
     )
     heating_load_of_building_in_watt: Sizable[float] = sized_field(rule=Size.HEATING_LOAD_IN_WATT.rounded(2))
-    specific_heating_load_of_building_in_watt_per_m2: Sizable[Optional[float]] = sized_field(rule=SPECIFIC_LOAD_LAW)
+    specific_heating_load_of_building_in_watt_per_m2: Sizable[Optional[float]] = sized_field(
+        rule=SPECIFIC_LOAD_LAW, optional=True
+    )
 
     @preset
     @classmethod

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -47,7 +47,7 @@ from hisim.caching import atomic_cache_write
 from hisim.components.configuration import HouseholdWarmWaterDemandConfig, PhysicsConfig
 from hisim.simulationparameters import SimulationParameters
 from hisim.component import OpexCostDataClass
-from hisim.config import ConfigBase, ComponentID, DisplayConfig, constructor, preset
+from hisim.config import ConfigBase, ComponentID, DisplayConfig, FactContribution, constructor, preset
 from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
 from hisim.components.lpg_car_information import CarProfileHandover, GenericCarInformation
 
@@ -86,6 +86,64 @@ class UtspLpgConnectorConfig(ConfigBase):
     guid: str = ""
     calculation_index_for_local_lpg: Optional[int] = None
     cars: Optional[List[str]] = None
+
+    def identity(self) -> str:
+        """The readable string that says which occupancy this is, for every component computed from its profiles.
+
+        A car's driving profile is one output of this connector's LoadProfileGenerator run, and that
+        run is decided by everything here -- the household templates, the energy intensity, the travel
+        routes, the transportation and charging device sets, the seed -- not by the household name
+        alone, which is all the car's configuration used to carry. So the car declares a field sized
+        from this string, this config contributes it (see :attr:`SIZING_CONTRIBUTIONS`), and the car's
+        cache key becomes complete without it ever reaching for the connector at run time.
+
+        It is readable rather than hashed because it is written into every recorded energy system
+        beside the car, where a reader should see which occupancy that was. Reference objects are
+        named by their ``Name``; their GUIDs add nothing a person can read and the names are unique
+        within the generator's catalogue.
+
+        Returns:
+            str: the mode, then the household names, then the sets and the seed, slash-separated.
+        """
+        households = self.household if isinstance(self.household, list) else [self.household]
+        parts = [
+            str(self.data_acquisition_mode.value),
+            "+".join(str(getattr(household, "Name", household)) for household in households),
+            str(self.energy_intensity.value),
+            self._reference_name(self.travel_route_set),
+            self._reference_name(self.transportation_device_set),
+            self._reference_name(self.charging_station_set),
+            "with-appliances" if self.profile_with_washing_machine_and_dishwasher else "no-appliances",
+            str(self.name_of_predefined_loadprofile) if self.name_of_predefined_loadprofile else "-",
+            self.guid or "-",
+        ]
+        return "/".join(parts)
+
+    @staticmethod
+    def _reference_name(reference: Any) -> str:
+        """Names one optional catalogue reference for :meth:`identity`.
+
+        Args:
+            reference: a ``JsonReference`` or ``None``.
+
+        Returns:
+            str: its ``Name``, or ``-`` when absent.
+        """
+        return "-" if reference is None else str(getattr(reference, "Name", reference))
+
+    @staticmethod
+    def identity_facts(config: "UtspLpgConnectorConfig", ctx: Any) -> Dict[str, Any]:
+        """Contributes this occupancy's identity to the sizing engine.
+
+        Args:
+            config: the connector configuration, fully resolved.
+            ctx: the sizing context; unused, the identity depends on this config alone.
+
+        Returns:
+            Dict[str, Any]: exactly the one fact :attr:`SIZING_CONTRIBUTIONS` declares.
+        """
+        del ctx
+        return {"occupancy_identity": config.identity()}
 
     @classmethod
     def get_main_classname(cls) -> str:
@@ -279,6 +337,15 @@ class UtspLpgConnectorConfig(ConfigBase):
             guid="",
             calculation_index_for_local_lpg=None,
         )
+
+
+# Declared after the class because it refers to it. A scenario normally has one occupancy, so the bare
+# fact ``occupancy_identity`` binds without the car naming a source; a scenario with several names the
+# one its car belongs to in the car's ``sizing_sources``, which is exactly the case the engine refuses
+# to guess.
+UtspLpgConnectorConfig.SIZING_CONTRIBUTIONS = (
+    FactContribution(facts=("occupancy_identity",), compute=UtspLpgConnectorConfig.identity_facts),
+)
 
 
 class UtspLpgConnector(cp.Component):

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -88,22 +88,19 @@ class UtspLpgConnectorConfig(ConfigBase):
     cars: Optional[List[str]] = None
 
     def identity(self) -> str:
-        """The readable string that says which occupancy this is, for every component computed from its profiles.
+        """Return a string that says which occupancy this is: everything that decides the LoadProfileGenerator run.
 
-        A car's driving profile is one output of this connector's LoadProfileGenerator run, and that
-        run is decided by everything here -- the household templates, the energy intensity, the travel
-        routes, the transportation and charging device sets, the seed -- not by the household name
-        alone, which is all the car's configuration used to carry. So the car declares a field sized
-        from this string, this config contributes it (see :attr:`SIZING_CONTRIBUTIONS`), and the car's
-        cache key becomes complete without it ever reaching for the connector at run time.
+        The car component stores this string in its configuration, sized from the occupancy through the
+        sizing engine, so that its cache key includes which occupancy produced its driving profile. The
+        household name alone is not enough: the energy intensity, the travel-route and device sets, the
+        appliance flag and the seed all change the profile. See ``roadmap/pylpg_flakiness.md`` F7.
 
-        It is readable rather than hashed because it is written into every recorded energy system
-        beside the car, where a reader should see which occupancy that was. Reference objects are
-        named by their ``Name``; their GUIDs add nothing a person can read and the names are unique
-        within the generator's catalogue.
+        Catalogue references are named by their ``Name``, which is unique within the generator's catalogue
+        and readable; the string is written into every recorded energy-system file.
 
         Returns:
-            str: the mode, then the household names, then the sets and the seed, slash-separated.
+            str: the acquisition mode, household names, energy intensity, the three sets, the appliance flag,
+            the predefined profile name and the seed, separated by ``/``.
         """
         households = self.household if isinstance(self.household, list) else [self.household]
         parts = [
@@ -121,26 +118,28 @@ class UtspLpgConnectorConfig(ConfigBase):
 
     @staticmethod
     def _reference_name(reference: Any) -> str:
-        """Names one optional catalogue reference for :meth:`identity`.
+        """Return the ``Name`` of a catalogue reference, or ``-`` if the reference is ``None``.
 
         Args:
             reference: a ``JsonReference`` or ``None``.
 
         Returns:
-            str: its ``Name``, or ``-`` when absent.
+            str: the name.
         """
         return "-" if reference is None else str(getattr(reference, "Name", reference))
 
     @staticmethod
     def identity_facts(config: "UtspLpgConnectorConfig", ctx: Any) -> Dict[str, Any]:
-        """Contributes this occupancy's identity to the sizing engine.
+        """Provide :meth:`identity` as the sizing fact ``occupancy_identity``.
+
+        Registered in ``SIZING_CONTRIBUTIONS`` below; the sizing engine calls it with the resolved config.
 
         Args:
-            config: the connector configuration, fully resolved.
-            ctx: the sizing context; unused, the identity depends on this config alone.
+            config: this connector configuration.
+            ctx: the sizing context; unused.
 
         Returns:
-            Dict[str, Any]: exactly the one fact :attr:`SIZING_CONTRIBUTIONS` declares.
+            Dict[str, Any]: ``{"occupancy_identity": config.identity()}``.
         """
         del ctx
         return {"occupancy_identity": config.identity()}

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -93,25 +93,31 @@ class UtspLpgConnectorConfig(ConfigBase):
         The car component stores this string in its configuration, sized from the occupancy through the
         sizing engine, so that its cache key includes which occupancy produced its driving profile. The
         household name alone is not enough: the energy intensity, the travel-route and device sets, the
-        appliance flag and the seed all change the profile. See ``roadmap/pylpg_flakiness.md`` F7.
+        appliance flag, the predefined profile (name and file) and the request guid all change the
+        profile. The local LPG's ``random_seed`` is deliberately not part of it, because it is wired
+        nowhere (both call sites pass ``None``); if it ever becomes configurable it must join this list.
+        ``calculation_index_for_local_lpg`` is deliberately not part of it either: it selects the
+        scratch directory a profile is computed in, not the profile's content, and parallel drivers
+        vary it per worker slot.
 
         Catalogue references are named by their ``Name``, which is unique within the generator's catalogue
         and readable; the string is written into every recorded energy-system file.
 
         Returns:
             str: the acquisition mode, household names, energy intensity, the three sets, the appliance flag,
-            the predefined profile name and the seed, separated by ``/``.
+            the predefined profile name, the predefined profile file and the request guid, separated by ``/``.
         """
         households = self.household if isinstance(self.household, list) else [self.household]
         parts = [
             str(self.data_acquisition_mode.value),
-            "+".join(str(getattr(household, "Name", household)) for household in households),
+            "+".join(self._reference_name(household) for household in households),
             str(self.energy_intensity.value),
             self._reference_name(self.travel_route_set),
             self._reference_name(self.transportation_device_set),
             self._reference_name(self.charging_station_set),
             "with-appliances" if self.profile_with_washing_machine_and_dishwasher else "no-appliances",
             str(self.name_of_predefined_loadprofile) if self.name_of_predefined_loadprofile else "-",
+            os.path.basename(str(self.predefined_loadprofile_filepaths)) if self.predefined_loadprofile_filepaths else "-",
             self.guid or "-",
         ]
         return "/".join(parts)

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -465,36 +465,33 @@ class WeatherConfig(ConfigBase):
         return config
 
     def identity(self) -> str:
-        """The readable string that says which weather this is, for every component computed against it.
+        """Return a short string that says which weather this configuration reads: station, data set, file stem.
 
-        A PV system's power series or a building's solar gains depend on the weather they were run
-        with, so their cache keys must too -- but their configs know nothing about the weather, and
-        looking the weather component up at run time is what the deprecated singleton did. Instead
-        the weather contributes this string as a sizing fact (see :attr:`SIZING_CONTRIBUTIONS`), the
-        downstream configs declare a field sized from it, and the key -- a hash over the whole config
-        -- becomes complete before the simulator exists.
+        Example: ``"Aachen/DWD_TRY/aachen_center"``. Components whose cached results depend on the weather
+        (PV, building) store this string in their own configuration, sized from the weather through the
+        sizing engine, so that their cache keys include which weather they were computed with. See
+        ``roadmap/pylpg_flakiness.md`` F7.
 
-        The string is readable rather than a hash because it is written into every recorded energy
-        system beside the component that depends on it, where a reader should be able to see at a
-        glance which weather that was. It names the station, the data set and the file stem: the
-        three things that decide what the weather component reads. The absolute directory is left
-        out on purpose, since it differs between machines and says nothing about the data.
+        It is a readable string rather than a hash because it is written into every recorded energy-system
+        file. The directory of ``source_path`` is left out because it differs between machines.
 
         Returns:
-            str: e.g. ``"Aachen/DWD_TRY_2015/TRY2015_507931060546_Jahr"``.
+            str: ``<location>/<data source>/<file stem>``.
         """
         return f"{self.location}/{self.data_source.value}/{os.path.basename(str(self.source_path))}"
 
     @staticmethod
     def identity_facts(config: "WeatherConfig", ctx: Any) -> Dict[str, Any]:
-        """Contributes this weather's identity to the sizing engine.
+        """Provide :meth:`identity` as the sizing fact ``weather_identity``.
+
+        Registered in ``SIZING_CONTRIBUTIONS`` below; the sizing engine calls it with the resolved config.
 
         Args:
-            config: the weather configuration, fully resolved (it has no sized fields of its own).
-            ctx: the sizing context; unused, the identity depends on this config alone.
+            config: this weather configuration.
+            ctx: the sizing context; unused.
 
         Returns:
-            Dict[str, Any]: exactly the one fact :attr:`SIZING_CONTRIBUTIONS` declares.
+            Dict[str, Any]: ``{"weather_identity": config.identity()}``.
         """
         del ctx
         return {"weather_identity": config.identity()}

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -7,6 +7,7 @@ import math
 import os
 from dataclasses import dataclass
 from enum import Enum, unique
+from pathlib import PurePath
 from typing import Any, Dict, List, Optional, Union
 
 from dataclasses_json import dataclass_json
@@ -465,20 +466,31 @@ class WeatherConfig(ConfigBase):
         return config
 
     def identity(self) -> str:
-        """Return a short string that says which weather this configuration reads: station, data set, file stem.
+        """Return a short string that says which weather this configuration reads: station, data set, file.
 
-        Example: ``"Aachen/DWD_TRY/aachen_center"``. Components whose cached results depend on the weather
-        (PV, building) store this string in their own configuration, sized from the weather through the
-        sizing engine, so that their cache keys include which weather they were computed with. See
-        ``roadmap/pylpg_flakiness.md`` F7.
+        Example: ``"Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"``.
+        Components whose cached results depend on the weather (PV, building) store this string in their
+        own configuration, sized from the weather through the sizing engine, so that their cache keys
+        include which weather they were computed with. See ``roadmap/pylpg_flakiness.md`` F7.
 
         It is a readable string rather than a hash because it is written into every recorded energy-system
-        file. The directory of ``source_path`` is left out because it differs between machines.
+        file. For a file under the repository's inputs directory the path relative to that directory is
+        kept -- the machine-specific prefix says nothing about the data, but the directories below the
+        inputs root are where the dataset families live (two of the shipped families could hold files of
+        the same name), so dropping them would let two different datasets share one identity. A file
+        outside the inputs directory contributes only its basename.
 
         Returns:
-            str: ``<location>/<data source>/<file stem>``.
+            str: ``<location>/<data source>/<inputs-relative path or basename>``.
         """
-        return f"{self.location}/{self.data_source.value}/{os.path.basename(str(self.source_path))}"
+        path = str(self.source_path)
+        try:
+            relative = os.path.relpath(path, utils.get_input_directory())
+        except ValueError:  # a different drive on Windows: no relative path exists
+            relative = None
+        if relative is None or relative.startswith(".."):
+            relative = os.path.basename(path)
+        return f"{self.location}/{self.data_source.value}/{PurePath(relative).as_posix()}"
 
     @staticmethod
     def identity_facts(config: "WeatherConfig", ctx: Any) -> Dict[str, Any]:

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -7,7 +7,7 @@ import math
 import os
 from dataclasses import dataclass
 from enum import Enum, unique
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from dataclasses_json import dataclass_json
 import numpy as np
@@ -17,7 +17,7 @@ import pvlib
 from hisim import loadtypes as lt
 from hisim import log, utils
 from hisim.caching import atomic_cache_write
-from hisim.config import ConfigBase, ComponentID, DisplayConfig, constructor, preset
+from hisim.config import ConfigBase, ComponentID, DisplayConfig, FactContribution, constructor, preset
 from hisim.component import Component, ComponentOutput, SingleTimeStepValues, OpexCostDataClass, CapexCostDataClass
 from hisim.simulationparameters import SimulationParameters
 from hisim.sim_repository_singleton import SingletonSimRepository, SingletonDictKeyEnum
@@ -464,6 +464,41 @@ class WeatherConfig(ConfigBase):
         )
         return config
 
+    def identity(self) -> str:
+        """The readable string that says which weather this is, for every component computed against it.
+
+        A PV system's power series or a building's solar gains depend on the weather they were run
+        with, so their cache keys must too -- but their configs know nothing about the weather, and
+        looking the weather component up at run time is what the deprecated singleton did. Instead
+        the weather contributes this string as a sizing fact (see :attr:`SIZING_CONTRIBUTIONS`), the
+        downstream configs declare a field sized from it, and the key -- a hash over the whole config
+        -- becomes complete before the simulator exists.
+
+        The string is readable rather than a hash because it is written into every recorded energy
+        system beside the component that depends on it, where a reader should be able to see at a
+        glance which weather that was. It names the station, the data set and the file stem: the
+        three things that decide what the weather component reads. The absolute directory is left
+        out on purpose, since it differs between machines and says nothing about the data.
+
+        Returns:
+            str: e.g. ``"Aachen/DWD_TRY_2015/TRY2015_507931060546_Jahr"``.
+        """
+        return f"{self.location}/{self.data_source.value}/{os.path.basename(str(self.source_path))}"
+
+    @staticmethod
+    def identity_facts(config: "WeatherConfig", ctx: Any) -> Dict[str, Any]:
+        """Contributes this weather's identity to the sizing engine.
+
+        Args:
+            config: the weather configuration, fully resolved (it has no sized fields of its own).
+            ctx: the sizing context; unused, the identity depends on this config alone.
+
+        Returns:
+            Dict[str, Any]: exactly the one fact :attr:`SIZING_CONTRIBUTIONS` declares.
+        """
+        del ctx
+        return {"weather_identity": config.identity()}
+
     @preset(note="the repository's reference climate")
     @classmethod
     def preset_standard(cls, name: str) -> "WeatherConfig":
@@ -513,6 +548,13 @@ class WeatherConfig(ConfigBase):
             data_source=data_source if data_source is not None else catalogue_source,
             predictive_control=False,
         )
+
+
+# Declared after the class because it refers to it. Every scenario has exactly one weather, so the
+# bare fact ``weather_identity`` binds to this contribution without any consumer naming a source.
+WeatherConfig.SIZING_CONTRIBUTIONS = (
+    FactContribution(facts=("weather_identity",), compute=WeatherConfig.identity_facts),
+)
 
 
 class Weather(Component):

--- a/hisim/config/context.py
+++ b/hisim/config/context.py
@@ -55,13 +55,10 @@ class SizingContext:
     set_heating_temperature_in_celsius: Optional[float] = None
     set_cooling_temperature_in_celsius: Optional[float] = None
 
-    # The two identity facts. They are not sizes, and that is deliberate: the engine is the typed
-    # successor of the singleton repository for *every* fact one component needs from another, and
-    # "which weather am I computed against" is such a fact. A component whose cached result depends
-    # on an upstream artifact declares that artifact's identity as a sized field, the upstream
-    # config contributes it, and the cache key -- which hashes the whole config -- becomes complete
-    # without the component ever reaching for the upstream component at run time. See
-    # ``roadmap/pylpg_flakiness.md`` F7.
+    # Identity facts. A component whose cached result depends on another component (PV on the
+    # weather, the car on the occupancy) declares that component's identity as a sized field; the
+    # other component contributes it here. The cache key hashes the whole config, so it then
+    # includes which upstream the result was computed with. See ``roadmap/pylpg_flakiness.md`` F7.
     weather_identity: Optional[str] = None
     occupancy_identity: Optional[str] = None
 

--- a/hisim/config/context.py
+++ b/hisim/config/context.py
@@ -55,6 +55,16 @@ class SizingContext:
     set_heating_temperature_in_celsius: Optional[float] = None
     set_cooling_temperature_in_celsius: Optional[float] = None
 
+    # The two identity facts. They are not sizes, and that is deliberate: the engine is the typed
+    # successor of the singleton repository for *every* fact one component needs from another, and
+    # "which weather am I computed against" is such a fact. A component whose cached result depends
+    # on an upstream artifact declares that artifact's identity as a sized field, the upstream
+    # config contributes it, and the cache key -- which hashes the whole config -- becomes complete
+    # without the component ever reaching for the upstream component at run time. See
+    # ``roadmap/pylpg_flakiness.md`` F7.
+    weather_identity: Optional[str] = None
+    occupancy_identity: Optional[str] = None
+
     def with_facts(self, **facts: Any) -> "SizingContext":
         """Returns a copy of this context with the given facts added or replaced.
 
@@ -118,3 +128,5 @@ class Size:
     MINIMAL_THERMAL_POWER_IN_WATT: ClassVar[_FactTerm] = _FactTerm("minimal_thermal_power_in_watt")
     SET_HEATING_TEMPERATURE_IN_CELSIUS: ClassVar[_FactTerm] = _FactTerm("set_heating_temperature_in_celsius")
     SET_COOLING_TEMPERATURE_IN_CELSIUS: ClassVar[_FactTerm] = _FactTerm("set_cooling_temperature_in_celsius")
+    WEATHER_IDENTITY: ClassVar[_FactTerm] = _FactTerm("weather_identity")
+    OCCUPANCY_IDENTITY: ClassVar[_FactTerm] = _FactTerm("occupancy_identity")

--- a/hisim/config/sizing.py
+++ b/hisim/config/sizing.py
@@ -140,7 +140,13 @@ def _sizable_decoder(value_type: Optional[type]) -> Callable[[Any], Any]:
     """
 
     def decode(raw: Any) -> Any:
-        if isinstance(raw, str) and raw == _AutoSize.WIRE_SPELLING:
+        # The sentinel itself can arrive here, not only its wire spelling: dataclasses_json runs the
+        # field decoder over a *missing* key's default as well as over a present value. Coercing the
+        # sentinel through ``value_type`` is wrong for every type and silent for one -- ``str(AUTO)`` is
+        # the wire spelling, so a string-typed sized field left out of a config block quietly turned
+        # from "size me" into the literal text "AUTO", and the engine, seeing a concrete value, left
+        # it alone. The sentinel passes through untouched, whatever the field's type.
+        if raw is AUTO or (isinstance(raw, str) and raw == _AutoSize.WIRE_SPELLING):
             return AUTO
         if value_type is not None and raw is not None and not isinstance(raw, value_type):
             return value_type(raw)

--- a/hisim/config/sizing.py
+++ b/hisim/config/sizing.py
@@ -168,12 +168,16 @@ class SizedFieldMetadata:
     #: The concrete type the field's wire decoder coerces into, recorded so that the
     #: class-creation check can tell a declared ``value_type`` from a forgotten one.
     VALUE_TYPE: ClassVar[str] = "hisim_sizing_value_type"
+    #: Whether the field's law may legitimately resolve to ``None``. Without this flag a
+    #: vacuous value (``None``, a blank string) on a sized field counts as unresolved,
+    #: because a JSON ``null`` must not slip past the AUTO guard into a cache key.
+    OPTIONAL: ClassVar[str] = "hisim_sizing_optional"
 
 
 def sized_field(
     *, rule: Any, default: Any = AUTO, value_type: Optional[type] = None,
     reads: Optional[Tuple[Any, ...]] = None, fields: Optional[Tuple[str, ...]] = None,
-    note: Optional[str] = None, **field_kwargs: Any,
+    note: Optional[str] = None, optional: bool = False, **field_kwargs: Any,
 ) -> Any:
     """Declares a sizable dataclass field: its law and its AUTO wire codec in one place.
 
@@ -196,6 +200,10 @@ def sized_field(
         note: Where the value comes from, when the author knows it (a standard, a
             datasheet). Optional and never a placeholder; it is recorded as-is and
             rendered by the audit trail so a hard-coded constant can cite its source.
+        optional: Declare that the law may legitimately resolve to ``None`` (the field is
+            ``Sizable[Optional[...]]``). Without it, ``None`` -- which a JSON ``null``
+            decodes to -- and a blank string count as unresolved, so they cannot slip past
+            the construction guard into a cache key.
         **field_kwargs: Passed through to ``dataclasses.field`` (respecting an existing
             ``metadata`` mapping by merging into it).
 
@@ -208,6 +216,8 @@ def sized_field(
         metadata[SizedFieldMetadata.NOTE] = note
     if value_type is not None:
         metadata[SizedFieldMetadata.VALUE_TYPE] = value_type
+    if optional:
+        metadata[SizedFieldMetadata.OPTIONAL] = True
     metadata.update(dataclasses_json_config(encoder=_encode_sizable, decoder=_sizable_decoder(value_type)))
     # invalid-field-call is a false positive here: this helper returns the field()
     # descriptor for use inside a dataclass body, exactly like dataclasses_json.config.
@@ -261,11 +271,14 @@ def sizable_fields(config_class: type) -> Mapping[str, SizingLaw]:
 
 
 def auto_fields(config: Any) -> Tuple[str, ...]:
-    """Names the fields of a config instance that currently carry the AUTO sentinel.
+    """Names the fields of a config instance that still require resolution.
 
     Used by the central ``Component.__init__`` check: a component must never be
     constructed from a config that still requires sizing, no matter whether the config
-    came from a preset, a scenario file or manual construction.
+    came from a preset, a scenario file or manual construction. For a *sized* field a
+    vacuous value counts as unresolved too: ``None`` (which a JSON ``null`` decodes to)
+    and, for strings, the empty string are never a resolved size -- letting them pass
+    would put a meaningless value into a cache key without any error.
     """
     if not dataclasses.is_dataclass(config):
         return ()
@@ -273,12 +286,39 @@ def auto_fields(config: Any) -> Tuple[str, ...]:
         field.name
         for field in dataclasses.fields(config)
         if _needs_sizing(getattr(config, field.name, None))
+        or (
+            SizedFieldMetadata.LAW in field.metadata
+            and not field.metadata.get(SizedFieldMetadata.OPTIONAL, False)
+            and _is_vacuous(getattr(config, field.name, None))
+        )
     )
 
 
 def _needs_sizing(value: Any) -> bool:
     """True when a field value still requires resolution: AUTO, or a per-preset law."""
     return value is AUTO or isinstance(value, SizingLaw)
+
+
+def _is_vacuous(value: Any) -> bool:
+    """True for values that can never be a resolved size: ``None``, or a blank string.
+
+    Only meaningful for sized fields -- an ordinary optional field holds ``None``
+    legitimately, so callers must pair this check with the field's sizing metadata.
+    """
+    return value is None or (isinstance(value, str) and not value.strip())
+
+
+def _optional_sized_fields(config_class: type) -> Set[str]:
+    """Names the sized fields of a class whose law may legitimately resolve to ``None``.
+
+    These are the fields declared with ``sized_field(..., optional=True)``; a vacuous value
+    on them is a resolved value, not a request for sizing.
+    """
+    return {
+        field.name
+        for field in dataclasses.fields(config_class)
+        if field.metadata.get(SizedFieldMetadata.OPTIONAL, False)
+    }
 
 
 def describe_auto_fields(config: Any) -> str:
@@ -444,10 +484,11 @@ def resolve_config(
     # A preset may override the class law for one field by assigning a SizingLaw as the
     # field value (the per-preset escape hatch) — e.g. the pellet boiler's minimal power
     # is a twelfth of its own maximal power, while the gas boiler's is a constant zero.
+    optional_fields = _optional_sized_fields(type(config))
     pending: Dict[str, SizingLaw] = {}
     for field_name, declared_law in laws.items():
         current = getattr(config, field_name)
-        if not _needs_sizing(current):
+        if not (_needs_sizing(current) or (_is_vacuous(current) and field_name not in optional_fields)):
             continue
         pending[field_name] = current if isinstance(current, SizingLaw) else declared_law
     own = OwnFields(config, pending)

--- a/hisim/config/sizing.py
+++ b/hisim/config/sizing.py
@@ -140,12 +140,10 @@ def _sizable_decoder(value_type: Optional[type]) -> Callable[[Any], Any]:
     """
 
     def decode(raw: Any) -> Any:
-        # The sentinel itself can arrive here, not only its wire spelling: dataclasses_json runs the
-        # field decoder over a *missing* key's default as well as over a present value. Coercing the
-        # sentinel through ``value_type`` is wrong for every type and silent for one -- ``str(AUTO)`` is
-        # the wire spelling, so a string-typed sized field left out of a config block quietly turned
-        # from "size me" into the literal text "AUTO", and the engine, seeing a concrete value, left
-        # it alone. The sentinel passes through untouched, whatever the field's type.
+        # dataclasses_json also runs this decoder on the *default* of a missing key, so ``raw`` can be
+        # the AUTO sentinel itself. It must pass through unchanged: coercing it with ``value_type``
+        # would turn it into the string "AUTO" for str-typed fields (silently -- ``str(AUTO)`` is the
+        # wire spelling), and the engine would then treat the field as already set.
         if raw is AUTO or (isinstance(raw, str) and raw == _AutoSize.WIRE_SPELLING):
             return AUTO
         if value_type is not None and raw is not None and not isinstance(raw, value_type):

--- a/hisim/energy_system_v3.schema.json
+++ b/hisim/energy_system_v3.schema.json
@@ -461,13 +461,25 @@
                         "type": "null"
                       }
                     ]
+                  },
+                  "weather_identity": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "const": "AUTO"
+                      }
+                    ]
                   }
                 }
               },
               "sizing_sources": {
                 "$ref": "#/$defs/sizing_sources",
                 "propertyNames": {
-                  "enum": []
+                  "enum": [
+                    "weather_identity"
+                  ]
                 }
               }
             }
@@ -1054,13 +1066,25 @@
                   },
                   "subsidy_as_percentage_of_investment_costs": {
                     "type": "number"
+                  },
+                  "occupancy_identity": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "const": "AUTO"
+                      }
+                    ]
                   }
                 }
               },
               "sizing_sources": {
                 "$ref": "#/$defs/sizing_sources",
                 "propertyNames": {
-                  "enum": []
+                  "enum": [
+                    "occupancy_identity"
+                  ]
                 }
               }
             }

--- a/hisim/json_executor.py
+++ b/hisim/json_executor.py
@@ -239,6 +239,8 @@ def setup_components_and_connections(scenario_data: dict[str, Any], sim: simulat
         sim.add_component(component, connect_automatically=component_def["connect_automatically"])
         component_dict[component.config.component_id.name] = component
 
+    _verify_identity_literals([component.config for component in component_dict.values()])
+
     # Connect components
     for conn in scenario_data.get("connections", []):
         try:
@@ -275,6 +277,52 @@ def setup_components_and_connections(scenario_data: dict[str, Any], sim: simulat
 
         except KeyError as e:
             raise ValueError(f"Malformed connection entry: missing {e}") from e
+
+
+#: The sizing facts that are identity strings of an upstream component. A scenario JSON records them
+#: as literals on the consumer configs (the JSON path has no sizing engine), so they can silently go
+#: stale when someone edits the provider block by hand; the check below is what catches that.
+_IDENTITY_FACTS = ("weather_identity", "occupancy_identity")
+
+
+def _verify_identity_literals(configs: list[Any]) -> None:
+    """Refuse a scenario whose recorded identity literals disagree with the provider in the same file.
+
+    On the JSON path ``weather_identity``/``occupancy_identity`` are frozen strings, written when the
+    scenario was generated. A user who edits the weather or occupancy block by hand and forgets the
+    literals would otherwise run with a cache key naming the *old* upstream -- and silently be served
+    entries computed for different data, which is exactly what the identity exists to prevent.
+
+    The provider of a fact is found through its class's ``SIZING_CONTRIBUTIONS``, the same declaration
+    the sizing engine uses on the YAML path. The check only fires when the file holds exactly one
+    provider for a fact; with none or several, no single expected value exists and the literal is
+    taken as given.
+
+    Args:
+        configs: the configs of every component built from the scenario, in file order.
+
+    Raises:
+        ValueError: naming the stale literal, the provider's actual identity, and the fix.
+    """
+    for fact in _IDENTITY_FACTS:
+        providers = [
+            config
+            for config in configs
+            if any(fact in contribution.facts for contribution in getattr(type(config), "SIZING_CONTRIBUTIONS", ()))
+        ]
+        if len(providers) != 1:
+            continue
+        expected = providers[0].identity()
+        for config in configs:
+            recorded = getattr(config, fact, None)
+            if isinstance(recorded, str) and recorded != expected:
+                raise ValueError(
+                    f"The scenario records {fact} = {recorded!r} on '{config.component_id.key}' "
+                    f"({type(config).__name__}), but the {type(providers[0]).__name__} in the same file "
+                    f"has identity {expected!r}. The literal went stale -- most likely the provider block "
+                    "was edited by hand. Regenerate the scenario JSON from its .py setup, or update the "
+                    "literal to the provider's identity."
+                )
 
 
 def _resolve_input_directory_placeholder(path_with_placeholder: str) -> str:

--- a/roadmap/pylpg_flakiness.md
+++ b/roadmap/pylpg_flakiness.md
@@ -387,24 +387,41 @@ in a shape the DTO consumes is better than solving it twice.
   `occupancy_identity: Sizable[str]`, each sized from the matching fact. The engine is the typed successor of the
   singleton repository for exactly this kind of cross-component fact, and it resolves before any component is
   built -- so the run-time lookup the stopgap needed, and the order dependence that came with it, never arise.
-- **The identity is a readable string, not a hash** `[decided 2026-09-02, owner]`:
-  `Aachen/DWD_TRY/aachen_center` names the station, the data set and the file stem, which are the three things
-  that decide what the weather component reads; the absolute directory is left out because it differs between
-  machines and says nothing about the data. For the occupancy it is the acquisition mode, the household names,
-  the energy intensity, the three catalogue sets, the appliance flag and the seed. Readable because the value is
-  written into every recorded energy system beside the component that depends on it, where a reader should see
-  which weather that was; the cache key hashes it anyway.
+- **The identity is a readable string, not a hash** `[decided 2026-09-02, owner; discriminator widened after
+  review 2026-09-05]`: `Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center`
+  names the station, the data set and the file. The machine-specific prefix of ``source_path`` is left out
+  because it differs between machines and says nothing about the data, but the path *below the inputs
+  directory* is kept: that is where the dataset families live, and two families could hold files of the same
+  name -- a bare file stem would let two different datasets share one identity (found in review). A file
+  outside the inputs directory contributes only its basename. For the occupancy it is the acquisition mode,
+  the household names, the energy intensity, the three catalogue sets, the appliance flag, the predefined
+  profile name, the predefined profile file and the request guid. Not part of it, deliberately: the local
+  LPG's ``random_seed`` (wired nowhere -- both call sites pass ``None``; it must join the identity if it ever
+  becomes configurable), ``calculation_index_for_local_lpg`` (a scratch-directory slot, not profile content;
+  parallel drivers vary it per worker), and ``cars`` (a dead config field nothing reads -- removing it is a
+  separate serialization change). Readable because the value is written into every recorded energy system
+  beside the component that depends on it, where a reader should see which weather that was; the cache key
+  hashes it anyway.
 - **The key needs no widening code at all.** Once the identity is a field of the downstream configuration, the
   legacy key -- a hash over the whole configuration JSON -- is complete by construction, and the DTO scheme later
   reads the same field as its `weather_artifact_key`. Nothing here is deleted when #584 arrives; it is what #584
   consumes.
-- **On the declarative path it costs nothing.** Every scenario has one weather, so the bare fact binds without a
-  `sizing_sources` line; the repository's example file resolves the building's identity with no edit to the file.
+- **On the declarative path it costs little.** For the shipped scenarios -- exactly one weather each -- the
+  bare fact binds without a `sizing_sources` line; the repository's example file resolves the building's
+  identity with no edit to the file. A scenario with several weathers must name its source in a
+  `sizing_sources` line, because a bare fact with two providers is ambiguous and the engine refuses it.
   On the Python path a setup sets the field before it builds the component
   (`my_building_config.weather_identity = my_weather_config.identity()`), because a config that still carries
-  `AUTO` is refused at construction -- which is the property that makes the fix hold: no run can produce an entry
-  under an incomplete key again. Every setup and every test that builds one of the three components was given
-  that line; a test with no weather in it sets a description instead of a station.
+  `AUTO` -- or a vacuous value: `None` from a JSON `null`, or an empty string -- is refused at construction,
+  which is the property that makes the fix hold: no run can produce an entry under an incomplete key again.
+  Every setup and every test that builds one of the three components was given that line; a test with no
+  weather in it sets a description instead of a station. **This is a breaking change for external setups**:
+  any script that builds a Building, PVSystem or Car directly must now set the identity field from its
+  upstream's `identity()` (or resolve through the sizing engine); the `ConfigSizingError` names the field and
+  the one-line fix. On the scenario-JSON path the identities are recorded literals (the JSON path has no
+  sizing engine); the executor cross-checks each literal against the identity of the file's single
+  weather/occupancy and refuses a stale one, so a hand-edited provider block cannot silently keep serving
+  cache entries computed for the old data.
 - **Solar thermal is not in this list.** F8 restricts its artifact to the solar position, whose inputs are
   already exactly its key, so it needs no widening at all.
 

--- a/roadmap/pylpg_flakiness.md
+++ b/roadmap/pylpg_flakiness.md
@@ -366,34 +366,51 @@ on one of them.
 
 ### Fixes
 
-**F7 — widen the keys of PV, building and car** `[decided 2026-08-31, owner]`
+**F7 — make the keys of PV, building and car complete** `[decided 2026-08-31, owner; implemented 2026-09-02 by a
+different mechanism than the one decided, see below]`
 
-**This fix is deliberately temporary and should be deleted, not defended.** PR #584 §3 answers the problem
-properly: a per-calculation DTO plus an automatic code fingerprint, which requires producers to be extracted
-into standalone modules first. That extraction is its own phase and lands after the local tier
-`[decided 2026-08-31]`. Between now and then, four caches can serve one household's results to another, so
-the keys are widened by hand in the meantime and removed when the DTO scheme arrives. Say so in the code, or
-someone will maintain it.
+The finding stands as written: PV, the building and the car keyed their cached artifacts on their *own*
+configuration while deriving them from an *upstream* one -- the weather for the first two, the occupancy for the
+car -- so two households sharing a PV config but not a weather shared one PV entry. PV's `location` string only
+tended to track the weather because setups copied one variable into both, a habit and not an invariant.
 
-- **PV and building** take the weather configuration's hash. Both derive their artifact from weather series
-  while keying on their own config; PV's `location` string only tends to track the weather because setups
-  copy one variable into both, which is a habit and not an invariant.
-- **The car takes a hash of the occupancy's configuration** `[decided 2026-08-31]`, not merely the household
-  name. The profile is a function of the whole occupancy setup — household, energy intensity, travel route
-  set, transportation device set — and any of those changes the driving pattern. Putting the household name
-  into `CarConfig` was rejected: it duplicates state that belongs to the occupancy, and two sources of truth
-  drift.
-  *How it reaches the car:* the occupancy already publishes the per-car profile into the simulation
-  repository, so it publishes the hash of its own configuration alongside, under the same identity. The car
-  reads both — the data it consumes and the fingerprint of what produced it — which is the same shape the DTO
-  scheme will formalise later, so this stopgap points in the right direction rather than away from it.
+**What was decided on 2026-08-31** was a stopgap: hash the upstream configuration into the downstream key by
+hand, have the occupancy publish that hash into the simulation repository beside the car profile, and delete all
+of it when #584's DTO scheme arrived. **What landed instead** keeps the finding and changes the mechanism, for a
+reason found while building the cache client's local tier: the DTO scheme does not remove the question of *how*
+PV learns the weather's identity -- its `weather_artifact_key` is "filled by the component" -- so solving it once
+in a shape the DTO consumes is better than solving it twice.
+
+- **The sizing engine carries the identity.** `WeatherConfig` contributes a `weather_identity` fact and
+  `UtspLpgConnectorConfig` an `occupancy_identity` fact (`SIZING_CONTRIBUTIONS`); `PVSystemConfig` and
+  `BuildingConfig` declare `weather_identity: Sizable[str]` and `CarConfig` declares
+  `occupancy_identity: Sizable[str]`, each sized from the matching fact. The engine is the typed successor of the
+  singleton repository for exactly this kind of cross-component fact, and it resolves before any component is
+  built -- so the run-time lookup the stopgap needed, and the order dependence that came with it, never arise.
+- **The identity is a readable string, not a hash** `[decided 2026-09-02, owner]`:
+  `Aachen/DWD_TRY/aachen_center` names the station, the data set and the file stem, which are the three things
+  that decide what the weather component reads; the absolute directory is left out because it differs between
+  machines and says nothing about the data. For the occupancy it is the acquisition mode, the household names,
+  the energy intensity, the three catalogue sets, the appliance flag and the seed. Readable because the value is
+  written into every recorded energy system beside the component that depends on it, where a reader should see
+  which weather that was; the cache key hashes it anyway.
+- **The key needs no widening code at all.** Once the identity is a field of the downstream configuration, the
+  legacy key -- a hash over the whole configuration JSON -- is complete by construction, and the DTO scheme later
+  reads the same field as its `weather_artifact_key`. Nothing here is deleted when #584 arrives; it is what #584
+  consumes.
+- **On the declarative path it costs nothing.** Every scenario has one weather, so the bare fact binds without a
+  `sizing_sources` line; the repository's example file resolves the building's identity with no edit to the file.
+  On the Python path a setup sets the field before it builds the component
+  (`my_building_config.weather_identity = my_weather_config.identity()`), because a config that still carries
+  `AUTO` is refused at construction -- which is the property that makes the fix hold: no run can produce an entry
+  under an incomplete key again. Every setup and every test that builds one of the three components was given
+  that line; a test with no weather in it sets a description instead of a station.
 - **Solar thermal is not in this list.** F8 restricts its artifact to the solar position, whose inputs are
   already exactly its key, so it needs no widening at all.
 
-**What this does not fix**, and must not be claimed to: a widened key still describes *inputs the component
+**What this does not fix**, and must not be claimed to: a complete key still describes *inputs the component
 knows about*. It cannot notice a change in code, in a library version, or in an input nobody thought to add.
-Those are what #584's `code_fingerprint` and `third_party_fingerprint` are for, and they are the reason this
-is a stopgap rather than a solution.
+Those are what #584's `code_fingerprint` and `third_party_fingerprint` are for.
 
 **F8 — cache the sun position, and nothing else** `[specified 2026-08-31, owner]`
 

--- a/system_setups/air_conditioned_house.py
+++ b/system_setups/air_conditioned_house.py
@@ -95,6 +95,11 @@ def setup_function(
     heating_reference_temperature = heating_reference_temperatures.set_index("Location").loc[
         "ES", "HeatingReferenceTemperature"
     ]
+    # The weather configuration is created before the building, because the building records which weather
+    # it is computed against (its weather_identity) and that has to be set before it is built. The weather
+    # component itself is added below, where it always was.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.SEVILLE)
+
     my_building_config = building.BuildingConfig(
         component_id=ComponentID(name="Building"),
         building_code="ES.ME.SFH.04.Gen.ReEx.001.003",
@@ -125,6 +130,7 @@ def setup_function(
         subsidy_as_percentage_of_investment_costs=None,
         lifetime_in_years=None,
     )
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(
         config=my_building_config,
         my_simulation_parameters=my_simulation_parameters,
@@ -141,7 +147,6 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     """Weather"""
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.SEVILLE)
 
     my_weather = weather.Weather(
         config=my_weather_config,
@@ -177,6 +182,7 @@ def setup_function(
         predictive_control=False,
         prediction_horizon=None,
     )
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/air_conditioned_house.py
+++ b/system_setups/air_conditioned_house.py
@@ -95,9 +95,8 @@ def setup_function(
     heating_reference_temperature = heating_reference_temperatures.set_index("Location").loc[
         "ES", "HeatingReferenceTemperature"
     ]
-    # The weather configuration is created before the building, because the building records which weather
-    # it is computed against (its weather_identity) and that has to be set before it is built. The weather
-    # component itself is added below, where it always was.
+    # The weather config is created first: the building config copies its identity (weather_identity)
+    # and must have it before the building is built. The weather component is still added below.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.SEVILLE)
 
     my_building_config = building.BuildingConfig(

--- a/system_setups/air_conditioned_house.scenario.json
+++ b/system_setups/air_conditioned_house.scenario.json
@@ -99,7 +99,8 @@
                 "subsidy_as_percentage_of_investment_costs": 0.0,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Seville/NSRDB/Seville"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],
@@ -191,7 +192,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Seville/NSRDB/Seville"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/system_setups/air_conditioned_house.scenario.json
+++ b/system_setups/air_conditioned_house.scenario.json
@@ -100,7 +100,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Seville/NSRDB/Seville"
+                "weather_identity": "Seville/NSRDB/weather/NSRDB/Seville/Seville"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],
@@ -193,7 +193,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Seville/NSRDB/Seville"
+                "weather_identity": "Seville/NSRDB/weather/NSRDB/Seville/Seville"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/system_setups/automatic_default_connections.py
+++ b/system_setups/automatic_default_connections.py
@@ -63,10 +63,9 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     # Build Basic Components
 
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/system_setups/automatic_default_connections.py
+++ b/system_setups/automatic_default_connections.py
@@ -63,10 +63,17 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     # Build Basic Components
 
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
 
     # Build Occupancy
@@ -76,13 +83,13 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     )
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
 
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Build PV
     my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_scaled_pv_system(
         rooftop_area_in_m2=my_building_information.roof_area_in_m2
     )
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/automatic_default_connections.scenario.json
+++ b/system_setups/automatic_default_connections.scenario.json
@@ -99,7 +99,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/system_setups/automatic_default_connections.scenario.json
+++ b/system_setups/automatic_default_connections.scenario.json
@@ -100,7 +100,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/system_setups/basic_household.py
+++ b/system_setups/basic_household.py
@@ -69,10 +69,9 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/system_setups/basic_household.py
+++ b/system_setups/basic_household.py
@@ -69,8 +69,15 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
 
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Build Occupancy
     my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
@@ -79,12 +86,12 @@ def setup_function(
     )
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
     # Build PV
     my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/basic_household.scenario.json
+++ b/system_setups/basic_household.scenario.json
@@ -99,7 +99,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],
@@ -195,7 +196,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/system_setups/basic_household.scenario.json
+++ b/system_setups/basic_household.scenario.json
@@ -100,7 +100,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],
@@ -197,7 +197,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/system_setups/basic_household_only_heating.py
+++ b/system_setups/basic_household_only_heating.py
@@ -63,8 +63,8 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         )
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
-    # Build Building. The weather configuration comes first, because the building records which weather it
-    # is computed against (its weather_identity); the weather component itself is added further down.
+    # Build Building. The weather config comes first because the building config copies its identity
+    # (weather_identity); the weather component itself is added further down.
     my_weather_config = weather.WeatherConfig.get_default(weather.LocationEnum.AACHEN)
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.weather_identity = my_weather_config.identity()

--- a/system_setups/basic_household_only_heating.py
+++ b/system_setups/basic_household_only_heating.py
@@ -63,9 +63,13 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
         )
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
-    # Build Building
+    # Build Building. The weather configuration comes first, because the building records which weather it
+    # is computed against (its weather_identity); the weather component itself is added further down.
+    my_weather_config = weather.WeatherConfig.get_default(weather.LocationEnum.AACHEN)
+    my_building_config = building.BuildingConfig.preset_standard("Building")
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(
-        config=building.BuildingConfig.preset_standard("Building"),
+        config=my_building_config,
         my_simulation_parameters=my_simulation_parameters,
     )
     my_building_information = my_building.my_building_information
@@ -78,7 +82,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
 
     # Build Weather
     my_weather = weather.Weather(
-        config=weather.WeatherConfig.get_default(weather.LocationEnum.AACHEN),
+        config=my_weather_config,
         my_simulation_parameters=my_simulation_parameters,
     )
 

--- a/system_setups/basic_household_only_heating.scenario.json
+++ b/system_setups/basic_household_only_heating.scenario.json
@@ -156,7 +156,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/system_setups/basic_household_only_heating.scenario.json
+++ b/system_setups/basic_household_only_heating.scenario.json
@@ -155,7 +155,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/system_setups/default_connections.py
+++ b/system_setups/default_connections.py
@@ -55,7 +55,14 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
 
     # Build Occupancy
@@ -66,7 +73,6 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     my_sim.add_component(my_weather)
 
@@ -75,6 +81,7 @@ def setup_function(
 
     # Build PV
     my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/default_connections.py
+++ b/system_setups/default_connections.py
@@ -55,10 +55,9 @@ def setup_function(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/system_setups/default_connections.scenario.json
+++ b/system_setups/default_connections.scenario.json
@@ -106,7 +106,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/default_connections.scenario.json
+++ b/system_setups/default_connections.scenario.json
@@ -105,7 +105,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/dynamic_components.py
+++ b/system_setups/dynamic_components.py
@@ -99,6 +99,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
     my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         my_simulation_parameters=my_simulation_parameters,
         config=my_photovoltaic_system_config,

--- a/system_setups/dynamic_components.scenario.json
+++ b/system_setups/dynamic_components.scenario.json
@@ -349,7 +349,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/dynamic_components.scenario.json
+++ b/system_setups/dynamic_components.scenario.json
@@ -348,7 +348,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -228,6 +228,16 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource,
+    )
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_config.max_thermal_building_demand_in_watt = max_thermal_building_demand_in_watt
@@ -256,6 +266,7 @@ def setup_function(
         my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -287,11 +298,6 @@ def setup_function(
 
     # Build Weather
     # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather_location,
-        weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource,
-    )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)
@@ -313,6 +319,7 @@ def setup_function(
     my_photovoltaic_system_config.azimuth = azimuth
     my_photovoltaic_system_config.tilt = tilt
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -228,10 +228,9 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,

--- a/system_setups/household_district_heating_building_sizer.scenario.json
+++ b/system_setups/household_district_heating_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_district_heating_building_sizer.scenario.json
+++ b/system_setups/household_district_heating_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -186,10 +186,9 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -186,6 +186,16 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource,
+    )
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_config.max_thermal_building_demand_in_watt = max_thermal_building_demand_in_watt
@@ -214,6 +224,7 @@ def setup_function(
         my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -245,11 +256,6 @@ def setup_function(
 
     # Build Weather
     # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather_location,
-        weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource,
-    )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)
@@ -271,6 +277,7 @@ def setup_function(
     my_photovoltaic_system_config.azimuth = azimuth
     my_photovoltaic_system_config.tilt = tilt
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_electric_heating_building_sizer.scenario.json
+++ b/system_setups/household_electric_heating_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_electric_heating_building_sizer.scenario.json
+++ b/system_setups/household_electric_heating_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -195,10 +195,9 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -195,6 +195,16 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource,
+    )
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_config.max_thermal_building_demand_in_watt = max_thermal_building_demand_in_watt
@@ -223,6 +233,7 @@ def setup_function(
         my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -253,11 +264,6 @@ def setup_function(
 
     # Build Weather
     # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather_location,
-        weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource,
-    )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)
@@ -279,6 +285,7 @@ def setup_function(
     my_photovoltaic_system_config.azimuth = azimuth
     my_photovoltaic_system_config.tilt = tilt
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_gas_building_sizer.scenario.json
+++ b/system_setups/household_gas_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_gas_building_sizer.scenario.json
+++ b/system_setups/household_gas_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_gas_solar_thermal.py
+++ b/system_setups/household_gas_solar_thermal.py
@@ -101,8 +101,15 @@ def setup_function(
     # Build Basic Components
 
     # Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(
         config=my_building_config,
         my_simulation_parameters=my_simulation_parameters,
@@ -116,7 +123,6 @@ def setup_function(
     )
 
     # Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
     my_weather = weather.Weather(
         config=my_weather_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_gas_solar_thermal.py
+++ b/system_setups/household_gas_solar_thermal.py
@@ -101,10 +101,9 @@ def setup_function(
     # Build Basic Components
 
     # Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/system_setups/household_gas_solar_thermal.scenario.json
+++ b/system_setups/household_gas_solar_thermal.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/system_setups/household_gas_solar_thermal.scenario.json
+++ b/system_setups/household_gas_solar_thermal.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/system_setups/household_gas_solar_thermal_building_sizer.py
+++ b/system_setups/household_gas_solar_thermal_building_sizer.py
@@ -186,6 +186,12 @@ def setup_function(
 
     # Building
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_config.max_thermal_building_demand_in_watt = max_thermal_building_demand_in_watt
@@ -214,6 +220,7 @@ def setup_function(
         my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -244,7 +251,6 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)
@@ -266,6 +272,7 @@ def setup_function(
     my_photovoltaic_system_config.azimuth = azimuth
     my_photovoltaic_system_config.tilt = tilt
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_gas_solar_thermal_building_sizer.py
+++ b/system_setups/household_gas_solar_thermal_building_sizer.py
@@ -186,10 +186,9 @@ def setup_function(
 
     # Building
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/system_setups/household_gas_solar_thermal_building_sizer.scenario.json
+++ b/system_setups/household_gas_solar_thermal_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_gas_solar_thermal_building_sizer.scenario.json
+++ b/system_setups/household_gas_solar_thermal_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -190,6 +190,16 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource,
+    )
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_config.max_thermal_building_demand_in_watt = max_thermal_building_demand_in_watt
@@ -218,6 +228,7 @@ def setup_function(
         my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -249,11 +260,6 @@ def setup_function(
 
     # Build Weather
     # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather_location,
-        weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource,
-    )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)
@@ -275,6 +281,7 @@ def setup_function(
     my_photovoltaic_system_config.azimuth = azimuth
     my_photovoltaic_system_config.tilt = tilt
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -190,10 +190,9 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,

--- a/system_setups/household_heatpump_building_sizer.scenario.json
+++ b/system_setups/household_heatpump_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_heatpump_building_sizer.scenario.json
+++ b/system_setups/household_heatpump_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_heatpump_car_building_sizer.py
+++ b/system_setups/household_heatpump_car_building_sizer.py
@@ -197,6 +197,12 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_config.max_thermal_building_demand_in_watt = max_thermal_building_demand_in_watt
@@ -225,6 +231,7 @@ def setup_function(
         my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -255,7 +262,6 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)
@@ -277,6 +283,7 @@ def setup_function(
     my_photovoltaic_system_config.azimuth = azimuth
     my_photovoltaic_system_config.tilt = tilt
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,
@@ -406,6 +413,7 @@ def setup_function(
             household_name=car_information_dict["household_name"],
             car_name=car_information_dict["car_name"],
         )
+        my_car_config.occupancy_identity = my_occupancy_config.identity()
         my_cars.append(
             generic_car.Car(
                 my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_heatpump_car_building_sizer.py
+++ b/system_setups/household_heatpump_car_building_sizer.py
@@ -197,10 +197,9 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/system_setups/household_heatpump_car_building_sizer.scenario.json
+++ b/system_setups/household_heatpump_car_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],
@@ -328,7 +328,7 @@
                 "lifetime_in_years": 18.0,
                 "maintenance_costs_in_euro_per_year": 889.96,
                 "subsidy_as_percentage_of_investment_costs": 0,
-                "occupancy_identity": "use_local_lpg/CHR01 Couple both at Work/EnergySaving/Travel Route Set for 10km Commuting Distance/Bus and one 30 km/h Car/Charging At Home with 11 kW/with-appliances/CHR01 Couple both at Work/-"
+                "occupancy_identity": "use_local_lpg/CHR01 Couple both at Work/EnergySaving/Travel Route Set for 10km Commuting Distance/Bus and one 30 km/h Car/Charging At Home with 11 kW/with-appliances/CHR01 Couple both at Work/-/-"
             },
             "config_full_classname": "hisim.components.generic_car.CarConfig",
             "inputs": [],

--- a/system_setups/household_heatpump_car_building_sizer.scenario.json
+++ b/system_setups/household_heatpump_car_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],
@@ -325,7 +327,8 @@
                 "investment_costs_in_euro": 44498.0,
                 "lifetime_in_years": 18.0,
                 "maintenance_costs_in_euro_per_year": 889.96,
-                "subsidy_as_percentage_of_investment_costs": 0
+                "subsidy_as_percentage_of_investment_costs": 0,
+                "occupancy_identity": "use_local_lpg/CHR01 Couple both at Work/EnergySaving/Travel Route Set for 10km Commuting Distance/Bus and one 30 km/h Car/Charging At Home with 11 kW/with-appliances/CHR01 Couple both at Work/-"
             },
             "config_full_classname": "hisim.components.generic_car.CarConfig",
             "inputs": [],

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.py
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.py
@@ -186,6 +186,12 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_config.max_thermal_building_demand_in_watt = max_thermal_building_demand_in_watt
@@ -214,6 +220,7 @@ def setup_function(
         my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -244,7 +251,6 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)
@@ -266,6 +272,7 @@ def setup_function(
     my_photovoltaic_system_config.azimuth = azimuth
     my_photovoltaic_system_config.tilt = tilt
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.py
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.py
@@ -186,10 +186,9 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.scenario.json
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.scenario.json
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_hydrogen_boiler_building_sizer.py
+++ b/system_setups/household_hydrogen_boiler_building_sizer.py
@@ -185,6 +185,12 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_config.max_thermal_building_demand_in_watt = max_thermal_building_demand_in_watt
@@ -213,6 +219,7 @@ def setup_function(
         my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -243,7 +250,6 @@ def setup_function(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)
@@ -265,6 +271,7 @@ def setup_function(
     my_photovoltaic_system_config.azimuth = azimuth
     my_photovoltaic_system_config.tilt = tilt
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_hydrogen_boiler_building_sizer.py
+++ b/system_setups/household_hydrogen_boiler_building_sizer.py
@@ -185,10 +185,9 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/system_setups/household_hydrogen_boiler_building_sizer.scenario.json
+++ b/system_setups/household_hydrogen_boiler_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_hydrogen_boiler_building_sizer.scenario.json
+++ b/system_setups/household_hydrogen_boiler_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -218,10 +218,9 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -218,6 +218,16 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource,
+    )
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_config.max_thermal_building_demand_in_watt = max_thermal_building_demand_in_watt
@@ -246,6 +256,7 @@ def setup_function(
         my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -277,11 +288,6 @@ def setup_function(
 
     # Build Weather
     # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather_location,
-        weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource,
-    )
 
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
@@ -304,6 +310,7 @@ def setup_function(
     my_photovoltaic_system_config.azimuth = azimuth
     my_photovoltaic_system_config.tilt = tilt
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_oil_building_sizer.scenario.json
+++ b/system_setups/household_oil_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_oil_building_sizer.scenario.json
+++ b/system_setups/household_oil_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -190,6 +190,16 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource,
+    )
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_config.max_thermal_building_demand_in_watt = max_thermal_building_demand_in_watt
@@ -218,6 +228,7 @@ def setup_function(
         my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -251,11 +262,6 @@ def setup_function(
     if isinstance(weather_datasource_raw, str):
         weather_datasource = weather.WeatherDataSourceEnum[weather_datasource_raw]
     # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather_location,
-        weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource,
-    )
 
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
@@ -278,6 +284,7 @@ def setup_function(
     my_photovoltaic_system_config.azimuth = azimuth
     my_photovoltaic_system_config.tilt = tilt
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -190,10 +190,9 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,

--- a/system_setups/household_pellets_building_sizer.scenario.json
+++ b/system_setups/household_pellets_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_pellets_building_sizer.scenario.json
+++ b/system_setups/household_pellets_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -191,10 +191,9 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather_location,
         weather_direct_filepath=weather_filepath,

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -191,6 +191,16 @@ def setup_function(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather_location,
+        weather_direct_filepath=weather_filepath,
+        weather_direct_data_source=weather_datasource,
+    )
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_config.max_thermal_building_demand_in_watt = max_thermal_building_demand_in_watt
@@ -219,6 +229,7 @@ def setup_function(
         my_building_config.building_heat_capacity_class = arche_type_config_.building_heat_capacity_class
 
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -250,11 +261,6 @@ def setup_function(
 
     # Build Weather
     # my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather_location,
-        weather_direct_filepath=weather_filepath,
-        weather_direct_data_source=weather_datasource,
-    )
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
 
     # Add to simulator
@@ -277,6 +283,7 @@ def setup_function(
     my_photovoltaic_system_config.azimuth = azimuth
     my_photovoltaic_system_config.tilt = tilt
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/household_wood_chips_building_sizer.scenario.json
+++ b/system_setups/household_wood_chips_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -140,7 +141,8 @@
                 "subsidy_as_percentage_of_investment_costs": null,
                 "predictive": false,
                 "predictive_control": false,
-                "prediction_horizon": null
+                "prediction_horizon": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/household_wood_chips_building_sizer.scenario.json
+++ b/system_setups/household_wood_chips_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],
@@ -142,7 +142,7 @@
                 "predictive": false,
                 "predictive_control": false,
                 "prediction_horizon": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.generic_pv_system.PVSystemConfig",
             "inputs": [],

--- a/system_setups/simple_air_conditioner_household_building_sizer.py
+++ b/system_setups/simple_air_conditioner_household_building_sizer.py
@@ -89,6 +89,12 @@ def setup_function(
 
     # =================================================================================================================================
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.set_heating_temperature_in_celsius = 20.0
     my_building_config.set_cooling_temperature_in_celsius = 25.0
@@ -99,13 +105,13 @@ def setup_function(
     )
     my_building_config.number_of_apartments = number_of_apartments
     my_building_config.enable_opening_windows = True
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(
         config=my_building_config, my_simulation_parameters=my_simulation_parameters
     )
 
     # =================================================================================================================================
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
     my_weather = weather.Weather(
         config=my_weather_config, my_simulation_parameters=my_simulation_parameters
     )

--- a/system_setups/simple_air_conditioner_household_building_sizer.py
+++ b/system_setups/simple_air_conditioner_household_building_sizer.py
@@ -89,10 +89,9 @@ def setup_function(
 
     # =================================================================================================================================
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/system_setups/simple_air_conditioner_household_building_sizer.scenario.json
+++ b/system_setups/simple_air_conditioner_household_building_sizer.scenario.json
@@ -37,7 +37,8 @@
                 "investment_costs_in_euro": null,
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
-                "subsidy_as_percentage_of_investment_costs": null
+                "subsidy_as_percentage_of_investment_costs": null,
+                "weather_identity": "Aachen/DWD_TRY/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/system_setups/simple_air_conditioner_household_building_sizer.scenario.json
+++ b/system_setups/simple_air_conditioner_household_building_sizer.scenario.json
@@ -38,7 +38,7 @@
                 "lifetime_in_years": null,
                 "maintenance_costs_in_euro_per_year": null,
                 "subsidy_as_percentage_of_investment_costs": null,
-                "weather_identity": "Aachen/DWD_TRY/aachen_center"
+                "weather_identity": "Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center"
             },
             "config_full_classname": "hisim.components.building.config.BuildingConfig",
             "inputs": [],

--- a/tests/energy_systems/uc1.realized.energy_system.yaml
+++ b/tests/energy_systems/uc1.realized.energy_system.yaml
@@ -71,10 +71,13 @@ components:
       lifetime_in_years: null
       maintenance_costs_in_euro_per_year: null
       subsidy_as_percentage_of_investment_costs: null
+      weather_identity: Aachen/DWD_TRY/aachen_center # sized from weather.weather_identity=Aachen/DWD_TRY/aachen_center
     inputs:
       - weather
       - occupancy
       - hds
+    sizing_sources:
+      weather_identity: weather.weather_identity # unique provider, written for re-execution
   hds_controller:
     class: hisim.components.heat_distribution_system.HeatDistributionController
     config: # built from preset: standard

--- a/tests/energy_systems/uc1.realized.energy_system.yaml
+++ b/tests/energy_systems/uc1.realized.energy_system.yaml
@@ -71,7 +71,7 @@ components:
       lifetime_in_years: null
       maintenance_costs_in_euro_per_year: null
       subsidy_as_percentage_of_investment_costs: null
-      weather_identity: Aachen/DWD_TRY/aachen_center # sized from weather.weather_identity=Aachen/DWD_TRY/aachen_center
+      weather_identity: Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center # sized from weather.weather_identity=Aachen/DWD_TRY/weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center
     inputs:
       - weather
       - occupancy

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -74,6 +74,7 @@ def test_building() -> None:
     # Set Residence
     my_residence_config = building.BuildingConfig.preset_standard("Building")
 
+    my_residence_config.weather_identity = my_weather_config.identity()
     my_residence = building.Building(
         config=my_residence_config,
         my_simulation_parameters=my_simulation_parameters,

--- a/tests/test_building_heating_demand.py
+++ b/tests/test_building_heating_demand.py
@@ -104,9 +104,16 @@ def test_house_with_idealized_electric_heater_for_testing_heating_demand(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.set_cooling_temperature_in_celsius = set_cooling_temperature_for_building_in_celsius
     my_building_config.set_heating_temperature_in_celsius = set_heating_temperature_for_building_in_celsius
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Occupancy
     my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
@@ -115,7 +122,6 @@ def test_house_with_idealized_electric_heater_for_testing_heating_demand(
     )
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Build Fake Heater Config
     my_idealized_electric_heater_config = idealized_electric_heater.IdealizedHeaterConfig(

--- a/tests/test_building_heating_demand.py
+++ b/tests/test_building_heating_demand.py
@@ -104,10 +104,9 @@ def test_house_with_idealized_electric_heater_for_testing_heating_demand(
     my_sim.set_simulation_parameters(my_simulation_parameters)
 
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/tests/test_building_manual_calculation_thermal_conductances.py
+++ b/tests/test_building_manual_calculation_thermal_conductances.py
@@ -51,6 +51,9 @@ def test_building_thermal_conductance_calculation() -> None:
     )
     my_residence_config.building_code = building_code
     my_residence_config.building_heat_capacity_class = building_heat_capacity_class
+    # No weather component takes part in this test; the identity only has to be set for the building to be
+    # buildable, and a description is more honest than a fake station name.
+    my_residence_config.weather_identity = "no weather component in this test"
     my_residence = building.Building(
         config=my_residence_config, my_simulation_parameters=my_simulation_parameters
     )

--- a/tests/test_building_one_day_snapshot.py
+++ b/tests/test_building_one_day_snapshot.py
@@ -307,6 +307,9 @@ class OneDaySnapshot:
         third simulation run.
         """
         config: BuildingConfig = BuildingConfig.preset_standard("Building")
+        # The snapshot drives the building with synthetic inputs and no weather component, so the
+        # identity is a description rather than a station; it has to be set for the building to build.
+        config.weather_identity = "synthetic winter day, no weather component"
         if variant_name == cls.SCALED_VARIANT_NAME:
             config = dataclasses.replace(
                 config,

--- a/tests/test_building_scalability_with_factor.py
+++ b/tests/test_building_scalability_with_factor.py
@@ -51,8 +51,8 @@ def test_building_scalability() -> None:
     # for building_code in d_f["Code_BuildingVariant"]:
     #     if isinstance(building_code, str):
     # Set Residence
-    # The weather configuration comes first, because the building records which weather it is computed
-    # against (its weather_identity); the weather component itself is added further down, as before.
+    # The weather config comes first because the building config copies its identity (weather_identity);
+    # the weather component itself is added further down, as before.
     my_weather_config = weather.WeatherConfig.get_default(
         location_entry=weather.LocationEnum.AACHEN
     )

--- a/tests/test_building_scalability_with_factor.py
+++ b/tests/test_building_scalability_with_factor.py
@@ -51,12 +51,19 @@ def test_building_scalability() -> None:
     # for building_code in d_f["Code_BuildingVariant"]:
     #     if isinstance(building_code, str):
     # Set Residence
+    # The weather configuration comes first, because the building records which weather it is computed
+    # against (its weather_identity); the weather component itself is added further down, as before.
+    my_weather_config = weather.WeatherConfig.get_default(
+        location_entry=weather.LocationEnum.AACHEN
+    )
+
     my_residence_config = (
         building.BuildingConfig.preset_standard("Building")
     )
     my_residence_config.absolute_conditioned_floor_area_in_m2 = (
         absolute_conditioned_floor_area_in_m2
     )
+    my_residence_config.weather_identity = my_weather_config.identity()
     my_residence = building.Building(
         config=my_residence_config,
         my_simulation_parameters=my_simulation_parameters,
@@ -75,9 +82,6 @@ def test_building_scalability() -> None:
     my_occupancy.i_prepare_simulation()
 
     # Set Weather
-    my_weather_config = weather.WeatherConfig.get_default(
-        location_entry=weather.LocationEnum.AACHEN
-    )
     my_weather = weather.Weather(
         config=my_weather_config, my_simulation_parameters=my_simulation_parameters
     )
@@ -141,6 +145,7 @@ def test_building_scalability() -> None:
         my_residence_config.absolute_conditioned_floor_area_in_m2 = (
             absolute_conditioned_floor_area_in_m2_scaled
         )
+        my_residence_config.weather_identity = my_weather_config.identity()
         my_residence = building.Building(
             config=my_residence_config,
             my_simulation_parameters=my_simulation_parameters,

--- a/tests/test_building_theoretical_thermal_demand.py
+++ b/tests/test_building_theoretical_thermal_demand.py
@@ -67,6 +67,7 @@ def _build_components(
     # Build Building
     my_building_config = building.BuildingConfig.preset_standard("Building")
 
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(
         config=my_building_config, my_simulation_parameters=my_simulation_parameters
     )

--- a/tests/test_building_with_external_u_values.py
+++ b/tests/test_building_with_external_u_values.py
@@ -81,10 +81,9 @@ def _build_components(
     set_cooling_temperature_for_building_in_celsius = 20.5
 
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/tests/test_building_with_external_u_values.py
+++ b/tests/test_building_with_external_u_values.py
@@ -81,6 +81,12 @@ def _build_components(
     set_cooling_temperature_for_building_in_celsius = 20.5
 
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.facade_u_value_in_watt_per_m2_per_kelvin = u_value_params.u_value_facade_in_watt_per_m2_per_kelvin
     my_building_config.roof_u_value_in_watt_per_m2_per_kelvin = u_value_params.u_value_roof_in_watt_per_m2_per_kelvin
@@ -88,6 +94,7 @@ def _build_components(
     my_building_config.door_u_value_in_watt_per_m2_per_kelvin = u_value_params.u_value_door_in_watt_per_m2_per_kelvin
     my_building_config.set_cooling_temperature_in_celsius = set_cooling_temperature_for_building_in_celsius
     my_building_config.set_heating_temperature_in_celsius = set_heating_temperature_for_building_in_celsius
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Occupancy
     my_occupancy_config = loadprofilegenerator_utsp_connector.UtspLpgConnectorConfig.get_default_utsp_connector_config()
@@ -96,7 +103,6 @@ def _build_components(
     )
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Build Fake Heater Config
     my_idealized_electric_heater_config = idealized_electric_heater.IdealizedHeaterConfig(

--- a/tests/test_config_contracts.py
+++ b/tests/test_config_contracts.py
@@ -206,8 +206,8 @@ class PilotWireFormat:
             "set_heating_temperature_in_celsius",
             "set_cooling_temperature_in_celsius",
         ),
-        "WeatherConfig": (),
-        "UtspLpgConnectorConfig": (),
+        "WeatherConfig": ("weather_identity",),
+        "UtspLpgConnectorConfig": ("occupancy_identity",),
         "ElectricityMeterConfig": (),
         "GenericBoilerControllerConfig": (),
     }

--- a/tests/test_controller_l2_energy_management_system.py
+++ b/tests/test_controller_l2_energy_management_system.py
@@ -100,10 +100,9 @@ def test_house(
     heating_reference_temperature_in_celsius = -7.0
 
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/tests/test_controller_l2_energy_management_system.py
+++ b/tests/test_controller_l2_energy_management_system.py
@@ -100,9 +100,16 @@ def test_house(
     heating_reference_temperature_in_celsius = -7.0
 
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -116,7 +123,6 @@ def test_house(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather.LocationEnum.AACHEN)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)
@@ -129,6 +135,7 @@ def test_house(
         module_database=generic_pv_system.PVLibModuleAndInverterEnum.SANDIA_MODULE_DATABASE,
         inverter_name="ABB__MICRO_0_25_I_OUTD_US_208_208V__CEC_2014_",
         inverter_database=generic_pv_system.PVLibModuleAndInverterEnum.SANDIA_INVERTER_DATABASE)
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,)

--- a/tests/test_electricity_meter.py
+++ b/tests/test_electricity_meter.py
@@ -60,12 +60,14 @@ def _build_system(
         generic_pv_system.PVSystemConfig.get_scaled_pv_system(share_of_maximum_pv_potential=1, rooftop_area_in_m2=120)
     )
 
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,
     )
     # Build Building
     my_building_config = building.BuildingConfig.preset_standard("Building")
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(
         config=my_building_config, my_simulation_parameters=my_simulation_parameters
     )

--- a/tests/test_energy_system_configure.py
+++ b/tests/test_energy_system_configure.py
@@ -66,6 +66,14 @@ class Systems:
     preset: condensing_gas
 """
 
+    #: The weather every building is computed against. A building records which weather that is as a
+    #: sized field, so a fixture with a building needs one weather in it -- exactly one, so that the
+    #: fact binds without a source line and the fixtures stay about the relation they were written for.
+    WEATHER: ClassVar[str] = """  weather:
+    class: hisim.components.weather.Weather
+    preset: standard
+"""
+
     @classmethod
     def parse(cls, entries: str) -> EnergySystemFile:
         """Parses one inline document made of the given component entries.
@@ -263,9 +271,9 @@ def test_a_system_of_converted_classes_is_configured_and_sized() -> None:
     the ordinary case actually goes through: the boiler's power band has to come out as the
     number the building's heating load implies.
     """
-    system = Systems.configure(Systems.building("building") + Systems.BOILER)
+    system = Systems.configure(Systems.WEATHER + Systems.building("building") + Systems.BOILER)
 
-    assert [name for name, _ in system.configs] == ["building", "boiler"]
+    assert [name for name, _ in system.configs] == ["weather", "building", "boiler"]
     boiler = system.config_of("boiler")
     assert isinstance(boiler.maximal_thermal_power_in_watt, float)
     assert boiler.maximal_thermal_power_in_watt > 0.0
@@ -281,7 +289,7 @@ def test_two_providers_of_one_fact_are_refused_with_the_candidates_and_a_paste_r
     the rule turns a working file into a puzzle the moment a second provider is added.
     """
     with pytest.raises(EnergySystemSizingError) as raised:
-        Systems.configure(Systems.building("house_a") + Systems.building("house_b") + Systems.BOILER)
+        Systems.configure(Systems.WEATHER + Systems.building("house_a") + Systems.building("house_b") + Systems.BOILER)
 
     message = str(raised.value)
     assert raised.value.error_id is EnergySystemErrorId.SIZING_AMBIGUOUS
@@ -299,7 +307,8 @@ def test_a_source_line_settles_the_ambiguity_the_two_providers_created() -> None
     having no effect at all.
     """
     system = Systems.configure(
-        Systems.building("house_a")
+        Systems.WEATHER
+        + Systems.building("house_a")
         + Systems.building("house_b")
         + """  boiler:
     class: hisim.components.generic_boiler.GenericBoiler
@@ -339,7 +348,8 @@ def test_a_source_naming_a_component_that_does_not_provide_the_fact_is_refused()
     """
     with pytest.raises(EnergySystemSizingError) as raised:
         Systems.configure(
-            Systems.building("building")
+            Systems.WEATHER
+            + Systems.building("building")
             + """  hds:
     class: hisim.components.heat_distribution_system.HeatDistribution
     preset: standard
@@ -368,7 +378,8 @@ def test_a_list_written_for_a_fact_a_law_reads_once_is_refused() -> None:
     """
     with pytest.raises(EnergySystemSizingError) as raised:
         Systems.configure(
-            Systems.building("building")
+            Systems.WEATHER
+            + Systems.building("building")
             + """  boiler:
     class: hisim.components.generic_boiler.GenericBoiler
     preset: condensing_gas
@@ -485,14 +496,16 @@ def test_auto_in_a_config_block_reopens_a_field_the_preset_had_pinned() -> None:
     than as the preset's fixed one.
     """
     pinned = Systems.configure(
-        Systems.building("building")
+        Systems.WEATHER
+        + Systems.building("building")
         + """  boiler:
     class: hisim.components.generic_boiler.GenericBoiler
     preset: condensing_gas_12kw
 """
     ).config_of("boiler")
     reopened = Systems.configure(
-        Systems.building("building")
+        Systems.WEATHER
+        + Systems.building("building")
         + """  boiler:
     class: hisim.components.generic_boiler.GenericBoiler
     preset: condensing_gas_12kw
@@ -516,7 +529,8 @@ def test_a_value_that_does_not_fit_its_field_is_refused_naming_the_entry() -> No
     """
     with pytest.raises(EnergySystemBindingError) as raised:
         Systems.configure(
-            Systems.building("building")
+            Systems.WEATHER
+            + Systems.building("building")
             + """  boiler:
     class: hisim.components.generic_boiler.GenericBoiler
     preset: condensing_gas
@@ -562,7 +576,7 @@ def test_a_fact_nobody_reads_produces_a_warning_and_not_a_refusal() -> None:
     group switched off — but it is also what a misspelled source line looks like from outside,
     so the run says it and continues.
     """
-    system = Systems.configure(Systems.building("building") + Systems.BOILER)
+    system = Systems.configure(Systems.WEATHER + Systems.building("building") + Systems.BOILER)
 
     assert any("conditioned_floor_area_in_m2" in line for line in system.warnings)
     assert all("building" in line or "boiler" in line for line in system.warnings)

--- a/tests/test_energy_system_wiring.py
+++ b/tests/test_energy_system_wiring.py
@@ -366,12 +366,16 @@ def test_an_input_fed_by_two_sources_is_rejected(tmp_path: Path) -> None:
         + """  building:
     class: hisim.components.building.Building
     preset: standard
+    sizing_sources:
+      weather_identity: weather.weather_identity
     inputs:
       - weather
       - input: TemperatureOutside
         from: other_weather.TemperatureOutside
 """
     )
+    # Two weathers make the building's weather_identity ambiguous, and sizing runs before wiring, so the
+    # fixture names its source: this test is about the second feed, not about which weather sizes it.
 
     with pytest.raises(EnergySystemWiringError) as failure:
         Systems.build(entries, tmp_path)

--- a/tests/test_fuel_meter.py
+++ b/tests/test_fuel_meter.py
@@ -96,6 +96,7 @@ def test_house(
     my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_scaled_pv_system(
         share_of_maximum_pv_potential=1, rooftop_area_in_m2=120
     )
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,
@@ -104,6 +105,7 @@ def test_house(
     # Build Building
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     my_building_information = building.BuildingInformation(config=my_building_config)
 

--- a/tests/test_gas_meter.py
+++ b/tests/test_gas_meter.py
@@ -91,6 +91,7 @@ def test_house(
     my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_scaled_pv_system(
         share_of_maximum_pv_potential=1, rooftop_area_in_m2=120
     )
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,
@@ -99,6 +100,7 @@ def test_house(
     # Build Building
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     my_building_information = building.BuildingInformation(config=my_building_config)
 

--- a/tests/test_generic_car.py
+++ b/tests/test_generic_car.py
@@ -93,6 +93,26 @@ class CarReports:
         return {"car_states": [{}], "car_locations": [{}], "driving_distances": [{}]}
 
 
+def _car_config(name: str, household_name: str, car_name: str) -> CarConfig:
+    """A car configuration for a test that publishes its driving profile by hand.
+
+    The occupancy identity is what the car's cache key is completed with in a real setup, where the
+    occupancy config contributes it; here there is no occupancy component, only a profile placed in the
+    repository directly, so the identity is a description of that.
+
+    Args:
+        name: The car's component name.
+        household_name: The household the profile is filed under.
+        car_name: The car within that household.
+
+    Returns:
+        CarConfig: buildable, with the identity set.
+    """
+    config = CarConfig.for_household(name=name, household_name=household_name, car_name=car_name)
+    config.occupancy_identity = f"profile published by the test for {household_name}"
+    return config
+
+
 @pytest.mark.base
 def test_the_car_constructor_takes_nothing_but_parameters_config_and_display():
     """The car is buildable the way the executor builds every component, and only that way.
@@ -182,7 +202,7 @@ def test_a_car_prepared_before_its_occupancy_says_so():
     """
     car = Car(
         my_simulation_parameters=SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60),
-        config=CarConfig.for_household(name="Car", household_name="CHR01", car_name="Small_Car"),
+        config=_car_config(name="Car", household_name="CHR01", car_name="Small_Car"),
     )
     car.set_sim_repo(SimRepository())
     with pytest.raises(CarProfileNotPublishedError) as raised:
@@ -204,7 +224,7 @@ def test_a_car_naming_a_profile_nobody_published_lists_the_ones_that_exist():
     )
     car = Car(
         my_simulation_parameters=SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60),
-        config=CarConfig.for_household(name="Car", household_name="CHR99", car_name="Truck"),
+        config=_car_config(name="Car", household_name="CHR99", car_name="Truck"),
     )
     car.set_sim_repo(repository)
     with pytest.raises(CarProfileNotPublishedError) as raised:
@@ -228,7 +248,7 @@ def test_a_car_registered_with_a_simulator_finds_the_published_profile():
     )
     car = Car(
         my_simulation_parameters=SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60),
-        config=CarConfig.for_household(name="VanOfCHR02", household_name="CHR02", car_name="Van"),
+        config=_car_config(name="VanOfCHR02", household_name="CHR02", car_name="Van"),
     )
     car.set_sim_repo(repository)
     car.i_prepare_simulation()

--- a/tests/test_generic_pv_system.py
+++ b/tests/test_generic_pv_system.py
@@ -53,6 +53,7 @@ def _run_pv_at_timestep_655(
     my_weather.set_sim_repo(repo)
     my_weather.i_prepare_simulation()
 
+    pvs_config.weather_identity = my_weather_config.identity()
     my_pvs = generic_pv_system.PVSystem(
         config=pvs_config, my_simulation_parameters=mysim
     )
@@ -166,6 +167,7 @@ def test_photovoltaic_cache_roundtrip(tmp_path) -> None:
     my_weather.i_prepare_simulation()
 
     my_pvs_config = generic_pv_system.PVSystemConfig.get_default_pv_system()
+    my_pvs_config.weather_identity = my_weather_config.identity()
     my_pvs = generic_pv_system.PVSystem(
         config=my_pvs_config, my_simulation_parameters=my_sim_params
     )
@@ -186,6 +188,7 @@ def test_photovoltaic_cache_roundtrip(tmp_path) -> None:
         == my_sim_params.timesteps
     )
 
+    my_pvs_config.weather_identity = my_weather_config.identity()
     my_pvs_cached = generic_pv_system.PVSystem(
         config=my_pvs_config, my_simulation_parameters=my_sim_params
     )

--- a/tests/test_heating_meter.py
+++ b/tests/test_heating_meter.py
@@ -92,6 +92,7 @@ def test_house(
     my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_scaled_pv_system(
         share_of_maximum_pv_potential=1, rooftop_area_in_m2=120
     )
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config,
         my_simulation_parameters=my_simulation_parameters,
@@ -100,6 +101,7 @@ def test_house(
     # Build Building
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     my_building_information = building.BuildingInformation(config=my_building_config)
 

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -461,7 +461,8 @@ def test_describe_config_covers_the_other_pilots_and_rejects_a_non_dataclass():
     assert tabula.parameters[0].name == "building_code"
     assert tabula.parameters[0].default is dataclasses.MISSING
     assert {parameter.name for parameter in tabula.parameters} >= {"number_of_apartments", "building_code"}
-    assert not building.sizable_fields
+    # The building sizes exactly one field from the system: which weather it is computed against.
+    assert [field.name for field in building.sizable_fields] == ["weather_identity"]
     assert "heating_load_in_watt" in building.facts_provided
 
     with pytest.raises(TypeError, match="config dataclass"):
@@ -501,7 +502,8 @@ def test_a_config_class_outside_the_kernel_resolves_through_resolve_all():
 
     building = BuildingConfig.preset_standard("Building")
     storage = _StorageConfig.preset_standard("Tank")
-    resolved = resolve_all([building, storage])
+    # No weather in this scenario, so the fact the building now reads is seeded by the test.
+    resolved = resolve_all([building, storage], seed=SizingContext(weather_identity="test weather"))
     resolved_storage = next(config for config in resolved if isinstance(config, _StorageConfig))
     volume = cast(float, resolved_storage.volume_in_liter)  # resolved: nothing left to size
     assert volume > 0.0

--- a/tests/test_simple_air_conditioner_household_building_sizer.py
+++ b/tests/test_simple_air_conditioner_household_building_sizer.py
@@ -78,6 +78,7 @@ def test_building_simulates_without_occupancy_connections() -> None:
 
     # Building — default German single-family home, no occupancy component
     my_building_config = building.BuildingConfig.preset_standard("Building")
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(
         config=my_building_config, my_simulation_parameters=my_simulation_parameters
     )

--- a/tests/test_singleton_sim_repository.py
+++ b/tests/test_singleton_sim_repository.py
@@ -70,6 +70,7 @@ def test_house(
     )
     # Build Building
     my_building_config = building.BuildingConfig.preset_standard("Building")
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(
         config=my_building_config, my_simulation_parameters=my_simulation_parameters
     )

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -57,6 +57,26 @@ class _SizableFixtureConfig(ConfigBase):
 
 @dataclass_json
 @dataclass
+class _StringSizedFixtureConfig(ConfigBase):
+    """A config with one string-typed sizable field, for the wire-format tests.
+
+    Identity facts such as the weather a component is computed against are strings, not
+    numbers, and a string is the one type whose constructor accepts the ``AUTO`` sentinel
+    without complaint -- ``str(AUTO)`` is the wire spelling -- which is what made the decoder
+    defect this fixture guards against silent.
+    """
+
+    component_id: ComponentID
+    upstream_identity: Sizable[str] = sized_field(rule=Size.WEATHER_IDENTITY, value_type=str)
+
+    @classmethod
+    def get_main_classname(cls) -> str:
+        """Returns the class name, as every config does."""
+        return cls.__name__
+
+
+@dataclass_json
+@dataclass
 class _UnsizableFixtureConfig(ConfigBase):
     """A config declaring no sizable field at all — the NothingToSizeError case."""
 
@@ -312,3 +332,28 @@ def test_ems_preset_has_nothing_to_size():
     assert config.strategy == "optimize_own_consumption"
     with pytest.raises(NothingToSizeError):
         config.resolve(SizingContext(heating_load_in_watt=10_000.0))
+
+
+@pytest.mark.base
+def test_a_string_typed_sizable_field_left_out_of_a_dict_is_still_auto():
+    """A missing sized field means "size me", whatever its type; it must never decode to the text "AUTO".
+
+    ``dataclasses_json`` runs the field decoder over a missing key's *default* as well as over a
+    present value, and the decoder used to coerce whatever it was handed through ``value_type``.
+    For an enum that raises; for ``str`` it silently produces the wire spelling as a real string,
+    which the engine then treats as a concrete value and leaves alone -- so a config block that
+    omitted the field was never sized and the run record caught it only afterwards.
+
+    Failure mode caught: an omitted string-typed sizable field arriving as ``"AUTO"`` instead of
+    ``AUTO``, on the config-block path of the energy-system format.
+    """
+    absent = _StringSizedFixtureConfig.from_dict({"component_id": {"name": "Fixture"}})
+    spelled = _StringSizedFixtureConfig.from_dict({"component_id": {"name": "Fixture"}, "upstream_identity": "AUTO"})
+    concrete = _StringSizedFixtureConfig.from_dict(
+        {"component_id": {"name": "Fixture"}, "upstream_identity": "Aachen/DWD_TRY/aachen_center"}
+    )
+
+    assert absent.upstream_identity is AUTO
+    assert spelled.upstream_identity is AUTO
+    assert concrete.upstream_identity == "Aachen/DWD_TRY/aachen_center"
+    assert sizing.auto_fields(absent) == ("upstream_identity",)

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -60,10 +60,8 @@ class _SizableFixtureConfig(ConfigBase):
 class _StringSizedFixtureConfig(ConfigBase):
     """A config with one string-typed sizable field, for the wire-format tests.
 
-    Identity facts such as the weather a component is computed against are strings, not
-    numbers, and a string is the one type whose constructor accepts the ``AUTO`` sentinel
-    without complaint -- ``str(AUTO)`` is the wire spelling -- which is what made the decoder
-    defect this fixture guards against silent.
+    ``str`` is the one type whose constructor accepts the ``AUTO`` sentinel without an error
+    (``str(AUTO)`` is the wire spelling), which is what made the decoder defect below silent.
     """
 
     component_id: ComponentID
@@ -336,16 +334,11 @@ def test_ems_preset_has_nothing_to_size():
 
 @pytest.mark.base
 def test_a_string_typed_sizable_field_left_out_of_a_dict_is_still_auto():
-    """A missing sized field means "size me", whatever its type; it must never decode to the text "AUTO".
+    """A sized field missing from a dict decodes to the ``AUTO`` sentinel, not to the string ``"AUTO"``.
 
-    ``dataclasses_json`` runs the field decoder over a missing key's *default* as well as over a
-    present value, and the decoder used to coerce whatever it was handed through ``value_type``.
-    For an enum that raises; for ``str`` it silently produces the wire spelling as a real string,
-    which the engine then treats as a concrete value and leaves alone -- so a config block that
-    omitted the field was never sized and the run record caught it only afterwards.
-
-    Failure mode caught: an omitted string-typed sizable field arriving as ``"AUTO"`` instead of
-    ``AUTO``, on the config-block path of the energy-system format.
+    ``dataclasses_json`` runs the field decoder on a missing key's default too. The decoder used to
+    coerce that default through ``value_type``; for ``str`` that produced the text ``"AUTO"``, which the
+    engine then treated as a set value and never sized.
     """
     absent = _StringSizedFixtureConfig.from_dict({"component_id": {"name": "Fixture"}})
     spelled = _StringSizedFixtureConfig.from_dict({"component_id": {"name": "Fixture"}, "upstream_identity": "AUTO"})

--- a/tests/test_sizing_engine.py
+++ b/tests/test_sizing_engine.py
@@ -171,7 +171,11 @@ def test_the_pilot_chain_resolves_without_any_sources_mapping():
     )
     hds = HeatDistributionConfig.preset_standard("HeatDistributionSystem")
     boiler = GenericBoilerConfig.preset_condensing_gas("CondensingGasBoiler")
-    resolved = resolve_all([hds, boiler, building, controller])  # deliberately shuffled
+    # The chain has no weather, and the building now records which weather it is computed against, so
+    # that one fact is seeded: the seed is the surrounding system, and here the system is the test.
+    resolved = resolve_all(
+        [hds, boiler, building, controller], seed=SizingContext(weather_identity="pilot weather")
+    )  # deliberately shuffled
     resolved_hds, resolved_boiler = resolved[0], resolved[1]
     assert resolved_hds.water_mass_flow_rate_in_kg_per_second == 0.27
     assert resolved_hds.heating_system is HeatDistributionSystemType.FLOORHEATING

--- a/tests/test_time_resolution.py
+++ b/tests/test_time_resolution.py
@@ -347,10 +347,9 @@ def run_cluster_house(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
-    # The weather configuration is created before anything that depends on it, because the building and
-    # the PV system record which weather they are computed against (their weather_identity) and that
-    # has to be set before those components are built. The weather component itself is added below,
-    # where it always was, so the order the simulator sees is unchanged.
+    # The weather config is created first: the building and PV configs copy its identity
+    # (weather_identity) and must have it before those components are built. The weather
+    # component itself is still added further down, so the simulator's component order is unchanged.
     my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
 
     my_building_config = building.BuildingConfig.preset_standard("Building")

--- a/tests/test_time_resolution.py
+++ b/tests/test_time_resolution.py
@@ -347,9 +347,16 @@ def run_cluster_house(
     # =================================================================================================================================
     # Build Basic Components
     # Build Building
+    # The weather configuration is created before anything that depends on it, because the building and
+    # the PV system record which weather they are computed against (their weather_identity) and that
+    # has to be set before those components are built. The weather component itself is added below,
+    # where it always was, so the order the simulator sees is unchanged.
+    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
+
     my_building_config = building.BuildingConfig.preset_standard("Building")
     my_building_config.heating_reference_temperature_in_celsius = heating_reference_temperature_in_celsius
     my_building_information = building.BuildingInformation(config=my_building_config)
+    my_building_config.weather_identity = my_weather_config.identity()
     my_building = building.Building(config=my_building_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_building, connect_automatically=True)
@@ -367,7 +374,6 @@ def run_cluster_house(
     my_sim.add_component(my_occupancy)
 
     # Build Weather
-    my_weather_config = weather.WeatherConfig.get_default(location_entry=weather_location)
     my_weather = weather.Weather(config=my_weather_config, my_simulation_parameters=my_simulation_parameters)
     # Add to simulator
     my_sim.add_component(my_weather)
@@ -378,6 +384,7 @@ def run_cluster_house(
         share_of_maximum_pv_potential=1,
         location=weather_location,
     )
+    my_photovoltaic_system_config.weather_identity = my_weather_config.identity()
     my_photovoltaic_system = generic_pv_system.PVSystem(
         config=my_photovoltaic_system_config, my_simulation_parameters=my_simulation_parameters,
     )

--- a/tests/test_weather_identity_sizing.py
+++ b/tests/test_weather_identity_sizing.py
@@ -68,34 +68,68 @@ class Keys:
 
 
 @pytest.mark.base
-def test_the_weather_identity_names_the_station_the_data_set_and_the_file_and_not_the_machine() -> None:
-    """The weather identity contains station, data set and file stem, and no directory.
+def test_the_weather_identity_names_the_dataset_and_the_file_and_not_the_machine() -> None:
+    """The weather identity contains station, data set and the inputs-relative path, and no machine prefix.
 
-    Two configs reading the same station from different checkouts must give the same identity, otherwise
-    a cache could never be shared between machines.
+    The path below the inputs directory stays because that is where the dataset families live: two
+    families could hold a file of the same name, and a bare file stem would let them share cache
+    entries. The prefix above the inputs directory is a property of the machine and must not appear,
+    otherwise a cache could never be shared between machines.
     """
     aachen = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN)
-    elsewhere = dataclasses.replace(aachen, source_path=str(pathlib.Path("/another/checkout") / pathlib.Path(aachen.source_path).name))
 
     identity = aachen.identity()
 
     assert identity.startswith("Aachen/")
     assert aachen.data_source.value in identity
     assert pathlib.Path(aachen.source_path).name in identity
-    assert "/another/checkout" not in elsewhere.identity()
-    assert elsewhere.identity() == identity
+    assert utils.get_input_directory() not in identity
+    # The dataset directory is the discriminator the file stem alone lacks.
+    dataset_directory = pathlib.Path(aachen.source_path).relative_to(utils.get_input_directory()).parts[1]
+    assert dataset_directory in identity
+
+
+@pytest.mark.base
+def test_two_datasets_sharing_a_file_name_get_different_identities(tmp_path: pathlib.Path) -> None:
+    """Same station file name in two dataset directories under the inputs root must not share an identity.
+
+    Catches: the identity falling back to the bare basename for files under the inputs directory,
+    which would key two different climates identically.
+    """
+    del tmp_path
+    inputs = pathlib.Path(utils.get_input_directory())
+    aachen = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN)
+    family_a = dataclasses.replace(aachen, source_path=str(inputs / "weather" / "family-a" / "station"))
+    family_b = dataclasses.replace(aachen, source_path=str(inputs / "weather" / "family-b" / "station"))
+
+    assert family_a.identity() != family_b.identity()
+
+    # A file outside the inputs directory contributes only its basename, so the machine prefix
+    # can never leak into the identity.
+    outside = dataclasses.replace(aachen, source_path="/somewhere/machine/specific/station")
+    assert "/somewhere" not in outside.identity()
+    assert outside.identity().endswith("/station")
 
 
 @pytest.mark.base
 def test_the_occupancy_identity_says_more_than_the_household_name() -> None:
-    """The occupancy identity changes with the seed, not only with the household name."""
+    """The occupancy identity changes with the request guid and the predefined profile file, not only the name.
+
+    The guid identifies the calculation request (it is not the LPG's random seed, which is wired
+    nowhere); the profile filepath routes to different files in predefined-profile mode. Both change
+    what the run produces, so both must move the identity.
+    """
     baseline = UtspLpgConnectorConfig.get_default_utsp_connector_config()
-    with_other_routes = dataclasses.replace(baseline, guid="another-seed")
+    with_other_guid = dataclasses.replace(baseline, guid="another-request")
+    with_other_file = dataclasses.replace(baseline, predefined_loadprofile_filepaths="/data/special_profile.csv")
 
     households = baseline.household if isinstance(baseline.household, list) else [baseline.household]
     assert str(households[0].Name) in baseline.identity()
     assert str(baseline.energy_intensity.value) in baseline.identity()
-    assert baseline.identity() != with_other_routes.identity()
+    assert baseline.identity() != with_other_guid.identity()
+    assert baseline.identity() != with_other_file.identity()
+    assert "special_profile.csv" in with_other_file.identity()
+    assert "/data/" not in with_other_file.identity(), "the machine-specific directory must not enter the identity"
 
 
 @pytest.mark.base
@@ -147,6 +181,75 @@ def test_the_engine_binds_the_weather_identity_with_nothing_declared_in_the_file
     for name in building_names:
         assert configured.config_of(name).weather_identity == expected
         assert configured.config_of(name).weather_identity is not AUTO
+
+
+@pytest.mark.base
+def test_the_engine_binds_the_occupancy_identity_from_the_contribution() -> None:
+    """The occupancy's declared contribution reaches a car through the engine, like the weather's does.
+
+    The weather side has an engine-level test; without this one, the occupancy's
+    ``SIZING_CONTRIBUTIONS`` registration and the ``identity_facts`` compute were executed by no test,
+    so a typo in the fact name would pass the suite and fail only in a real car scenario.
+    """
+    from hisim.config.engine import resolve_all  # pylint: disable=import-outside-toplevel
+
+    occupancy = UtspLpgConnectorConfig.get_default_utsp_connector_config()
+    car = CarConfig.for_household(name="Car", household_name="CHR01", car_name="Small_Car")
+    assert car.occupancy_identity is AUTO
+
+    resolved = resolve_all([occupancy, car], seed=SizingContext(weather_identity="pilot weather"))
+
+    resolved_car = resolved[1]
+    assert resolved_car.occupancy_identity == occupancy.identity()
+
+
+@pytest.mark.base
+def test_a_vacuous_identity_is_refused_like_auto() -> None:
+    """``None`` (a JSON ``null``) and the empty string count as unresolved, not as a resolved identity.
+
+    Both used to slip past the AUTO guard and put a meaningless value into the cache key -- the
+    incomplete-key hole F7 closes, reopened through the wire path.
+    """
+    import json  # pylint: disable=import-outside-toplevel
+
+    from hisim.components.building.building import Building  # pylint: disable=import-outside-toplevel
+
+    with pytest.warns(RuntimeWarning, match="weather_identity"):
+        nulled = BuildingConfig.from_dict(
+            {**json.loads(BuildingConfig.preset_standard("B").to_json()), "weather_identity": None}
+        )
+    assert "weather_identity" in nulled.auto_fields()
+
+    emptied = BuildingConfig.preset_standard("B2")
+    emptied.weather_identity = ""
+    with pytest.raises(ConfigSizingError, match="weather_identity"):
+        Building(config=emptied, my_simulation_parameters=Keys.PARAMETERS)
+
+
+@pytest.mark.base
+def test_a_stale_identity_literal_in_a_scenario_is_refused() -> None:
+    """The scenario executor refuses a recorded identity that disagrees with the file's own provider.
+
+    On the JSON path the identities are frozen literals; a user who edits the weather block by hand
+    and forgets the literal would silently reuse cache entries computed for the old weather.
+
+    Catches: the cross-check being dropped, or failing to find the provider through its
+    ``SIZING_CONTRIBUTIONS``.
+    """
+    from hisim.json_executor import _verify_identity_literals  # pylint: disable=import-outside-toplevel
+
+    weather = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN)
+    building = Keys.sized_from(BuildingConfig.preset_standard("Building"), weather_identity=weather.identity())
+
+    _verify_identity_literals([weather, building])  # matching literal passes
+
+    seville = WeatherConfig.get_default(location_entry=LocationEnum.SEVILLE)
+    stale = Keys.sized_from(BuildingConfig.preset_standard("Building"), weather_identity=seville.identity())
+    with pytest.raises(ValueError, match="stale"):
+        _verify_identity_literals([weather, stale])
+
+    # With two providers no single expected value exists, so the literal is taken as given.
+    _verify_identity_literals([weather, seville, stale])
 
 
 @pytest.mark.base

--- a/tests/test_weather_identity_sizing.py
+++ b/tests/test_weather_identity_sizing.py
@@ -1,0 +1,190 @@
+"""Tests for the identity facts: how a cached result's key comes to describe the upstream it depends on.
+
+``roadmap/pylpg_flakiness.md`` F7 is the finding that a PV system's, a building's and a car's cache
+keys described their *owner* and not their *inputs*: the PV key hashed the PV config, which knows
+nothing about the weather it was run with, so two runs against two weathers shared one entry. The fix
+is not to widen the key by hand but to make the configuration complete -- the upstream config
+contributes its readable identity as a sizing fact, the downstream config declares a field sized from
+it, and the key, which hashes the whole config, is complete by construction.
+
+These tests pin the four things that make that work: the identity strings are readable and say what
+decides the data; the sizing engine binds them with nothing declared in the file; every key moves when
+its upstream changes; and a downstream component cannot be built without the fact, because the whole
+point is that no run can ever produce an entry under an incomplete key again.
+
+Each test states the failure mode it catches.
+"""
+
+# clean
+
+import dataclasses
+import pathlib
+from typing import Any
+
+import pytest
+
+from hisim import utils
+from hisim.components.building.config import BuildingConfig
+from hisim.components.generic_car import CarConfig
+from hisim.components.generic_pv_system import PVSystemConfig
+from hisim.components.loadprofilegenerator_utsp_connector import UtspLpgConnectorConfig
+from hisim.components.weather import LocationEnum, WeatherConfig
+from hisim.config import AUTO, ConfigSizingError, SizingContext
+from hisim.energy_system.configure import configure_energy_system
+from hisim.energy_system.loader import load_energy_system
+from hisim.simulationparameters import SimulationParameters
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+class Keys:
+    """Computes cache keys the way the components do, so the tests assert on the real material."""
+
+    PARAMETERS = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=900)
+
+    @classmethod
+    def of(cls, config: Any) -> str:
+        """The legacy key material of a config: its JSON plus the simulation key, as every writer hashes it.
+
+        Args:
+            config: A configuration with every sized field resolved.
+
+        Returns:
+            str: the key material.
+        """
+        return utils.build_cache_key_string(config, cls.PARAMETERS)
+
+    @staticmethod
+    def sized_from(config: Any, **facts: Any) -> Any:
+        """Resolves a config against just the given facts.
+
+        Args:
+            config: The configuration to resolve.
+            **facts: The facts the surrounding system would provide.
+
+        Returns:
+            The resolved copy.
+        """
+        return config.resolve(SizingContext().with_facts(**facts))
+
+
+@pytest.mark.base
+def test_the_weather_identity_names_the_station_the_data_set_and_the_file_and_not_the_machine() -> None:
+    """The identity is readable and decided by the data, not by where the repository is checked out.
+
+    Two weather configs that read the same station from two different directories are the same
+    weather, and they must produce the same downstream keys or a cache could never be shared between
+    two machines.
+
+    Catches: an absolute path leaking into the identity, or the identity dropping one of the three
+    things that decide what the weather component reads.
+    """
+    aachen = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN)
+    elsewhere = dataclasses.replace(aachen, source_path=str(pathlib.Path("/another/checkout") / pathlib.Path(aachen.source_path).name))
+
+    identity = aachen.identity()
+
+    assert identity.startswith("Aachen/")
+    assert aachen.data_source.value in identity
+    assert pathlib.Path(aachen.source_path).name in identity
+    assert "/another/checkout" not in elsewhere.identity()
+    assert elsewhere.identity() == identity
+
+
+@pytest.mark.base
+def test_the_occupancy_identity_says_more_than_the_household_name() -> None:
+    """The car's key used to carry the household name alone; the identity carries what decides the profile.
+
+    Catches: two occupancies with the same household but different travel routes producing the same
+    identity, which is the collision the car's key used to have.
+    """
+    baseline = UtspLpgConnectorConfig.get_default_utsp_connector_config()
+    with_other_routes = dataclasses.replace(baseline, guid="another-seed")
+
+    households = baseline.household if isinstance(baseline.household, list) else [baseline.household]
+    assert str(households[0].Name) in baseline.identity()
+    assert str(baseline.energy_intensity.value) in baseline.identity()
+    assert baseline.identity() != with_other_routes.identity()
+
+
+@pytest.mark.base
+def test_a_pv_key_moves_when_the_weather_does_and_a_building_key_too() -> None:
+    """L1 of the cache-testing spec: perturb the upstream, the downstream key changes.
+
+    This is the whole of F7 for these two components. Before, the PV key was identical for Aachen and
+    Seville; now the weather's identity is part of the PV configuration and therefore of the key.
+
+    Catches: the sized field falling out of the key -- a ``to_json`` that skips it, say.
+    """
+    aachen = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN).identity()
+    seville = WeatherConfig.get_default(location_entry=LocationEnum.SEVILLE).identity()
+
+    pv = PVSystemConfig.get_default_pv_system()
+    building = BuildingConfig.preset_standard("Building")
+
+    assert Keys.of(Keys.sized_from(pv, weather_identity=aachen)) != Keys.of(Keys.sized_from(pv, weather_identity=seville))
+    assert Keys.of(Keys.sized_from(building, weather_identity=aachen)) != Keys.of(
+        Keys.sized_from(building, weather_identity=seville)
+    )
+
+
+@pytest.mark.base
+def test_a_car_key_moves_when_the_occupancy_does() -> None:
+    """The same for the car and its occupancy: the household name is no longer all the key knows.
+
+    Catches: two cars of the same household name under different occupancies sharing a cache entry.
+    """
+    baseline = UtspLpgConnectorConfig.get_default_utsp_connector_config()
+    other = dataclasses.replace(baseline, guid="another-seed")
+    car = CarConfig.for_household(name="Car", household_name="CHR01", car_name="Small_Car")
+
+    assert Keys.of(Keys.sized_from(car, occupancy_identity=baseline.identity())) != Keys.of(
+        Keys.sized_from(car, occupancy_identity=other.identity())
+    )
+
+
+@pytest.mark.base
+def test_the_engine_binds_the_weather_identity_with_nothing_declared_in_the_file() -> None:
+    """On the file path the fact needs no ``sizing_sources`` line: one weather, one provider, it binds.
+
+    Uses the repository's own hand-written example, so this is the real loader, the real engine and a
+    real file rather than a fixture shaped to pass.
+
+    Catches: the contribution not being registered, or the field not being sized on the declarative
+    path -- either of which would leave every recorded energy system with an incomplete key.
+    """
+    repository_root = pathlib.Path(__file__).resolve().parents[1]
+    model = load_energy_system(repository_root / "energy_systems" / "gas_boiler_household.energy_system.yaml")
+
+    configured = configure_energy_system(model)
+
+    weather_names = [name for name in model.components if isinstance(configured.config_of(name), WeatherConfig)]
+    assert len(weather_names) == 1
+    expected = configured.config_of(weather_names[0]).identity()
+    building_names = [name for name in model.components if isinstance(configured.config_of(name), BuildingConfig)]
+    assert building_names, "the example has a building"
+    for name in building_names:
+        assert configured.config_of(name).weather_identity == expected
+        assert configured.config_of(name).weather_identity is not AUTO
+
+
+@pytest.mark.base
+def test_a_building_cannot_be_built_without_knowing_its_weather() -> None:
+    """The construction-time check is what makes the fix hold: no run can produce an entry under an incomplete key.
+
+    Catches: the sized field being given a concrete default that lets an unsized building through,
+    which would quietly restore the old incomplete key for every setup that forgot the assignment.
+    """
+    from hisim.components.building.building import Building  # pylint: disable=import-outside-toplevel
+
+    config = BuildingConfig.preset_standard("Building")
+    assert config.weather_identity is AUTO
+
+    with pytest.raises(ConfigSizingError, match="weather_identity"):
+        Building(config=config, my_simulation_parameters=Keys.PARAMETERS)

--- a/tests/test_weather_identity_sizing.py
+++ b/tests/test_weather_identity_sizing.py
@@ -1,18 +1,11 @@
-"""Tests for the identity facts: how a cached result's key comes to describe the upstream it depends on.
+"""Tests for the identity facts (``roadmap/pylpg_flakiness.md`` F7).
 
-``roadmap/pylpg_flakiness.md`` F7 is the finding that a PV system's, a building's and a car's cache
-keys described their *owner* and not their *inputs*: the PV key hashed the PV config, which knows
-nothing about the weather it was run with, so two runs against two weathers shared one entry. The fix
-is not to widen the key by hand but to make the configuration complete -- the upstream config
-contributes its readable identity as a sizing fact, the downstream config declares a field sized from
-it, and the key, which hashes the whole config, is complete by construction.
-
-These tests pin the four things that make that work: the identity strings are readable and say what
-decides the data; the sizing engine binds them with nothing declared in the file; every key moves when
-its upstream changes; and a downstream component cannot be built without the fact, because the whole
-point is that no run can ever produce an entry under an incomplete key again.
-
-Each test states the failure mode it catches.
+PV, building and car results are computed from an upstream component -- the weather or the occupancy --
+but their cache keys used to hash only their own configuration, so two runs with different weathers
+could share one entry. Now the upstream config contributes a readable identity string as a sizing fact,
+the downstream config declares a field sized from it, and the key (a hash of the whole config) includes
+it. These tests pin the identity strings, the key sensitivity, the engine binding on the file path, and
+the refusal to build a component whose identity was never set.
 """
 
 # clean
@@ -44,16 +37,16 @@ __status__ = "development"
 
 
 class Keys:
-    """Computes cache keys the way the components do, so the tests assert on the real material."""
+    """Computes cache key material the way the components do."""
 
     PARAMETERS = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=900)
 
     @classmethod
     def of(cls, config: Any) -> str:
-        """The legacy key material of a config: its JSON plus the simulation key, as every writer hashes it.
+        """Return the key material of a config under the shared simulation parameters.
 
         Args:
-            config: A configuration with every sized field resolved.
+            config: a configuration with all sized fields resolved.
 
         Returns:
             str: the key material.
@@ -62,11 +55,11 @@ class Keys:
 
     @staticmethod
     def sized_from(config: Any, **facts: Any) -> Any:
-        """Resolves a config against just the given facts.
+        """Resolve a config against the given facts only.
 
         Args:
-            config: The configuration to resolve.
-            **facts: The facts the surrounding system would provide.
+            config: the configuration.
+            **facts: the sizing facts to provide.
 
         Returns:
             The resolved copy.
@@ -76,14 +69,10 @@ class Keys:
 
 @pytest.mark.base
 def test_the_weather_identity_names_the_station_the_data_set_and_the_file_and_not_the_machine() -> None:
-    """The identity is readable and decided by the data, not by where the repository is checked out.
+    """The weather identity contains station, data set and file stem, and no directory.
 
-    Two weather configs that read the same station from two different directories are the same
-    weather, and they must produce the same downstream keys or a cache could never be shared between
-    two machines.
-
-    Catches: an absolute path leaking into the identity, or the identity dropping one of the three
-    things that decide what the weather component reads.
+    Two configs reading the same station from different checkouts must give the same identity, otherwise
+    a cache could never be shared between machines.
     """
     aachen = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN)
     elsewhere = dataclasses.replace(aachen, source_path=str(pathlib.Path("/another/checkout") / pathlib.Path(aachen.source_path).name))
@@ -99,11 +88,7 @@ def test_the_weather_identity_names_the_station_the_data_set_and_the_file_and_no
 
 @pytest.mark.base
 def test_the_occupancy_identity_says_more_than_the_household_name() -> None:
-    """The car's key used to carry the household name alone; the identity carries what decides the profile.
-
-    Catches: two occupancies with the same household but different travel routes producing the same
-    identity, which is the collision the car's key used to have.
-    """
+    """The occupancy identity changes with the seed, not only with the household name."""
     baseline = UtspLpgConnectorConfig.get_default_utsp_connector_config()
     with_other_routes = dataclasses.replace(baseline, guid="another-seed")
 
@@ -115,12 +100,9 @@ def test_the_occupancy_identity_says_more_than_the_household_name() -> None:
 
 @pytest.mark.base
 def test_a_pv_key_moves_when_the_weather_does_and_a_building_key_too() -> None:
-    """L1 of the cache-testing spec: perturb the upstream, the downstream key changes.
+    """Changing the weather changes the PV key and the building key.
 
-    This is the whole of F7 for these two components. Before, the PV key was identical for Aachen and
-    Seville; now the weather's identity is part of the PV configuration and therefore of the key.
-
-    Catches: the sized field falling out of the key -- a ``to_json`` that skips it, say.
+    Before F7 the PV key was identical for Aachen and Seville.
     """
     aachen = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN).identity()
     seville = WeatherConfig.get_default(location_entry=LocationEnum.SEVILLE).identity()
@@ -136,10 +118,7 @@ def test_a_pv_key_moves_when_the_weather_does_and_a_building_key_too() -> None:
 
 @pytest.mark.base
 def test_a_car_key_moves_when_the_occupancy_does() -> None:
-    """The same for the car and its occupancy: the household name is no longer all the key knows.
-
-    Catches: two cars of the same household name under different occupancies sharing a cache entry.
-    """
+    """Changing the occupancy changes the car key."""
     baseline = UtspLpgConnectorConfig.get_default_utsp_connector_config()
     other = dataclasses.replace(baseline, guid="another-seed")
     car = CarConfig.for_household(name="Car", household_name="CHR01", car_name="Small_Car")
@@ -151,13 +130,9 @@ def test_a_car_key_moves_when_the_occupancy_does() -> None:
 
 @pytest.mark.base
 def test_the_engine_binds_the_weather_identity_with_nothing_declared_in_the_file() -> None:
-    """On the file path the fact needs no ``sizing_sources`` line: one weather, one provider, it binds.
+    """On the file path the fact binds without a ``sizing_sources`` line: one weather, one provider.
 
-    Uses the repository's own hand-written example, so this is the real loader, the real engine and a
-    real file rather than a fixture shaped to pass.
-
-    Catches: the contribution not being registered, or the field not being sized on the declarative
-    path -- either of which would leave every recorded energy system with an incomplete key.
+    Uses the repository's own example file, so this exercises the real loader and engine.
     """
     repository_root = pathlib.Path(__file__).resolve().parents[1]
     model = load_energy_system(repository_root / "energy_systems" / "gas_boiler_household.energy_system.yaml")
@@ -176,10 +151,9 @@ def test_the_engine_binds_the_weather_identity_with_nothing_declared_in_the_file
 
 @pytest.mark.base
 def test_a_building_cannot_be_built_without_knowing_its_weather() -> None:
-    """The construction-time check is what makes the fix hold: no run can produce an entry under an incomplete key.
+    """A building whose ``weather_identity`` is still ``AUTO`` is refused at construction.
 
-    Catches: the sized field being given a concrete default that lets an unsized building through,
-    which would quietly restore the old incomplete key for every setup that forgot the assignment.
+    This is what makes the fix hold: no run can write a cache entry under an incomplete key.
     """
     from hisim.components.building.building import Building  # pylint: disable=import-outside-toplevel
 


### PR DESCRIPTION
## Problem

`roadmap/pylpg_flakiness.md` F7: a PV system's power series, a building's solar gains and a car's driving profile are each computed from an *upstream* component (weather, weather, occupancy), but their cache keys hashed only their *own* configuration. Two households sharing a PV config but not a weather shared one PV entry. PV's `location` string only tracked the weather because setups copied one variable into both — a habit, not an invariant. The fix decided on 2026-08-31 (hash the upstream config by hand, delete later) was blocked on *how* PV learns the weather's identity: the singleton it uses today is deprecated, and the DTO scheme inherits the same question (`weather_artifact_key` is "filled by the component").

## What was done

- **The sizing engine carries the identity.** `WeatherConfig` contributes a `weather_identity` fact, `UtspLpgConnectorConfig` an `occupancy_identity` fact; `PVSystemConfig` and `BuildingConfig` declare `weather_identity: Sizable[str]`, `CarConfig` declares `occupancy_identity`. The engine is the typed successor of the singleton for exactly this kind of cross-component fact, and it resolves before any component is built.
- **Readable identities**, not hashes: `Aachen/DWD_TRY/aachen_center` (station / data set / file stem; no directory) — because the value is written into every recorded energy system beside the component that depends on it. With the identity a field of the config, the legacy key (a hash over the whole config) is complete by construction; **no key code changed**.
- **File path**: zero edits — the example file resolved `building.weather_identity` on the first try; the recorded mockup gained exactly `weather_identity: Aachen/DWD_TRY/aachen_center # sized from weather.weather_identity`.
- **Python path**: 35 setup sites and 30 test sites set the field before construction (a config still carrying `AUTO` is refused at construction — that is what makes the fix hold). In 18 setups the weather config statement moved above the building, with a comment; the weather *component* stays where it was, so simulator order is unchanged. Kernel tests that model a building alone seed the fact; the configure fixtures gained a `WEATHER` entry; one two-weather wiring fixture names its source.
- **A pre-existing sizing-kernel bug surfaced and is fixed here**: `dataclasses_json` runs a field's decoder over a *missing* key's default, and `_sizable_decoder` coerced whatever it got through `value_type`. `str(AUTO)` is the wire spelling, so a string-typed sized field omitted from a `config:` block silently became the literal text `"AUTO"`; the engine saw a concrete value and left it, and only the record's EF-60 check caught it. One guard line; numeric fields never hit it; kernel regression test added.
- 19 scenario JSONs regenerated; exported schema regenerated; minimal-mockup record golden blessed deliberately through its regeneration variable.

## Result

Base suite **4518 passed / 0 failed**; **golden OK (16 pairs)** — every key changed, every entry recomputed cold, no golden value moved. 8 new tests, each shown to fail without the fix. **Downstream:** #598's 22 twins must be re-recorded after this merges (every PV/Building/Car block gains the identity line). `PVSystemConfig.location` is now redundant and can disagree with the field beside it — logged as F-3 in `roadmap/p4_random_findings.md` for the PV conversion, not fixed piecemeal.

_Follow-up commit on this branch: the docstrings and comments this PR added were rewritten in plain language after review feedback (what → how it is used → short why). No code changes._