### PR TITLE
Give the CHP the KPI entries that kept a whole setup out of
  the golden gate

### DIFF
--- a/hisim/components/advanced_fuel_cell.py
+++ b/hisim/components/advanced_fuel_cell.py
@@ -15,7 +15,7 @@ from hisim.component import Component, SingleTimeStepValues, ComponentInput, Com
 from hisim import loadtypes as lt
 
 from hisim.components.configuration import PhysicsConfig
-from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiTagEnumClass
+from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiHelperClass, KpiTagEnumClass
 from hisim import utils
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
@@ -661,6 +661,12 @@ class CHP(Component):
 
         Returns:
             List[KpiEntry]: the four entries, tagged as CHP.
+
+        Raises:
+            ValueError: When one of the four output columns is not found for this component, is
+                empty, or carries NaN — pandas would silently drop NaN from a sum and an all-NaN
+                column would report zero, so a KPI is either computed from complete values or
+                refused by name, never reported wrongly in silence.
         """
         seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep
         electrical_energy_in_kilowatt_hour = None
@@ -672,13 +678,19 @@ class CHP(Component):
                 continue
             column = postprocessing_results.iloc[:, index]
             if output.field_name == self.ElectricityOutput and output.unit == lt.Units.WATT:
-                electrical_energy_in_kilowatt_hour = round(float(column.sum()) * seconds_per_timestep / 3600 * 1e-3, 3)
+                electrical_energy_in_kilowatt_hour = self._energy_in_kilowatt_hour(
+                    self._checked_column(column, "Electrical energy produced"), seconds_per_timestep
+                )
             elif output.field_name == self.ThermalOutputPower and output.unit == lt.Units.WATT:
-                thermal_energy_in_kilowatt_hour = round(float(column.sum()) * seconds_per_timestep / 3600 * 1e-3, 3)
+                thermal_energy_in_kilowatt_hour = self._energy_in_kilowatt_hour(
+                    self._checked_column(column, "Thermal energy produced"), seconds_per_timestep
+                )
             elif output.field_name == self.GasDemandReal and output.unit == lt.Units.KG_PER_SEC:
-                fuel_consumed_in_kg = round(float(column.sum()) * seconds_per_timestep, 6)
-            elif output.field_name == self.NumberofCycles:
-                number_of_cycles = float(column.iloc[-1])
+                fuel_consumed_in_kg = round(
+                    float(self._checked_column(column, "Fuel consumed").sum()) * seconds_per_timestep, 6
+                )
+            elif output.field_name == self.NumberofCycles and output.unit == lt.Units.ANY:
+                number_of_cycles = float(self._checked_column(column, "Number of activation cycles").iloc[-1])
 
         entries = [
             ("Electrical energy produced", "kWh", electrical_energy_in_kilowatt_hour),
@@ -693,9 +705,57 @@ class CHP(Component):
                     f"{self.component_name}; the KPI cannot be reported as absent silently."
                 )
         return [
-            KpiEntry(name=name, unit=unit, value=value, tag=KpiTagEnumClass.CHP, description=self.component_name)
+            KpiEntry(
+                name=name,
+                unit=unit,
+                value=value,
+                tag=KpiTagEnumClass.CHP,
+                description=self.component_name,
+                name_of_source_component=self.component_name,
+            )
             for name, unit, value in entries
         ]
+
+    def _checked_column(self, column: pd.Series, kpi_name: str) -> pd.Series:
+        """Returns a KPI's column only when every value in it is real.
+
+        pandas drops NaN from a sum by default, so an output that was present but never written
+        would report zero energy instead of failing, and a NaN in the last row would make the
+        cycle count literally NaN — both are the silent absence the missing-output guard exists
+        to prevent, arriving through the values instead of through the column list.
+
+        Args:
+            column: The output's per-timestep values.
+            kpi_name: The KPI the column feeds, for the refusal.
+
+        Returns:
+            The column, unchanged.
+
+        Raises:
+            ValueError: When the column is empty or carries NaN.
+        """
+        if column.empty or bool(column.isna().any()):
+            raise ValueError(
+                f"The CHP output for the KPI '{kpi_name}' of {self.component_name} is "
+                f"{'empty' if column.empty else 'carrying NaN'}; the KPI would be silently wrong "
+                "rather than absent, so it is refused instead."
+            )
+        return column
+
+    @staticmethod
+    def _energy_in_kilowatt_hour(column: pd.Series, seconds_per_timestep: int) -> float:
+        """Integrates one power column to energy, through the one shared conversion.
+
+        Args:
+            column: The power values in watt, one per timestep.
+            seconds_per_timestep: The constant timestep length.
+
+        Returns:
+            The energy in kilowatt-hours, rounded to the three decimals the entries declare.
+        """
+        return round(
+            KpiHelperClass.compute_total_energy_from_power_timeseries(column, seconds_per_timestep), 3
+        )
 
     def write_to_report(self) -> List[str]:
         """Write to report."""

--- a/hisim/components/advanced_fuel_cell.py
+++ b/hisim/components/advanced_fuel_cell.py
@@ -15,6 +15,7 @@ from hisim.component import Component, SingleTimeStepValues, ComponentInput, Com
 from hisim import loadtypes as lt
 
 from hisim.components.configuration import PhysicsConfig
+from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiTagEnumClass
 from hisim import utils
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
@@ -639,6 +640,62 @@ class CHP(Component):
 
         stsv.set_output_value(self.gas_demand_target_channel, gas_demand_target)  # CHP runs with
         stsv.set_output_value(self.gas_demand_real_used_channel, gas_demand_real_used)  # ThermalPowerOutput
+
+    def get_component_kpi_entries(
+        self,
+        all_outputs: List[ComponentOutput],
+        postprocessing_results: pd.DataFrame,
+    ) -> List[KpiEntry]:
+        """Calculates KPIs for the CHP and returns all KPI entries as a list.
+
+        Four indicators describe what the unit did over the simulated period: the electrical
+        and thermal energy it produced, integrated from its power outputs; the fuel mass it
+        actually burned, integrated from the real fuel draw (not the requested one, which can
+        differ when the storage cannot deliver); and how many on/off cycles it went through,
+        read as the final value of its cumulative cycle counter. Cycles are an indicator of
+        their own because wear grows with switching, not with runtime.
+
+        Args:
+            all_outputs: every output column of the run, searched for this component's by name.
+            postprocessing_results: the per-timestep values of those columns.
+
+        Returns:
+            List[KpiEntry]: the four entries, tagged as CHP.
+        """
+        seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep
+        electrical_energy_in_kilowatt_hour = None
+        thermal_energy_in_kilowatt_hour = None
+        fuel_consumed_in_kg = None
+        number_of_cycles = None
+        for index, output in enumerate(all_outputs):
+            if output.component_name != self.component_name:
+                continue
+            column = postprocessing_results.iloc[:, index]
+            if output.field_name == self.ElectricityOutput and output.unit == lt.Units.WATT:
+                electrical_energy_in_kilowatt_hour = round(float(column.sum()) * seconds_per_timestep / 3600 * 1e-3, 3)
+            elif output.field_name == self.ThermalOutputPower and output.unit == lt.Units.WATT:
+                thermal_energy_in_kilowatt_hour = round(float(column.sum()) * seconds_per_timestep / 3600 * 1e-3, 3)
+            elif output.field_name == self.GasDemandReal and output.unit == lt.Units.KG_PER_SEC:
+                fuel_consumed_in_kg = round(float(column.sum()) * seconds_per_timestep, 6)
+            elif output.field_name == self.NumberofCycles:
+                number_of_cycles = float(column.iloc[-1])
+
+        entries = [
+            ("Electrical energy produced", "kWh", electrical_energy_in_kilowatt_hour),
+            ("Thermal energy produced", "kWh", thermal_energy_in_kilowatt_hour),
+            ("Fuel consumed", "kg", fuel_consumed_in_kg),
+            ("Number of activation cycles", "-", number_of_cycles),
+        ]
+        for name, unit, value in entries:
+            if value is None:
+                raise ValueError(
+                    f"The CHP output for the KPI '{name}' was not found among the run's columns for "
+                    f"{self.component_name}; the KPI cannot be reported as absent silently."
+                )
+        return [
+            KpiEntry(name=name, unit=unit, value=value, tag=KpiTagEnumClass.CHP, description=self.component_name)
+            for name, unit, value in entries
+        ]
 
     def write_to_report(self) -> List[str]:
         """Write to report."""

--- a/hisim/postprocessing/kpi_computation/kpi_structure.py
+++ b/hisim/postprocessing/kpi_computation/kpi_structure.py
@@ -18,6 +18,7 @@ class KpiTagEnumClass(Enum):
     BUILDING = "Building"
     AIR_CONDITIONER = "Air Conditioner"
     BATTERY = "Battery"
+    CHP = "CHP"
     HEAT_DISTRIBUTION_SYSTEM = "Heat Distribution System"
     HEATPUMP_SPACE_HEATING = "Heat Pump For Space Heating"
     HEATPUMP_DOMESTIC_HOT_WATER = "Heat Pump For Domestic Hot Water"

--- a/tests/test_advanced_fuel_cell.py
+++ b/tests/test_advanced_fuel_cell.py
@@ -5,6 +5,7 @@
 import math
 from typing import NamedTuple
 
+import pandas as pd
 import pytest
 
 from hisim import component as cp
@@ -13,6 +14,7 @@ from hisim import loadtypes as lt
 from hisim import log
 from hisim.simulationparameters import SimulationParameters
 from hisim.config import ComponentID
+from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass
 from tests import functions_for_testing as fft
 
 
@@ -243,3 +245,54 @@ def test_chp_state_defaults() -> None:
     # Negative electricity output is rejected.
     with pytest.raises(ValueError, match="Impossible CHPState"):
         advanced_fuel_cell.CHPState(electricity_output=-1.0)
+
+
+@pytest.mark.base
+def test_chp_kpi_entries_integrate_the_period() -> None:
+    """The four CHP KPIs integrate power to energy, mass flow to mass, and read the final cycle count.
+
+    Two timesteps of 60 s at 3000 W electrical and 4000 W thermal are 0.1 kWh electrical and
+    (4000+4000)*60/3600/1000 kWh thermal; a fuel draw of 0.001 kg/s over both steps is 0.12 kg; a
+    cycle counter ending at 2 reports 2 cycles. The values are computed here by hand, so a broken
+    integration cannot agree with itself.
+    """
+    setup = build_chp_system(operating_mode="electricity", gas_type="Methan")
+    chp = setup.chp
+    outputs = [
+        chp.el_power_channel,
+        chp.th_power_channel,
+        chp.gas_demand_real_used_channel,
+        chp.number_of_cycles_channel,
+    ]
+    frame = pd.DataFrame(
+        {
+            0: [3000.0, 3000.0],
+            1: [4000.0, 4000.0],
+            2: [0.001, 0.001],
+            3: [1.0, 2.0],
+        }
+    )
+
+    entries = {entry.name: entry for entry in chp.get_component_kpi_entries(outputs, frame)}
+
+    assert entries["Electrical energy produced"].value == pytest.approx(round(3000.0 * 2 * 60 / 3600 / 1000, 3))
+    assert entries["Thermal energy produced"].value == pytest.approx(round(4000.0 * 2 * 60 / 3600 / 1000, 3))
+    assert entries["Fuel consumed"].value == pytest.approx(round(0.001 * 2 * 60, 6))
+    assert entries["Number of activation cycles"].value == 2.0
+    assert all(entry.tag is KpiTagEnumClass.CHP for entry in entries.values())
+    assert all(isinstance(entry.value, float) for entry in entries.values()), (
+        "a numpy scalar here would crash the KPI json writer"
+    )
+
+
+@pytest.mark.base
+def test_chp_kpi_entries_refuse_a_missing_output() -> None:
+    """A KPI whose output column is absent raises naming the KPI instead of reporting nothing.
+
+    Catches: a renamed output silently dropping its KPI from every future reference.
+    """
+    setup = build_chp_system(operating_mode="electricity", gas_type="Methan")
+    chp = setup.chp
+
+    with pytest.raises(ValueError, match="Electrical energy produced"):
+        chp.get_component_kpi_entries([chp.th_power_channel], pd.DataFrame({0: [4000.0]}))

--- a/tests/test_advanced_fuel_cell.py
+++ b/tests/test_advanced_fuel_cell.py
@@ -2,6 +2,7 @@
 
 # clean
 
+import json
 import math
 from typing import NamedTuple
 
@@ -255,6 +256,75 @@ def test_chp_kpi_entries_integrate_the_period() -> None:
     (4000+4000)*60/3600/1000 kWh thermal; a fuel draw of 0.001 kg/s over both steps is 0.12 kg; a
     cycle counter ending at 2 reports 2 cycles. The values are computed here by hand, so a broken
     integration cannot agree with itself.
+
+    A foreign component's 'ElectricityOutput' column in watt is prepended the way the real caller
+    hands the whole run's outputs over, because the component_name filter is what keeps the CHP
+    from summing another device's power — a mutation dropping that filter must fail here, not in
+    a live setup.
+    """
+    setup = build_chp_system(operating_mode="electricity", gas_type="Methan")
+    chp = setup.chp
+    foreign = cp.ComponentOutput(
+        "PVSystem",
+        "ElectricityOutput",
+        lt.LoadTypes.ELECTRICITY,
+        lt.Units.WATT,
+        component_id=ComponentID(name="PVSystem"),
+    )
+    outputs = [
+        foreign,
+        chp.el_power_channel,
+        chp.th_power_channel,
+        chp.gas_demand_real_used_channel,
+        chp.number_of_cycles_channel,
+    ]
+    frame = pd.DataFrame(
+        {
+            0: [5000.0, 5000.0],
+            1: [3000.0, 3000.0],
+            2: [4000.0, 4000.0],
+            3: [0.001, 0.001],
+            4: [1.0, 2.0],
+        }
+    )
+
+    entries = {entry.name: entry for entry in chp.get_component_kpi_entries(outputs, frame)}
+
+    assert entries["Electrical energy produced"].value == pytest.approx(round(3000.0 * 2 * 60 / 3600 / 1000, 3))
+    assert entries["Thermal energy produced"].value == pytest.approx(round(4000.0 * 2 * 60 / 3600 / 1000, 3))
+    assert entries["Fuel consumed"].value == pytest.approx(round(0.001 * 2 * 60, 6))
+    assert entries["Number of activation cycles"].value == 2.0
+    assert all(entry.tag is KpiTagEnumClass.CHP for entry in entries.values())
+    assert all(entry.name_of_source_component == chp.component_name for entry in entries.values()), (
+        "the source component is the disambiguator a future multi-CHP collision fix keys on"
+    )
+    for entry in entries.values():
+        json.dumps(entry.to_dict())  # the webtool writer serializes exactly this; it must not raise
+
+
+@pytest.mark.base
+def test_chp_kpi_entries_refuse_a_missing_output() -> None:
+    """A KPI whose output column is absent raises naming the KPI instead of reporting nothing.
+
+    Catches: an output dropped from the run's column list silently dropping its KPI. (A consistent
+    rename would update the matcher and the channel together — both read the same ClassVar — so a
+    rename is not what this guards; absence is.)
+    """
+    setup = build_chp_system(operating_mode="electricity", gas_type="Methan")
+    chp = setup.chp
+
+    with pytest.raises(ValueError, match="Electrical energy produced"):
+        chp.get_component_kpi_entries([chp.th_power_channel], pd.DataFrame({0: [4000.0]}))
+
+
+@pytest.mark.base
+def test_chp_kpi_entries_refuse_nan_instead_of_understating() -> None:
+    """A NaN in a KPI column raises instead of being silently dropped from the sum.
+
+    pandas sums with skipna by default, so an all-NaN column is 0.0 and a partial NaN column
+    understates the energy while looking exactly like a real value — the silent absence the
+    missing-output guard exists to prevent, arriving through the values. Never reachable in a
+    normal run (outputs initialize to 0.0), which is why it must be loud when it does happen.
     """
     setup = build_chp_system(operating_mode="electricity", gas_type="Methan")
     chp = setup.chp
