### PR TITLE
Retry a local LoadProfileGenerator calculation that died on its own locked database

### DIFF
--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -1414,9 +1414,8 @@ class UtspLpgConnector(cp.Component):
                 # about whether what it needs is in it. Which files are indispensable is already
                 # recorded against each name, so it is read from there rather than from a position
                 # in the returned tuple, which would go wrong silently if that tuple ever changed.
-                # Running and checking are one call because the one failure that is worth a second
-                # attempt -- the generator dying on its own locked sqlite file -- is only known after
-                # the check; see PylpgWorkspace.execute_and_verify.
+                # Run and check are one call, because whether to retry (only for a locked database)
+                # is known only after the check. See PylpgWorkspace.execute_and_verify.
                 declared_result_files = self.define_required_result_files()[0]
                 required_result_files = [
                     file_name

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -1404,26 +1404,27 @@ class UtspLpgConnector(cp.Component):
                 with open(calcspecfilename, "w", encoding="utf-8") as calcspecfile:
                     jsonrequest = request.to_json(indent=4)
                     calcspecfile.write(jsonrequest)
-                lpe.execute_lpg_binaries()
-
                 path_to_result_folder = os.path.join(lpe.calculation_directory, request.CalcSpec.OutputDirectory)
-                # Checked here, not by the readers downstream. pylpg discards the binary's return
-                # code, so a failed calculation is indistinguishable from a successful one until
-                # somebody opens a file that was never written -- and the FileNotFoundError that
-                # results names one arbitrary json and never mentions the LoadProfileGenerator.
+                # The results are checked here, not by the readers downstream. pylpg discards the
+                # binary's return code, so a failed calculation is indistinguishable from a successful
+                # one until somebody opens a file that was never written -- and the FileNotFoundError
+                # that results names one arbitrary json and never mentions the LoadProfileGenerator.
                 # The names, not merely the count: a calculation that dies partway leaves some of
                 # its outputs behind, and a directory that is non-empty tells the reader nothing
                 # about whether what it needs is in it. Which files are indispensable is already
                 # recorded against each name, so it is read from there rather than from a position
                 # in the returned tuple, which would go wrong silently if that tuple ever changed.
+                # Running and checking are one call because the one failure that is worth a second
+                # attempt -- the generator dying on its own locked sqlite file -- is only known after
+                # the check; see PylpgWorkspace.execute_and_verify.
                 declared_result_files = self.define_required_result_files()[0]
                 required_result_files = [
                     file_name
                     for file_name, requirement in declared_result_files.items()
                     if requirement == datastructures.ResultFileRequirement.REQUIRED
                 ]
-                PylpgWorkspace.verify_results_were_produced(
-                    calculation_index, str(path_to_result_folder), required_files=required_result_files
+                PylpgWorkspace.execute_and_verify(
+                    lpe, calculation_index, str(path_to_result_folder), required_files=required_result_files
                 )
 
         return str(path_to_result_folder)

--- a/hisim/components/pylpg_workspace.py
+++ b/hisim/components/pylpg_workspace.py
@@ -224,30 +224,28 @@ class PylpgWorkspace:
         result_folder: str,
         required_files: Sequence[str],
     ) -> None:
-        """Runs the generator and checks its results, trying again when it died on a locked database.
+        """Run the generator and check its results; if it died on a locked database, wait and try again.
 
-        The generator writes its results into sqlite files in WAL mode from several of its own
-        threads, and on a slow disk -- a two-core CI runner, typically -- one of them can find the
-        file busy and the whole run dies with ``SQLiteException: database is locked``. Nothing about
-        the request is wrong when that happens; the same calculation a moment later succeeds. So that
-        one failure, recognised by its text in the generator's log, is retried after a pause, while
-        every other failure is raised at once: a missing household or a bad calcspec will not get
-        better by waiting, and re-running it would only hide the real message under a delay.
+        The LoadProfileGenerator writes its results into sqlite files from several threads, and on a slow disk
+        (a CI runner, typically) one of them can find the file busy; the run then dies with
+        ``SQLiteException: database is locked`` although nothing about the request is wrong. That failure is
+        recognised by its text in the generator's log and retried after each delay in
+        :attr:`RETRY_DELAYS_IN_SECONDS`. Any other failure is raised immediately, because waiting would not
+        help and a retry would only delay the real message.
 
-        Each attempt reruns the binary in the same calculation directory; the generator deletes and
-        recreates its results folder itself, so a partial result from the failed attempt cannot
-        survive into the verification of the next one.
+        Each attempt reruns the binary in the same directory. The generator deletes and recreates its results
+        folder itself, so a partial result from a failed attempt cannot pass the next check.
 
         Args:
-            executor: the executor whose ``execute_lpg_binaries`` runs the calculation.
-            calculation_index: the calculation's index, named in the failure.
+            executor: the pylpg executor whose ``execute_lpg_binaries`` runs the calculation.
+            calculation_index: the calculation's index, named in the failure message.
             result_folder: where the generator writes its results.
-            required_files: the result files the caller cannot do without.
+            required_files: the result files that must exist for the run to count as successful.
 
         Raises:
-            LocalLpgCalculationFailedError: when the calculation failed for a reason that is not a
-                locked database, or kept failing on a locked database after every retry; in the
-                second case the message says how many attempts were made.
+            LocalLpgCalculationFailedError: for any failure other than a locked database, or for a database
+                that stayed locked through every retry; in that case the message says how many attempts
+                were made.
         """
         attempts = len(cls.RETRY_DELAYS_IN_SECONDS) + 1
         for attempt in range(1, attempts + 1):

--- a/hisim/components/pylpg_workspace.py
+++ b/hisim/components/pylpg_workspace.py
@@ -23,7 +23,8 @@ import os
 import pathlib
 import shutil
 import sys
-from typing import ClassVar, Iterator, List, Optional, Sequence
+import time
+from typing import ClassVar, Iterator, List, Optional, Sequence, Tuple
 
 from pylpg import lpg_execution
 
@@ -205,6 +206,70 @@ class PylpgWorkspace:
         log.information("Installing the LoadProfileGenerator binaries under an exclusive lock.")
         package_directory = pathlib.Path(lpg_execution.__file__).parent.absolute()
         lpg_execution.LPGExecutor.retrieve_lpg_binaries(package_directory)
+
+    #: The fragments of a generator log that mark a failure worth trying again. Only sqlite's busy
+    #: error qualifies: it is the one failure that is about timing rather than about the request.
+    RETRY_SIGNATURES: ClassVar[Tuple[str, ...]] = ("database is locked",)
+
+    #: How long to wait before each retry, in seconds; the length of the tuple is the number of
+    #: retries. Two of them, backing off, bound the extra cost of a genuinely stuck calculation to
+    #: under half a minute while giving a merely slow disk time to catch up.
+    RETRY_DELAYS_IN_SECONDS: ClassVar[Tuple[float, ...]] = (5.0, 15.0)
+
+    @classmethod
+    def execute_and_verify(
+        cls,
+        executor: "lpg_execution.LPGExecutor",
+        calculation_index: int,
+        result_folder: str,
+        required_files: Sequence[str],
+    ) -> None:
+        """Runs the generator and checks its results, trying again when it died on a locked database.
+
+        The generator writes its results into sqlite files in WAL mode from several of its own
+        threads, and on a slow disk -- a two-core CI runner, typically -- one of them can find the
+        file busy and the whole run dies with ``SQLiteException: database is locked``. Nothing about
+        the request is wrong when that happens; the same calculation a moment later succeeds. So that
+        one failure, recognised by its text in the generator's log, is retried after a pause, while
+        every other failure is raised at once: a missing household or a bad calcspec will not get
+        better by waiting, and re-running it would only hide the real message under a delay.
+
+        Each attempt reruns the binary in the same calculation directory; the generator deletes and
+        recreates its results folder itself, so a partial result from the failed attempt cannot
+        survive into the verification of the next one.
+
+        Args:
+            executor: the executor whose ``execute_lpg_binaries`` runs the calculation.
+            calculation_index: the calculation's index, named in the failure.
+            result_folder: where the generator writes its results.
+            required_files: the result files the caller cannot do without.
+
+        Raises:
+            LocalLpgCalculationFailedError: when the calculation failed for a reason that is not a
+                locked database, or kept failing on a locked database after every retry; in the
+                second case the message says how many attempts were made.
+        """
+        attempts = len(cls.RETRY_DELAYS_IN_SECONDS) + 1
+        for attempt in range(1, attempts + 1):
+            executor.execute_lpg_binaries()
+            try:
+                cls.verify_results_were_produced(calculation_index, result_folder, required_files=required_files)
+                return
+            except LocalLpgCalculationFailedError as error:
+                locked = any(signature in str(error) for signature in cls.RETRY_SIGNATURES)
+                if not locked or attempt == attempts:
+                    if locked:
+                        raise LocalLpgCalculationFailedError(
+                            f"{error}\nThe calculation was attempted {attempts} times and died on a locked "
+                            f"database every time, so this is not the transient contention a retry is for."
+                        ) from error
+                    raise
+                delay = cls.RETRY_DELAYS_IN_SECONDS[attempt - 1]
+                log.warning(
+                    f"Local LoadProfileGenerator calculation {calculation_index} died on a locked database "
+                    f"(attempt {attempt} of {attempts}); trying again in {delay:g} s."
+                )
+                time.sleep(delay)
 
     LOG_FILE_NAME: ClassVar[str] = "Log.CommandlineCalculation.txt"
     LOG_LINES_TO_QUOTE: ClassVar[int] = 30

--- a/hisim/components/pylpg_workspace.py
+++ b/hisim/components/pylpg_workspace.py
@@ -212,8 +212,9 @@ class PylpgWorkspace:
     RETRY_SIGNATURES: ClassVar[Tuple[str, ...]] = ("database is locked",)
 
     #: How long to wait before each retry, in seconds; the length of the tuple is the number of
-    #: retries. Two of them, backing off, bound the extra cost of a genuinely stuck calculation to
-    #: under half a minute while giving a merely slow disk time to catch up.
+    #: retries. Two of them, backing off, add at most twenty seconds of waiting and give a merely slow
+    #: disk time to catch up. Each retry is also a full run of the generator, which costs what a run
+    #: costs, so a genuinely stuck calculation takes three runs to fail instead of one.
     RETRY_DELAYS_IN_SECONDS: ClassVar[Tuple[float, ...]] = (5.0, 15.0)
 
     @classmethod
@@ -233,8 +234,11 @@ class PylpgWorkspace:
         :attr:`RETRY_DELAYS_IN_SECONDS`. Any other failure is raised immediately, because waiting would not
         help and a retry would only delay the real message.
 
-        Each attempt reruns the binary in the same directory. The generator deletes and recreates its results
-        folder itself, so a partial result from a failed attempt cannot pass the next check.
+        Each attempt reruns the binary in the same calculation directory, whose copy of the toolchain the
+        executor set up once. The results folder is removed before a retry, so a partial result from a failed
+        attempt cannot pass the next attempt's check. The caller holds the generator lock throughout, the
+        pauses included: the contention is inside this one run, and letting another calculation start during
+        the pause would add to it rather than relieve it.
 
         Args:
             executor: the pylpg executor whose ``execute_lpg_binaries`` runs the calculation.
@@ -255,18 +259,21 @@ class PylpgWorkspace:
                 return
             except LocalLpgCalculationFailedError as error:
                 locked = any(signature in str(error) for signature in cls.RETRY_SIGNATURES)
-                if not locked or attempt == attempts:
-                    if locked:
-                        raise LocalLpgCalculationFailedError(
-                            f"{error}\nThe calculation was attempted {attempts} times and died on a locked "
-                            f"database every time, so this is not the transient contention a retry is for."
-                        ) from error
+                if not locked:
                     raise
+                if attempt == attempts:
+                    raise LocalLpgCalculationFailedError(
+                        f"{error}\nThe calculation was attempted {attempts} times and the generator's log "
+                        f"mentioned a locked database after every attempt, so this is not the transient "
+                        "contention a retry is for."
+                    ) from error
                 delay = cls.RETRY_DELAYS_IN_SECONDS[attempt - 1]
                 log.warning(
                     f"Local LoadProfileGenerator calculation {calculation_index} died on a locked database "
                     f"(attempt {attempt} of {attempts}); trying again in {delay:g} s."
                 )
+                # Whatever the failed attempt left behind must not satisfy the next attempt's check.
+                shutil.rmtree(result_folder, ignore_errors=True)
                 time.sleep(delay)
 
     LOG_FILE_NAME: ClassVar[str] = "Log.CommandlineCalculation.txt"

--- a/roadmap/pylpg_flakiness.md
+++ b/roadmap/pylpg_flakiness.md
@@ -487,6 +487,8 @@ Also in this fix:
   would only mistranslate it, and an `AttributeError` dressed up as advice about configuring a profile source
   is worse than the plain traceback. The guidance above is printed alongside, not instead. If a specific
   failure turns out to deserve a retry, that is added then, for that failure, on evidence.
+  *That case arrived: #627 (2026-09-04) retries the locked-database failure, twice, and nothing else. See
+  §11.*
 - Delete the `:904` site outright — its `try:` body is `pass` with a `# todo`, so it can only ever have been
   a no-op that made the code look defensive.
 
@@ -686,8 +688,13 @@ Add to that:
 
 - **Do not re-bless the golden references** to match a downgraded run. The references are right; the run was
   wrong. Blessing them would make the substituted household the new definition of correct.
-- **Do not add retries** around the sqlite errors. Retrying hides Fault B rather than fixing it, and the
-  existing two-attempt loop is what turns one transient error into a silent household swap.
+- ~~Do not add retries around the sqlite errors.~~ **Narrowed 2026-09-04 (#627).** The objection was to the
+  old two-attempt loop, which turned one transient error into a silent household swap; F1 removed the swap,
+  and #611 removed the cross-process sharing that was Fault B. What remained on CI was `database is locked`
+  inside a single run, and F1 foresaw this case: one retry, for one failure, on evidence. A run whose log
+  ends in that line is rerun after 5 s and again after 15 s, in the same directory with its results folder
+  removed first; every other failure is still raised at once, and a database that stays locked fails after
+  three attempts saying so. Nothing is hidden and no household changes.
 - ~~Do not delete the fallback outright.~~ **Superseded 2026-08-31.** This document first argued the
   fallback was worth keeping behind an opt-in. The owner's objection is better: if UTSP is configured and
   unavailable, the useful response is an error telling you to configure it differently, not a different

--- a/tests/test_pylpg_workspace.py
+++ b/tests/test_pylpg_workspace.py
@@ -291,12 +291,11 @@ def test_optional_files_are_not_required(tmp_path: Any) -> None:
 
 
 class ScriptedGenerator:
-    """A stand-in for the executor and the result check together, playing back a scripted run.
+    """Replaces the executor and the result check with a scripted sequence of outcomes.
 
-    Each entry of ``outcomes`` is what one attempt's verification does: ``None`` for success, or the
-    message of the ``LocalLpgCalculationFailedError`` it raises. The class counts how often the binary
-    was run and records every pause the retry asked for, which is all the retry tests need to see;
-    nothing here touches the filesystem or the generator.
+    Each entry of ``outcomes`` is what one attempt's check does: ``None`` for success, or the message of the
+    ``LocalLpgCalculationFailedError`` to raise. The class counts binary runs and records requested pauses
+    instead of sleeping. Nothing touches the filesystem or the generator.
     """
 
     def __init__(self, outcomes: List[Optional[str]]) -> None:
@@ -310,7 +309,7 @@ class ScriptedGenerator:
         self.sleeps: List[float] = []
 
     def execute_lpg_binaries(self) -> None:
-        """Counts a run of the binary; the outcome is decided at verification, as in the real flow."""
+        """Count one run of the binary. The outcome is decided by :meth:`verify`, as in the real flow."""
         self.runs += 1
 
     def verify(self, calculation_index: int, result_folder: str, required_files: Any = None) -> None:
@@ -344,7 +343,7 @@ class ScriptedGenerator:
 
 
 class LockedLog:
-    """The one line of a generator log that marks the failure worth retrying, as the generator writes it."""
+    """The generator log line that marks a locked database, spelled as the generator writes it."""
 
     TEXT: ClassVar[str] = (
         "Unhandled exception. code = Busy (5), message = SQLiteException (0x87AF00AA): database is locked"
@@ -355,11 +354,7 @@ class LockedLog:
 def test_a_calculation_that_died_on_a_locked_database_is_run_again_after_a_pause(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The transient failure is retried, with the first configured delay, and a success ends it.
-
-    Catches: the lock being treated as final -- which is how every golden-year job on a slow runner
-    was failing -- or a retry that does not wait, which would meet the same busy file again.
-    """
+    """A locked-database failure followed by success: two runs, one pause of the first configured delay."""
     script = ScriptedGenerator([LockedLog.TEXT, None])
     script.install(monkeypatch)
 
@@ -373,11 +368,7 @@ def test_a_calculation_that_died_on_a_locked_database_is_run_again_after_a_pause
 def test_a_database_that_stays_locked_is_given_up_on_after_the_configured_retries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Every delay is used once and then the failure is raised, saying how many attempts were made.
-
-    Catches: an unbounded retry on a calculation that is genuinely stuck, which would hang a job
-    instead of failing it.
-    """
+    """A database locked on every attempt: every delay is used once, then the error names the attempt count."""
     attempts = len(PylpgWorkspace.RETRY_DELAYS_IN_SECONDS) + 1
     script = ScriptedGenerator([LockedLog.TEXT] * attempts)
     script.install(monkeypatch)
@@ -393,11 +384,7 @@ def test_a_database_that_stays_locked_is_given_up_on_after_the_configured_retrie
 
 @pytest.mark.base
 def test_any_other_failure_is_raised_at_once_without_a_retry(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A missing result file, a bad request: waiting would not help, so nothing is retried.
-
-    Catches: the retry widening into a blanket "try everything three times", which would hide every
-    real failure behind twenty seconds of delay and two more copies of the same message.
-    """
+    """A failure that is not a locked database is raised after one run, with no pause."""
     script = ScriptedGenerator(["the results directory is missing 2 of the 9 files the run needs"])
     script.install(monkeypatch)
 

--- a/tests/test_pylpg_workspace.py
+++ b/tests/test_pylpg_workspace.py
@@ -294,8 +294,9 @@ class ScriptedGenerator:
     """Replaces the executor and the result check with a scripted sequence of outcomes.
 
     Each entry of ``outcomes`` is what one attempt's check does: ``None`` for success, or the message of the
-    ``LocalLpgCalculationFailedError`` to raise. The class counts binary runs and records requested pauses
-    instead of sleeping. Nothing touches the filesystem or the generator.
+    ``LocalLpgCalculationFailedError`` to raise. The class counts binary runs, records requested pauses instead
+    of sleeping, and records which folders were discarded instead of deleting them. Nothing touches the
+    filesystem or the generator.
     """
 
     def __init__(self, outcomes: List[Optional[str]]) -> None:
@@ -307,6 +308,7 @@ class ScriptedGenerator:
         self.outcomes = list(outcomes)
         self.runs = 0
         self.sleeps: List[float] = []
+        self.discarded: List[str] = []
 
     def execute_lpg_binaries(self) -> None:
         """Count one run of the binary. The outcome is decided by :meth:`verify`, as in the real flow."""
@@ -332,14 +334,20 @@ class ScriptedGenerator:
         """Records a pause instead of taking it."""
         self.sleeps.append(seconds)
 
+    def discard(self, path: str, ignore_errors: bool = False) -> None:
+        """Records a results folder being discarded instead of deleting it."""
+        del ignore_errors
+        self.discarded.append(path)
+
     def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Points the workspace's check and pause at this script.
+        """Points the workspace's check, pause and folder removal at this script.
 
         Args:
             monkeypatch: the test's monkeypatch.
         """
         monkeypatch.setattr(PylpgWorkspace, "verify_results_were_produced", self.verify)
         monkeypatch.setattr("hisim.components.pylpg_workspace.time.sleep", self.sleep)
+        monkeypatch.setattr("hisim.components.pylpg_workspace.shutil.rmtree", self.discard)
 
 
 class LockedLog:
@@ -354,31 +362,36 @@ class LockedLog:
 def test_a_calculation_that_died_on_a_locked_database_is_run_again_after_a_pause(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A locked-database failure followed by success: two runs, one pause of the first configured delay."""
+    """A locked-database failure followed by success: two runs, the results discarded in between, one 5 s pause.
+
+    The delays are written as literals here and below, so that a change to the policy has to be made in the
+    tests too.
+    """
     script = ScriptedGenerator([LockedLog.TEXT, None])
     script.install(monkeypatch)
 
     PylpgWorkspace.execute_and_verify(script, 7, "/results", required_files=["a.json"])  # type: ignore[arg-type]
 
     assert script.runs == 2
-    assert script.sleeps == [PylpgWorkspace.RETRY_DELAYS_IN_SECONDS[0]]
+    assert script.discarded == ["/results"]
+    assert script.sleeps == [5.0]
 
 
 @pytest.mark.base
 def test_a_database_that_stays_locked_is_given_up_on_after_the_configured_retries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A database locked on every attempt: every delay is used once, then the error names the attempt count."""
-    attempts = len(PylpgWorkspace.RETRY_DELAYS_IN_SECONDS) + 1
-    script = ScriptedGenerator([LockedLog.TEXT] * attempts)
+    """A database locked on every attempt: three runs, two pauses of 5 s and 15 s, then an error naming the count."""
+    script = ScriptedGenerator([LockedLog.TEXT] * 3)
     script.install(monkeypatch)
 
     with pytest.raises(LocalLpgCalculationFailedError) as raised:
         PylpgWorkspace.execute_and_verify(script, 7, "/results", required_files=["a.json"])  # type: ignore[arg-type]
 
-    assert script.runs == attempts
-    assert script.sleeps == list(PylpgWorkspace.RETRY_DELAYS_IN_SECONDS)
-    assert f"attempted {attempts} times" in str(raised.value)
+    assert script.runs == 3
+    assert script.discarded == ["/results", "/results"]
+    assert script.sleeps == [5.0, 15.0]
+    assert "attempted 3 times" in str(raised.value)
     assert "database is locked" in str(raised.value), "the generator's own message must survive"
 
 
@@ -393,3 +406,65 @@ def test_any_other_failure_is_raised_at_once_without_a_retry(monkeypatch: pytest
 
     assert script.runs == 1
     assert not script.sleeps
+    assert not script.discarded
+
+
+class GeneratorOnDisk:
+    """Stands in for the binary only: it writes files where the real one would, and the real check reads them.
+
+    The first run leaves the generator's log ending in the locked-database line and one of the two required
+    files, the way a run that died partway does. The second run writes both files. What the folder held when
+    each run started is recorded, so a test can see whether the first attempt's leftovers were still there.
+    """
+
+    def __init__(self, calculation_directory: pathlib.Path, result_folder: pathlib.Path) -> None:
+        """Prepares the stand-in.
+
+        Args:
+            calculation_directory: where the generator writes its log.
+            result_folder: where it writes its results.
+        """
+        self.calculation_directory = calculation_directory
+        self.result_folder = result_folder
+        self.runs = 0
+        self.files_present_at_start: List[List[str]] = []
+
+    def execute_lpg_binaries(self) -> None:
+        """Writes what the scripted run of the binary would have left behind."""
+        self.runs += 1
+        self.files_present_at_start.append(
+            sorted(path.name for path in self.result_folder.iterdir()) if self.result_folder.is_dir() else []
+        )
+        self.result_folder.mkdir(parents=True, exist_ok=True)
+        (self.result_folder / "a.json").write_text("{}", encoding="utf-8")
+        if self.runs == 1:
+            (self.calculation_directory / PylpgWorkspace.LOG_FILE_NAME).write_text(
+                "Calculating...\n" + LockedLog.TEXT + "\n", encoding="utf-8"
+            )
+        else:
+            (self.result_folder / "b.json").write_text("{}", encoding="utf-8")
+            (self.calculation_directory / PylpgWorkspace.LOG_FILE_NAME).write_text("Finished.\n", encoding="utf-8")
+
+
+@pytest.mark.base
+def test_the_real_check_recognises_the_locked_database_in_the_log_and_the_retry_starts_clean(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The retry decision runs on the real result check, reading a real log, and the rerun finds no leftovers.
+
+    Catches: the check no longer quoting the log tail into its message, which would turn every locked
+    database into an immediate failure; and a retry that inherits the failed attempt's partial results.
+    """
+    calculation_directory = tmp_path / "C7"
+    result_folder = calculation_directory / "results"
+    calculation_directory.mkdir()
+    generator = GeneratorOnDisk(calculation_directory, result_folder)
+    monkeypatch.setattr("hisim.components.pylpg_workspace.time.sleep", lambda seconds: None)
+
+    PylpgWorkspace.execute_and_verify(
+        generator, 7, str(result_folder), required_files=["a.json", "b.json"]  # type: ignore[arg-type]
+    )
+
+    assert generator.runs == 2
+    assert generator.files_present_at_start == [[], []], "the second run must start without the first one's a.json"
+    assert (result_folder / "b.json").is_file()

--- a/tests/test_pylpg_workspace.py
+++ b/tests/test_pylpg_workspace.py
@@ -15,7 +15,7 @@ which is why they are ``base`` rather than ``utsp``.
 # clean
 
 import pathlib
-from typing import Any
+from typing import Any, ClassVar, List, Optional
 
 import pytest
 
@@ -288,3 +288,121 @@ def test_optional_files_are_not_required(tmp_path: Any) -> None:
     (results / "required.csv").write_text("x", encoding="utf-8")
 
     PylpgWorkspace.verify_results_were_produced(700, str(results), required_files=["required.csv"])
+
+
+class ScriptedGenerator:
+    """A stand-in for the executor and the result check together, playing back a scripted run.
+
+    Each entry of ``outcomes`` is what one attempt's verification does: ``None`` for success, or the
+    message of the ``LocalLpgCalculationFailedError`` it raises. The class counts how often the binary
+    was run and records every pause the retry asked for, which is all the retry tests need to see;
+    nothing here touches the filesystem or the generator.
+    """
+
+    def __init__(self, outcomes: List[Optional[str]]) -> None:
+        """Prepares the script.
+
+        Args:
+            outcomes: one entry per attempt, in order.
+        """
+        self.outcomes = list(outcomes)
+        self.runs = 0
+        self.sleeps: List[float] = []
+
+    def execute_lpg_binaries(self) -> None:
+        """Counts a run of the binary; the outcome is decided at verification, as in the real flow."""
+        self.runs += 1
+
+    def verify(self, calculation_index: int, result_folder: str, required_files: Any = None) -> None:
+        """Plays back the next scripted outcome.
+
+        Args:
+            calculation_index: ignored.
+            result_folder: ignored.
+            required_files: ignored.
+
+        Raises:
+            LocalLpgCalculationFailedError: when the next scripted outcome is a message.
+        """
+        del calculation_index, result_folder, required_files
+        outcome = self.outcomes.pop(0)
+        if outcome is not None:
+            raise LocalLpgCalculationFailedError(outcome)
+
+    def sleep(self, seconds: float) -> None:
+        """Records a pause instead of taking it."""
+        self.sleeps.append(seconds)
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Points the workspace's check and pause at this script.
+
+        Args:
+            monkeypatch: the test's monkeypatch.
+        """
+        monkeypatch.setattr(PylpgWorkspace, "verify_results_were_produced", self.verify)
+        monkeypatch.setattr("hisim.components.pylpg_workspace.time.sleep", self.sleep)
+
+
+class LockedLog:
+    """The one line of a generator log that marks the failure worth retrying, as the generator writes it."""
+
+    TEXT: ClassVar[str] = (
+        "Unhandled exception. code = Busy (5), message = SQLiteException (0x87AF00AA): database is locked"
+    )
+
+
+@pytest.mark.base
+def test_a_calculation_that_died_on_a_locked_database_is_run_again_after_a_pause(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The transient failure is retried, with the first configured delay, and a success ends it.
+
+    Catches: the lock being treated as final -- which is how every golden-year job on a slow runner
+    was failing -- or a retry that does not wait, which would meet the same busy file again.
+    """
+    script = ScriptedGenerator([LockedLog.TEXT, None])
+    script.install(monkeypatch)
+
+    PylpgWorkspace.execute_and_verify(script, 7, "/results", required_files=["a.json"])  # type: ignore[arg-type]
+
+    assert script.runs == 2
+    assert script.sleeps == [PylpgWorkspace.RETRY_DELAYS_IN_SECONDS[0]]
+
+
+@pytest.mark.base
+def test_a_database_that_stays_locked_is_given_up_on_after_the_configured_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every delay is used once and then the failure is raised, saying how many attempts were made.
+
+    Catches: an unbounded retry on a calculation that is genuinely stuck, which would hang a job
+    instead of failing it.
+    """
+    attempts = len(PylpgWorkspace.RETRY_DELAYS_IN_SECONDS) + 1
+    script = ScriptedGenerator([LockedLog.TEXT] * attempts)
+    script.install(monkeypatch)
+
+    with pytest.raises(LocalLpgCalculationFailedError) as raised:
+        PylpgWorkspace.execute_and_verify(script, 7, "/results", required_files=["a.json"])  # type: ignore[arg-type]
+
+    assert script.runs == attempts
+    assert script.sleeps == list(PylpgWorkspace.RETRY_DELAYS_IN_SECONDS)
+    assert f"attempted {attempts} times" in str(raised.value)
+    assert "database is locked" in str(raised.value), "the generator's own message must survive"
+
+
+@pytest.mark.base
+def test_any_other_failure_is_raised_at_once_without_a_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing result file, a bad request: waiting would not help, so nothing is retried.
+
+    Catches: the retry widening into a blanket "try everything three times", which would hide every
+    real failure behind twenty seconds of delay and two more copies of the same message.
+    """
+    script = ScriptedGenerator(["the results directory is missing 2 of the 9 files the run needs"])
+    script.install(monkeypatch)
+
+    with pytest.raises(LocalLpgCalculationFailedError, match="missing 2 of the 9"):
+        PylpgWorkspace.execute_and_verify(script, 7, "/results", required_files=["a.json"])  # type: ignore[arg-type]
+
+    assert script.runs == 1
+    assert not script.sleeps


### PR DESCRIPTION
## Problem

Golden-year jobs on CI keep failing with `SQLiteException (0x87AF00AA): database is locked`. #611 removed the one cause HiSim contributed ??? concurrent calculations sharing one database ??? by giving each calculation its own copy of the toolchain, and a golden-year job runs one setup in one process, so what remains is contention *inside a single run*: the generator writes its results sqlite in WAL mode from several of its own threads (`roadmap/pylpg_flakiness.md:178,192`), and a two-core runner's disk makes one of them find the file busy. Nothing about the request is wrong; the same calculation a moment later succeeds.

## What was done

- `PylpgWorkspace.execute_and_verify(...)` replaces the separate run + result check in the connector. It retries **only** the failure recognised by `database is locked` in the generator's own log (which #618 already quotes into the exception): twice, after 5 s and 15 s, in the same calculation directory. Before each retry the results folder is removed in Python, so a partial result from a failed attempt cannot pass the next attempt's check ??? the binary's own cleanup is not relied on.
- Every other failure is raised at once: a missing household or a bad calcspec will not get better by waiting, and retrying would hide the real message under a delay. A database that stays locked through every retry fails saying "attempted 3 times" and that the log mentioned a locked database after every attempt.
- The whole sequence runs under the generator lock, pauses included, on purpose: the contention is inside this one run, and letting another calculation start during the pause would add to it.
- Tests: fail-then-succeed (2 runs, results discarded once, one 5 s pause), never-succeed (3 runs, two discards, 5 s and 15 s, message names the count), other-failure (1 run, no pause, no discard) ??? the policy pinned as literals ??? plus one test that runs the real result check against a real log ending in the locked-database line, with a binary stand-in that leaves a partial result the first time, and checks that the rerun starts from an empty folder.
- `roadmap/pylpg_flakiness.md`: section 11's "do not add retries" and F1's "no retry" now record this carve-out, which F1 had foreseen ("for a specific failure, on evidence"), and why the original objection (the silent household swap) no longer applies.

## Result

Transient lock failures no longer fail the job. A genuinely stuck run costs two more full generator runs plus 20 s of waiting and then fails with a clearer message. Base suite 4514 / 0 on the first two commits; the third passes test_pylpg_workspace (18), prospector 0, pylint 10.00, mypy clean. **Diagnostic still wanted**: a ~20-line excerpt of one failing golden-year job ??? if the locked file is `profilegenerator.db3` rather than `Results.*.sqlite`, or the log contains "pylpg did not leave a binary at ???", #611's per-calculation copy is not taking effect on the runner and there is a second, real fix behind this one.

The third commit answers the automated review of this PR: the results folder is cleared before a retry instead of trusting the binary to do it, the cost comment counts the reruns and the lock, the exhausted-retry message claims only what is known, the loop's nested condition is flattened, the tests pin the policy literally and exercise the real log-reading check, and the roadmap records the carve-out.
