### PR TITLE
Refuse the zero-share trap fleet-wide, and write down the grouping worklist

### DIFF
--- a/roadmap/declarative_energy_systems/grouping_worklist.md
+++ b/roadmap/declarative_energy_systems/grouping_worklist.md
@@ -1,0 +1,109 @@
+# Grouping the fleet: the worklist
+
+An inventory of every configuration-dependent branch and condition in the 22 recorded setups
+(read 2026-09-06, on the grouping branch), taken as the plan for grouping the whole fleet the way
+`household_heatpump_building_sizer` was grouped. The generated state of the work lives in
+[grouping_overview.md](grouping_overview.md); this file says what is left, what it costs, and what
+has to be fixed before a grouping can be honest. Line numbers are from the inventory date and will
+drift; the named constructs will not.
+
+## The map
+
+Eleven of the twelve config-driven setups are one file with the heat generator swapped ("the sizer
+skeleton"): the same module-config read with a silent-fallback probe, the same archetype-driven
+sizing cascade, one structural fork (`use_battery_and_ems` — the energy manager and the battery
+against a directly fed meter), and, until fixed, the same silent zero-share coupling. The twelfth,
+`simple_air_conditioner_household_building_sizer`, reads no energy-system field and has no fork.
+`household_gas_solar_thermal` is a hidden thirteenth config consumer: it demands an energy-system
+config, ignores all four of its fields, and reads one archetype value
+(`number_of_dwellings_per_building`).
+
+| Setup | sizer? | structural forks | non-config hazards | zero-share coupling |
+|---|---|---|---|---|
+| `simple_system_setup_one` / `_two` | no | 0 | 0 | n.a. |
+| `default_connections` | no | 0 | 0 | n.a. |
+| `basic_household` | no | 0 | 0 | n.a. |
+| `basic_household_only_heating` | no | 0 | 0 | n.a. |
+| `dynamic_components` | no | 0 | 0 | n.a. |
+| `electrolyzer_with_renewables` | no | 0 | 1 (bundled CSV) | n.a. |
+| `automatic_default_connections` | no | 1 (hplib-Group wire-or-raise) | 1 (hplib DB content) | n.a. |
+| `air_conditioned_house` | no | 0 | 1 (reference-temp CSV; duplicated Seville) | n.a. |
+| `household_gas_solar_thermal` | hidden | 0 | 1 (module-config probe) | no |
+| `simple_air_conditioner_household_building_sizer` | yes | 0 | 1 (module-config probe) | n.a. |
+| `household_gas_building_sizer` | yes | 1 (EMS/battery) | 4 | fixed |
+| `household_oil_building_sizer` | yes | 1 | 4 | fixed |
+| `household_pellets_building_sizer` | yes | 1 | 4 | fixed |
+| `household_wood_chips_building_sizer` | yes | 1 | 4 | fixed |
+| `household_hydrogen_boiler_building_sizer` | yes | 1 | 4 | fixed |
+| `household_district_heating_building_sizer` | yes | 1 | 4 | fixed |
+| `household_electric_heating_building_sizer` | yes | 1 (no HDS axis at all) | 4 | fixed |
+| `household_gas_solar_thermal_building_sizer` | yes | 1 | 4 | fixed |
+| `household_heatpump_solar_thermal_building_sizer` | yes | 2 (+ hplib-Group) | 5 | fixed |
+| `household_heatpump_car_building_sizer` | yes | 3 (+ hplib-Group, surplus charging) | 6 | fixed |
+| `household_heatpump_building_sizer` | yes | 2 (+ hplib-Group) | 5 | fixed — **grouped** |
+
+## Fixes owed before or during the grouping
+
+- [x] **The zero-share refusal, fleet-wide** (found 2026-09-06). The silent coupling
+  `if share_of_maximum_pv_potential != 0 and use_battery_and_ems:` — a zero share switching off
+  the battery and the energy manager as a side effect — existed verbatim in all eleven large
+  sizers. Fixed for the heat pump first, then replicated across the other ten with one
+  parametrized refusal test; done on this branch.
+- [ ] **The module-config probe swallows every read error.** `read_in_configs`
+  (`hisim/building_sizer_utils/interface_configs/modular_household_config.py`, the
+  catch-everything fallback) makes a missing file, a typo'd path, a JSON syntax error and a schema
+  mismatch indistinguishable from "no config given": the run silently simulates the shipped
+  default household with only a warning between them. Narrow it to "no config given" and let a
+  config that exists but cannot be read refuse.
+- [ ] **`hasattr(Households, name)` drops a typo'd LPG household silently** (sizer skeleton), so a
+  misspelled name quietly builds a smaller household. Refuse the unknown name instead.
+- [ ] **Nine sizers mutate `my_sim.my_module_config` to a dict on the fallback path**; the two
+  heat-pump sizers do not, so downstream readers see a different type depending on the sibling.
+  One behavior for all eleven.
+- [ ] **Four sizers ignore `weather_filepath`/`weather_datasource`**
+  (gas_solar_thermal_building_sizer, heatpump_car, heatpump_solar_thermal, hydrogen): the same
+  archetype config yields a different weather source across the fleet. Either read them or refuse
+  them.
+- [ ] **`household_heatpump_car_building_sizer`, EMS off**: the cars are built but nothing feeds
+  their charging power to the electricity meter, so EV load leaves the balance entirely. Decide
+  whether that world is legal before its grouping states it.
+- [ ] **`air_conditioned_house` duplicates its location** (a `"Seville"` string for the PV beside
+  `LocationEnum.SEVILLE` for the weather); one edit without the other silently desynchronizes the
+  two. One spelling, one place.
+
+## Environment couplings a recording has to pin, not fix
+
+The two `/benchtop/2024-k-rieck-hisim/` existence probes (inputs cache and LPG cache) and the
+local-LPG requirement decide input provenance per machine; the hplib-Group fork branches on the
+heat-pump database rather than on configuration (wire `TemperatureInputPrimary` to weather for
+groups 1 and 4, `KeyError` otherwise — also in the non-sizer `automatic_default_connections`).
+None of these is a grouping decision, but each is a reason a recording or a probe run can differ
+between machines, so the grouping of an affected setup names them rather than discovering them.
+
+## The grouping order
+
+1. - [ ] **The eight boiler-family sizers as one job** (gas, oil, pellets, wood_chips, hydrogen,
+   district_heating, gas_solar_thermal, electric_heating): the identical skeleton means one probe
+   list pattern and one judgement pattern, adjusted per file only for the known divergences —
+   electric heating has no heat-distribution axis, district heating alone emits the two plot
+   options, four ignore the weather-source fields.
+2. - [ ] **`household_heatpump_solar_thermal_building_sizer`**: two structural forks and a
+   nonstandard skeleton (hand-wired controllers added after the EMS branch, its own component
+   order).
+3. - [ ] **`household_heatpump_car_building_sizer`**, last and hardest: three interacting forks,
+   the `car_surplus_charging` literal that is at once a knob and a fork, and a component count
+   that is a property of the occupancy dataset rather than of any configuration — the grouped
+   format has no spelling for that today.
+4. - [ ] **The nine trivial setups** (`simple_system_setup_one`/`_two`, `default_connections`,
+   `basic_household`, `basic_household_only_heating`, `dynamic_components`,
+   `electrolyzer_with_renewables`, `simple_air_conditioner_household_building_sizer`,
+   `household_gas_solar_thermal`): single configuration, no forks — group whenever convenient;
+   their overview sections already state the whole inventory.
+5. - [ ] **`automatic_default_connections` and `air_conditioned_house`**: small, but each carries
+   one environment coupling (hplib database; reference-temperature CSV plus the duplicated
+   location) to pin first.
+
+One axis is shared by all 22 and belongs to no single setup: every `setup_function` invents its
+own parameters when `my_simulation_parameters is None`, so the no-parameters-file path is a
+configuration of its own. The recorded twins all pin an explicit parameters file, which is the
+right answer; the axis is named here so nobody mistakes the twins for covering it.

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -119,6 +119,17 @@ def setup_function(
     arche_type_config_ = my_config.archetype_config_
     energy_system_config_ = my_config.energy_system_config_
 
+    # A rooftop share of zero used to switch off the battery and the energy management system as a
+    # side effect further down, so the run silently became the metered household while the config
+    # still said otherwise. Refuse the combination here, before a single component is built.
+    if energy_system_config_.share_of_maximum_pv_potential == 0 and energy_system_config_.use_battery_and_ems:
+        raise ValueError(
+            "share_of_maximum_pv_potential is 0 while use_battery_and_ems is true. The zero share used to "
+            "switch off the battery and the energy manager as a side effect, so this configuration silently "
+            "built the metered household instead of the one it asked for. Set use_battery_and_ems to false to "
+            "build the metered household explicitly, or give share_of_maximum_pv_potential a value above zero."
+        )
+
     # Set Simulation Parameters
     default_year = 2021
     if my_simulation_parameters is None:
@@ -417,8 +428,9 @@ def setup_function(
         config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
     )
 
-    # use ems and battery only when PV is used
-    if share_of_maximum_pv_potential != 0 and energy_system_config_.use_battery_and_ems:
+    # The battery and the energy manager are one decision. A zero rooftop share can no longer reach
+    # this point with the manager switched on: it is refused at the top of the setup.
+    if energy_system_config_.use_battery_and_ems:
 
         # Build EMS
         my_electricity_controller_config = (
@@ -477,7 +489,7 @@ def setup_function(
         my_sim.add_component(my_advanced_battery)
         my_sim.add_component(my_electricity_controller, connect_automatically=True)
 
-    # when no PV is used, connect electricty meter automatically
+    # without an energy manager, connect the electricity meter automatically to every participant
     else:
         my_sim.add_component(my_electricity_meter, connect_automatically=True)
 

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -86,6 +86,17 @@ def setup_function(
     arche_type_config_ = my_config.archetype_config_
     energy_system_config_ = my_config.energy_system_config_
 
+    # A rooftop share of zero used to switch off the battery and the energy management system as a
+    # side effect further down, so the run silently became the metered household while the config
+    # still said otherwise. Refuse the combination here, before a single component is built.
+    if energy_system_config_.share_of_maximum_pv_potential == 0 and energy_system_config_.use_battery_and_ems:
+        raise ValueError(
+            "share_of_maximum_pv_potential is 0 while use_battery_and_ems is true. The zero share used to "
+            "switch off the battery and the energy manager as a side effect, so this configuration silently "
+            "built the metered household instead of the one it asked for. Set use_battery_and_ems to false to "
+            "build the metered household explicitly, or give share_of_maximum_pv_potential a value above zero."
+        )
+
     # Set Simulation Parameters
     default_year = 2021
     if my_simulation_parameters is None:
@@ -320,8 +331,9 @@ def setup_function(
         config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
     )
 
-    # use ems and battery only when PV is used
-    if share_of_maximum_pv_potential != 0 and energy_system_config_.use_battery_and_ems:
+    # The battery and the energy manager are one decision. A zero rooftop share can no longer reach
+    # this point with the manager switched on: it is refused at the top of the setup.
+    if energy_system_config_.use_battery_and_ems:
 
         # Build EMS
         my_electricity_controller_config = (
@@ -380,7 +392,7 @@ def setup_function(
         my_sim.add_component(my_advanced_battery)
         my_sim.add_component(my_electricity_controller, connect_automatically=True)
 
-    # when no PV is used, connect electricty meter automatically
+    # without an energy manager, connect the electricity meter automatically to every participant
     else:
         my_sim.add_component(my_electricity_meter, connect_automatically=True)
 

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -86,6 +86,17 @@ def setup_function(
     arche_type_config_ = my_config.archetype_config_
     energy_system_config_ = my_config.energy_system_config_
 
+    # A rooftop share of zero used to switch off the battery and the energy management system as a
+    # side effect further down, so the run silently became the metered household while the config
+    # still said otherwise. Refuse the combination here, before a single component is built.
+    if energy_system_config_.share_of_maximum_pv_potential == 0 and energy_system_config_.use_battery_and_ems:
+        raise ValueError(
+            "share_of_maximum_pv_potential is 0 while use_battery_and_ems is true. The zero share used to "
+            "switch off the battery and the energy manager as a side effect, so this configuration silently "
+            "built the metered household instead of the one it asked for. Set use_battery_and_ems to false to "
+            "build the metered household explicitly, or give share_of_maximum_pv_potential a value above zero."
+        )
+
     # Set Simulation Parameters
     default_year = 2021
     if my_simulation_parameters is None:
@@ -393,8 +404,9 @@ def setup_function(
     )
     my_sim.add_component(my_gas_meter, connect_automatically=True)
 
-    # use ems and battery only when PV is used
-    if share_of_maximum_pv_potential != 0 and energy_system_config_.use_battery_and_ems:
+    # The battery and the energy manager are one decision. A zero rooftop share can no longer reach
+    # this point with the manager switched on: it is refused at the top of the setup.
+    if energy_system_config_.use_battery_and_ems:
 
         # Build EMS
         my_electricity_controller_config = (
@@ -453,7 +465,7 @@ def setup_function(
         my_sim.add_component(my_advanced_battery)
         my_sim.add_component(my_electricity_controller, connect_automatically=True)
 
-    # when no PV is used, connect electricty meter automatically
+    # without an energy manager, connect the electricity meter automatically to every participant
     else:
         my_sim.add_component(my_electricity_meter, connect_automatically=True)
 

--- a/system_setups/household_gas_solar_thermal_building_sizer.py
+++ b/system_setups/household_gas_solar_thermal_building_sizer.py
@@ -84,6 +84,17 @@ def setup_function(
     arche_type_config_ = my_config.archetype_config_
     energy_system_config_ = my_config.energy_system_config_
 
+    # A rooftop share of zero used to switch off the battery and the energy management system as a
+    # side effect further down, so the run silently became the metered household while the config
+    # still said otherwise. Refuse the combination here, before a single component is built.
+    if energy_system_config_.share_of_maximum_pv_potential == 0 and energy_system_config_.use_battery_and_ems:
+        raise ValueError(
+            "share_of_maximum_pv_potential is 0 while use_battery_and_ems is true. The zero share used to "
+            "switch off the battery and the energy manager as a side effect, so this configuration silently "
+            "built the metered household instead of the one it asked for. Set use_battery_and_ems to false to "
+            "build the metered household explicitly, or give share_of_maximum_pv_potential a value above zero."
+        )
+
     # Set Simulation Parameters
     default_year = 2021
     if my_simulation_parameters is None:
@@ -430,8 +441,9 @@ def setup_function(
     )
     my_sim.add_component(my_gas_meter, connect_automatically=True)
 
-    # use ems and battery only when PV is used
-    if share_of_maximum_pv_potential != 0 and energy_system_config_.use_battery_and_ems:
+    # The battery and the energy manager are one decision. A zero rooftop share can no longer reach
+    # this point with the manager switched on: it is refused at the top of the setup.
+    if energy_system_config_.use_battery_and_ems:
 
         # Build EMS
         my_electricity_controller_config = (
@@ -490,7 +502,7 @@ def setup_function(
         my_sim.add_component(my_advanced_battery)
         my_sim.add_component(my_electricity_controller, connect_automatically=True)
 
-    # when no PV is used, connect electricty meter automatically
+    # without an energy manager, connect the electricity meter automatically to every participant
     else:
         my_sim.add_component(my_electricity_meter, connect_automatically=True)
 

--- a/system_setups/household_heatpump_car_building_sizer.py
+++ b/system_setups/household_heatpump_car_building_sizer.py
@@ -94,6 +94,17 @@ def setup_function(
     arche_type_config_ = my_config.archetype_config_
     energy_system_config_ = my_config.energy_system_config_
 
+    # A rooftop share of zero used to switch off the battery and the energy management system as a
+    # side effect further down, so the run silently became the metered household while the config
+    # still said otherwise. Refuse the combination here, before a single component is built.
+    if energy_system_config_.share_of_maximum_pv_potential == 0 and energy_system_config_.use_battery_and_ems:
+        raise ValueError(
+            "share_of_maximum_pv_potential is 0 while use_battery_and_ems is true. The zero share used to "
+            "switch off the battery and the energy manager as a side effect, so this configuration silently "
+            "built the metered household instead of the one it asked for. Set use_battery_and_ems to false to "
+            "build the metered household explicitly, or give share_of_maximum_pv_potential a value above zero."
+        )
+
     # Set Simulation Parameters
     default_year = 2021
     simu_params_year = default_year
@@ -465,8 +476,9 @@ def setup_function(
         config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
     )
 
-    # use ems and battery only when PV is used
-    if share_of_maximum_pv_potential != 0 and energy_system_config_.use_battery_and_ems:
+    # The battery and the energy manager are one decision. A zero rooftop share can no longer reach
+    # this point with the manager switched on: it is refused at the top of the setup.
+    if energy_system_config_.use_battery_and_ems:
 
         # Build EMS
         my_electricity_controller_config = (
@@ -574,7 +586,7 @@ def setup_function(
         my_sim.add_component(my_advanced_battery)
         my_sim.add_component(my_electricity_controller, connect_automatically=True)
 
-    # when no PV is used, connect electricty meter automatically
+    # without an energy manager, connect the electricity meter automatically to every participant
     else:
         for car, car_battery, car_battery_controller in zip(my_cars, my_car_batteries, my_car_battery_controllers):
             # add to simulator

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.py
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.py
@@ -85,6 +85,17 @@ def setup_function(
     arche_type_config_ = my_config.archetype_config_
     energy_system_config_ = my_config.energy_system_config_
 
+    # A rooftop share of zero used to switch off the battery and the energy management system as a
+    # side effect further down, so the run silently became the metered household while the config
+    # still said otherwise. Refuse the combination here, before a single component is built.
+    if energy_system_config_.share_of_maximum_pv_potential == 0 and energy_system_config_.use_battery_and_ems:
+        raise ValueError(
+            "share_of_maximum_pv_potential is 0 while use_battery_and_ems is true. The zero share used to "
+            "switch off the battery and the energy manager as a side effect, so this configuration silently "
+            "built the metered household instead of the one it asked for. Set use_battery_and_ems to false to "
+            "build the metered household explicitly, or give share_of_maximum_pv_potential a value above zero."
+        )
+
     # Set Simulation Parameters
     default_year = 2021
     if my_simulation_parameters is None:
@@ -442,8 +453,9 @@ def setup_function(
         config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
     )
 
-    # use ems and battery only when PV is used
-    if share_of_maximum_pv_potential != 0 and energy_system_config_.use_battery_and_ems:
+    # The battery and the energy manager are one decision. A zero rooftop share can no longer reach
+    # this point with the manager switched on: it is refused at the top of the setup.
+    if energy_system_config_.use_battery_and_ems:
 
         # Build EMS
         my_electricity_controller_config = (
@@ -502,7 +514,7 @@ def setup_function(
         my_sim.add_component(my_advanced_battery)
         my_sim.add_component(my_electricity_controller, connect_automatically=True)
 
-    # when no PV is used, connect electricty meter automatically
+    # without an energy manager, connect the electricity meter automatically to every participant
     else:
         my_sim.add_component(my_electricity_meter, connect_automatically=True)
 

--- a/system_setups/household_hydrogen_boiler_building_sizer.py
+++ b/system_setups/household_hydrogen_boiler_building_sizer.py
@@ -86,6 +86,17 @@ def setup_function(
     arche_type_config_ = my_config.archetype_config_
     energy_system_config_ = my_config.energy_system_config_
 
+    # A rooftop share of zero used to switch off the battery and the energy management system as a
+    # side effect further down, so the run silently became the metered household while the config
+    # still said otherwise. Refuse the combination here, before a single component is built.
+    if energy_system_config_.share_of_maximum_pv_potential == 0 and energy_system_config_.use_battery_and_ems:
+        raise ValueError(
+            "share_of_maximum_pv_potential is 0 while use_battery_and_ems is true. The zero share used to "
+            "switch off the battery and the energy manager as a side effect, so this configuration silently "
+            "built the metered household instead of the one it asked for. Set use_battery_and_ems to false to "
+            "build the metered household explicitly, or give share_of_maximum_pv_potential a value above zero."
+        )
+
     # Set Simulation Parameters
     default_year = 2021
     if my_simulation_parameters is None:
@@ -379,8 +390,9 @@ def setup_function(
     )
     my_sim.add_component(my_gas_meter, connect_automatically=True)
 
-    # use ems and battery only when PV is used
-    if share_of_maximum_pv_potential != 0 and energy_system_config_.use_battery_and_ems:
+    # The battery and the energy manager are one decision. A zero rooftop share can no longer reach
+    # this point with the manager switched on: it is refused at the top of the setup.
+    if energy_system_config_.use_battery_and_ems:
 
         # Build EMS
         my_electricity_controller_config = (
@@ -439,7 +451,7 @@ def setup_function(
         my_sim.add_component(my_advanced_battery)
         my_sim.add_component(my_electricity_controller, connect_automatically=True)
 
-    # when no PV is used, connect electricty meter automatically
+    # without an energy manager, connect the electricity meter automatically to every participant
     else:
         my_sim.add_component(my_electricity_meter, connect_automatically=True)
 

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -112,6 +112,17 @@ def setup_function(
     arche_type_config_ = my_config.archetype_config_
     energy_system_config_ = my_config.energy_system_config_
 
+    # A rooftop share of zero used to switch off the battery and the energy management system as a
+    # side effect further down, so the run silently became the metered household while the config
+    # still said otherwise. Refuse the combination here, before a single component is built.
+    if energy_system_config_.share_of_maximum_pv_potential == 0 and energy_system_config_.use_battery_and_ems:
+        raise ValueError(
+            "share_of_maximum_pv_potential is 0 while use_battery_and_ems is true. The zero share used to "
+            "switch off the battery and the energy manager as a side effect, so this configuration silently "
+            "built the metered household instead of the one it asked for. Set use_battery_and_ems to false to "
+            "build the metered household explicitly, or give share_of_maximum_pv_potential a value above zero."
+        )
+
     # Set Simulation Parameters
     default_year = 2021
     if my_simulation_parameters is None:
@@ -421,8 +432,9 @@ def setup_function(
         config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
     )
 
-    # use ems and battery only when PV is used
-    if share_of_maximum_pv_potential != 0 and energy_system_config_.use_battery_and_ems:
+    # The battery and the energy manager are one decision. A zero rooftop share can no longer reach
+    # this point with the manager switched on: it is refused at the top of the setup.
+    if energy_system_config_.use_battery_and_ems:
 
         # Build EMS
         my_electricity_controller_config = (
@@ -481,7 +493,7 @@ def setup_function(
         my_sim.add_component(my_advanced_battery)
         my_sim.add_component(my_electricity_controller, connect_automatically=True)
 
-    # when no PV is used, connect electricty meter automatically
+    # without an energy manager, connect the electricity meter automatically to every participant
     else:
         my_sim.add_component(my_electricity_meter, connect_automatically=True)
 

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -86,6 +86,17 @@ def setup_function(
     arche_type_config_ = my_config.archetype_config_
     energy_system_config_ = my_config.energy_system_config_
 
+    # A rooftop share of zero used to switch off the battery and the energy management system as a
+    # side effect further down, so the run silently became the metered household while the config
+    # still said otherwise. Refuse the combination here, before a single component is built.
+    if energy_system_config_.share_of_maximum_pv_potential == 0 and energy_system_config_.use_battery_and_ems:
+        raise ValueError(
+            "share_of_maximum_pv_potential is 0 while use_battery_and_ems is true. The zero share used to "
+            "switch off the battery and the energy manager as a side effect, so this configuration silently "
+            "built the metered household instead of the one it asked for. Set use_battery_and_ems to false to "
+            "build the metered household explicitly, or give share_of_maximum_pv_potential a value above zero."
+        )
+
     # Set Simulation Parameters
     default_year = 2021
     if my_simulation_parameters is None:
@@ -395,8 +406,9 @@ def setup_function(
         config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
     )
 
-    # use ems and battery only when PV is used
-    if share_of_maximum_pv_potential != 0 and energy_system_config_.use_battery_and_ems:
+    # The battery and the energy manager are one decision. A zero rooftop share can no longer reach
+    # this point with the manager switched on: it is refused at the top of the setup.
+    if energy_system_config_.use_battery_and_ems:
 
         # Build EMS
         my_electricity_controller_config = (
@@ -455,7 +467,7 @@ def setup_function(
         my_sim.add_component(my_advanced_battery)
         my_sim.add_component(my_electricity_controller, connect_automatically=True)
 
-    # when no PV is used, connect electricty meter automatically
+    # without an energy manager, connect the electricity meter automatically to every participant
     else:
         my_sim.add_component(my_electricity_meter, connect_automatically=True)
 

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -86,6 +86,17 @@ def setup_function(
     arche_type_config_ = my_config.archetype_config_
     energy_system_config_ = my_config.energy_system_config_
 
+    # A rooftop share of zero used to switch off the battery and the energy management system as a
+    # side effect further down, so the run silently became the metered household while the config
+    # still said otherwise. Refuse the combination here, before a single component is built.
+    if energy_system_config_.share_of_maximum_pv_potential == 0 and energy_system_config_.use_battery_and_ems:
+        raise ValueError(
+            "share_of_maximum_pv_potential is 0 while use_battery_and_ems is true. The zero share used to "
+            "switch off the battery and the energy manager as a side effect, so this configuration silently "
+            "built the metered household instead of the one it asked for. Set use_battery_and_ems to false to "
+            "build the metered household explicitly, or give share_of_maximum_pv_potential a value above zero."
+        )
+
     # Set Simulation Parameters
     default_year = 2021
     if my_simulation_parameters is None:
@@ -409,8 +420,9 @@ def setup_function(
         config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
     )
 
-    # use ems and battery only when PV is used
-    if share_of_maximum_pv_potential != 0 and energy_system_config_.use_battery_and_ems:
+    # The battery and the energy manager are one decision. A zero rooftop share can no longer reach
+    # this point with the manager switched on: it is refused at the top of the setup.
+    if energy_system_config_.use_battery_and_ems:
 
         # Build EMS
         my_electricity_controller_config = (
@@ -469,7 +481,7 @@ def setup_function(
         my_sim.add_component(my_advanced_battery)
         my_sim.add_component(my_electricity_controller, connect_automatically=True)
 
-    # when no PV is used, connect electricty meter automatically
+    # without an energy manager, connect the electricity meter automatically to every participant
     else:
         my_sim.add_component(my_electricity_meter, connect_automatically=True)
 

--- a/tests/test_system_setups_households_for_building_sizer.py
+++ b/tests/test_system_setups_households_for_building_sizer.py
@@ -11,10 +11,10 @@ loaded and checked to contain finite numeric KPI values, including the
 tests verify real post-processing output rather than only that the run did not
 crash.
 
-One test in this file runs no simulation at all: the heat pump setup refuses a
-zero rooftop photovoltaic share while the energy manager is switched on, and that
-refusal is raised before any component is built, so it is checked by initializing
-the setup and catching the error.
+One test family in this file runs no simulation at all: every building-sizer setup
+refuses a zero rooftop photovoltaic share while the energy manager is switched on,
+and that refusal is raised before any component is built, so it is checked by
+initializing each setup once and catching the error.
 """
 # clean
 import json
@@ -292,17 +292,40 @@ def test_household_heatpump_car(building_sizer_result_directory: str) -> None:
 
 
 @pytest.mark.base
-def test_household_heatpump_refuses_zero_pv_share_with_energy_manager(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "setup_file_name, default_config_getter_name",
+    [
+        ("household_district_heating_building_sizer.py", "get_default_config_for_household_district_heating"),
+        ("household_electric_heating_building_sizer.py", "get_default_config_for_household_electric_heating"),
+        ("household_gas_building_sizer.py", "get_default_config_for_household_gas"),
+        ("household_gas_solar_thermal_building_sizer.py", "get_default_config_for_household_gas_solar_thermal"),
+        ("household_heatpump_building_sizer.py", "get_default_config_for_household_heatpump"),
+        ("household_heatpump_car_building_sizer.py", "get_default_config_for_household_heatpump"),
+        (
+            "household_heatpump_solar_thermal_building_sizer.py",
+            "get_default_config_for_household_heatpump_solar_thermal",
+        ),
+        ("household_hydrogen_boiler_building_sizer.py", "get_default_config_for_household_hydrogen"),
+        ("household_oil_building_sizer.py", "get_default_config_for_household_oil"),
+        ("household_pellets_building_sizer.py", "get_default_config_for_household_pellet"),
+        ("household_wood_chips_building_sizer.py", "get_default_config_for_household_wood_chips"),
+    ],
+)
+def test_building_sizer_setup_refuses_zero_pv_share_with_energy_manager(
+    setup_file_name: str, default_config_getter_name: str, tmp_path: Path
+) -> None:
     """Test that a zero rooftop share combined with the energy manager is refused up front.
 
     ``share_of_maximum_pv_potential = 0`` used to switch off the battery and the energy management
     system as a side effect, so the run quietly became the metered household while the module
-    configuration still asked for the managed one. The setup now refuses the combination before it
-    builds a single component, which is why this test needs no simulation: it hands
-    ``initialize_from_python`` a module configuration with the zero share and the manager left on and
-    asserts that the refusal arrives and names both fields the caller has to decide between.
+    configuration still asked for the managed one. Every building-sizer setup now refuses the
+    combination before it builds a single component, which is why this test needs no simulation: for
+    each setup it takes that setup's own default ``ModularHouseholdConfig`` (named by
+    ``default_config_getter_name``), sets the zero share and leaves the manager on, hands the written
+    file to ``initialize_from_python`` and asserts that the refusal arrives and names both fields the
+    caller has to decide between.
     """
-    household_config = ModularHouseholdConfig.get_default_config_for_household_heatpump()
+    household_config = getattr(ModularHouseholdConfig, default_config_getter_name)()
     assert household_config.energy_system_config_ is not None
     household_config.energy_system_config_.share_of_maximum_pv_potential = 0.0
     household_config.energy_system_config_.use_battery_and_ems = True
@@ -314,8 +337,9 @@ def test_household_heatpump_refuses_zero_pv_share_with_energy_manager(tmp_path: 
     written_config = read_in_configs(str(config_path))
     assert written_config is not None and written_config.energy_system_config_ is not None
     assert written_config.energy_system_config_.share_of_maximum_pv_potential == 0.0
+    assert written_config.energy_system_config_.use_battery_and_ems is True
 
-    setup_path = Path(__file__).resolve().parent.parent / "system_setups" / "household_heatpump_building_sizer.py"
+    setup_path = Path(__file__).resolve().parents[1] / "system_setups" / setup_file_name
     with pytest.raises(ValueError) as refusal:
         hisim_main.initialize_from_python(
             str(setup_path),


### PR DESCRIPTION
## Problem

Two results of the fleet-wide setup inventory missed the #638 merge window.

First, the zero-share trap #638 fixed in the heat-pump sizer exists verbatim in its ten large
siblings: the guard `if share_of_maximum_pv_potential != 0 and use_battery_and_ems:` reads a
photovoltaic share of zero as "switch off the battery and the energy manager too", so a
configuration asking for zero photovoltaics with the manager on silently builds the metered
household instead of the one it asked for — in gas, oil, pellets, wood-chips, hydrogen,
district-heating, electric-heating, gas-solar-thermal, heatpump-solar-thermal and heatpump-car.

Second, the inventory that found this — every configuration-dependent branch and condition in all
22 recorded setups — lived only in a conversation, and it is the plan for grouping the rest of the
fleet.

## Done

- Each of the ten sizers gains the same early refusal the heat pump got in #638: a `ValueError`
  before any component is built, naming both fields and both remedies. The downstream guard
  collapses to the manager flag alone, since the zero-share half is unreachable past the refusal.
  The two config-driven setups without the guard (`simple_air_conditioner_household_building_sizer`,
  `household_gas_solar_thermal`) were verified and left untouched.
- The single refusal test became one parametrized test over all eleven sizers, each driven through
  its own default module configuration (the car sizer shares the heat pump's getter, having none of
  its own), with the config round-trip asserted so a silent fallback to defaults cannot fake a pass.
  Eleven refusals fire in under two seconds, from the repository root and from inside `tests/`
  alike.
- `roadmap/declarative_energy_systems/grouping_worklist.md` writes the inventory down: the map
  (eleven of the twelve config-driven setups are one skeleton with the heat generator swapped;
  `household_gas_solar_thermal` is a hidden config consumer that demands an energy-system config
  and ignores it), the fixes owed before a grouping can be honest, the environment couplings a
  recording pins rather than fixes, and the grouping order — the eight boiler-family sizers as one
  job, the solar-thermal heat pump with its own skeleton, the car sizer last (its component count
  is a property of the occupancy dataset, which the format has no spelling for today), the nine
  trivial setups whenever convenient.

## Result

No recorded twin, scenario file or golden reference moves — every committed recording runs at a
share of one. The only behavioral change is that an impossible request now fails loudly at
construction instead of silently building a different system. One known consumer of the loud
failure is deliberately deferred: RenoVisor derives the share and the manager flag independently,
so a battery-without-photovoltaics request on a sizer setup now refuses; its explicit pairing rule
comes in a separate change after P4, as agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
