### PR TITLE
Keep hisim/inputs/cache between CI runs, so a profile computed once is not computed again

### DIFF
--- a/.github/actions/hisim-cache/action.yml
+++ b/.github/actions/hisim-cache/action.yml
@@ -2,19 +2,27 @@ name: HiSim inputs cache
 description: >
   Restores or saves hisim/inputs/cache between workflow runs, so a job finds the weather series and
   LoadProfileGenerator profiles the previous run of the same job computed instead of recomputing them
-  from cold. Every entry in that directory is self-validating -- its name is the hash of the inputs
-  that produced it and a companion .meta file records them -- so a restored directory can never serve a
-  wrong result; a key that does not match is simply a miss. That is what makes it safe to always
-  restore the most recent cache and always save a new one.
+  from cold. Every entry in that directory is named by the hash of the configuration that produced it
+  and carries a .meta file recording that configuration, so a restored entry is only ever used for the
+  configuration it was computed for, and an entry nothing asks for is simply ignored. That is what
+  makes it safe to always restore the most recent cache of a job.
+
+  What the name does not cover is the code that computed the entry. A job that finds its weather
+  series and profiles already computed does not exercise the reader or the generator that would
+  have computed them, so an edit to those is first exercised by a run whose entries are missing.
+  Deleting the repository's caches (Actions > Caches) forces that run.
 
   The LoadProfileGenerator is the reason this exists. Eleven of the twenty-two system setups run it
-  locally, six workflows run those setups, and the generator's own sqlite writes are flaky on a slow
+  locally, seven workflows run those setups, and the generator's own sqlite writes are flaky on a slow
   runner. A profile it computed once does not have to be computed again, and a profile that is not
   computed cannot fail.
 
 inputs:
   mode:
-    description: "'restore' before the simulations run, 'save' after them (use if: always() on the save)."
+    description: >
+      'restore' before the simulations run, 'save' after them. Put if: always() on the save, so a
+      run that failed after computing entries still keeps them; a run that failed inside the
+      generator produced none, so there is nothing wrong to keep either way.
     required: true
   scope:
     description: >
@@ -26,32 +34,57 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check the mode
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+      run: |
+        case "$MODE" in
+          restore|save) ;;
+          *) echo "::error::hisim-cache: mode must be 'restore' or 'save', got '$MODE'"; exit 1 ;;
+        esac
+
     - name: Derive the cache key
       id: key
       shell: bash
+      env:
+        SCOPE: ${{ inputs.scope }}
       run: |
-        # Three parts, from coarsest to finest. The scheme hash covers the files that decide how an
-        # entry is named and validated; when they change, a fresh lineage of caches starts rather than
-        # a growing archive of entries under names nothing will ask for again. The scope is the
-        # caller's matrix cell. The run id makes every save unique, so a save never collides with an
-        # existing key and the restore's prefix match always finds the most recent one.
+        # A key names one state of the directory: the layout version (bump it to abandon every
+        # existing cache), the runner OS, the scheme (a hash of the files that decide how an entry is
+        # named and validated; when they change, a fresh lineage of caches starts rather than a
+        # growing archive of entries under names nothing will ask for again), the caller's scope, and
+        # a hash of the directory's content. On save, unchanged content gives a key that already
+        # exists and the save is skipped; new content gives a new key. The restore asks for a key no
+        # save ever writes, so it always falls through to the prefix and gets the most recent cache of
+        # this scope. An empty or missing directory is not saved: it would become the most recent
+        # cache and hide the full one before it.
+        layout=1
         scheme="$(cat hisim/utils.py hisim/caching/*.py | sha256sum | cut -c1-12)"
