### PR TITLE
Make every component and port name an identifier

### DIFF
--- a/hisim/component.py
+++ b/hisim/component.py
@@ -66,7 +66,18 @@ class ComponentOutput:  # noqa: too-few-public-methods
         The identity is deliberately REQUIRED (keyword-only): an output without an owner would
         silently fall into the default building group and corrupt per-building KPIs, so a
         missing identity must fail at construction rather than at aggregation.
+
+        The field name is held to the same identifier rule as the component name, and for the
+        same reason: a declarative energy-system file addresses a producing port as the dotted
+        half of ``from: <component>.<port>``, and that grammar accepts an identifier and nothing
+        else. Checking it here rather than in the recorder means a port nobody could reference
+        fails the moment the class declaring it is built, instead of years later when something
+        first tries to write that system down.
+
+        Raises:
+            ValueError: If ``field_name`` is not a well-formed identifier.
         """
+        cfg.NameSyntax.require_identifier(field_name, "component output")
         self.full_name: str = object_name + " # " + field_name
         self.component_name: str = object_name
         self.field_name: str = field_name
@@ -121,7 +132,15 @@ class ComponentInput:  # noqa: too-few-public-methods
                 this for mandatory inputs whose source output may legitimately
                 not exist (e.g. a heat pump's DHW electrical power output when
                 domestic hot water preparation is disabled).
+
+        Raises:
+            ValueError: If ``field_name`` is not a well-formed identifier. An input is written
+                as its own key in a declarative energy-system file rather than behind a dot, so
+                the grammar does not force the rule on it the way it does on an output; it is
+                enforced anyway, because an input and an output of the same flow that spelled
+                their names by different rules would be a trap for every reader of both.
         """
+        cfg.NameSyntax.require_identifier(field_name, "component input")
         self.fullname: str = object_name + " # " + field_name
         self.component_name: str = object_name
         self.field_name: str = field_name

--- a/hisim/component.py
+++ b/hisim/component.py
@@ -207,7 +207,32 @@ class Component:
         my_config: cfg.ConfigBase,
         my_display_config: cfg.DisplayConfig,
     ) -> None:
-        """Initializes the component class."""
+        """Initializes the component class.
+
+        Args:
+            name: The unique runtime name of this component, normally
+                ``config.component_id.key``. It becomes the prefix of every output name and
+                therefore of every result column, and it is the key a declarative
+                energy-system file addresses this component by, so it has to be a plain
+                identifier.
+            my_simulation_parameters: The simulation-wide parameters (time range, resolution,
+                post-processing options) the component reads and is stepped with.
+            my_config: The component's own configuration; it must be a
+                :class:`~hisim.config.ConfigBase` and must no longer carry any unresolved
+                ``AUTO`` field.
+            my_display_config: How this component is presented in postprocessing, the report
+                and the webtool.
+
+        Raises:
+            ValueError: If ``name`` is not a usable identifier, if ``my_simulation_parameters``
+                is ``None``, or if ``my_config`` is not a ``ConfigBase``.
+            ConfigSizingError: If ``my_config`` still has fields awaiting sizing.
+        """
+        # The single choke point where a component's runtime name becomes real. Enforcing the
+        # identifier rule here catches a name typed in a setup and a name that arrived from a
+        # config class's own default alike, which a check on the declarative file's keys would
+        # never see: a defaulted identity is one nobody has to write down.
+        cfg.NameSyntax.require_identifier(name, "component")
         self.component_name: str = name
         self.inputs: List[ComponentInput] = []
         self.outputs: List[ComponentOutput] = []

--- a/hisim/component.py
+++ b/hisim/component.py
@@ -75,8 +75,12 @@ class ComponentOutput:  # noqa: too-few-public-methods
         first tries to write that system down.
 
         Raises:
-            ValueError: If ``field_name`` is not a well-formed identifier.
+            ValueError: If ``field_name`` or ``object_name`` is not a well-formed identifier.
+                The prefix is normally the already-validated component name, but a direct
+                construction can pass anything, and an unusable prefix would defeat the rule
+                on the very column name it exists for.
         """
+        cfg.NameSyntax.require_identifier(object_name, "component")
         cfg.NameSyntax.require_identifier(field_name, "component output")
         self.full_name: str = object_name + " # " + field_name
         self.component_name: str = object_name
@@ -134,12 +138,14 @@ class ComponentInput:  # noqa: too-few-public-methods
                 domestic hot water preparation is disabled).
 
         Raises:
-            ValueError: If ``field_name`` is not a well-formed identifier. An input is written
-                as its own key in a declarative energy-system file rather than behind a dot, so
-                the grammar does not force the rule on it the way it does on an output; it is
-                enforced anyway, because an input and an output of the same flow that spelled
-                their names by different rules would be a trap for every reader of both.
+            ValueError: If ``field_name`` or ``object_name`` is not a well-formed identifier.
+                An input is written as its own key in a declarative energy-system file rather
+                than behind a dot, so the grammar does not force the rule on it the way it does
+                on an output; it is enforced anyway, because an input and an output of the same
+                flow that spelled their names by different rules would be a trap for every
+                reader of both.
         """
+        cfg.NameSyntax.require_identifier(object_name, "component")
         cfg.NameSyntax.require_identifier(field_name, "component input")
         self.fullname: str = object_name + " # " + field_name
         self.component_name: str = object_name

--- a/hisim/components/advanced_fuel_cell.py
+++ b/hisim/components/advanced_fuel_cell.py
@@ -177,7 +177,7 @@ class CHP(Component):
     # OperatingModelSignal="OperatingModelSignal" #-->Wärme oder Stromgeführt. Nötig?
 
     # Output
-    MassflowOutput: ClassVar[str] = "Hot Water Energy Output"
+    MassflowOutput: ClassVar[str] = "HotWaterEnergyOutput"
     MassflowOutputTemperature: ClassVar[str] = "MassflowOutputTemperature"
     ElectricityOutput: ClassVar[str] = "ElectricityOutput"
     GasDemandTarget: ClassVar[str] = "GasDemandTarget"

--- a/hisim/components/advanced_fuel_cell_controller.py
+++ b/hisim/components/advanced_fuel_cell_controller.py
@@ -291,22 +291,22 @@ class ExtendedController(Component):
     """Extended Controller class."""
 
     # inputs
-    ElectricityDemand: str = "Electricity Demand"  # W
-    PV_Production: str = "PV Production"  # W
+    ElectricityDemand: str = "ElectricityDemand"  # W
+    PV_Production: str = "PVProduction"  # W
 
     # temperatures (input)
-    Temperature0Percent: str = "Temperature 0 Percent"  # °C
-    Temperature20Percent: str = "Temperature 20 Percent"  # °C
-    Temperature40Percent: str = "Temperature 40 Percent"  # °C
-    Temperature60Percent: str = "Temperature 60 Percent"  # °C
-    Temperature80Percent: str = "Temperature 80 Percent"  # °C
-    Temperature100Percent: str = "Temperature 100 Percent"  # °C
+    Temperature0Percent: str = "Temperature0Percent"  # °C
+    Temperature20Percent: str = "Temperature20Percent"  # °C
+    Temperature40Percent: str = "Temperature40Percent"  # °C
+    Temperature60Percent: str = "Temperature60Percent"  # °C
+    Temperature80Percent: str = "Temperature80Percent"  # °C
+    Temperature100Percent: str = "Temperature100Percent"  # °C
 
     # Output
-    ControllerCHP: str = "Controller CHP"
-    ControllerGasHeater: str = "Controller Gas Heater"
-    PowerToElectrolyzer: str = "Power To Electrolyzer"
-    PowerFromOrToGrid: str = "Power From Or To Grid"
+    ControllerCHP: str = "ControllerCHP"
+    ControllerGasHeater: str = "ControllerGasHeater"
+    PowerToElectrolyzer: str = "PowerToElectrolyzer"
+    PowerFromOrToGrid: str = "PowerFromOrToGrid"
 
     RuntimeCounterCHP: str = "RuntimeCounterCHP"
     RuntimeCounterGasHeater: str = "RuntimeCounterGasHeater"

--- a/hisim/components/controller_l1_chp.py
+++ b/hisim/components/controller_l1_chp.py
@@ -67,7 +67,7 @@ class L1CHPControllerConfig(ConfigBase):
     ) -> "L1CHPControllerConfig":
         """Returns default configuration for the CHP controller."""
         if component_id is None:
-            component_id = ComponentID(name="CHP Controller")
+            component_id = ComponentID(name="CHPController")
         config = L1CHPControllerConfig(
             component_id=component_id,
             source_weight=1,
@@ -91,7 +91,7 @@ class L1CHPControllerConfig(ConfigBase):
     ) -> "L1CHPControllerConfig":
         """Returns default configuration for the fuel cell controller."""
         if component_id is None:
-            component_id = ComponentID(name="Fuel Cell Controller")
+            component_id = ComponentID(name="FuelCellController")
         config = L1CHPControllerConfig(
             component_id=component_id,
             source_weight=1,
@@ -116,7 +116,7 @@ class L1CHPControllerConfig(ConfigBase):
         """Returns default configuration for the CHP controller, when buffer storage for heating is available."""
         # minus - 1 in heating season, so that buffer heats up one day ahead, and modelling to building works.
         if component_id is None:
-            component_id = ComponentID(name="CHP Controller")
+            component_id = ComponentID(name="CHPController")
         config = L1CHPControllerConfig(
             component_id=component_id,
             source_weight=1,
@@ -141,7 +141,7 @@ class L1CHPControllerConfig(ConfigBase):
         """Returns default configuration for the fuel cell controller, when buffer storage for heating is available."""
         # minus - 1 in heating season, so that buffer heats up one day ahead, and modelling to building works.
         if component_id is None:
-            component_id = ComponentID(name="CHP Controller")
+            component_id = ComponentID(name="CHPController")
         config = L1CHPControllerConfig(
             component_id=component_id,
             source_weight=1,

--- a/hisim/components/controller_l1_electrolyzer.py
+++ b/hisim/components/controller_l1_electrolyzer.py
@@ -40,7 +40,7 @@ class L1ElectrolyzerControllerConfig(ConfigBase):
     ) -> "L1ElectrolyzerControllerConfig":
         """Returns the default configuration of an electrolyzer controller."""
         if component_id is None:
-            component_id = ComponentID(name="L1 Electrolyzer Controller")
+            component_id = ComponentID(name="L1ElectrolyzerController")
         config = L1ElectrolyzerControllerConfig(
             component_id=component_id,
             source_weight=1,

--- a/hisim/components/controller_l1_example_controller.py
+++ b/hisim/components/controller_l1_example_controller.py
@@ -66,8 +66,8 @@ class SimpleController(Component):
     (off) when it exceeds the high threshold.
     """
 
-    StorageFillLevel: str = "Fill Level Percent"
-    GasHeaterPowerPercent: str = "Gas Heater Power Level"
+    StorageFillLevel: str = "FillLevelPercent"
+    GasHeaterPowerPercent: str = "GasHeaterPowerLevel"
 
     FILL_LEVEL_LOW_THRESHOLD: float = 0.4
     FILL_LEVEL_HIGH_THRESHOLD: float = 0.99

--- a/hisim/components/controller_l1_fuel_cell.py
+++ b/hisim/components/controller_l1_fuel_cell.py
@@ -50,7 +50,7 @@ class FuelCellControllerConfig(ConfigBase):
     ) -> Any:
         """Get a default electrolyzer controller config."""
         if component_id is None:
-            component_id = ComponentID(name="Default fuel cell controller")
+            component_id = ComponentID(name="DefaultFuelCellController")
         config = FuelCellControllerConfig(
             component_id=component_id,
             nom_output=100.0,
@@ -80,7 +80,7 @@ class FuelCellControllerConfig(ConfigBase):
         """Initializes the config variables based on the JSON-file."""
 
         if component_id is None:
-            component_id = ComponentID(name="Fuel Cell Controller")
+            component_id = ComponentID(name="FuelCellController")
         config_json = cls.read_config(fuel_cell_name)
 
         config = FuelCellControllerConfig(

--- a/hisim/components/controller_l1_rsoc.py
+++ b/hisim/components/controller_l1_rsoc.py
@@ -91,7 +91,7 @@ class RsocControllerConfig(ConfigBase):
         """
 
         if component_id is None:
-            component_id = ComponentID(name="rSCO l1 Controller")
+            component_id = ComponentID(name="RscoL1Controller")
         if config_json is None:
             config_json = cls.read_config(rsoc_name)
         config = RsocControllerConfig(

--- a/hisim/components/controller_l1_rsoc.py
+++ b/hisim/components/controller_l1_rsoc.py
@@ -127,8 +127,8 @@ class RsocController(Component):
     PowerVsDemand: ClassVar[str] = "PowerVsDemand"
     CurtailedLoad: ClassVar[str] = "CurtailedLoad"
     CurtailedPower: ClassVar[str] = "CurtailedPower"
-    TotalOffCount: ClassVar[str] = "# of times the system was switched off"
-    TotalStandbyCount: ClassVar[str] = "# of times the system was to standby mode"
+    TotalOffCount: ClassVar[str] = "TotalOffCount"
+    TotalStandbyCount: ClassVar[str] = "TotalStandbyCount"
     SwitchCount: ClassVar[str] = "SwitchCount"
 
     def __init__(

--- a/hisim/components/controller_l2_rsoc_battery_system.py
+++ b/hisim/components/controller_l2_rsoc_battery_system.py
@@ -92,7 +92,7 @@ class RsocBatteryControllerConfig(ConfigBase):
         file being present.
         """
         if component_id is None:
-            component_id = ComponentID(name="rSOC and Battery Controller")
+            component_id = ComponentID(name="RsocAndBatteryController")
         if config_data is None:
             config_data = cls.read_config(rsoc_name)
 

--- a/hisim/components/controller_mpc.py
+++ b/hisim/components/controller_mpc.py
@@ -183,7 +183,7 @@ class MpcController(cp.Component):
     # weather
     TemperatureOutside = "TemperatureOutside"
     # building
-    TemperatureMean = "Residence Temperature"
+    TemperatureMean = "ResidenceTemperature"
 
     # Outputs
     TemperatureMeanStateSpace = "TemperatureMeanStateSpace"

--- a/hisim/components/controller_pid.py
+++ b/hisim/components/controller_pid.py
@@ -360,7 +360,7 @@ class PIDController(cp.Component):
     """
 
     # Inputs
-    TemperatureMean: str = "Residence Temperature"  # uncontrolled temperature
+    TemperatureMean: str = "ResidenceTemperature"  # uncontrolled temperature
     TemperatureMeanPrevious: str = "TemperatureMeanPrevious"
     TemperatureAir: str = "TemperatureAir"
     HeatFluxWallNode: str = "HeatFluxWallNode"

--- a/hisim/components/csvloader.py
+++ b/hisim/components/csvloader.py
@@ -134,7 +134,7 @@ class CSVLoader(cp.Component):
 
     """
 
-    Output1: str = "CSV Profile"
+    Output1: str = "CSVProfile"
 
     def __init__(
         self,

--- a/hisim/components/example_component.py
+++ b/hisim/components/example_component.py
@@ -48,7 +48,7 @@ class ExampleComponentConfig(ConfigBase):
     ) -> "ExampleComponentConfig":
         """Gets a default Example Component."""
         if component_id is None:
-            component_id = ComponentID(name="Example Component")
+            component_id = ComponentID(name="ExampleComponent")
         return ExampleComponentConfig(
             component_id=component_id,
             electricity=-1e3,

--- a/hisim/components/example_component.py
+++ b/hisim/components/example_component.py
@@ -89,7 +89,7 @@ class ExampleComponent(Component):
 
     # Outputs
     ElectricityOutput: str = "ElectricityOutput"
-    TemperatureMean: str = "Residence Temperature"
+    TemperatureMean: str = "ResidenceTemperature"
     StoredEnergy: str = "StoredEnergy"
 
     def __init__(

--- a/hisim/components/example_storage.py
+++ b/hisim/components/example_storage.py
@@ -94,11 +94,11 @@ class SimpleStorageConfig(ConfigBase):
 class SimpleStorage(Component):
     """A class to simulate the Simple Storage."""
 
-    ChargingAmount: str = "Charging Amount"
-    DischargingAmount: str = "Discharging Amount"
-    ActualStorageDelta: str = "Actual Storage Delta"
-    CurrentFillLevel: str = "Current Fill Level Absolute"
-    CurrentFillLevelPercent: str = "Current Fill Level Percent"
+    ChargingAmount: str = "ChargingAmount"
+    DischargingAmount: str = "DischargingAmount"
+    ActualStorageDelta: str = "ActualStorageDelta"
+    CurrentFillLevel: str = "CurrentFillLevelAbsolute"
+    CurrentFillLevelPercent: str = "CurrentFillLevelPercent"
 
     def __init__(
         self,

--- a/hisim/components/example_storage.py
+++ b/hisim/components/example_storage.py
@@ -82,7 +82,7 @@ class SimpleStorageConfig(ConfigBase):
     ) -> "SimpleStorageConfig":
         """Gets a default Simple Storage."""
         if component_id is None:
-            component_id = ComponentID(name="Simple Thermal Storage")
+            component_id = ComponentID(name="SimpleThermalStorage")
         return SimpleStorageConfig(
             component_id=component_id,
             loadtype=lt.LoadTypes.WARM_WATER,

--- a/hisim/components/example_template.py
+++ b/hisim/components/example_template.py
@@ -51,7 +51,7 @@ class ComponentNameConfig(ConfigBase):
     ) -> "ComponentNameConfig":
         """Gets a default ComponentName."""
         if component_id is None:
-            component_id = ComponentID(name="ComponentName default")
+            component_id = ComponentID(name="ComponentNameDefault")
         return ComponentNameConfig(
             component_id=component_id,
             loadtype=loadtypes.LoadTypes.ELECTRICITY,

--- a/hisim/components/example_transformer.py
+++ b/hisim/components/example_transformer.py
@@ -45,14 +45,14 @@ class ExampleTransformerConfig(ConfigBase):
 
         Args:
             component_id: Structured identity (name, building, unit) of the transformer.
-                Defaults to a building-less identity named ``"Example Transformer default"``.
+                Defaults to a building-less identity named ``"ExampleTransformerDefault"``.
 
         Returns:
             A config with ``LoadTypes.ANY`` / ``Units.ANY`` and the name
-            ``"Example Transformer default"``.
+            ``"ExampleTransformerDefault"``.
         """
         if component_id is None:
-            component_id = ComponentID(name="Example Transformer default")
+            component_id = ComponentID(name="ExampleTransformerDefault")
         return ExampleTransformerConfig(
             component_id=component_id,
             loadtype=lt.LoadTypes.ANY,

--- a/hisim/components/example_transformer.py
+++ b/hisim/components/example_transformer.py
@@ -104,7 +104,7 @@ class ExampleTransformer(Component):
     MODELS_NO_DEVICE: ClassVar[bool] = True
 
     TransformerInput1: str = "Input1"
-    TransformerInput2: str = "Optional Input1"
+    TransformerInput2: str = "OptionalInput1"
     TransformerOutput1: str = "MyTransformerOutput"
     TransformerOutput2: str = "MyTransformerOutput2"
 

--- a/hisim/components/generic_electrolyzer_and_h2_storage.py
+++ b/hisim/components/generic_electrolyzer_and_h2_storage.py
@@ -255,16 +255,16 @@ class AdvancedElectrolyzer(Component):
     """Advanced Electrolyzer class."""
 
     # input
-    ElectricityInput = "Electricity Input"  # W
+    ElectricityInput = "ElectricityInput"  # W
     HydrogenNotStored = "HydrogenNotStored"  # kg/s
     # output
-    WaterDemand = "Water Demand"  # kg/s
-    HydrogenOutput = "Hydrogen Output"  # kg/s
-    OxygenOutput = "Oxygen Output"  # kg/s
-    EnergyLosses = "Energy Losses"  # W
-    UnusedPower = "Unused Power"  # W
-    ElectrolyzerEfficiency = "Electrolyzer Efficiency"  # -
-    PowerLevel = "Power Level"  # %
+    WaterDemand = "WaterDemand"  # kg/s
+    HydrogenOutput = "HydrogenOutput"  # kg/s
+    OxygenOutput = "OxygenOutput"  # kg/s
+    EnergyLosses = "EnergyLosses"  # W
+    UnusedPower = "UnusedPower"  # W
+    ElectrolyzerEfficiency = "ElectrolyzerEfficiency"  # -
+    PowerLevel = "PowerLevel"  # %
     ElectricityRealNeeded = "ElectricityRealNeeded"
 
     def __init__(
@@ -623,18 +623,18 @@ class HydrogenStorage(Component):
     """Hydrogen storage class."""
 
     # input
-    ChargingHydrogenAmount = "Charging Hydrogen Amount"  # kg/s
+    ChargingHydrogenAmount = "ChargingHydrogenAmount"  # kg/s
     DischargingHydrogenAmountTarget = "DischargingHydrogenAmountTarget"  # kg/s
     # output
-    CurrentHydrogenFillLevel = "Current Hydrogen Fill Level Absolute"  # kg
-    CurrentHydrogenFillLevelPercent = "Current Hydrogen Fill Level Percent"  # %
-    StorageDelta = "Storage Delta"  # kg
-    HydrogenNotStored = "Hydrogen Not Stored"  # kg
-    HydrogenNotReleased = "Hydrogen Not Released"  # kg
+    CurrentHydrogenFillLevel = "CurrentHydrogenFillLevelAbsolute"  # kg
+    CurrentHydrogenFillLevelPercent = "CurrentHydrogenFillLevelPercent"  # %
+    StorageDelta = "StorageDelta"  # kg
+    HydrogenNotStored = "HydrogenNotStored"  # kg
+    HydrogenNotReleased = "HydrogenNotReleased"  # kg
 
-    HydrogenStorageEnergyDemand = "Hydrogen Storage Energy Demand"  # W
-    HydrogenLosses = "Hydrogen Losses"  # kg
-    DischargingHydrogenAmountReal = "Discharging Hydrogen Amount Real"  # kg/s
+    HydrogenStorageEnergyDemand = "HydrogenStorageEnergyDemand"  # W
+    HydrogenLosses = "HydrogenLosses"  # kg
+    DischargingHydrogenAmountReal = "DischargingHydrogenAmountReal"  # kg/s
 
     def __init__(
         self,

--- a/hisim/components/generic_heat_pump.py
+++ b/hisim/components/generic_heat_pump.py
@@ -625,7 +625,7 @@ class GenericHeatPumpController(cp.Component):
     """
 
     # Inputs
-    TemperatureMean = "Residence Temperature"
+    TemperatureMean = "ResidenceTemperature"
     ElectricityInput = "ElectricityInput"
 
     # Outputs

--- a/hisim/components/generic_smart_device.py
+++ b/hisim/components/generic_smart_device.py
@@ -59,7 +59,7 @@ class SmartDeviceConfig(ConfigBase):
     ) -> "SmartDeviceConfig":
         """Gets a default config."""
         if component_id is None:
-            component_id = ComponentID(name="Smart Device")
+            component_id = ComponentID(name="SmartDevice")
         return SmartDeviceConfig(
             component_id=component_id,
             identifier="Identifier",

--- a/hisim/components/loadprofilegenerator_utsp_connector.py
+++ b/hisim/components/loadprofilegenerator_utsp_connector.py
@@ -309,14 +309,14 @@ class UtspLpgConnector(cp.Component):
     """
 
     # Inputs
-    WW_MassInput: str = "Warm Water Mass Input"  # kg/s
-    WW_TemperatureInput: str = "Warm Water Temperature Input"  # °C
+    WW_MassInput: str = "WarmWaterMassInput"  # kg/s
+    WW_TemperatureInput: str = "WarmWaterTemperatureInput"  # °C
 
     # Outputs
-    WW_MassOutput: str = "Mass Output"  # kg/s
-    WW_TemperatureOutput: str = "Temperature Output"  # °C
-    EnergyDischarged: str = "Energy Discharged"  # W
-    DemandSatisfied: str = "Demand Satisfied"  # 0 or 1
+    WW_MassOutput: str = "MassOutput"  # kg/s
+    WW_TemperatureOutput: str = "TemperatureOutput"  # °C
+    EnergyDischarged: str = "EnergyDischarged"  # W
+    DemandSatisfied: str = "DemandSatisfied"  # 0 or 1
 
     NumberOfResidents: str = "NumberOfResidents"
     HeatingByResidents: str = "HeatingByResidents"

--- a/hisim/components/random_numbers.py
+++ b/hisim/components/random_numbers.py
@@ -62,7 +62,7 @@ class RandomNumbers(Component):
     # see Component.MODELS_NO_DEVICE.
     MODELS_NO_DEVICE: ClassVar[bool] = True
 
-    RandomOutput: ClassVar[str] = "Random Numbers"
+    RandomOutput: ClassVar[str] = "RandomNumbers"
 
     def __init__(
         self,

--- a/hisim/components/sumbuilder.py
+++ b/hisim/components/sumbuilder.py
@@ -162,8 +162,8 @@ class SumBuilderForTwoInputs(Component):
     # buy and nothing to run. See Component.MODELS_NO_DEVICE.
     MODELS_NO_DEVICE: ClassVar[bool] = True
 
-    SumInput1: str = "Input 1"
-    SumInput2: str = "Input 2"
+    SumInput1: str = "Input1"
+    SumInput2: str = "Input2"
     SumOutput: str = "Sum"
 
     def __init__(
@@ -248,9 +248,9 @@ class SumBuilderForThreeInputs(Component):
     # buy and nothing to run. See Component.MODELS_NO_DEVICE.
     MODELS_NO_DEVICE: ClassVar[bool] = True
 
-    SumInput1: str = "Input 1"
-    SumInput2: str = "Input 2"
-    SumInput3: str = "Input 3"
+    SumInput1: str = "Input1"
+    SumInput2: str = "Input2"
+    SumInput3: str = "Input3"
     SumOutput: str = "Sum"
 
     def __init__(

--- a/hisim/components/transformer_rectifier.py
+++ b/hisim/components/transformer_rectifier.py
@@ -43,7 +43,7 @@ class TransformerConfig(ConfigBase):
     def get_default_transformer_config(cls) -> TransformerConfig:
         """Gets a default ``TransformerConfig`` instance."""
         return TransformerConfig(
-            component_id=ComponentID(name="Generic Transformer and rectifier Unit"), efficiency=0.95
+            component_id=ComponentID(name="GenericTransformerAndRectifier"), efficiency=0.95
         )
 
 

--- a/hisim/config/__init__.py
+++ b/hisim/config/__init__.py
@@ -7,6 +7,10 @@ the other way round:
 
     - :mod:`hisim.config.base` — ``ComponentID``, ``ConfigBase`` and ``DisplayConfig``,
       the three classes every component configuration is built from.
+    - :mod:`hisim.config.names` — ``NameSyntax``: the one identifier grammar a component
+      name, an energy-system file key and a reference all obey, kept here because its two
+      enforcers (``hisim/component.py`` and ``hisim/energy_system/model.py``) sit on
+      opposite sides of the dependency direction and can only share a definition below both.
     - :mod:`hisim.config.presets` — the ``@preset`` and ``@constructor`` decorators
       giving a config class its typed named defaults and named constructors, their
       registries (``presets_of``, ``constructors_of``) and the preset-provenance stamp.
@@ -30,7 +34,7 @@ the other way round:
       a component makes, and the only module here that reads ``hisim.loadtypes``.
 
 The submodules are listed in dependency order, which is also the order this ``__init__``
-imports them: ``presets``, ``laws`` and ``report`` are leaves, ``context`` builds its
+imports them: ``names``, ``presets``, ``laws`` and ``report`` are leaves, ``context`` builds its
 ``Size`` terms from ``laws``, ``sizing`` uses ``laws`` and ``presets`` (to normalize field
 rules and carry the preset stamp onto a resolved copy), ``base`` uses ``context``,
 ``sizing`` and ``presets`` (whose builder-name check it runs from
@@ -61,6 +65,7 @@ fully-qualified path.
 # clean
 
 from hisim.config.base import ComponentID, ConfigBase, DisplayConfig
+from hisim.config.names import NameSyntax
 from hisim.config.presets import (
     BuilderKind,
     ConfigBuilder,
@@ -137,6 +142,7 @@ __all__ = [
     "FactContribution",
     "FieldInfo",
     "Many",
+    "NameSyntax",
     "NothingToSizeError",
     "OwnFields",
     "ParameterInfo",

--- a/hisim/config/base.py
+++ b/hisim/config/base.py
@@ -35,6 +35,7 @@ from dataclasses_json import dataclass_json
 # line. The aliases keep the module-level functions reachable from the identically named
 # ``ConfigBase`` methods that delegate to them.
 from hisim.config.context import SizingContext
+from hisim.config.names import NameSyntax
 from hisim.config.presets import check_builder_declarations
 from hisim.config.sizing import (
     SizedFieldMetadata,
@@ -182,15 +183,24 @@ class ComponentID:
     DEFAULT_BUILDING_LABEL: ClassVar[str] = "BUI1"
 
     def __post_init__(self) -> None:
-        """Validates the identity right after construction.
+        """Validates the identity right after construction, one field at a time.
 
-        The name is the only mandatory part of a component identity, and an empty or
-        whitespace-only name would silently produce an empty or malformed key later on.
-        Rejecting it here turns a confusing downstream naming problem into an immediate,
-        clearly attributable error.
+        Every present field has to be an identifier on its own, because the key joins them
+        verbatim: a building label with a space or a leading digit would make the joined key
+        fail the name rule at component construction with a message blaming the *name* for a
+        string the author never typed. Rejecting each field here means the refusal names the
+        field that is actually wrong, at the moment the identity is created — and a key built
+        from valid identifier fields is an identifier by construction.
+
+        Raises:
+            ValueError: If ``name``, ``building`` or ``unit`` is present and not an
+                identifier; the message names the offending field and the rule it broke.
         """
-        if not isinstance(self.name, str) or not self.name.strip():
-            raise ValueError(f"A ComponentID needs a non-empty name, but got {self.name!r}.")
+        NameSyntax.require_identifier(self.name, "component")
+        if self.building is not None:
+            NameSyntax.require_identifier(self.building, "building label")
+        if self.unit is not None:
+            NameSyntax.require_identifier(self.unit, "unit label")
 
     @property
     def key(self) -> str:

--- a/hisim/config/introspection.py
+++ b/hisim/config/introspection.py
@@ -83,8 +83,10 @@ class PresetInfo:
 
     #: Instance name handed to a preset builder purely to inspect the result. It is never
     #: part of a description and never reaches a simulation; it is spelled unmistakably so
-    #: that it is obvious if it ever leaks into an error message.
-    PROBE_NAME: ClassVar[str] = "<describe-probe>"
+    #: that it is obvious if it ever leaks into an error message — while still being a valid
+    #: identifier, because the builder puts it into a ComponentID and the identity layer
+    #: refuses anything a result column or a declarative file could not carry.
+    PROBE_NAME: ClassVar[str] = "_describe_probe_"
 
     name: str
     canonical: bool

--- a/hisim/config/names.py
+++ b/hisim/config/names.py
@@ -1,0 +1,127 @@
+"""The one identifier rule every name in HiSim obeys, defined where both users can reach it.
+
+A component's runtime name is not decoration. It is the prefix of every output name and
+therefore of every result column, it is the key a declarative energy-system file addresses
+that component by, and it is the string a reference in such a file resolves against. Those
+three roles only stay the same string if the name is a plain identifier, so exactly one
+grammar governs all of them: a letter or underscore followed by letters, digits or
+underscores.
+
+The rule lives in :mod:`hisim.config` rather than next to either of its users because it has
+two of them on opposite sides of the dependency direction. ``hisim/energy_system/model.py``
+enforces it on what an author writes in a file, ``hisim/component.py`` enforces it on what a
+component is constructed with, and the energy-system package already imports the component
+runtime, so the component runtime cannot import back. The configuration package is the
+bottom layer both of them import, which makes it the only place a single definition can sit.
+"""
+
+# clean
+
+from __future__ import annotations
+
+import re
+from typing import Any, ClassVar, Optional, Pattern, TypeGuard
+
+
+class NameSyntax:
+    """The identifier grammar shared by component names, file keys and references.
+
+    The class carries the one pattern a name has to match plus the two character sets whose
+    presence means the author wrote something other than a name at all — a glob pattern or a
+    filesystem path. Both are called out separately when a name is rejected, because "this is
+    not an identifier" is unhelpful feedback for someone who deliberately typed ``pv_*`` or
+    ``../pv`` and needs to be told that patterns and paths are not part of this vocabulary.
+
+    Everything here is a class-level constant or a classmethod; the class is never
+    instantiated and holds no state. It exists to give the rule one name and one home, so
+    that a change to the grammar is a change in a single place rather than in every module
+    that happens to validate a name.
+    """
+
+    #: The one identifier syntax of HiSim names: a letter or underscore, then letters,
+    #: digits or underscores. Used for component names, group names, fact names and port
+    #: names alike, so that a reader never has to remember which allows what.
+    IDENTIFIER_PATTERN: ClassVar[Pattern[str]] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+    #: Characters that only appear in wildcard or glob syntax. Their presence is always
+    #: reported as its own problem rather than as a name failing the pattern: the author
+    #: meant a pattern, and patterns are not part of this vocabulary.
+    WILDCARD_CHARACTERS: ClassVar[str] = "*?[]"
+
+    #: Characters that only appear in filesystem paths. A name identifies a component, never
+    #: a location, so any of them means a path was written where a name belongs.
+    PATH_CHARACTERS: ClassVar[str] = "/\\"
+
+    @classmethod
+    def is_identifier(cls, value: Any) -> TypeGuard[str]:
+        """Reports whether ``value`` is a string that satisfies the identifier grammar.
+
+        This is the plain predicate form of the rule, for callers that want to branch on a
+        name rather than reject it — a schema exporter listing which of a file's keys are
+        addressable, for instance. It is deliberately total: any object may be passed, and
+        anything that is not a matching string simply answers ``False``. The return is a type
+        guard, so a caller that has checked a raw YAML value may go on treating it as a
+        ``str`` without a second ``isinstance`` for the type checker's benefit.
+
+        Args:
+            value: The candidate name. Values of any type are accepted, because names arrive
+                from YAML documents where an unquoted token may have been typed as a number
+                or a boolean before it ever reaches this check.
+
+        Returns:
+            ``True`` if ``value`` is a ``str`` matching :attr:`IDENTIFIER_PATTERN`.
+        """
+        return isinstance(value, str) and cls.IDENTIFIER_PATTERN.match(value) is not None
+
+    @classmethod
+    def explain_violation(cls, value: Any) -> Optional[str]:
+        """Names the specific rule ``value`` breaks, or ``None`` if it breaks none.
+
+        The wording is shared by every caller so that a component rejected at construction
+        time and a file key rejected at load time tell the author the same thing about the
+        same string. The wildcard and path cases are separated from the general case because
+        they are the two mistakes with a distinct intent behind them, and saying "wildcards
+        are not part of this format version" is far more actionable than repeating the
+        character set an identifier may use.
+
+        Args:
+            value: The candidate name, of any type.
+
+        Returns:
+            A short phrase completing "``'x'`` is not a usable name: …", or ``None`` when the
+            value is a well-formed identifier.
+        """
+        if not isinstance(value, str):
+            return f"a name must be a string, not {type(value).__name__}"
+        if not value:
+            return "a name must not be empty"
+        if any(character in value for character in cls.WILDCARD_CHARACTERS):
+            return "wildcards are not part of this vocabulary"
+        if any(character in value for character in cls.PATH_CHARACTERS):
+            return "a name identifies a component, never a path"
+        if cls.IDENTIFIER_PATTERN.match(value) is None:
+            return "a name starts with a letter or underscore and continues with letters, digits or underscores"
+        return None
+
+    @classmethod
+    def require_identifier(cls, value: Any, role: str) -> None:
+        """Raises unless ``value`` is a well-formed name for the given role.
+
+        This is the enforcing form used at the two points where a name becomes real: when a
+        component is constructed with its runtime name, and when a declarative file's key is
+        read. Rejecting there rather than downstream means an unusable name surfaces at the
+        moment it is introduced, with the offending string in the message, instead of as a
+        malformed result column or an unresolvable reference much later.
+
+        Args:
+            value: The candidate name, of any type.
+            role: What the name stands for — ``"component"``, ``"group"``, ``"fact"`` — so the
+                message says which of HiSim's names was rejected.
+
+        Raises:
+            ValueError: If ``value`` is not a string matching :attr:`IDENTIFIER_PATTERN`. The
+                message names the offending string, the role and the rule it broke.
+        """
+        problem = cls.explain_violation(value)
+        if problem is not None:
+            raise ValueError(f"'{value}' is not a usable {role} name: {problem}.")

--- a/hisim/config/names.py
+++ b/hisim/config/names.py
@@ -8,8 +8,9 @@ grammar governs all of them: a letter or underscore followed by letters, digits 
 underscores.
 
 The rule lives in :mod:`hisim.config` rather than next to either of its users because it has
-two of them on opposite sides of the dependency direction. ``hisim/energy_system/model.py``
-enforces it on what an author writes in a file, ``hisim/component.py`` enforces it on what a
+two of them on opposite sides of the dependency direction. ``hisim/energy_system/names.py``
+enforces it on what an author writes in a file — the loader and the entry readers refuse
+their keys and references through it — while ``hisim/component.py`` enforces it on what a
 component is constructed with, and the energy-system package already imports the component
 runtime, so the component runtime cannot import back. The configuration package is the
 bottom layer both of them import, which makes it the only place a single definition can sit.
@@ -107,10 +108,13 @@ class NameSyntax:
     def require_identifier(cls, value: Any, role: str) -> None:
         """Raises unless ``value`` is a well-formed name for the given role.
 
-        This is the enforcing form used at the two points where a name becomes real: when a
-        component is constructed with its runtime name, and when a declarative file's key is
-        read. Rejecting there rather than downstream means an unusable name surfaces at the
-        moment it is introduced, with the offending string in the message, instead of as a
+        This is the enforcing form used where a runtime name becomes real: a component
+        identity's fields, the component's constructed name, and both halves of a port. The
+        declarative file format enforces the same grammar through ``NameRules``, whose
+        refusals carry their own error family but build their wording from
+        :meth:`explain_violation`, so a rejected file key and a rejected runtime name tell
+        the author the same thing about the same string. Rejecting at introduction means an
+        unusable name surfaces with the offending string in the message, instead of as a
         malformed result column or an unresolvable reference much later.
 
         Args:

--- a/hisim/energy_system/names.py
+++ b/hisim/energy_system/names.py
@@ -16,9 +16,9 @@ therefore rejected here, at the one place a name or a reference enters the model
 
 from __future__ import annotations
 
-import re
 from typing import Any, ClassVar, Optional, Pattern, Tuple
 
+from hisim.config import NameSyntax
 from hisim.energy_system.errors import EnergySystemErrorId, EnergySystemFormatError
 
 
@@ -38,16 +38,16 @@ class NameRules:
 
     #: The one identifier syntax of the format, used for component names, group names,
     #: variant and option names, fact names and port names alike.
-    IDENTIFIER_PATTERN: ClassVar[Pattern[str]] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+    IDENTIFIER_PATTERN: ClassVar[Pattern[str]] = NameSyntax.IDENTIFIER_PATTERN
 
     #: Characters that only appear in wildcard or glob syntax. Their presence is always a
     #: rejection rather than a name failing the identifier pattern: the author meant a
     #: pattern, and patterns are not part of this format version.
-    WILDCARD_CHARACTERS: ClassVar[str] = "*?[]"
+    WILDCARD_CHARACTERS: ClassVar[str] = NameSyntax.WILDCARD_CHARACTERS
 
     #: Characters that only appear in filesystem paths. A reference addresses a component
     #: by name, never by location, so any of them means a path was written instead.
-    PATH_CHARACTERS: ClassVar[str] = "/\\"
+    PATH_CHARACTERS: ClassVar[str] = NameSyntax.PATH_CHARACTERS
 
     #: The separator between the two halves of a reference.
     REFERENCE_SEPARATOR: ClassVar[str] = "."
@@ -73,7 +73,7 @@ class NameRules:
             EnergySystemFormatError: ``EF-08`` if the value is not a string or does not
                 match the identifier pattern.
         """
-        if not isinstance(value, str) or cls.IDENTIFIER_PATTERN.match(value) is None:
+        if not NameSyntax.is_identifier(value):
             raise EnergySystemFormatError(
                 EnergySystemErrorId.INVALID_NAME,
                 location,
@@ -119,7 +119,7 @@ class NameRules:
             expected = "'<component>.<fact>'" if require_member else "'<component>' or '<component>.<Output>'"
             raise cls._reference_error(location, value, f"a reference is written {expected}")
         for part in parts:
-            if cls.IDENTIFIER_PATTERN.match(part) is None:
+            if not NameSyntax.is_identifier(part):
                 raise cls._reference_error(location, value, f"'{part}' is not a usable name")
         return parts[0], parts[1] if len(parts) == 2 else None
 

--- a/hisim/energy_system/names.py
+++ b/hisim/energy_system/names.py
@@ -40,16 +40,9 @@ class NameRules:
     #: variant and option names, fact names and port names alike.
     IDENTIFIER_PATTERN: ClassVar[Pattern[str]] = NameSyntax.IDENTIFIER_PATTERN
 
-    #: Characters that only appear in wildcard or glob syntax. Their presence is always a
-    #: rejection rather than a name failing the identifier pattern: the author meant a
-    #: pattern, and patterns are not part of this format version.
-    WILDCARD_CHARACTERS: ClassVar[str] = NameSyntax.WILDCARD_CHARACTERS
-
-    #: Characters that only appear in filesystem paths. A reference addresses a component
-    #: by name, never by location, so any of them means a path was written instead.
-    PATH_CHARACTERS: ClassVar[str] = NameSyntax.PATH_CHARACTERS
-
-    #: The separator between the two halves of a reference.
+    #: The separator between the two halves of a reference. The wildcard and path character
+    #: sets live only on :class:`NameSyntax`; the reference grammar reads them through
+    #: :meth:`NameSyntax.explain_violation`, so the rule and its wording cannot drift.
     REFERENCE_SEPARATOR: ClassVar[str] = "."
 
     @classmethod
@@ -74,10 +67,12 @@ class NameRules:
                 match the identifier pattern.
         """
         if not NameSyntax.is_identifier(value):
+            # is_identifier is the narrowing type guard; explain_violation names the one rule
+            # the value breaks, so the file-side refusal reads exactly like the runtime one.
             raise EnergySystemFormatError(
                 EnergySystemErrorId.INVALID_NAME,
                 location,
-                f"'{value}' is not a usable {role} name.",
+                f"'{value}' is not a usable {role} name: {NameSyntax.explain_violation(value)}.",
                 remedy=(
                     "A name starts with a letter or underscore and continues with "
                     "letters, digits or underscores."
@@ -110,17 +105,16 @@ class NameRules:
         """
         if not isinstance(value, str) or not value:
             raise cls._reference_error(location, value, "a reference must be a non-empty string")
-        if any(character in value for character in cls.WILDCARD_CHARACTERS):
-            raise cls._reference_error(location, value, "wildcards are not part of this format version")
-        if any(character in value for character in cls.PATH_CHARACTERS):
-            raise cls._reference_error(location, value, "a reference names a component, never a path")
         parts = value.split(cls.REFERENCE_SEPARATOR)
         if len(parts) > 2 or (require_member and len(parts) != 2):
             expected = "'<component>.<fact>'" if require_member else "'<component>' or '<component>.<Output>'"
             raise cls._reference_error(location, value, f"a reference is written {expected}")
         for part in parts:
-            if not NameSyntax.is_identifier(part):
-                raise cls._reference_error(location, value, f"'{part}' is not a usable name")
+            # The shared grammar names the specific mistake — a wildcard, a path, an empty
+            # half — so a reference and a runtime name refuse the same string the same way.
+            problem = NameSyntax.explain_violation(part)
+            if problem is not None:
+                raise cls._reference_error(location, value, f"'{part}' is not a usable name: {problem}")
         return parts[0], parts[1] if len(parts) == 2 else None
 
     @classmethod

--- a/hisim/postprocessing/postprocessing_main.py
+++ b/hisim/postprocessing/postprocessing_main.py
@@ -385,7 +385,7 @@ class PostProcessor:
         """Makes special plots for debugging if only a single day was calculated."""
         chart_single_day_class = _load_attribute("hisim.postprocessing.chart_singleday", "ChartSingleDay")
         for index, output in enumerate(ppdt.all_outputs):
-            if output.full_name == "Dummy # Residence Temperature":
+            if output.full_name == "Dummy # ResidenceTemperature":
                 my_days = chart_single_day_class(
                     output=output.full_name,
                     component_name=output.component_name,

--- a/hisim/postprocessing/postprocessing_main.py
+++ b/hisim/postprocessing/postprocessing_main.py
@@ -383,35 +383,23 @@ class PostProcessor:
         report_image_entries: List[ReportImageEntry],
     ) -> None:
         """Makes special plots for debugging if only a single day was calculated."""
+        # A special-case arm once compared full_name against a hard-coded "Dummy" component
+        # that nothing in the repository constructs; the branch could never fire and was
+        # removed rather than have its magic string maintained through every rename.
         chart_single_day_class = _load_attribute("hisim.postprocessing.chart_singleday", "ChartSingleDay")
         for index, output in enumerate(ppdt.all_outputs):
-            if output.full_name == "Dummy # ResidenceTemperature":
-                my_days = chart_single_day_class(
-                    output=output.full_name,
-                    component_name=output.component_name,
-                    units=output.unit,
-                    directory_path=ppdt.simulation_parameters.result_directory,
-                    time_correction_factor_in_hours=ppdt.time_correction_factor_in_hours_per_timestep,
-                    data_with_units=ppdt.results.iloc[:, index],
-                    day=0,
-                    month=0,
-                    output2_with_units=ppdt.results.iloc[:, 11],
-                    output_description=output.output_description,
-                    figure_format=ppdt.simulation_parameters.figure_format,
-                )
-            else:
-                my_days = chart_single_day_class(
-                    output=output.full_name,
-                    component_name=output.component_name,
-                    units=output.unit,
-                    directory_path=ppdt.simulation_parameters.result_directory,
-                    time_correction_factor_in_hours=ppdt.time_correction_factor_in_hours_per_timestep,
-                    data_with_units=ppdt.results.iloc[:, index],
-                    day=0,
-                    month=0,
-                    output_description=output.output_description,
-                    figure_format=ppdt.simulation_parameters.figure_format,
-                )
+            my_days = chart_single_day_class(
+                output=output.full_name,
+                component_name=output.component_name,
+                units=output.unit,
+                directory_path=ppdt.simulation_parameters.result_directory,
+                time_correction_factor_in_hours=ppdt.time_correction_factor_in_hours_per_timestep,
+                data_with_units=ppdt.results.iloc[:, index],
+                day=0,
+                month=0,
+                output_description=output.output_description,
+                figure_format=ppdt.simulation_parameters.figure_format,
+            )
             my_entry = my_days.plot(close=True)
             report_image_entries.append(my_entry)
 

--- a/obsolete/tests/test_advanced_heat_pump_hplib.py
+++ b/obsolete/tests/test_advanced_heat_pump_hplib.py
@@ -87,7 +87,7 @@ def test_heat_pump_hplib() -> None:
 
     # Initialize component
     heatpump_config: HeatPumpHplibConfig = HeatPumpHplibConfig(
-        component_id=ComponentID(name="Heat Pump"),
+        component_id=ComponentID(name="HeatPump"),
         model=model,
         group_id=group_id,
         heating_reference_temperature_in_celsius=t_in,
@@ -155,11 +155,11 @@ def test_get_heatpump_cycles_counts_off_to_on_transitions(time_off_series: list[
     instance = _make_heatpump_instance()
     postprocessing_results = pd.DataFrame({"other": [0] * len(time_off_series), "TimeOff": time_off_series})
     output = cp.ComponentOutput(
-        "Heat Pump",
+        "HeatPump",
         HeatPumpHplib.TimeOff,
         lt.LoadTypes.TIME,
         lt.Units.SECONDS,
-        component_id=ComponentID("Heat Pump"),
+        component_id=ComponentID("HeatPump"),
     )
     assert (
         instance.get_heatpump_cycles(output=output, index=1, postprocessing_results=postprocessing_results)
@@ -174,11 +174,11 @@ def test_get_heatpump_cycles_ignores_non_timeoff_output() -> None:
     # [5, 0, 5, 0] would yield 2 cycles for a TimeOff output; a non-TimeOff output must return 0.
     postprocessing_results = pd.DataFrame({"ThermalOutputPower": [5, 0, 5, 0]})
     output = cp.ComponentOutput(
-        "Heat Pump",
+        "HeatPump",
         HeatPumpHplib.ThermalOutputPower,
         lt.LoadTypes.HEATING,
         lt.Units.WATT,
-        component_id=ComponentID("Heat Pump"),
+        component_id=ComponentID("HeatPump"),
     )
     assert instance.get_heatpump_cycles(output=output, index=0, postprocessing_results=postprocessing_results) == 0
 
@@ -197,11 +197,11 @@ def test_get_heatpump_cycles_propagates_non_index_errors() -> None:
     # _RaisingValue, whose == raises TypeError (not IndexError).
     postprocessing_results = pd.DataFrame({"other": [0, 0, 0], "TimeOff": [5, _RaisingValue(), 0]})
     output = cp.ComponentOutput(
-        "Heat Pump",
+        "HeatPump",
         HeatPumpHplib.TimeOff,
         lt.LoadTypes.TIME,
         lt.Units.SECONDS,
-        component_id=ComponentID("Heat Pump"),
+        component_id=ComponentID("HeatPump"),
     )
     with pytest.raises(TypeError, match="comparison failure should propagate"):
         instance.get_heatpump_cycles(output=output, index=1, postprocessing_results=postprocessing_results)

--- a/system_setups/electrolyzer_with_renewables.py
+++ b/system_setups/electrolyzer_with_renewables.py
@@ -64,7 +64,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     multiplier = 1  # Multiplier factor for amplification (if needed)
 
     # Set transformer and rectifier parameter
-    name = "Standard transformer and rectifier unit"
+    name = "StandardTransformerAndRectifier"
     efficiency = 0.95  # from literature
     loadtype = lt.LoadTypes.ELECTRICITY
     unit = lt.Units.KILOWATT

--- a/system_setups/electrolyzer_with_renewables.scenario.json
+++ b/system_setups/electrolyzer_with_renewables.scenario.json
@@ -7,7 +7,7 @@
             "component_full_classname": "hisim.components.transformer_rectifier.Transformer",
             "configuration": {
                 "component_id": {
-                    "name": "Standard transformer and rectifier unit",
+                    "name": "StandardTransformerAndRectifier",
                     "building": null,
                     "unit": null
                 },
@@ -91,13 +91,13 @@
                 "field_name": "CSV Profile"
             },
             "target": {
-                "component_name": "Standard transformer and rectifier unit",
+                "component_name": "StandardTransformerAndRectifier",
                 "field_name": "Input1"
             }
         },
         {
             "source": {
-                "component_name": "Standard transformer and rectifier unit",
+                "component_name": "StandardTransformerAndRectifier",
                 "field_name": "MyTransformerOutput"
             },
             "target": {

--- a/system_setups/electrolyzer_with_renewables.scenario.json
+++ b/system_setups/electrolyzer_with_renewables.scenario.json
@@ -88,7 +88,7 @@
         {
             "source": {
                 "component_name": "CSV",
-                "field_name": "CSV Profile"
+                "field_name": "CSVProfile"
             },
             "target": {
                 "component_name": "StandardTransformerAndRectifier",

--- a/system_setups/simple_system_setup_one.py
+++ b/system_setups/simple_system_setup_one.py
@@ -34,7 +34,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     # Create first RandomNumbers object and adds to simulator
     my_rn1 = RandomNumbers(
         config=RandomNumbersConfig(
-            component_id=ComponentID(name="Random numbers 100-200"),
+            component_id=ComponentID(name="RandomNumbers100To200"),
             timesteps=my_simulation_parameters.timesteps,
             minimum=100,
             maximum=200,
@@ -46,7 +46,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     # Create second RandomNumbers object and adds to simulator
     my_rn2 = RandomNumbers(
         config=RandomNumbersConfig(
-            component_id=ComponentID(name="Random numbers 10-20"),
+            component_id=ComponentID(name="RandomNumbers10To20"),
             timesteps=my_simulation_parameters.timesteps,
             minimum=10,
             maximum=20,

--- a/system_setups/simple_system_setup_one.scenario.json
+++ b/system_setups/simple_system_setup_one.scenario.json
@@ -7,7 +7,7 @@
             "component_full_classname": "hisim.components.random_numbers.RandomNumbers",
             "configuration": {
                 "component_id": {
-                    "name": "Random numbers 100-200",
+                    "name": "RandomNumbers100To200",
                     "building": null,
                     "unit": null
                 },
@@ -24,7 +24,7 @@
             "component_full_classname": "hisim.components.random_numbers.RandomNumbers",
             "configuration": {
                 "component_id": {
-                    "name": "Random numbers 10-20",
+                    "name": "RandomNumbers10To20",
                     "building": null,
                     "unit": null
                 },
@@ -57,7 +57,7 @@
     "connections": [
         {
             "source": {
-                "component_name": "Random numbers 100-200",
+                "component_name": "RandomNumbers100To200",
                 "field_name": "Random Numbers"
             },
             "target": {
@@ -67,7 +67,7 @@
         },
         {
             "source": {
-                "component_name": "Random numbers 10-20",
+                "component_name": "RandomNumbers10To20",
                 "field_name": "Random Numbers"
             },
             "target": {

--- a/system_setups/simple_system_setup_one.scenario.json
+++ b/system_setups/simple_system_setup_one.scenario.json
@@ -58,21 +58,21 @@
         {
             "source": {
                 "component_name": "RandomNumbers100To200",
-                "field_name": "Random Numbers"
+                "field_name": "RandomNumbers"
             },
             "target": {
                 "component_name": "Sum",
-                "field_name": "Input 1"
+                "field_name": "Input1"
             }
         },
         {
             "source": {
                 "component_name": "RandomNumbers10To20",
-                "field_name": "Random Numbers"
+                "field_name": "RandomNumbers"
             },
             "target": {
                 "component_name": "Sum",
-                "field_name": "Input 2"
+                "field_name": "Input2"
             }
         }
     ]

--- a/system_setups/simple_system_setup_two.py
+++ b/system_setups/simple_system_setup_two.py
@@ -41,7 +41,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     # Create first RandomNumbers object and adds to simulator
     my_rn1 = RandomNumbers(
         config=RandomNumbersConfig(
-            component_id=ComponentID(name="Random numbers 100-200"),
+            component_id=ComponentID(name="RandomNumbers100To200"),
             timesteps=my_simulation_parameters.timesteps,
             minimum=100,
             maximum=200,
@@ -53,7 +53,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     # Create second RandomNumbers object and adds to simulator
     my_rn2 = RandomNumbers(
         config=RandomNumbersConfig(
-            component_id=ComponentID(name="Random numbers 10-20"),
+            component_id=ComponentID(name="RandomNumbers10To20"),
             timesteps=my_simulation_parameters.timesteps,
             minimum=10,
             maximum=20,

--- a/system_setups/simple_system_setup_two.scenario.json
+++ b/system_setups/simple_system_setup_two.scenario.json
@@ -74,7 +74,7 @@
         {
             "source": {
                 "component_name": "RandomNumbers10To20",
-                "field_name": "Random Numbers"
+                "field_name": "RandomNumbers"
             },
             "target": {
                 "component_name": "ExampleTransformerDefault",
@@ -84,11 +84,11 @@
         {
             "source": {
                 "component_name": "RandomNumbers100To200",
-                "field_name": "Random Numbers"
+                "field_name": "RandomNumbers"
             },
             "target": {
                 "component_name": "Sum",
-                "field_name": "Input 1"
+                "field_name": "Input1"
             }
         },
         {
@@ -98,7 +98,7 @@
             },
             "target": {
                 "component_name": "Sum",
-                "field_name": "Input 2"
+                "field_name": "Input2"
             }
         }
     ]

--- a/system_setups/simple_system_setup_two.scenario.json
+++ b/system_setups/simple_system_setup_two.scenario.json
@@ -7,7 +7,7 @@
             "component_full_classname": "hisim.components.random_numbers.RandomNumbers",
             "configuration": {
                 "component_id": {
-                    "name": "Random numbers 100-200",
+                    "name": "RandomNumbers100To200",
                     "building": null,
                     "unit": null
                 },
@@ -24,7 +24,7 @@
             "component_full_classname": "hisim.components.random_numbers.RandomNumbers",
             "configuration": {
                 "component_id": {
-                    "name": "Random numbers 10-20",
+                    "name": "RandomNumbers10To20",
                     "building": null,
                     "unit": null
                 },
@@ -41,7 +41,7 @@
             "component_full_classname": "hisim.components.example_transformer.ExampleTransformer",
             "configuration": {
                 "component_id": {
-                    "name": "Example Transformer default",
+                    "name": "ExampleTransformerDefault",
                     "building": null,
                     "unit": null
                 },
@@ -73,17 +73,17 @@
     "connections": [
         {
             "source": {
-                "component_name": "Random numbers 10-20",
+                "component_name": "RandomNumbers10To20",
                 "field_name": "Random Numbers"
             },
             "target": {
-                "component_name": "Example Transformer default",
+                "component_name": "ExampleTransformerDefault",
                 "field_name": "Input1"
             }
         },
         {
             "source": {
-                "component_name": "Random numbers 100-200",
+                "component_name": "RandomNumbers100To200",
                 "field_name": "Random Numbers"
             },
             "target": {
@@ -93,7 +93,7 @@
         },
         {
             "source": {
-                "component_name": "Example Transformer default",
+                "component_name": "ExampleTransformerDefault",
                 "field_name": "MyTransformerOutput"
             },
             "target": {

--- a/tests/test_component_id.py
+++ b/tests/test_component_id.py
@@ -6,7 +6,9 @@ hashable value object, that it survives a JSON round trip as a nested object ins
 configuration, and that the derived name no longer depends on the ``multiple_buildings``
 simulation parameter. They also cover the postprocessing grouping helpers that replaced the
 former name-substring matching, so that a district-style setup can be verified without
-running a full district simulation.
+running a full district simulation. A final section covers the identifier rule the runtime
+name has to satisfy, and that the declarative file format enforces the very same rule from
+the very same definition.
 """
 
 # clean
@@ -20,8 +22,9 @@ from dataclasses_json import dataclass_json
 
 from hisim import component as cp
 from hisim import loadtypes as lt
-from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.config import ConfigBase, ComponentID, DisplayConfig, NameSyntax
 from hisim.components import example_component
+from hisim.energy_system.model import NameRules
 from hisim.simulationparameters import SimulationParameters
 
 
@@ -212,11 +215,11 @@ def test_default_factories_produce_building_less_identities() -> None:
     """
     config = example_component.ExampleComponentConfig.get_default_example_component()
     assert config.component_id.building is None
-    assert config.component_id.key == "Example Component"
+    assert config.component_id.key == "ExampleComponent"
 
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     component = example_component.ExampleComponent(config=config, my_simulation_parameters=sim_params)
-    assert component.get_component_name() == "Example Component"
+    assert component.get_component_name() == "ExampleComponent"
     assert component.component_id is config.component_id
 
 
@@ -225,7 +228,7 @@ def test_outputs_carry_the_identity_of_their_component() -> None:
     """Every output records the identity of the component that produced it."""
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     config = example_component.ExampleComponentConfig.get_default_example_component(
-        component_id=ComponentID(name="Example Component", building="BUI2")
+        component_id=ComponentID(name="ExampleComponent", building="BUI2")
     )
     component = example_component.ExampleComponent(config=config, my_simulation_parameters=sim_params)
     assert component.outputs
@@ -269,9 +272,9 @@ def test_district_style_setup_groups_by_building() -> None:
     """
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
     identities = [
-        ComponentID(name="Example Component", building="BUI1"),
-        ComponentID(name="Example Component", building="BUI2"),
-        ComponentID(name="Example Component", building=lt.DistrictNames.DISTRICT.value),
+        ComponentID(name="ExampleComponent", building="BUI1"),
+        ComponentID(name="ExampleComponent", building="BUI2"),
+        ComponentID(name="ExampleComponent", building=lt.DistrictNames.DISTRICT.value),
     ]
     components = [
         example_component.ExampleComponent(
@@ -282,9 +285,9 @@ def test_district_style_setup_groups_by_building() -> None:
     ]
 
     assert [component.get_component_name() for component in components] == [
-        "BUI1_Example Component",
-        "BUI2_Example Component",
-        "District_Example Component",
+        "BUI1_ExampleComponent",
+        "BUI2_ExampleComponent",
+        "District_ExampleComponent",
     ]
 
     building_objects = {component.component_id.building_label for component in components}
@@ -296,3 +299,60 @@ def test_district_style_setup_groups_by_building() -> None:
     for component in components:
         for output in component.outputs:
             assert output.building_label == component.component_id.building
+
+
+# --------------------------------------------------------------------------- #
+# The identifier rule on the runtime name
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.base
+def test_a_component_refuses_a_runtime_name_that_is_not_an_identifier() -> None:
+    """Constructing a component with a name that is not a plain identifier fails immediately.
+
+    The runtime name is the prefix of every result column and the key a declarative
+    energy-system file addresses the component by, so a name with a space or a hyphen in it
+    cannot be expressed by a file at all. ``Component.__init__`` is the one place that name
+    becomes real, and rejecting there means the mistake surfaces where it was made rather
+    than as an unwritable recording much later.
+    """
+    sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    config = example_component.ExampleComponentConfig.get_default_example_component(
+        component_id=ComponentID(name="Example Component")
+    )
+    with pytest.raises(ValueError) as rejection:
+        example_component.ExampleComponent(config=config, my_simulation_parameters=sim_params)
+    assert "Example Component" in str(rejection.value)
+    assert "component name" in str(rejection.value)
+
+
+@pytest.mark.base
+def test_the_identifier_rule_names_the_specific_mistake() -> None:
+    """Each way of getting a name wrong is reported as itself, not as one generic message.
+
+    A glob pattern and a filesystem path are deliberate acts, not typos, so telling their
+    author that patterns and paths are not part of the vocabulary is far more useful than
+    repeating which characters an identifier may contain.
+    """
+    NameSyntax.require_identifier("Pv_South_1", "component")
+    with pytest.raises(ValueError, match="wildcards are not part of this vocabulary"):
+        NameSyntax.require_identifier("pv_*", "component")
+    with pytest.raises(ValueError, match="never a path"):
+        NameSyntax.require_identifier("../pv", "component")
+    with pytest.raises(ValueError, match="must not be empty"):
+        NameSyntax.require_identifier("", "component")
+    with pytest.raises(ValueError, match="must be a string"):
+        NameSyntax.require_identifier(3, "component")
+
+
+@pytest.mark.base
+def test_the_file_format_and_the_component_runtime_share_one_identifier_rule() -> None:
+    """The energy-system format's name grammar is the same object the component runtime uses.
+
+    Two copies of one regular expression would drift, and a name accepted at construction but
+    refused as a file key — or the reverse — is exactly the failure the shared definition
+    exists to make impossible.
+    """
+    assert NameRules.IDENTIFIER_PATTERN is NameSyntax.IDENTIFIER_PATTERN
+    assert NameRules.WILDCARD_CHARACTERS == NameSyntax.WILDCARD_CHARACTERS
+    assert NameRules.PATH_CHARACTERS == NameSyntax.PATH_CHARACTERS

--- a/tests/test_component_id.py
+++ b/tests/test_component_id.py
@@ -24,6 +24,7 @@ from hisim import component as cp
 from hisim import loadtypes as lt
 from hisim.config import ConfigBase, ComponentID, DisplayConfig, NameSyntax
 from hisim.components import example_component
+from hisim.energy_system.errors import EnergySystemFormatError
 from hisim.energy_system.model import NameRules
 from hisim.simulationparameters import SimulationParameters
 
@@ -307,23 +308,62 @@ def test_district_style_setup_groups_by_building() -> None:
 
 
 @pytest.mark.base
-def test_a_component_refuses_a_runtime_name_that_is_not_an_identifier() -> None:
-    """Constructing a component with a name that is not a plain identifier fails immediately.
+def test_a_component_id_refuses_every_field_that_is_not_an_identifier() -> None:
+    """A ComponentID with a non-identifier name, building or unit fails at construction, by field.
 
-    The runtime name is the prefix of every result column and the key a declarative
-    energy-system file addresses the component by, so a name with a space or a hyphen in it
-    cannot be expressed by a file at all. ``Component.__init__`` is the one place that name
-    becomes real, and rejecting there means the mistake surfaces where it was made rather
-    than as an unwritable recording much later.
+    The key joins the present fields verbatim, so a building label with a space or a leading
+    digit would make the joined key fail the name rule later — at component construction, with
+    a message blaming the *name* for a string the author never typed. Refusing each field where
+    the identity is created names the field that is actually wrong.
+    """
+    with pytest.raises(ValueError, match="component name"):
+        ComponentID(name="Example Component")
+    with pytest.raises(ValueError, match="building label"):
+        ComponentID(name="Weather", building="BUI 1")
+    with pytest.raises(ValueError, match="building label"):
+        ComponentID(name="Weather", building="101")
+    with pytest.raises(ValueError, match="unit label"):
+        ComponentID(name="HeatPump", building="BUI1", unit="APT 2")
+    assert ComponentID(name="HeatPump", building="BUI1", unit="APT2").key == "BUI1_APT2_HeatPump"
+
+
+@pytest.mark.base
+def test_a_component_refuses_a_runtime_name_that_is_not_an_identifier() -> None:
+    """The runtime name passed to ``Component.__init__`` is checked as the last line of defence.
+
+    Every in-tree caller passes the already-validated ``component_id.key``, but the name is a
+    plain argument and a direct construction could pass anything; the key check is what keeps
+    the two from diverging silently.
     """
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    config = example_component.ExampleComponentConfig.get_default_example_component(
-        component_id=ComponentID(name="Example Component")
-    )
+    config = example_component.ExampleComponentConfig.get_default_example_component()
     with pytest.raises(ValueError) as rejection:
-        example_component.ExampleComponent(config=config, my_simulation_parameters=sim_params)
-    assert "Example Component" in str(rejection.value)
+        cp.Component(
+            name="Bad Name",
+            my_simulation_parameters=sim_params,
+            my_config=config,
+            my_display_config=DisplayConfig(),
+        )
+    assert "Bad Name" in str(rejection.value)
     assert "component name" in str(rejection.value)
+
+
+@pytest.mark.base
+def test_a_port_refuses_a_field_or_object_name_that_is_not_an_identifier() -> None:
+    """Both halves of a port's full name are held to the identifier rule at construction.
+
+    The field name becomes the dotted half of ``from: <component>.<port>`` in a declarative
+    file, and the object name is the column prefix; a port nobody could reference or a prefix
+    that defeats the rule must fail when the port is built, not years later when something
+    first tries to write the system down.
+    """
+    identity = ComponentID(name="Source")
+    with pytest.raises(ValueError, match="component output"):
+        cp.ComponentOutput("Source", "Bad Port", lt.LoadTypes.ELECTRICITY, lt.Units.WATT, component_id=identity)
+    with pytest.raises(ValueError, match="component input"):
+        cp.ComponentInput("Source", "Bad Port", lt.LoadTypes.ELECTRICITY, lt.Units.WATT, True)
+    with pytest.raises(ValueError, match="component name"):
+        cp.ComponentOutput("Bad Prefix", "Out", lt.LoadTypes.ELECTRICITY, lt.Units.WATT, component_id=identity)
 
 
 @pytest.mark.base
@@ -347,12 +387,28 @@ def test_the_identifier_rule_names_the_specific_mistake() -> None:
 
 @pytest.mark.base
 def test_the_file_format_and_the_component_runtime_share_one_identifier_rule() -> None:
-    """The energy-system format's name grammar is the same object the component runtime uses.
+    """The two enforcers accept and refuse the same strings with the same explanation.
 
-    Two copies of one regular expression would drift, and a name accepted at construction but
-    refused as a file key — or the reverse — is exactly the failure the shared definition
-    exists to make impossible.
+    A name accepted at construction but refused as a file key — or the reverse — is exactly
+    the failure the shared definition exists to make impossible, so this feeds the same
+    strings through both enforcers instead of asserting how the modules are wired: a drift in
+    actual behaviour fails here even if the wiring still looks shared.
     """
+    NameSyntax.require_identifier("Pv_South_1", "component")
+    assert NameRules.check_identifier("Pv_South_1", "key", "component") == "Pv_South_1"
+
+    for bad, phrase in (
+        ("pv 1", "letter or underscore"),
+        ("pv_*", "wildcards are not part of this vocabulary"),
+        ("../pv", "never a path"),
+    ):
+        with pytest.raises(ValueError, match=phrase):
+            NameSyntax.require_identifier(bad, "component")
+        with pytest.raises(EnergySystemFormatError, match=phrase):
+            NameRules.check_identifier(bad, "some.key", "component")
+
+    with pytest.raises(EnergySystemFormatError, match="wildcards are not part of this vocabulary"):
+        NameRules.split_reference("pv_*.Output", "some.key", require_member=False)
+
+    # The exporter publishes the pattern itself, so the object stays shared, not copied.
     assert NameRules.IDENTIFIER_PATTERN is NameSyntax.IDENTIFIER_PATTERN
-    assert NameRules.WILDCARD_CHARACTERS == NameSyntax.WILDCARD_CHARACTERS
-    assert NameRules.PATH_CHARACTERS == NameSyntax.PATH_CHARACTERS

--- a/tests/test_controller_l1_example_controller.py
+++ b/tests/test_controller_l1_example_controller.py
@@ -46,15 +46,19 @@ def test_get_default_config_custom_building() -> None:
 
 
 @pytest.mark.base
-def test_get_default_config_empty_building() -> None:
-    """An empty building is accepted unchanged (no coercion/rejection)."""
-    config = SimpleControllerConfig.get_default_config(component_id=ComponentID(name="SimpleController", building=""))
-    _assert_defaults(config, "")
+def test_get_default_config_empty_building_is_refused() -> None:
+    """An empty building label is refused at the identity, naming the field.
+
+    Passed through, it would silently join into a key with a leading underscore — a component
+    nobody addressed that way — so the identity layer refuses it where it is written.
+    """
+    with pytest.raises(ValueError, match="building label"):
+        ComponentID(name="SimpleController", building="")
 
 
 @pytest.mark.base
 def test_get_default_config_arbitrary_building() -> None:
-    """``get_default_config`` forwards any string as the building."""
+    """``get_default_config`` forwards any identifier as the building."""
     config = SimpleControllerConfig.get_default_config(
         component_id=ComponentID(name="SimpleController", building="haus42")
     )

--- a/tests/test_controller_l1_generic_electrolyzer.py
+++ b/tests/test_controller_l1_generic_electrolyzer.py
@@ -16,7 +16,7 @@ def test_electrolyzer_controller() -> None:
     seconds_per_timestep = 60
     my_simulation_parameters = SimulationParameters.one_day_only(2021, seconds_per_timestep)
 
-    name: str = "Test-Controller"
+    name: str = "TestController"
     nom_load: float = 800.0  # [kW]
     min_load: float = 300.0  # [kW]
     max_load: float = 1000.0  # [kW]

--- a/tests/test_controller_l1_generic_electrolyzer.py
+++ b/tests/test_controller_l1_generic_electrolyzer.py
@@ -46,7 +46,7 @@ def test_electrolyzer_controller() -> None:
     # Set Fake Inputs
     load_input = cp.ComponentOutput(
         "FakeProvidedLoad",
-        "Provided Load",
+        "ProvidedLoad",
         lt.LoadTypes.ELECTRICITY,
         lt.Units.KILOWATT,
         component_id=ComponentID("FakeProvidedLoad"),

--- a/tests/test_controller_l1_rsoc.py
+++ b/tests/test_controller_l1_rsoc.py
@@ -47,7 +47,7 @@ def test_config_rsoc_from_in_memory_dict() -> None:
         rsoc_name="RSOC_TEST", config_json=_make_rsoc_config_dict()
     )
     assert config.component_id.building is None
-    assert config.component_id.name == "rSCO l1 Controller"
+    assert config.component_id.name == "RscoL1Controller"
     assert config.nom_load_soec == 40.0
     assert config.min_load_soec == 2.315
     assert config.max_load_soec == 49.64
@@ -67,7 +67,7 @@ def test_config_rsoc_building_override_and_defaults() -> None:
     """config_rsoc forwards the component identity and applies defaults for missing keys."""
     config = controller_l1_rsoc.RsocControllerConfig.config_rsoc(
         rsoc_name="RSOC_TEST",
-        component_id=ComponentID(name="rSCO l1 Controller", building="BUI2"),
+        component_id=ComponentID(name="RscoL1Controller", building="BUI2"),
         config_json={"nom_load_soec": 40.0},
     )
     assert config.component_id.building == "BUI2"

--- a/tests/test_controller_l2_rsoc_battery_system.py
+++ b/tests/test_controller_l2_rsoc_battery_system.py
@@ -44,7 +44,7 @@ def test_config_rsoc_from_in_memory_dict() -> None:
         config_data=_make_rsoc_config_dict(),
     )
     assert config.component_id.building is None
-    assert config.component_id.name == "rSOC and Battery Controller"
+    assert config.component_id.name == "RsocAndBatteryController"
     assert config.nom_load_soec_in_kw == 40.0
     assert config.min_load_soec_in_kw == 2.315
     assert config.max_load_soec_in_kw == 49.64
@@ -61,7 +61,7 @@ def test_config_rsoc_building_override_and_defaults() -> None:
     config = l2.RsocBatteryControllerConfig.config_rsoc(
         rsoc_name="RSOC_TEST",
         operation_mode="MinimumLoad",
-        component_id=ComponentID(name="rSOC and Battery Controller", building="BUI2"),
+        component_id=ComponentID(name="RsocAndBatteryController", building="BUI2"),
         config_data={"nom_load_soec": 40.0},
     )
     assert config.component_id.building == "BUI2"
@@ -162,7 +162,7 @@ def _make_legacy_serialized_payload() -> dict[str, object]:
     ``field_name`` aliases on the renamed dataclass must keep loading them.
     """
     return {
-        "component_id": {"name": "rSOC and Battery Controller", "building": None, "unit": None},
+        "component_id": {"name": "RsocAndBatteryController", "building": None, "unit": None},
         "nom_load_soec_in_kW": 40.0,
         "min_load_soec_in_kW": 2.315,
         "max_load_soec_in_kW": 49.64,

--- a/tests/test_example_component.py
+++ b/tests/test_example_component.py
@@ -35,7 +35,7 @@ def test_example_component() -> None:
     # Define outputs
     thermal_energy_delivered_output = cp.ComponentOutput(
         object_name="source",
-        field_name="thermal energy delivered",
+        field_name="ThermalEnergyDelivered",
         load_type=lt.LoadTypes.HEATING,
         unit=lt.Units.WATT,
         component_id=ComponentID("source"),

--- a/tests/test_example_template.py
+++ b/tests/test_example_template.py
@@ -86,7 +86,7 @@ def test_get_default_template_component_no_args() -> None:
     """``get_default_template_component`` returns hardcoded defaults when called with no arguments."""
     config = example_template.ComponentNameConfig.get_default_template_component()
     assert config.component_id.building is None
-    assert config.component_id.name == "ComponentName default"
+    assert config.component_id.name == "ComponentNameDefault"
     assert config.loadtype == lt.LoadTypes.ELECTRICITY
     assert config.unit == lt.Units.WATT
 
@@ -95,10 +95,10 @@ def test_get_default_template_component_no_args() -> None:
 def test_get_default_template_component_custom_building() -> None:
     """Passing a component_id with a building only changes that; all other fields keep defaults."""
     config = example_template.ComponentNameConfig.get_default_template_component(
-        component_id=ComponentID(name="ComponentName default", building="MyHouse")
+        component_id=ComponentID(name="ComponentNameDefault", building="MyHouse")
     )
     assert config.component_id.building == "MyHouse"
-    assert config.component_id.name == "ComponentName default"
+    assert config.component_id.name == "ComponentNameDefault"
     assert config.loadtype == lt.LoadTypes.ELECTRICITY
     assert config.unit == lt.Units.WATT
 
@@ -107,10 +107,10 @@ def test_get_default_template_component_custom_building() -> None:
 def test_get_default_template_component_empty_building() -> None:
     """An empty building is passed through without validation."""
     config = example_template.ComponentNameConfig.get_default_template_component(
-        component_id=ComponentID(name="ComponentName default", building="")
+        component_id=ComponentID(name="ComponentNameDefault", building="")
     )
     assert config.component_id.building == ""
-    assert config.component_id.name == "ComponentName default"
+    assert config.component_id.name == "ComponentNameDefault"
     assert config.loadtype == lt.LoadTypes.ELECTRICITY
     assert config.unit == lt.Units.WATT
 

--- a/tests/test_example_template.py
+++ b/tests/test_example_template.py
@@ -104,15 +104,14 @@ def test_get_default_template_component_custom_building() -> None:
 
 
 @pytest.mark.base
-def test_get_default_template_component_empty_building() -> None:
-    """An empty building is passed through without validation."""
-    config = example_template.ComponentNameConfig.get_default_template_component(
-        component_id=ComponentID(name="ComponentNameDefault", building="")
-    )
-    assert config.component_id.building == ""
-    assert config.component_id.name == "ComponentNameDefault"
-    assert config.loadtype == lt.LoadTypes.ELECTRICITY
-    assert config.unit == lt.Units.WATT
+def test_get_default_template_component_empty_building_is_refused() -> None:
+    """An empty building label is refused at the identity, naming the field.
+
+    Passed through, it would silently join into a key with a leading underscore — a component
+    nobody addressed that way — so the identity layer refuses it where it is written.
+    """
+    with pytest.raises(ValueError, match="building label"):
+        ComponentID(name="ComponentNameDefault", building="")
 
 
 @pytest.mark.base

--- a/tests/test_generic_price_signal.py
+++ b/tests/test_generic_price_signal.py
@@ -54,13 +54,14 @@ def test_get_default_price_signal_config_custom_building() -> None:
 
 
 @pytest.mark.base
-def test_get_default_price_signal_config_empty_building() -> None:
-    """An empty building is accepted unchanged (no coercion/rejection)."""
-    config = PriceSignalConfig.get_default_price_signal_config(
-        component_id=ComponentID(name="PriceSignal", building="")
-    )
-    assert isinstance(config, PriceSignalConfig)
-    _assert_defaults(config, "")
+def test_get_default_price_signal_config_empty_building_is_refused() -> None:
+    """An empty building label is refused at the identity, naming the field.
+
+    Passed through, it would silently join into a key with a leading underscore — a component
+    nobody addressed that way — so the identity layer refuses it where it is written.
+    """
+    with pytest.raises(ValueError, match="building label"):
+        ComponentID(name="PriceSignal", building="")
 
 
 @pytest.mark.base

--- a/tests/test_more_advanced_heat_pump_hplib.py
+++ b/tests/test_more_advanced_heat_pump_hplib.py
@@ -92,7 +92,7 @@ def test_heat_pump_hplib_new() -> None:
 
     # Initialize component
     heatpump_config = MoreAdvancedHeatPumpHPLibConfig(
-        component_id=ComponentID(name="Heat Pump"),
+        component_id=ComponentID(name="HeatPump"),
         model=model,
         fluid_primary_side="air",
         group_id=group_id,

--- a/tests/test_more_advanced_heat_pump_hplib_only_sh.py
+++ b/tests/test_more_advanced_heat_pump_hplib_only_sh.py
@@ -70,7 +70,7 @@ def test_heat_pump_hplib_new() -> None:
 
     # Initialize component
     heatpump_config = MoreAdvancedHeatPumpHPLibConfig(
-        component_id=ComponentID(name="Heat Pump"),
+        component_id=ComponentID(name="HeatPump"),
         model=model,
         fluid_primary_side="air",
         group_id=group_id,

--- a/tests/test_system_chart_build_graph.py
+++ b/tests/test_system_chart_build_graph.py
@@ -84,10 +84,10 @@ def _real_nodes(graph: pydot.Dot) -> list:
 def _two_component_setup() -> PostProcessingDataTransfer:
     """A Source -> Controller wiring used by several tests."""
     source = _FakeComponent("Source")
-    controller = _FakeComponent("Controller Thing")
+    controller = _FakeComponent("ControllerThing")
     output = ComponentOutput("Source", "Out", LoadTypes.ANY, Units.WATT, component_id=ComponentID("Source"))
     controller_input = _make_input(
-        target_name="Controller Thing",
+        target_name="ControllerThing",
         field_name="In",
         unit=Units.WATT,
         src_object_name="Source",
@@ -117,7 +117,7 @@ def test_build_graph_creates_one_node_per_component() -> None:
     chart = SystemChart(_two_component_setup())
     graph = chart._build_graph(with_labels=False, with_class_names=False, with_results=False)
     names = sorted(n.get_name() for n in _real_nodes(graph))
-    assert names == ["Controller Thing", "Source"]
+    assert names == ["ControllerThing", "Source"]
 
 
 @pytest.mark.base
@@ -127,7 +127,7 @@ def test_build_graph_controller_fillcolor_selection() -> None:
     graph = chart._build_graph(with_labels=False, with_class_names=False, with_results=False)
     fillcolors = {n.get_name(): n.get("fillcolor") for n in _real_nodes(graph)}
     assert fillcolors["Source"] == "darkgray"
-    assert fillcolors["Controller Thing"] == "lightgray"
+    assert fillcolors["ControllerThing"] == "lightgray"
 
 
 @pytest.mark.base
@@ -138,7 +138,7 @@ def test_build_graph_with_class_names_appends_class() -> None:
     names = {n.get_name() for n in _real_nodes(graph)}
     # The class name of the fake component is appended after a newline.
     assert "Source\n_FakeComponent" in names
-    assert "Controller Thing\n_FakeComponent" in names
+    assert "ControllerThing\n_FakeComponent" in names
 
 
 @pytest.mark.base
@@ -149,20 +149,20 @@ def test_build_graph_edge_without_label() -> None:
     edges = graph.get_edges()
     assert len(edges) == 1
     assert edges[0].get_source() == "Source"
-    assert edges[0].get_destination() == "Controller Thing"
+    assert edges[0].get_destination() == "ControllerThing"
     assert edges[0].get("label") in (None, "")
 
 
 @pytest.mark.base
 def test_build_graph_edge_label_format_and_celsius_replacement() -> None:
     """Edge labels combine src-field, target-field and unit, and replace °C with &#8451;."""
-    controller = _FakeComponent("Controller Thing")
+    controller = _FakeComponent("ControllerThing")
     boiler = _FakeComponent("Boiler")
     celsius_input = _make_input(
         target_name="Boiler",
         field_name="TemperatureIn",
         unit=Units.CELSIUS,
-        src_object_name="Controller Thing",
+        src_object_name="ControllerThing",
         src_field_name="TemperatureOut",
     )
     ppdt = _make_ppdt(
@@ -232,10 +232,10 @@ def test_build_graph_with_results_appends_cumulative_value() -> None:
 def _make_two_component_ppdt(output_unit: Units) -> PostProcessingDataTransfer:
     """Build a Source -> Controller wiring whose output uses ``output_unit``."""
     source = _FakeComponent("Source")
-    controller = _FakeComponent("Controller Thing")
+    controller = _FakeComponent("ControllerThing")
     output = ComponentOutput("Source", "Out", LoadTypes.ANY, output_unit, component_id=ComponentID("Source"))
     controller_input = _make_input(
-        target_name="Controller Thing",
+        target_name="ControllerThing",
         field_name="In",
         unit=output_unit,
         src_object_name="Source",
@@ -311,13 +311,13 @@ def test_build_graph_with_results_celsius_mean_annotation() -> None:
 @pytest.mark.base
 def test_build_graph_with_results_without_source_output_omits_value() -> None:
     """An input lacking a ComponentOutput source gets no cumulative value appended."""
-    controller = _FakeComponent("Controller Thing")
+    controller = _FakeComponent("ControllerThing")
     boiler = _FakeComponent("Boiler")
     input_no_output = _make_input(
         target_name="Boiler",
         field_name="In",
         unit=Units.WATT,
-        src_object_name="Controller Thing",
+        src_object_name="ControllerThing",
         src_field_name="Out",
         source_output=None,
     )

--- a/tests/test_transformer_rectifier.py
+++ b/tests/test_transformer_rectifier.py
@@ -29,7 +29,7 @@ def test_get_default_transformer_config_returns_config_with_documented_defaults(
     config = TransformerConfig.get_default_transformer_config()
     assert isinstance(config, TransformerConfig)
     assert config.component_id.building is None
-    assert config.component_id.name == "Generic Transformer and rectifier Unit"
+    assert config.component_id.name == "GenericTransformerAndRectifier"
     assert config.efficiency == pytest.approx(0.95)
 
 


### PR DESCRIPTION
Extracted from #598 (1/7). The stack replaces that PR; merge order is 1 to 7, each PR based on the previous branch.

## Problem
A declarative energy-system file addresses components and ports as identifiers (`from: <component>.<port>`), but four component names and a handful of port names in the fleet were not identifiers, and nothing stopped new ones from appearing.

## Done
The four non-identifier component names are renamed, and the rule is enforced where a name becomes real: `ComponentID` for component names, `ComponentOutput`/`ComponentInput` construction for port names. Scenario JSONs are regenerated; the regeneration reproduces the committed files exactly.

## Result
A name nobody could reference in a declarative file fails the moment the class declaring it is built, instead of when something first tries to write that system down. This is the one seam with breaking-change character: downstream code addressing the renamed components or ports by their old names must follow the rename.

## Breaking, deliberately

Every renamed port and component name is a hard break for setup code outside this repository:
setups wire by exact string and result-CSV columns carry the names, and there is no deprecation
shim — accepting the old names for a transition period would re-admit exactly the non-identifier
state this PR exists to end. Everything in-repo (setups, scenario JSONs, tests, golden
references) is updated and verified clean of the old spellings; external setup authors rename at
upgrade time, with construction-time errors naming each offending string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