@@ -266,33 +336,12 @@ def test_chp_kpi_entries_integrate_the_period() -> None:
     ]
     frame = pd.DataFrame(
         {
-            0: [3000.0, 3000.0],
+            0: [3000.0, float("nan")],
             1: [4000.0, 4000.0],
             2: [0.001, 0.001],
             3: [1.0, 2.0],
         }
     )
 
-    entries = {entry.name: entry for entry in chp.get_component_kpi_entries(outputs, frame)}
-
-    assert entries["Electrical energy produced"].value == pytest.approx(round(3000.0 * 2 * 60 / 3600 / 1000, 3))
-    assert entries["Thermal energy produced"].value == pytest.approx(round(4000.0 * 2 * 60 / 3600 / 1000, 3))
-    assert entries["Fuel consumed"].value == pytest.approx(round(0.001 * 2 * 60, 6))
-    assert entries["Number of activation cycles"].value == 2.0
-    assert all(entry.tag is KpiTagEnumClass.CHP for entry in entries.values())
-    assert all(isinstance(entry.value, float) for entry in entries.values()), (
-        "a numpy scalar here would crash the KPI json writer"
-    )
-
-
-@pytest.mark.base
-def test_chp_kpi_entries_refuse_a_missing_output() -> None:
-    """A KPI whose output column is absent raises naming the KPI instead of reporting nothing.
-
-    Catches: a renamed output silently dropping its KPI from every future reference.
-    """
-    setup = build_chp_system(operating_mode="electricity", gas_type="Methan")
-    chp = setup.chp
-
     with pytest.raises(ValueError, match="Electrical energy produced"):