-        scope="$(printf '%s' "${{ inputs.scope }}" | tr -c 'A-Za-z0-9_.-' '_')"
-        prefix="hisim-inputs-cache-1-${RUNNER_OS}-${scheme}-${scope}-"
+        scope="$(printf '%s' "$SCOPE" | tr -c 'A-Za-z0-9_.-' '_')"
+        prefix="hisim-inputs-cache-${layout}-${RUNNER_OS}-${scheme}-${scope}-"
+        if [ -n "$(find hisim/inputs/cache -type f -print -quit 2>/dev/null)" ]; then
+          content="$(find hisim/inputs/cache -type f -print0 | LC_ALL=C sort -z | xargs -0 sha256sum | sha256sum | cut -c1-12)"
+          echo "has_content=true" >> "$GITHUB_OUTPUT"
+        else
+          content="none"
+          echo "has_content=false" >> "$GITHUB_OUTPUT"
+        fi
         echo "prefix=${prefix}" >> "$GITHUB_OUTPUT"
-        echo "key=${prefix}${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+        echo "save_key=${prefix}${content}" >> "$GITHUB_OUTPUT"
+        echo "restore_key=${prefix}latest" >> "$GITHUB_OUTPUT"
 
     - name: Restore the most recent cache for this scope
       if: inputs.mode == 'restore'
       uses: actions/cache/restore@v4
       with:
         path: hisim/inputs/cache
-        key: ${{ steps.key.outputs.key }}
+        key: ${{ steps.key.outputs.restore_key }}
         restore-keys: ${{ steps.key.outputs.prefix }}
 
     - name: Save this run's cache for the next one
-      if: inputs.mode == 'save'
+      if: inputs.mode == 'save' && steps.key.outputs.has_content == 'true'
       uses: actions/cache/save@v4
       with:
         path: hisim/inputs/cache
-        key: ${{ steps.key.outputs.key }}
+        key: ${{ steps.key.outputs.save_key }}

--- a/.github/actions/hisim-cache/action.yml
+++ b/.github/actions/hisim-cache/action.yml
@@ -1,0 +1,57 @@
+name: HiSim inputs cache
+description: >
+  Restores or saves hisim/inputs/cache between workflow runs, so a job finds the weather series and
+  LoadProfileGenerator profiles the previous run of the same job computed instead of recomputing them
+  from cold. Every entry in that directory is self-validating -- its name is the hash of the inputs
+  that produced it and a companion .meta file records them -- so a restored directory can never serve a
+  wrong result; a key that does not match is simply a miss. That is what makes it safe to always
+  restore the most recent cache and always save a new one.
+
+  The LoadProfileGenerator is the reason this exists. Eleven of the twenty-two system setups run it
+  locally, six workflows run those setups, and the generator's own sqlite writes are flaky on a slow
+  runner. A profile it computed once does not have to be computed again, and a profile that is not
+  computed cannot fail.
+
+inputs:
+  mode:
+    description: "'restore' before the simulations run, 'save' after them (use if: always() on the save)."
+    required: true
+  scope:
+    description: >
+      What distinguishes this job from its siblings -- its matrix cell, typically. Each scope restores
+      its own most recent cache and saves under its own key, so a cell's entries are exactly the ones
+      it needs and no cell overwrites another's.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Derive the cache key
+      id: key
+      shell: bash
+      run: |
+        # Three parts, from coarsest to finest. The scheme hash covers the files that decide how an
+        # entry is named and validated; when they change, a fresh lineage of caches starts rather than
+        # a growing archive of entries under names nothing will ask for again. The scope is the
+        # caller's matrix cell. The run id makes every save unique, so a save never collides with an
+        # existing key and the restore's prefix match always finds the most recent one.
+        scheme="$(cat hisim/utils.py hisim/caching/*.py | sha256sum | cut -c1-12)"
+        scope="$(printf '%s' "${{ inputs.scope }}" | tr -c 'A-Za-z0-9_.-' '_')"
+        prefix="hisim-inputs-cache-1-${RUNNER_OS}-${scheme}-${scope}-"
+        echo "prefix=${prefix}" >> "$GITHUB_OUTPUT"
+        echo "key=${prefix}${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore the most recent cache for this scope
+      if: inputs.mode == 'restore'
+      uses: actions/cache/restore@v4
+      with:
+        path: hisim/inputs/cache
+        key: ${{ steps.key.outputs.key }}
+        restore-keys: ${{ steps.key.outputs.prefix }}
+
+    - name: Save this run's cache for the next one
+      if: inputs.mode == 'save'
+      uses: actions/cache/save@v4
+      with:
+        path: hisim/inputs/cache
+        key: ${{ steps.key.outputs.key }}

