### PR TITLE
Let a cache entry computed on one machine be found on another: hash only what decides the result

### DIFF
--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -205,19 +205,16 @@ class UtspLpgConnectorConfig(ConfigBase):
         return household.Name
 
     def cache_key_view(self) -> "UtspLpgConnectorConfig":
-        """The configuration as hashed into the occupancy cache key, without what does not decide the profile.
+        """Return the copy hashed into the occupancy cache key, without the fields that only place the run.
 
-        Three fields describe how and where a run happens rather than what it computes.
-        ``result_dir_path`` says where the request's result file is written; ``cache_dir_path`` says
-        where the entry itself goes; ``calculation_index_for_local_lpg`` says which working directory
-        the generator was scheduled into. None of them changes a single value of the profile, and the
-        first is an absolute path that differs on every machine -- which is why a LoadProfileGenerator
-        result computed here has never once been found by a CI runner, or vice versa. They are cleared
-        from the view, so the key is decided by the household, the energy intensity, the catalogue
-        sets, the seed and the simulation parameters, and by nothing else.
+        ``result_dir_path`` (where the result file is written), ``cache_dir_path`` (where the entry goes) and
+        ``calculation_index_for_local_lpg`` (which working directory the generator used) do not change the
+        profile. The first is an absolute path that differs between machines, which is why an occupancy entry
+        computed on one machine was never found on another. The three are cleared; the key is then decided by
+        the household, the energy intensity, the catalogue sets, the seed and the simulation parameters.
 
         Returns:
-            UtspLpgConnectorConfig: a deep copy with the three run-placement fields cleared.
+            UtspLpgConnectorConfig: a deep copy with the three fields cleared.
         """
         view = super().cache_key_view()
         view.result_dir_path = ""

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -204,23 +204,22 @@ class UtspLpgConnectorConfig(ConfigBase):
             )
         return household.Name
 
-    def cache_key_view(self) -> "UtspLpgConnectorConfig":
-        """Return the copy hashed into the occupancy cache key, without the fields that only place the run.
+    def _clear_non_key_fields(self, view: "UtspLpgConnectorConfig") -> None:
+        """Clear the fields that only place the run from the copy hashed into the occupancy cache key.
 
         ``result_dir_path`` (where the result file is written), ``cache_dir_path`` (where the entry goes) and
         ``calculation_index_for_local_lpg`` (which working directory the generator used) do not change the
         profile. The first is an absolute path that differs between machines, which is why an occupancy entry
-        computed on one machine was never found on another. The three are cleared; the key is then decided by
-        the household, the energy intensity, the catalogue sets, the seed and the simulation parameters.
+        computed on one machine was never found on another. Every other field stays key material, including
+        ``predefined_loadprofile_filepaths``: an external profile directory decides the result, and it is
+        machine-specific by nature, so an entry computed from one is not portable.
 
-        Returns:
-            UtspLpgConnectorConfig: a deep copy with the three fields cleared.
+        Args:
+            view: the copy to adjust.
         """
-        view = super().cache_key_view()
         view.result_dir_path = ""
         view.cache_dir_path = None
         view.calculation_index_for_local_lpg = None
-        return view
 
     @constructor(note="the household catalogue of the LoadProfileGenerator")
     @classmethod

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -204,6 +204,27 @@ class UtspLpgConnectorConfig(ConfigBase):
             )
         return household.Name
 
+    def cache_key_view(self) -> "UtspLpgConnectorConfig":
+        """The configuration as hashed into the occupancy cache key, without what does not decide the profile.
+
+        Three fields describe how and where a run happens rather than what it computes.
+        ``result_dir_path`` says where the request's result file is written; ``cache_dir_path`` says
+        where the entry itself goes; ``calculation_index_for_local_lpg`` says which working directory
+        the generator was scheduled into. None of them changes a single value of the profile, and the
+        first is an absolute path that differs on every machine -- which is why a LoadProfileGenerator
+        result computed here has never once been found by a CI runner, or vice versa. They are cleared
+        from the view, so the key is decided by the household, the energy intensity, the catalogue
+        sets, the seed and the simulation parameters, and by nothing else.
+
+        Returns:
+            UtspLpgConnectorConfig: a deep copy with the three run-placement fields cleared.
+        """
+        view = super().cache_key_view()
+        view.result_dir_path = ""
+        view.cache_dir_path = None
+        view.calculation_index_for_local_lpg = None
+        return view
+
     @constructor(note="the household catalogue of the LoadProfileGenerator")
     @classmethod
     def for_household(

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -464,6 +464,29 @@ class WeatherConfig(ConfigBase):
         )
         return config
 