-        chp.get_component_kpi_entries([chp.th_power_channel], pd.DataFrame({0: [4000.0]}))
+        chp.get_component_kpi_entries(outputs, frame)


### PR DESCRIPTION
Unblocks the second-to-last setup for the golden week gate (see `roadmap/p3_cleanup_todos.md`, stage 2).

## Problem
`dynamic_components` could not compute KPIs at all: the advanced fuel cell raised `NotImplementedError` for its KPI entries, refusing the whole run. The CHP is a device with real indicators, so #616's models-no-device default is not for it.

## Done
`CHP.get_component_kpi_entries` reports the four indicators that describe what the unit did: electrical and thermal energy produced (integrated from its power outputs), fuel actually consumed (integrated from the real draw, not the requested one), and the number of activation cycles (the final value of its cumulative counter — wear grows with switching, not runtime). Values are plain floats, deliberately: a numpy scalar crashes the KPI json writer, which the probe run demonstrated. A missing output refuses loudly naming the KPI. `KpiTagEnumClass` gains the CHP tag; two hand-computed tests pin the integration math and the refusal.

## Result
The setup computes 57 KPIs end to end and joins the golden week gate with a blessing once this merges (on the `golden_week_coverage` PR or a follow-up). Two findings recorded in the todos rather than papered over: both CHPs idle through the probe window (honest zeros), and two same-class components in one building still collapse into one flattened KPI group — a pre-existing collision the setup's two batteries already exhibit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