--- a/.github/workflows/golden-check.yml
+++ b/.github/workflows/golden-check.yml
@@ -54,9 +54,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install HiSim package
         run: uv pip install --system -e .
-      # Weather series and LoadProfileGenerator profiles computed by the previous run of this job are
-      # restored here, so the simulations below find them instead of recomputing them from cold. Every
-      # entry validates itself against its own name, so a stale cache is a miss, never a wrong answer.
+      # The previous run's weather series and LoadProfileGenerator profiles; see the action.
       - name: Restore the HiSim inputs cache
         uses: ./.github/actions/hisim-cache
         with:
@@ -71,9 +69,7 @@ jobs:
           name: golden-report-${{ matrix.setup }}-${{ matrix.param }}
           path: results/golden-ref-check/report.*
           if-no-files-found: warn
-      # Saved even when the job failed: a run that failed on a KPI comparison still computed valid
-      # entries, and a run that failed inside the LoadProfileGenerator produced none, so there is
-      # nothing wrong to keep either way.
+      # Kept even when the job failed; see the action for why that is safe.
       - name: Save the HiSim inputs cache
         if: always()
         uses: ./.github/actions/hisim-cache

--- a/.github/workflows/golden-check.yml
+++ b/.github/workflows/golden-check.yml
@@ -54,6 +54,14 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install HiSim package
         run: uv pip install --system -e .
+      # Weather series and LoadProfileGenerator profiles computed by the previous run of this job are
+      # restored here, so the simulations below find them instead of recomputing them from cold. Every
+      # entry validates itself against its own name, so a stale cache is a miss, never a wrong answer.
+      - name: Restore the HiSim inputs cache
+        uses: ./.github/actions/hisim-cache
+        with:
+          mode: restore
+          scope: ${{ github.workflow }}-${{ matrix.setup }}-${{ matrix.param }}
       - name: Golden KPI check
         run: python scripts/golden_check.py --setup "${{ matrix.setup }}" --param "${{ matrix.param }}"
       - name: Upload deviation report
@@ -63,6 +71,15 @@ jobs:
           name: golden-report-${{ matrix.setup }}-${{ matrix.param }}
           path: results/golden-ref-check/report.*
           if-no-files-found: warn
+      # Saved even when the job failed: a run that failed on a KPI comparison still computed valid
+      # entries, and a run that failed inside the LoadProfileGenerator produced none, so there is
+      # nothing wrong to keep either way.
+      - name: Save the HiSim inputs cache
+        if: always()
+        uses: ./.github/actions/hisim-cache
+        with:
+          mode: save
+          scope: ${{ github.workflow }}-${{ matrix.setup }}-${{ matrix.param }}
 
   summary:
     name: golden-check summary

--- a/.github/workflows/golden-json-check.yml
+++ b/.github/workflows/golden-json-check.yml
@@ -75,6 +75,14 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install HiSim package
         run: uv pip install --system -e .
+      # Weather series and LoadProfileGenerator profiles computed by the previous run of this job are
+      # restored here, so the simulations below find them instead of recomputing them from cold. Every
+      # entry validates itself against its own name, so a stale cache is a miss, never a wrong answer.
+      - name: Restore the HiSim inputs cache
+        uses: ./.github/actions/hisim-cache
+        with:
+          mode: restore
+          scope: ${{ github.workflow }}-${{ matrix.setup }}-${{ matrix.param }}
       - name: Golden KPI check (JSON)
         run: |
           python scripts/golden_check.py \