+    def cache_key_view(self) -> "WeatherConfig":
+        """The configuration as hashed into the weather cache key, with the data file spelled portably.
+
+        ``source_path`` decides which file is read, so it belongs in the key -- but it is an absolute
+        path, and the same catalogue file lives under ``/home/noah/.../hisim/inputs`` on one machine
+        and ``/home/runner/work/.../hisim/inputs`` on another. Hashed as it stands, every weather
+        entry is private to the checkout that wrote it, and the cache every other component depends
+        on can never be shared. Under the inputs directory the path is therefore spelled relative to
+        it, which is the same string everywhere the repository is checked out; a file from anywhere
+        else keeps its name only, since its directory says nothing about its contents either.
+
+        Returns:
+            WeatherConfig: a deep copy with ``source_path`` made portable.
+        """
+        view = super().cache_key_view()
+        inputs_directory = os.path.abspath(utils.get_input_directory())
+        source = os.path.abspath(str(self.source_path))
+        if os.path.commonpath([inputs_directory, source]) == inputs_directory:
+            view.source_path = os.path.relpath(source, inputs_directory).replace(os.sep, "/")
+        else:
+            view.source_path = os.path.basename(source)
+        return view
+
     @preset(note="the repository's reference climate")
     @classmethod
     def preset_standard(cls, name: str) -> "WeatherConfig":

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -465,18 +465,16 @@ class WeatherConfig(ConfigBase):
         return config
 
     def cache_key_view(self) -> "WeatherConfig":
-        """The configuration as hashed into the weather cache key, with the data file spelled portably.
+        """Return the copy hashed into the weather cache key, with ``source_path`` made portable.
 
-        ``source_path`` decides which file is read, so it belongs in the key -- but it is an absolute
-        path, and the same catalogue file lives under ``/home/noah/.../hisim/inputs`` on one machine
-        and ``/home/runner/work/.../hisim/inputs`` on another. Hashed as it stands, every weather
-        entry is private to the checkout that wrote it, and the cache every other component depends
-        on can never be shared. Under the inputs directory the path is therefore spelled relative to
-        it, which is the same string everywhere the repository is checked out; a file from anywhere
-        else keeps its name only, since its directory says nothing about its contents either.
+        ``source_path`` selects the data file, so it belongs in the key, but it is an absolute path that
+        differs between machines. Under the inputs directory it is rewritten relative to that directory
+        (``weather/DWD_TRY/...``), which is the same on every checkout. A file outside the inputs directory
+        keeps only its file name. Dropping the path entirely is not an option: a custom weather file would then
+        collide with the catalogue entry of the same station.
 
         Returns:
-            WeatherConfig: a deep copy with ``source_path`` made portable.
+            WeatherConfig: a deep copy with ``source_path`` rewritten.
         """
         view = super().cache_key_view()
         inputs_directory = os.path.abspath(utils.get_input_directory())

--- a/hisim/components/weather.py
+++ b/hisim/components/weather.py
@@ -464,26 +464,41 @@ class WeatherConfig(ConfigBase):
         )
         return config
 
-    def cache_key_view(self) -> "WeatherConfig":
-        """Return the copy hashed into the weather cache key, with ``source_path`` made portable.
+    def _clear_non_key_fields(self, view: "WeatherConfig") -> None:
+        """Make ``source_path`` portable in the copy hashed into the weather cache key.
 
-        ``source_path`` selects the data file, so it belongs in the key, but it is an absolute path that
-        differs between machines. Under the inputs directory it is rewritten relative to that directory
-        (``weather/DWD_TRY/...``), which is the same on every checkout. A file outside the inputs directory
-        keeps only its file name. Dropping the path entirely is not an option: a custom weather file would then
-        collide with the catalogue entry of the same station.
+        ``source_path`` selects the data file, so it stays in the key, but for a catalogue file it is an
+        absolute path that differs between checkouts. A file under the inputs directory is therefore spelled
+        relative to that directory with forward slashes
+        (``weather/test-reference-years_1995-2012_1-location/data_processed/aachen_center``), which is the
+        same on every machine. A file outside the inputs directory keeps its absolute path: it is
+        machine-specific by nature, and shortening it to its file name would make two different files that
+        share a name collide in the cache.
 
-        Returns:
-            WeatherConfig: a deep copy with ``source_path`` rewritten.
+        Args:
+            view: the copy to adjust.
         """
-        view = super().cache_key_view()
         inputs_directory = os.path.abspath(utils.get_input_directory())
         source = os.path.abspath(str(self.source_path))
-        if os.path.commonpath([inputs_directory, source]) == inputs_directory:
+        if self._is_under(inputs_directory, source):
             view.source_path = os.path.relpath(source, inputs_directory).replace(os.sep, "/")
-        else:
-            view.source_path = os.path.basename(source)
-        return view
+
+    @staticmethod
+    def _is_under(directory: str, path: str) -> bool:
+        """Whether ``path`` lies inside ``directory``, both absolute.
+
+        Args:
+            directory: the absolute directory.
+            path: the absolute path to test.
+
+        Returns:
+            bool: True if ``path`` is ``directory`` or below it. False when the two are on different
+            drives, where ``os.path.commonpath`` raises instead of answering.
+        """
+        try:
+            return os.path.commonpath([directory, path]) == directory
+        except ValueError:
+            return False
 
     @preset(note="the repository's reference climate")
     @classmethod

--- a/hisim/config/base.py
+++ b/hisim/config/base.py
@@ -321,26 +321,20 @@ class ConfigBase:
         return cls.__module__ + "." + cls.__name__
 
     def cache_key_view(self: ConfigBaseT) -> ConfigBaseT:
-        """Returns the copy of this configuration whose JSON is hashed into a cache key.
+        """Return the copy of this configuration that is hashed into its cache key.
 
-        A cache entry belongs to a calculation, and a calculation is decided by some of a
-        configuration's fields and not by others. The base rule, applied to every config, is
-        that the building a component sits in is not one of them: the same PV system computes
-        the same series in every house, so ``component_id.building`` is cleared before hashing
-        or the same work would be filed under a different name per house.
+        Not every field of a configuration affects the cached result. The base rule, applied to every config,
+        clears ``component_id.building``: the same PV system computes the same series in every house, so the
+        house must not be part of the key.
 
-        Subclasses override this to remove what else does not decide the result -- where a
-        result file is written, which worker index a run was scheduled on -- and to make what
-        does decide it portable, such as a data-file path spelled relative to the inputs
-        directory rather than to one machine's checkout. Those are the two things that stop a
-        cache entry computed on one machine from being found on another, and they were what
-        kept the LoadProfileGenerator and weather caches from ever being shared between a
-        workstation and a CI runner (``roadmap/cache_service_spec.md`` §3.1, "only
-        result-relevant fields"). An override calls this method first and adjusts the copy it
-        gets back; the copy is deep, so nothing here can touch the live configuration.
+        Subclasses override this to clear fields that do not affect the result (where a result file is
+        written, which worker index a run used) and to make file paths portable (relative to the inputs
+        directory instead of absolute), so that an entry computed on one machine can be found on another.
+        An override calls ``super().cache_key_view()`` first and adjusts the copy it gets back; the copy is
+        deep, so the live configuration is never modified. See ``roadmap/cache_service_spec.md`` §3.1.
 
         Returns:
-            A deep copy of this configuration with the fields that are not key material cleared.
+            A deep copy of this configuration with the non-key fields cleared or normalised.
         """
         view = copy.deepcopy(self)
         component_id = getattr(view, "component_id", None)

--- a/hisim/config/base.py
+++ b/hisim/config/base.py
@@ -18,6 +18,7 @@ delegate to :mod:`hisim.config.sizing`) without closing an import cycle through
 
 from __future__ import annotations
 
+import copy
 import dataclasses as dc
 import enum
 import sys
@@ -318,6 +319,35 @@ class ConfigBase:
     def get_config_classname(cls):
         """Gets the class name. Helper function for default connections."""
         return cls.__module__ + "." + cls.__name__
+
+    def cache_key_view(self: ConfigBaseT) -> ConfigBaseT:
+        """Returns the copy of this configuration whose JSON is hashed into a cache key.
+
+        A cache entry belongs to a calculation, and a calculation is decided by some of a
+        configuration's fields and not by others. The base rule, applied to every config, is
+        that the building a component sits in is not one of them: the same PV system computes
+        the same series in every house, so ``component_id.building`` is cleared before hashing
+        or the same work would be filed under a different name per house.
+
+        Subclasses override this to remove what else does not decide the result -- where a
+        result file is written, which worker index a run was scheduled on -- and to make what
+        does decide it portable, such as a data-file path spelled relative to the inputs
+        directory rather than to one machine's checkout. Those are the two things that stop a
+        cache entry computed on one machine from being found on another, and they were what
+        kept the LoadProfileGenerator and weather caches from ever being shared between a
+        workstation and a CI runner (``roadmap/cache_service_spec.md`` §3.1, "only
+        result-relevant fields"). An override calls this method first and adjusts the copy it
+        gets back; the copy is deep, so nothing here can touch the live configuration.
+
+        Returns:
+            A deep copy of this configuration with the fields that are not key material cleared.
+        """
+        view = copy.deepcopy(self)
+        component_id = getattr(view, "component_id", None)
+        if component_id is not None:
+            # The identity is frozen, hence the replacement rather than an assignment.
+            setattr(view, "component_id", dc.replace(component_id, building=None))
+        return view
 
     def to_dict(self) -> Dict[str, Any]:
         """Dumps this configuration as a plain dict of its dataclass fields.

--- a/hisim/config/base.py
+++ b/hisim/config/base.py
@@ -325,13 +325,11 @@ class ConfigBase:
 
         Not every field of a configuration affects the cached result. The base rule, applied to every config,
         clears ``component_id.building``: the same PV system computes the same series in every house, so the
-        house must not be part of the key.
+        house must not be part of the key. Then the copy is handed to ``_clear_non_key_fields``, which a
+        subclass overrides to remove its own non-key fields. The base rule always runs, whatever the subclass
+        does; this method is not meant to be overridden.
 
-        Subclasses override this to clear fields that do not affect the result (where a result file is
-        written, which worker index a run used) and to make file paths portable (relative to the inputs
-        directory instead of absolute), so that an entry computed on one machine can be found on another.
-        An override calls ``super().cache_key_view()`` first and adjusts the copy it gets back; the copy is
-        deep, so the live configuration is never modified. See ``roadmap/cache_service_spec.md`` §3.1.
+        The copy is deep, so neither this method nor the hook ever modifies the live configuration.
 
         Returns:
             A deep copy of this configuration with the non-key fields cleared or normalised.
@@ -341,7 +339,22 @@ class ConfigBase:
         if component_id is not None:
             # The identity is frozen, hence the replacement rather than an assignment.
             setattr(view, "component_id", dc.replace(component_id, building=None))
+        self._clear_non_key_fields(view)
         return view
+
+    def _clear_non_key_fields(self: ConfigBaseT, view: ConfigBaseT) -> None:
+        """Remove from ``view`` the fields of this configuration that do not decide the cached result.
+
+        ``view`` is the deep copy that ``cache_key_view`` is about to hash, with the building already
+        cleared. A subclass overrides this to clear fields that only place a run (where a result file is
+        written, which worker index was used) and to make file paths portable (relative to the inputs
+        directory instead of absolute), so that an entry computed on one machine can be found on another.
+        The override mutates ``view`` in place and does not need to call ``super()``. The default clears
+        nothing.
+
+        Args:
+            view: the copy to adjust; the live configuration is a different object.
+        """
 
     def to_dict(self) -> Dict[str, Any]:
         """Dumps this configuration as a plain dict of its dataclass fields.

--- a/hisim/utils.py
+++ b/hisim/utils.py
@@ -403,31 +403,26 @@ def get_cache_file(
 
 
 def build_cache_key_string(parameter_class: Any, my_simulation_parameters: SimulationParameters) -> str:
-    """Builds the raw string a cache entry's name is hashed from, and its metadata records verbatim.
+    """Return the string a cache entry's filename is hashed from and its ``.meta`` file records.
 
-    The string is shared by three callers that must agree exactly: the lookup that turns it into a
-    filename, the writer that stores it beside the entry, and the validation that recomputes the hash
-    from the stored copy. Splitting it out of ``get_cache_file`` is what lets a writer record the
-    inputs that actually produced its bytes rather than re-deriving what was asked for.
+    The same string is used by the lookup (hashed into the filename), by the writer (stored beside the
+    entry) and by the validation (re-hashed and compared with the filename), so it is built in one place.
 
-    What is hashed is the configuration's *cache key view* -- ``ConfigBase.cache_key_view`` -- not the
-    configuration itself. The base view clears the component's building, because the cached data
-    depends on what the component is and how it is parameterized, not on which house it sits in. A
-    config class whose fields include things that do not decide the result, or paths that would spell
-    differently on another machine, overrides the view to clear or normalise them; that is what makes
-    an entry computed on a workstation findable on a CI runner. A parameter class that is not a
-    ``ConfigBase`` -- tests pass minimal stand-ins -- is hashed as it is, building cleared if it has one.
+    What is hashed is ``parameter_class.cache_key_view()`` when the class provides it (every
+    ``ConfigBase`` does): a copy with the fields that do not affect the result cleared and any paths made
+    portable. A parameter class without that method -- tests pass minimal stand-ins -- is hashed as it is,
+    with ``component_id.building`` cleared if it has one.
 
     Args:
-        parameter_class: the configuration dataclass, which must provide ``to_json``.
+        parameter_class: the configuration; must provide ``to_json``.
         my_simulation_parameters: contributes start, end, resolution, year, timesteps and country.
 
     Returns:
         str: the configuration JSON followed by the simulation parameters' unique key.
 
     Raises:
-        ValueError: if ``my_simulation_parameters`` is None, or the resulting string is too short to
-            be a real configuration, which would mean the caller passed something empty.
+        ValueError: if ``my_simulation_parameters`` is None, or the result is too short to be a real
+            configuration.
     """
     if my_simulation_parameters is None:
         raise ValueError("Simulation parameters was none.")

--- a/hisim/utils.py
+++ b/hisim/utils.py
@@ -7,7 +7,6 @@ import inspect
 import itertools
 import json
 import os
-import dataclasses
 from dataclasses import dataclass
 from functools import lru_cache
 from functools import reduce as freduce
@@ -410,8 +409,7 @@ def build_cache_key_string(parameter_class: Any, my_simulation_parameters: Simul
 
     What is hashed is ``parameter_class.cache_key_view()`` when the class provides it (every
     ``ConfigBase`` does): a copy with the fields that do not affect the result cleared and any paths made
-    portable. A parameter class without that method -- tests pass minimal stand-ins -- is hashed as it is,
-    with ``component_id.building`` cleared if it has one.
+    portable. A parameter class without that method -- tests pass minimal stand-ins -- is hashed as it is.
 
     Args:
         parameter_class: the configuration; must provide ``to_json``.
@@ -427,15 +425,8 @@ def build_cache_key_string(parameter_class: Any, my_simulation_parameters: Simul
     if my_simulation_parameters is None:
         raise ValueError("Simulation parameters was none.")
     view_method = getattr(parameter_class, "cache_key_view", None)
-    if callable(view_method):
-        parameter_class_copy = view_method()
-    else:
-        parameter_class_copy = copy.deepcopy(parameter_class)
-        component_id = getattr(parameter_class_copy, "component_id", None)
-        if component_id is not None:
-            # The identity is frozen, hence the replacement rather than an assignment.
-            setattr(parameter_class_copy, "component_id", dataclasses.replace(component_id, building=None))
-    json_str = parameter_class_copy.to_json() + my_simulation_parameters.get_unique_key()
+    hashed = view_method() if callable(view_method) else parameter_class
+    json_str = hashed.to_json() + my_simulation_parameters.get_unique_key()
     if len(json_str) < 5:
         raise ValueError("Empty json detected for caching. This is a bug.")
     return str(json_str)

--- a/hisim/utils.py
+++ b/hisim/utils.py
@@ -410,9 +410,13 @@ def build_cache_key_string(parameter_class: Any, my_simulation_parameters: Simul
     from the stored copy. Splitting it out of ``get_cache_file`` is what lets a writer record the
     inputs that actually produced its bytes rather than re-deriving what was asked for.
 
-    The component's building is removed from its identity first. The cached data depends on what the
-    component is and how it is parameterized, not on which building it happens to sit in, and leaving
-    the building in would file the same computation under a different name for every house.
+    What is hashed is the configuration's *cache key view* -- ``ConfigBase.cache_key_view`` -- not the
+    configuration itself. The base view clears the component's building, because the cached data
+    depends on what the component is and how it is parameterized, not on which house it sits in. A
+    config class whose fields include things that do not decide the result, or paths that would spell
+    differently on another machine, overrides the view to clear or normalise them; that is what makes
+    an entry computed on a workstation findable on a CI runner. A parameter class that is not a
+    ``ConfigBase`` -- tests pass minimal stand-ins -- is hashed as it is, building cleared if it has one.
 
     Args:
         parameter_class: the configuration dataclass, which must provide ``to_json``.
@@ -427,11 +431,15 @@ def build_cache_key_string(parameter_class: Any, my_simulation_parameters: Simul
     """
     if my_simulation_parameters is None:
         raise ValueError("Simulation parameters was none.")
-    parameter_class_copy = copy.deepcopy(parameter_class)
-    component_id = getattr(parameter_class_copy, "component_id", None)
-    if component_id is not None:
-        # The identity is frozen, hence the replacement rather than an assignment.
-        setattr(parameter_class_copy, "component_id", dataclasses.replace(component_id, building=None))
+    view_method = getattr(parameter_class, "cache_key_view", None)
+    if callable(view_method):
+        parameter_class_copy = view_method()
+    else:
+        parameter_class_copy = copy.deepcopy(parameter_class)
+        component_id = getattr(parameter_class_copy, "component_id", None)
+        if component_id is not None:
+            # The identity is frozen, hence the replacement rather than an assignment.
+            setattr(parameter_class_copy, "component_id", dataclasses.replace(component_id, building=None))
     json_str = parameter_class_copy.to_json() + my_simulation_parameters.get_unique_key()
     if len(json_str) < 5:
         raise ValueError("Empty json detected for caching. This is a bug.")

--- a/tests/test_cache_key_portability.py
+++ b/tests/test_cache_key_portability.py
@@ -3,7 +3,8 @@
 Two caches used to hash machine-specific paths -- the LoadProfileGenerator connector its
 ``result_dir_path``, the weather its absolute ``source_path`` -- so their entries could never be shared
 between machines. These tests pin the two overrides and the base rule: fields that decide the result
-move the key, fields that only place the run do not, and no key contains an absolute path.
+move the key, fields that only place the run do not, and a key built from the repository's own data
+files contains no absolute path.
 """
 
 # clean
@@ -17,6 +18,8 @@ from typing import Any
 import pytest
 
 from hisim import utils
+from utspclient.helpers.lpgdata import EnergyIntensityType
+
 from hisim.components.loadprofilegenerator_utsp_connector import UtspLpgConnectorConfig
 from hisim.components.weather import LocationEnum, WeatherConfig
 from hisim.config import ComponentID
@@ -37,8 +40,9 @@ class Keys:
 
     PARAMETERS = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=900)
 
-    #: A JSON string value that starts at the filesystem root: the shape of a machine-specific path.
-    ABSOLUTE_PATH_VALUE = re.compile(r'"[a-z_]+": "/[^"]*"')
+    #: A JSON string value that starts at a filesystem root, POSIX (``/``) or Windows (``C:\\``): the shape
+    #: of a machine-specific path.
+    ABSOLUTE_PATH_VALUE = re.compile(r'"[a-z_]+": "(?:/|[A-Za-z]:\\\\)[^"]*"')
 
     @classmethod
     def of(cls, config: Any) -> str:
@@ -132,7 +136,8 @@ def test_what_decides_the_occupancy_profile_still_moves_its_key() -> None:
 
     assert Keys.of(baseline) != Keys.of(dataclasses.replace(baseline, guid="another-seed"))
     assert Keys.of(baseline) != Keys.of(dataclasses.replace(baseline, profile_with_washing_machine_and_dishwasher=False))
-    other_intensity = [member for member in type(baseline.energy_intensity) if member is not baseline.energy_intensity][0]
+    assert baseline.energy_intensity is not EnergyIntensityType.EnergyIntensive, "pick another member below"
+    other_intensity = EnergyIntensityType.EnergyIntensive
     assert Keys.of(baseline) != Keys.of(dataclasses.replace(baseline, energy_intensity=other_intensity))
 
 
@@ -162,15 +167,39 @@ def test_a_different_weather_file_has_a_different_key() -> None:
     """Making the path portable must not make two files look alike.
 
     Catches: a view that drops the path altogether, so a custom weather file collides with the
-    catalogue entry of the same station.
+    catalogue entry of the same station; and one that keeps only the file name, so two custom files
+    that share a name in different directories collide with each other.
     """
     aachen = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN)
     seville = WeatherConfig.get_default(location_entry=LocationEnum.SEVILLE)
-    custom = dataclasses.replace(aachen, source_path="/data/measured/my_station_2021.csv")
+    custom = dataclasses.replace(aachen, source_path="/data/measured/my_station_2021")
+    same_name_elsewhere = dataclasses.replace(aachen, source_path="/data/other_lab/my_station_2021")
 
     assert Keys.of(aachen) != Keys.of(seville)
     assert Keys.of(aachen) != Keys.of(custom)
-    assert '"source_path": "my_station_2021.csv"' in Keys.of(custom), "a file outside the inputs keeps its name only"
+    assert Keys.of(custom) != Keys.of(same_name_elsewhere)
+    assert '"source_path": "/data/measured/my_station_2021"' in Keys.of(custom), (
+        "a file outside the inputs directory keeps its absolute path"
+    )
+
+
+@pytest.mark.base
+def test_the_base_rule_survives_an_override() -> None:
+    """The building is cleared for a config with its own hook, not only for one without.
+
+    Catches: a hook design that lets a subclass bypass the base rule, so the weather or occupancy key
+    becomes house-specific again.
+    """
+    weather = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN)
+    occupancy = UtspLpgConnectorConfig.get_default_utsp_connector_config()
+    for in_house_a in (weather, occupancy):
+        in_house_b = dataclasses.replace(
+            in_house_a, component_id=dataclasses.replace(in_house_a.component_id, building="BUI2")
+        )
+        in_house_a.component_id = dataclasses.replace(in_house_a.component_id, building="BUI1")
+
+        assert Keys.of(in_house_a) == Keys.of(in_house_b), type(in_house_a).__name__
+        assert '"building": null' in Keys.of(in_house_a), type(in_house_a).__name__
 
 
 @pytest.mark.base

--- a/tests/test_cache_key_portability.py
+++ b/tests/test_cache_key_portability.py
@@ -1,0 +1,202 @@
+"""Tests for the cache key view: what a configuration hashes, and what it deliberately leaves out.
+
+A cache entry computed on one machine is worth having on another only if both derive the same key from
+the same calculation. Two of HiSim's six caches never could. The LoadProfileGenerator connector hashed
+``result_dir_path``, an absolute path that says where a result file is written and differs on every
+machine; the weather hashed ``source_path``, which does select the file but is spelled from the root of
+one checkout. So the two most expensive artifacts HiSim caches were private to whichever machine wrote
+them, and a CI runner recomputed both from cold on every run.
+
+``ConfigBase.cache_key_view`` is the one place a config says what is not key material and how a path is
+made portable; ``hisim.utils.build_cache_key_string`` hashes the view. These tests pin the view for the
+two classes that override it and the base rule for every class that does not. They are the L1 layer of
+``roadmap/cache_protocol_testing.md`` for the two upstream caches: a field that decides the result moves
+the key, a field that does not leaves it alone, and no key contains a path that names a machine.
+
+Each test states the failure mode it catches.
+"""
+
+# clean
+
+import dataclasses
+import os
+import pathlib
+import re
+from typing import Any
+
+import pytest
+
+from hisim import utils
+from hisim.components.loadprofilegenerator_utsp_connector import UtspLpgConnectorConfig
+from hisim.components.weather import LocationEnum, WeatherConfig
+from hisim.config import ComponentID
+from hisim.components.generic_pv_system import PVSystemConfig
+from hisim.simulationparameters import SimulationParameters
+
+__authors__ = "Noah Pflugradt"
+__copyright__ = "Copyright 2021-2026, FZJ-IEK-3 "
+__license__ = "MIT"
+__version__ = "1"
+__maintainer__ = "Noah Pflugradt"
+__email__ = "n.pflugradt@fz-juelich.de"
+__status__ = "development"
+
+
+class Keys:
+    """Derives key material the way the components do, and looks inside it."""
+
+    PARAMETERS = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=900)
+
+    #: A JSON string value that starts at the filesystem root: the shape of a machine-specific path.
+    ABSOLUTE_PATH_VALUE = re.compile(r'"[a-z_]+": "/[^"]*"')
+
+    @classmethod
+    def of(cls, config: Any) -> str:
+        """The key material of a configuration under the shared simulation parameters.
+
+        Args:
+            config: The configuration.
+
+        Returns:
+            str: what is hashed into the entry's name and recorded beside it.
+        """
+        return utils.build_cache_key_string(config, cls.PARAMETERS)
+
+    @classmethod
+    def absolute_paths_in(cls, material: str) -> list:
+        """Every absolute path spelled into key material.
+
+        Args:
+            material: The key material.
+
+        Returns:
+            list: the offending ``"field": "/..."`` fragments, empty for a portable key.
+        """
+        return cls.ABSOLUTE_PATH_VALUE.findall(material)
+
+
+@pytest.mark.base
+def test_the_base_view_clears_the_building_and_nothing_else() -> None:
+    """The rule every config had before this change is the rule every config keeps.
+
+    Catches: the hook regressing the one normalisation the key always had, which would file the same
+    PV series under a different name per house again.
+    """
+    in_house_a = PVSystemConfig.get_default_pv_system()
+    in_house_a.component_id = dataclasses.replace(in_house_a.component_id, building="BUI1")
+    in_house_b = PVSystemConfig.get_default_pv_system()
+    in_house_b.component_id = dataclasses.replace(in_house_b.component_id, building="BUI2")
+
+    assert Keys.of(in_house_a) == Keys.of(in_house_b)
+    assert in_house_a.component_id.building == "BUI1", "the view must be a copy; the live config keeps its building"
+    assert Keys.of(in_house_a) != Keys.of(dataclasses.replace(in_house_a, power_in_watt=1.0))
+
+
+@pytest.mark.base
+def test_a_config_that_is_not_a_config_base_is_still_hashed() -> None:
+    """Tests hand ``get_cache_file`` minimal stand-ins with only ``to_json``; they keep working.
+
+    Catches: the key function assuming every parameter class has the hook.
+    """
+
+    @dataclasses.dataclass
+    class StandIn:
+        """The smallest thing the key function accepts."""
+
+        name: str = "demo"
+
+        def to_json(self) -> str:
+            """The stand-in's JSON."""
+            return '{"name": "demo"}'
+
+    assert Keys.of(StandIn()).startswith('{"name": "demo"}')
+
+
+@pytest.mark.base
+def test_where_the_occupancy_result_is_written_does_not_change_its_key() -> None:
+    """The three run-placement fields are not key material.
+
+    Catches: the defect this change exists for -- an absolute ``result_dir_path`` in the key, so that
+    no LoadProfileGenerator entry computed on one machine is ever found on another.
+    """
+    baseline = UtspLpgConnectorConfig.get_default_utsp_connector_config()
+    elsewhere = dataclasses.replace(
+        baseline,
+        result_dir_path="/home/runner/work/HiSim/HiSim/hisim/results",
+        cache_dir_path="/tmp/somewhere",
+        calculation_index_for_local_lpg=4242,
+    )
+
+    assert Keys.of(baseline) == Keys.of(elsewhere)
+    assert not Keys.absolute_paths_in(Keys.of(baseline)), Keys.absolute_paths_in(Keys.of(baseline))
+
+
+@pytest.mark.base
+def test_what_decides_the_occupancy_profile_still_moves_its_key() -> None:
+    """Removing fields from the key must not remove the ones that matter.
+
+    Catches: an over-eager view that clears a field the profile depends on, which would hand one
+    household's profile to another.
+    """
+    baseline = UtspLpgConnectorConfig.get_default_utsp_connector_config()
+
+    assert Keys.of(baseline) != Keys.of(dataclasses.replace(baseline, guid="another-seed"))
+    assert Keys.of(baseline) != Keys.of(dataclasses.replace(baseline, profile_with_washing_machine_and_dishwasher=False))
+    other_intensity = [member for member in type(baseline.energy_intensity) if member is not baseline.energy_intensity][0]
+    assert Keys.of(baseline) != Keys.of(dataclasses.replace(baseline, energy_intensity=other_intensity))
+
+
+@pytest.mark.base
+def test_the_same_weather_file_under_two_checkouts_has_one_key(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A catalogue file is spelled relative to the inputs directory, so the checkout's location drops out.
+
+    Catches: the weather key naming the machine, which made the entry every other component depends on
+    private to whoever computed it.
+    """
+    here = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN)
+    relative = os.path.relpath(here.source_path, utils.get_input_directory())
+    other_checkout = tmp_path / "other" / "hisim" / "inputs"
+    there = dataclasses.replace(here, source_path=str(other_checkout / relative))
+
+    key_here = Keys.of(here)
+    monkeypatch.setattr(utils, "get_input_directory", lambda: str(other_checkout))
+    key_there = Keys.of(there)
+
+    assert key_here == key_there
+    assert not Keys.absolute_paths_in(key_here), Keys.absolute_paths_in(key_here)
+    assert relative.replace(os.sep, "/") in key_here, "the relative spelling must be what the key carries"
+
+
+@pytest.mark.base
+def test_a_different_weather_file_has_a_different_key() -> None:
+    """Making the path portable must not make two files look alike.
+
+    Catches: a view that drops the path altogether, so a custom weather file collides with the
+    catalogue entry of the same station.
+    """
+    aachen = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN)
+    seville = WeatherConfig.get_default(location_entry=LocationEnum.SEVILLE)
+    custom = dataclasses.replace(aachen, source_path="/data/measured/my_station_2021.csv")
+
+    assert Keys.of(aachen) != Keys.of(seville)
+    assert Keys.of(aachen) != Keys.of(custom)
+    assert '"source_path": "my_station_2021.csv"' in Keys.of(custom), "a file outside the inputs keeps its name only"
+
+
+@pytest.mark.base
+def test_the_view_never_touches_the_live_configuration() -> None:
+    """The component reads its real paths after the key is built; the view must be a copy.
+
+    Catches: an override that assigns into ``self``, which would send the weather reader to a
+    relative path it cannot open.
+    """
+    weather = WeatherConfig.get_default(location_entry=LocationEnum.AACHEN)
+    occupancy = UtspLpgConnectorConfig.get_default_utsp_connector_config()
+    source_before, result_dir_before = weather.source_path, occupancy.result_dir_path
+
+    Keys.of(weather)
+    Keys.of(occupancy)
+
+    assert weather.source_path == source_before
+    assert occupancy.result_dir_path == result_dir_before
+    assert isinstance(weather.component_id, ComponentID)

--- a/tests/test_cache_key_portability.py
+++ b/tests/test_cache_key_portability.py
@@ -16,14 +16,13 @@ import re
 from typing import Any
 
 import pytest
-
-from hisim import utils
 from utspclient.helpers.lpgdata import EnergyIntensityType
 
+from hisim import utils
+from hisim.components.generic_pv_system import PVSystemConfig
 from hisim.components.loadprofilegenerator_utsp_connector import UtspLpgConnectorConfig
 from hisim.components.weather import LocationEnum, WeatherConfig
 from hisim.config import ComponentID
-from hisim.components.generic_pv_system import PVSystemConfig
 from hisim.simulationparameters import SimulationParameters
 
 __authors__ = "Noah Pflugradt"

--- a/tests/test_cache_key_portability.py
+++ b/tests/test_cache_key_portability.py
@@ -1,19 +1,9 @@
-"""Tests for the cache key view: what a configuration hashes, and what it deliberately leaves out.
+"""Tests for ``ConfigBase.cache_key_view``: what a configuration hashes into its cache key and what it leaves out.
 
-A cache entry computed on one machine is worth having on another only if both derive the same key from
-the same calculation. Two of HiSim's six caches never could. The LoadProfileGenerator connector hashed
-``result_dir_path``, an absolute path that says where a result file is written and differs on every
-machine; the weather hashed ``source_path``, which does select the file but is spelled from the root of
-one checkout. So the two most expensive artifacts HiSim caches were private to whichever machine wrote
-them, and a CI runner recomputed both from cold on every run.
-
-``ConfigBase.cache_key_view`` is the one place a config says what is not key material and how a path is
-made portable; ``hisim.utils.build_cache_key_string`` hashes the view. These tests pin the view for the
-two classes that override it and the base rule for every class that does not. They are the L1 layer of
-``roadmap/cache_protocol_testing.md`` for the two upstream caches: a field that decides the result moves
-the key, a field that does not leaves it alone, and no key contains a path that names a machine.
-
-Each test states the failure mode it catches.
+Two caches used to hash machine-specific paths -- the LoadProfileGenerator connector its
+``result_dir_path``, the weather its absolute ``source_path`` -- so their entries could never be shared
+between machines. These tests pin the two overrides and the base rule: fields that decide the result
+move the key, fields that only place the run do not, and no key contains an absolute path.
 """
 
 # clean


### PR DESCRIPTION
## Problem

Two of HiSim's six caches were private to the machine that wrote them. The LoadProfileGenerator connector hashed `result_dir_path` ??? an absolute path (`/home/noah/???` here, `/home/runner/work/???` on CI) that decides only where a result file is written, nothing about the profile. The weather hashed `source_path`, which does select the file but is spelled from the root of one checkout. So the two most expensive artifacts HiSim caches could never be shared between a workstation and CI, or between two runners, and every CI run recomputed both from cold. No cache ??? `actions/cache` (#630), the service later ??? can hit across machines until this is fixed.

## What was done

- **`ConfigBase.cache_key_view()`** ??? returns the deep copy of a configuration whose JSON is hashed. It clears the component's building (the rule every config already had) and then calls the hook **`_clear_non_key_fields(view)`**, which a subclass overrides to drop its own non-key fields. The base rule runs whatever the subclass does; there is no `super()` to forget. `build_cache_key_string` hashes the view, so the lookup, the writer's recorded metadata and the validation agree by construction. Non-`ConfigBase` stand-ins (tests) are hashed as they are.
- **UTSP connector**: clears `result_dir_path`, `cache_dir_path`, `calculation_index_for_local_lpg`. Everything else stays key material, including `predefined_loadprofile_filepaths`: an external profile directory decides the result and is machine-specific by nature, so that mode is not portable, and the docstring says so.
- **Weather**: a `source_path` under the inputs directory is spelled relative to it with forward slashes (`weather/test-reference-years_???/aachen_center`, identical on every checkout). A file outside the inputs directory keeps its absolute path ??? a correct miss on another machine rather than a collision between two custom files that share a name. `os.path.commonpath` raising across Windows drives is caught and treated as "outside inputs".
- 8 tests: placement fields don't move the key, every field the profile depends on does, the same weather file under two checkouts has one key, a different file has another, two same-named custom files differ, no catalogue key carries an absolute path (POSIX or drive-letter), the building rule holds for the overriding configs too, the view never touches the live config.

## Result

Base suite 4518 / 0 on the first two commits; the third (review fixes) passes the portability, caching and utils tests (20) plus the base tests touching caching, weather and keys (51), mypy clean. **Golden OK (16 pairs) on a fully cold cache** ??? and that run is its own cold???warm proof: 16 pairs, **2 LPG executions**, 14 hits on entries written moments earlier under the new names. **On merge:** every weather and LPG key changes once; each machine recomputes them once; the old files are orphaned (never discarded) and can go with the cache directory whenever convenient.

The third commit answers the automated review of this PR: the `super()` contract is replaced by a template method, the basename collision for custom weather files is removed, the Windows cross-drive crash is guarded, a dead duplicate of the building rule and a reference to an uncommitted spec are gone.