@@ -87,6 +95,15 @@ jobs:
           name: golden-json-report-${{ matrix.setup }}-${{ matrix.param }}
           path: results/golden-ref-check/report.*
           if-no-files-found: warn
+      # Saved even when the job failed: a run that failed on a KPI comparison still computed valid
+      # entries, and a run that failed inside the LoadProfileGenerator produced none, so there is
+      # nothing wrong to keep either way.
+      - name: Save the HiSim inputs cache
+        if: always()
+        uses: ./.github/actions/hisim-cache
+        with:
+          mode: save
+          scope: ${{ github.workflow }}-${{ matrix.setup }}-${{ matrix.param }}
 
   summary:
     name: golden-json-check summary

--- a/.github/workflows/golden-json-check.yml
+++ b/.github/workflows/golden-json-check.yml
@@ -75,9 +75,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install HiSim package
         run: uv pip install --system -e .
-      # Weather series and LoadProfileGenerator profiles computed by the previous run of this job are
-      # restored here, so the simulations below find them instead of recomputing them from cold. Every
-      # entry validates itself against its own name, so a stale cache is a miss, never a wrong answer.
+      # The previous run's weather series and LoadProfileGenerator profiles; see the action.
       - name: Restore the HiSim inputs cache
         uses: ./.github/actions/hisim-cache
         with:
@@ -95,9 +93,7 @@ jobs:
           name: golden-json-report-${{ matrix.setup }}-${{ matrix.param }}
           path: results/golden-ref-check/report.*
           if-no-files-found: warn
-      # Saved even when the job failed: a run that failed on a KPI comparison still computed valid
-      # entries, and a run that failed inside the LoadProfileGenerator produced none, so there is
-      # nothing wrong to keep either way.
+      # Kept even when the job failed; see the action for why that is safe.
       - name: Save the HiSim inputs cache
         if: always()
         uses: ./.github/actions/hisim-cache

--- a/.github/workflows/golden-year.yml
+++ b/.github/workflows/golden-year.yml
@@ -68,6 +68,14 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install HiSim package
         run: uv pip install --system -e .
+      # Weather series and LoadProfileGenerator profiles computed by the previous run of this job are
+      # restored here, so the simulations below find them instead of recomputing them from cold. Every
+      # entry validates itself against its own name, so a stale cache is a miss, never a wrong answer.
+      - name: Restore the HiSim inputs cache
+        uses: ./.github/actions/hisim-cache
+        with:
+          mode: restore
+          scope: ${{ github.workflow }}-${{ matrix.setup }}-${{ matrix.param }}
       - name: Golden KPI check (full year)
         run: python scripts/golden_check.py --setup "${{ matrix.setup }}" --param "${{ matrix.param }}"
       - name: Upload deviation report
@@ -77,6 +85,15 @@ jobs:
           name: golden-year-report-${{ matrix.setup }}-${{ matrix.param }}
           path: results/golden-ref-check/report.*
           if-no-files-found: warn
+      # Saved even when the job failed: a run that failed on a KPI comparison still computed valid
+      # entries, and a run that failed inside the LoadProfileGenerator produced none, so there is
+      # nothing wrong to keep either way.
+      - name: Save the HiSim inputs cache
+        if: always()
+        uses: ./.github/actions/hisim-cache
+        with:
+          mode: save
+          scope: ${{ github.workflow }}-${{ matrix.setup }}-${{ matrix.param }}
 
   summary:
     name: golden-year summary

--- a/.github/workflows/golden-year.yml
+++ b/.github/workflows/golden-year.yml
@@ -68,9 +68,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install HiSim package
         run: uv pip install --system -e .
-      # Weather series and LoadProfileGenerator profiles computed by the previous run of this job are
-      # restored here, so the simulations below find them instead of recomputing them from cold. Every
-      # entry validates itself against its own name, so a stale cache is a miss, never a wrong answer.
+      # The previous run's weather series and LoadProfileGenerator profiles; see the action.
       - name: Restore the HiSim inputs cache
         uses: ./.github/actions/hisim-cache
         with:
@@ -85,9 +83,7 @@ jobs:
           name: golden-year-report-${{ matrix.setup }}-${{ matrix.param }}
           path: results/golden-ref-check/report.*
           if-no-files-found: warn
-      # Saved even when the job failed: a run that failed on a KPI comparison still computed valid
-      # entries, and a run that failed inside the LoadProfileGenerator produced none, so there is
-      # nothing wrong to keep either way.
+      # Kept even when the job failed; see the action for why that is safe.
       - name: Save the HiSim inputs cache
         if: always()
         uses: ./.github/actions/hisim-cache

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -144,7 +144,20 @@ jobs:
     - name: Install HiSim package
       run: |
         uv pip install --system -e .
+    # The previous run's weather series and LoadProfileGenerator profiles; see the action.
+    - name: Restore the HiSim inputs cache
+      uses: ./.github/actions/hisim-cache
+      with:
+        mode: restore
+        scope: ${{ github.workflow }}-basic-execution
     - name: Run hisim_main.py directly from the command line
       working-directory: ./system_setups/
       run: |
         python ../hisim/hisim_main.py household_heatpump_building_sizer.py
+    # Kept even when the job failed; see the action for why that is safe.
+    - name: Save the HiSim inputs cache
+      if: always()
+      uses: ./.github/actions/hisim-cache
+      with:
+        mode: save
+        scope: ${{ github.workflow }}-basic-execution

--- a/.github/workflows/scenario-json-freshness.yml
+++ b/.github/workflows/scenario-json-freshness.yml
@@ -56,6 +56,14 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install HiSim package
         run: uv pip install --system -e .
+      # Weather series and LoadProfileGenerator profiles computed by the previous run of this job are
+      # restored here, so the simulations below find them instead of recomputing them from cold. Every
+      # entry validates itself against its own name, so a stale cache is a miss, never a wrong answer.
+      - name: Restore the HiSim inputs cache
+        uses: ./.github/actions/hisim-cache
+        with:
+          mode: restore
+          scope: ${{ github.workflow }}
       - name: Regenerate all scenario JSONs
         run: |
           # Auto-adapt parallelism to the runner: one worker per vCPU, capped so a
@@ -127,3 +135,12 @@ jobs:
           name: scenario-json-converter-logs
           path: results/regenerate_scenario_jsons/
           if-no-files-found: ignore
+      # Saved even when the job failed: a run that failed on a KPI comparison still computed valid
+      # entries, and a run that failed inside the LoadProfileGenerator produced none, so there is
+      # nothing wrong to keep either way.
+      - name: Save the HiSim inputs cache
+        if: always()
+        uses: ./.github/actions/hisim-cache
+        with:
+          mode: save
+          scope: ${{ github.workflow }}

--- a/.github/workflows/scenario-json-freshness.yml
+++ b/.github/workflows/scenario-json-freshness.yml
@@ -56,9 +56,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install HiSim package
         run: uv pip install --system -e .
-      # Weather series and LoadProfileGenerator profiles computed by the previous run of this job are
-      # restored here, so the simulations below find them instead of recomputing them from cold. Every
-      # entry validates itself against its own name, so a stale cache is a miss, never a wrong answer.
+      # The previous run's weather series and LoadProfileGenerator profiles; see the action.
       - name: Restore the HiSim inputs cache
         uses: ./.github/actions/hisim-cache
         with:
@@ -135,9 +133,7 @@ jobs:
           name: scenario-json-converter-logs
           path: results/regenerate_scenario_jsons/
           if-no-files-found: ignore
-      # Saved even when the job failed: a run that failed on a KPI comparison still computed valid
-      # entries, and a run that failed inside the LoadProfileGenerator produced none, so there is
-      # nothing wrong to keep either way.
+      # Kept even when the job failed; see the action for why that is safe.
       - name: Save the HiSim inputs cache
         if: always()
         uses: ./.github/actions/hisim-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,14 @@ jobs:
     - name: Install HiSim package
       run: |
         uv pip install --system -e .
+    # Weather series and LoadProfileGenerator profiles computed by the previous run of this job are
+    # restored here, so the simulations below find them instead of recomputing them from cold. Every
+    # entry validates itself against its own name, so a stale cache is a miss, never a wrong answer.
+    - name: Restore the HiSim inputs cache
+      uses: ./.github/actions/hisim-cache
+      with:
+        mode: restore
+        scope: ${{ github.workflow }}-${{ matrix.name }}
     - name: Test with pytest
       working-directory: ./tests/
       env:
@@ -89,6 +97,15 @@ jobs:
         path: tests/.coverage.*
         include-hidden-files: true
         if-no-files-found: warn
+    # Saved even when the job failed: a run that failed on a KPI comparison still computed valid
+    # entries, and a run that failed inside the LoadProfileGenerator produced none, so there is
+    # nothing wrong to keep either way.
+    - name: Save the HiSim inputs cache
+      if: always()
+      uses: ./.github/actions/hisim-cache
+      with:
+        mode: save
+        scope: ${{ github.workflow }}-${{ matrix.name }}
 
   coverage:
     name: combine coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,9 +65,7 @@ jobs:
     - name: Install HiSim package
       run: |
         uv pip install --system -e .
-    # Weather series and LoadProfileGenerator profiles computed by the previous run of this job are
-    # restored here, so the simulations below find them instead of recomputing them from cold. Every
-    # entry validates itself against its own name, so a stale cache is a miss, never a wrong answer.
+    # The previous run's weather series and LoadProfileGenerator profiles; see the action.
     - name: Restore the HiSim inputs cache
       uses: ./.github/actions/hisim-cache
       with:
@@ -97,9 +95,7 @@ jobs:
         path: tests/.coverage.*
         include-hidden-files: true
         if-no-files-found: warn
-    # Saved even when the job failed: a run that failed on a KPI comparison still computed valid
-    # entries, and a run that failed inside the LoadProfileGenerator produced none, so there is
-    # nothing wrong to keep either way.
+    # Kept even when the job failed; see the action for why that is safe.
     - name: Save the HiSim inputs cache
       if: always()
       uses: ./.github/actions/hisim-cache

--- a/tests/test_lpg_utsp_connector_no_downgrade.py
+++ b/tests/test_lpg_utsp_connector_no_downgrade.py
@@ -21,6 +21,7 @@ import pytest
 
 from hisim import utils
 from hisim.components import loadprofilegenerator_utsp_connector as lpg_connector
+from hisim.components.pylpg_workspace import PylpgWorkspace
 from hisim.simulationparameters import SimulationParameters
 
 __authors__ = "Noah Pflugradt"
@@ -74,12 +75,18 @@ def test_local_lpg_failure_propagates_instead_of_swapping_the_household(
     pylpg installation looks like from the connector's side. The old code caught that, logged a
     warning, set ``USE_PREDEFINED_PROFILE`` and finished successfully; the new code must let the
     exception through with the mode untouched.
+
+    The binary installation is stubbed out too. It runs only when the generator's executable is not
+    on disk, and it reaches for a method of the executor class that the stub above does not have;
+    whether the executable is on disk depends on whether an earlier test computed a profile, which
+    a warm cache makes false. The test must not depend on that.
     """
 
     def raise_instead_of_executing(*_args: Any, **_kwargs: Any) -> Any:
         raise UnreachableProfileSourceError("pylpg is not available in this test")
 
     monkeypatch.setattr(lpg_connector.lpg_execution, "LPGExecutor", raise_instead_of_executing)
+    monkeypatch.setattr(PylpgWorkspace, "install_binaries_if_missing", classmethod(lambda cls: None))
     config = build_connector_config(lpg_connector.LpgDataAcquisitionMode.USE_LOCAL_LPG, str(tmp_path))
     simulation_parameters = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
 


### PR DESCRIPTION
## Problem

Eleven of the 22 system setups run the LoadProfileGenerator locally, seven workflows run those setups, and no workflow used `actions/cache` ??? every CI run started with an empty `hisim/inputs/cache`, recomputing every weather series and occupancy profile from cold on every push. The generator's sqlite writes are flaky on a slow runner (#627), so a fair share of those recomputations failed before finishing. A profile computed last time does not have to be computed again, and a profile that is not computed cannot fail. This is the `actions/cache` phase of `roadmap/cache_service_spec.md` ??10, brought forward because it needs no server and it is where the flakiness bites.

## What was done

- One composite action, `.github/actions/hisim-cache`, with `mode: restore|save` (anything else fails the step) and a `scope`. Key = `hisim-inputs-cache-1-<os>-<scheme hash>-<scope>-<content hash>`. The scheme hash covers the files that decide how an entry is named and validated (`hisim/utils.py`, `hisim/caching/*`); a change to them starts a fresh lineage instead of growing an archive of orphans. The content hash is that of the directory at save time, so a run whose entries are unchanged finds its key already taken and saves nothing, a run with new entries saves under a new key, and a re-run of a workflow saves like any other run. The restore asks for a key no save ever writes and falls through to the prefix, which yields the most recent cache of the same scope. An empty or missing directory is never saved, so it cannot become the most recent cache and hide the full one before it.
- Restore after the install and save `if: always()` as the last step in the simulating jobs of six workflows ??? golden-check, golden-json-check, golden-year (scope = setup + param), tests (scope = marker), scenario-json-freshness (the setups are constructed there, and the connector runs the generator from its constructor), and quality's basic-execution job, which runs the heat pump sizer with the local generator. Per-cell scoping: each matrix cell restores exactly its own entries and never overwrites a sibling's. Save-on-failure because a job that failed after computing entries still computed valid ones, and a job that failed inside the generator computed none.
- golden-update is deliberately left cold: reference values come from a full computation, and the job runs rarely.
- What a restored entry guarantees, and what it does not: its name is the hash of the configuration that produced it and a `.meta` file records that configuration, so it is only ever used for that configuration and an entry nothing asks for is ignored. The name does not cover the code that computed it, so a job that finds its entries already computed does not exercise the weather reader or the generator; an edit to those is first exercised by a run whose entries are missing, and deleting the repository's caches under Actions > Caches forces that run. The directory is gitignored, so a restored cache is invisible to the freshness diff and the tests' stray-file guard (both checked).

## Result

All YAML validates. The key derivation and the mode guard were run locally: the content hash is stable across runs with the same directory, changes when a file is added, and an empty or missing directory yields no save. **Not verifiable locally beyond that** ??? the first CI run is cold and saves; the second hits (expect `Get PV results from cache` / weather / occupancy hits in its log and a much shorter LPG phase). Independent of #629: without it a runner finds only what a runner wrote, which is all CI needs; #629 is what makes workstation entries shareable too.

The second commit answers the automated review of this PR: the run id in the key (a full upload per run, and no save on a re-run) is replaced by a content hash, an empty directory is no longer saved, an unknown `mode` fails instead of doing nothing, quality's basic-execution job is wired in, the "never a wrong result" claim is replaced by what the entry name does and does not cover, and the ten copied comment blocks (two of which spoke of a KPI comparison in workflows that have none) are one line each.

The third commit fixes a test the warm cache exposed. `test_local_lpg_failure_propagates_instead_of_swapping_the_household` stubs the LPG executor class with a bare function and passed only because an earlier test in the run had computed a profile and thereby installed the generator's binaries, so the connector skipped the installation. With the cache restored, that earlier test hits the cache, installs nothing, and the connector reaches the installation, which asks the stub for a method it does not have. The test now stubs the installation too and holds regardless of what ran before it ??? verified locally with the binaries forced absent.
