### PR TITLE
Ask the channel declarations at runtime, not tag literals beside them

### DIFF
--- a/hisim/components/controller_l2_energy_management_system.py
+++ b/hisim/components/controller_l2_energy_management_system.py
@@ -641,6 +641,9 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
         outputs_sorted = []
 
         for ind, source_weight in enumerate(source_weights):
+            # Literal on purpose: the first tag is this one participant's component type, so the
+            # query names no fixed channel tag set and the dispatch side has no channel-key
+            # accessor yet. See roadmap/p3_cleanup_todos.md, the aggregator-lookup migration item.
             outputs = self.get_all_dynamic_outputs(
                 tags=[
                     component_types_sorted[ind],
@@ -656,13 +659,9 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
                     raise ValueError("Dynamic input is not connected to dynamic output")
         outputs_sorted = list(OrderedDict.fromkeys(outputs_sorted))
 
-        production_inputs = self.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION])
-        consumption_uncontrolled_inputs = self.get_dynamic_inputs(
-            tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED]
-        )
-        consumption_ems_controlled_inputs = self.get_dynamic_inputs(
-            tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_EMS_CONTROLLED]
-        )
+        production_inputs = self.get_channel_inputs(self.PRODUCTION_CHANNEL)
+        consumption_uncontrolled_inputs = self.get_channel_inputs(self.CONSUMPTION_UNCONTROLLED_CHANNEL)
+        consumption_ems_controlled_inputs = self.get_channel_inputs(self.CONSUMPTION_CONTROLLED_CHANNEL)
 
         return (
             inputs_sorted,

--- a/hisim/components/controller_l2_energy_management_system.py
+++ b/hisim/components/controller_l2_energy_management_system.py
@@ -191,6 +191,12 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
     #: former while an ordinary controllable consumer — a heat pump, whose extra descriptive tag
     #: no channel consumes — falls to the latter. That mirrors the ranking code's existing
     #: "is this participant a battery" branch instead of inventing a new tag value for it.
+    #:
+    #: One runtime lookup deliberately reads no channel: the ranking code's per-participant
+    #: dispatch-output query, whose first tag is that one participant's component type, so it
+    #: names no fixed tag set — and it reads outputs, for which no channel-key accessor exists.
+    #: A dispatch-side accessor would be a design of its own, not a near-match to force onto
+    #: :meth:`~hisim.dynamic_component.DynamicComponent.get_channel_inputs`.
     CHANNELS: Tuple[DynamicConnectionChannel, ...] = (
         DynamicConnectionChannel(
             key=PRODUCTION_CHANNEL,
@@ -641,9 +647,7 @@ class L2GenericEnergyManagementSystem(dynamic_component.DynamicComponent):
         outputs_sorted = []
 
         for ind, source_weight in enumerate(source_weights):
-            # Literal on purpose: the first tag is this one participant's component type, so the
-            # query names no fixed channel tag set and the dispatch side has no channel-key
-            # accessor yet. See roadmap/p3_cleanup_todos.md, the aggregator-lookup migration item.
+            # Literal on purpose: a per-participant dispatch-output query, see the CHANNELS docstring.
             outputs = self.get_all_dynamic_outputs(
                 tags=[
                     component_types_sorted[ind],

--- a/hisim/components/electricity_meter.py
+++ b/hisim/components/electricity_meter.py
@@ -526,10 +526,8 @@ class ElectricityMeter(DynamicComponent):
         """Simulate the grid energy balancer."""
 
         if timestep == 0:
-            self.production_inputs = self.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION])
-            self.consumption_uncontrolled_inputs = self.get_dynamic_inputs(
-                tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED]
-            )
+            self.production_inputs = self.get_channel_inputs(self.PRODUCTION_CHANNEL)
+            self.consumption_uncontrolled_inputs = self.get_channel_inputs(self.CONSUMPTION_UNCONTROLLED_CHANNEL)
 
         # ELECTRICITY #
 
@@ -540,6 +538,8 @@ class ElectricityMeter(DynamicComponent):
         )
 
         if lt.DistrictNames.is_district(self.config.component_id.building):
+            # Literal on purpose: the buildings tag narrows the production channel and no channel
+            # declares it. See roadmap/p3_cleanup_todos.md, the aggregator-lookup migration item.
             production_inputs_building = self.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION, lt.ComponentType.BUILDINGS])
 
             building_electricity_surplus_unused = (
@@ -550,6 +550,8 @@ class ElectricityMeter(DynamicComponent):
                 building_electricity_surplus_unused,
             )
 
+            # Literal on purpose, for the same reason as the production query above: the buildings
+            # tag narrows the consumption channel and no channel declares it.
             consumption_inputs_building = self.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED, lt.ComponentType.BUILDINGS])
 
             consumption_of_buildings = (

--- a/hisim/components/electricity_meter.py
+++ b/hisim/components/electricity_meter.py
@@ -538,8 +538,7 @@ class ElectricityMeter(DynamicComponent):
         )
 
         if lt.DistrictNames.is_district(self.config.component_id.building):
-            # Literal on purpose: the buildings tag narrows the production channel and no channel
-            # declares it. See roadmap/p3_cleanup_todos.md, the aggregator-lookup migration item.
+            # Literal on purpose: subset matching, see the CHANNELS docstring.
             production_inputs_building = self.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION, lt.ComponentType.BUILDINGS])
 
             building_electricity_surplus_unused = (
@@ -550,8 +549,7 @@ class ElectricityMeter(DynamicComponent):
                 building_electricity_surplus_unused,
             )
 
-            # Literal on purpose, for the same reason as the production query above: the buildings
-            # tag narrows the consumption channel and no channel declares it.
+            # Literal on purpose: subset matching, see the CHANNELS docstring.
             consumption_inputs_building = self.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED, lt.ComponentType.BUILDINGS])
 
             consumption_of_buildings = (

--- a/hisim/components/fuel_meter.py
+++ b/hisim/components/fuel_meter.py
@@ -355,7 +355,7 @@ class FuelMeter(DynamicComponent):
         """
 
         if timestep == 0:
-            self.consumption_uncontrolled_inputs = self.get_dynamic_inputs(tags=[lt.InandOutputType.HEAT_CONSUMPTION])
+            self.consumption_uncontrolled_inputs = self.get_channel_inputs(self.CONSUMPTION_UNCONTROLLED_CHANNEL)
 
         # get sum of consumptions of all inputs
         consumption_uncontrolled_in_watt_hour = sum(

--- a/hisim/components/gas_meter.py
+++ b/hisim/components/gas_meter.py
@@ -346,10 +346,8 @@ class GasMeter(DynamicComponent):
         """Simulate the grid energy balancer."""
 
         if timestep == 0:
-            self.production_inputs = self.get_dynamic_inputs(tags=[lt.InandOutputType.GAS_PRODUCTION])
-            self.consumption_uncontrolled_inputs = self.get_dynamic_inputs(
-                tags=[lt.InandOutputType.GAS_CONSUMPTION_UNCONTROLLED]
-            )
+            self.production_inputs = self.get_channel_inputs(self.PRODUCTION_CHANNEL)
+            self.consumption_uncontrolled_inputs = self.get_channel_inputs(self.CONSUMPTION_UNCONTROLLED_CHANNEL)
 
         # GAS #
 

--- a/hisim/components/heating_meter.py
+++ b/hisim/components/heating_meter.py
@@ -306,8 +306,8 @@ class HeatingMeter(DynamicComponent):
         """
 
         if timestep == 0:
-            self.production_inputs = self.get_dynamic_inputs(tags=[lt.InandOutputType.HEAT_DELIVERED])
-            self.consumption_uncontrolled_inputs = self.get_dynamic_inputs(tags=[lt.InandOutputType.HEAT_CONSUMPTION])
+            self.production_inputs = self.get_channel_inputs(self.PRODUCTION_CHANNEL)
+            self.consumption_uncontrolled_inputs = self.get_channel_inputs(self.CONSUMPTION_UNCONTROLLED_CHANNEL)
 
         # get sum of production and consumption for all inputs for each iteration
         production_in_watt = (

--- a/roadmap/p3_cleanup_todos.md
+++ b/roadmap/p3_cleanup_todos.md
@@ -92,12 +92,16 @@ survives only in a conversation. Items are removed when done, not ticked and kep
   participant lookups in the five aggregators — the EMS and the electricity, fuel, gas and heating
   meters — now go through `DynamicComponent.get_channel_inputs(key)`, so the `CHANNELS` declaration
   is the single source of truth for validation and for simulation alike and the two cannot drift.
-  Three lookups stay literal and say so in a comment, because their tag set matches no channel
-  exactly and forcing a near-match would change what they sum: the electricity meter's two
-  per-building queries, which narrow a channel with a buildings tag no channel declares, and the
-  EMS's per-participant dispatch-output query, whose first tag is the participant's own component
-  type. Both carve-outs want channels of their own, not a wider helper. Remove this entry once the
-  branch is on main; the two code comments point here, so retarget them in the same edit.
+  Three lookups stay literal and say so in a one-line comment pointing at their class's
+  ``CHANNELS`` docstring, because their tag set matches no channel exactly and forcing a
+  near-match would change what they sum. The electricity meter's two per-building queries are a
+  settled design, not a debt: the meter's ``CHANNELS`` docstring is the canonical statement that
+  they need no channel of their own, since subset matching lets a feed carrying the buildings tag
+  select the channel while the tag survives on the created port. The EMS's per-participant
+  dispatch-output query is the genuine remainder — its first tag is the participant's own
+  component type, and the output side has no channel-key accessor; a dispatch accessor is a
+  candidate design of its own, not a decided follow-up. Remove this entry once the branch is on
+  main; the code comments point at the class docstrings, so nothing dangles.
 
 ## Deferred by design (not P3's debt, listed so it is findable)
 

--- a/roadmap/p3_cleanup_todos.md
+++ b/roadmap/p3_cleanup_todos.md
@@ -87,14 +87,17 @@ survives only in a conversation. Items are removed when done, not ticked and kep
   twenty-one; after a week of green runs on main, delete that one line (the workflow header
   carries the same instruction) and the gate blocks. This subsumes the AC-P3.4 item above — the
   first green run is the evidence, the week of them is the confidence.
-- [ ] **Migrate every aggregator's `i_simulate` lookup onto its channel declarations** (decided
-  2026-09-05, #634 review round). All five aggregators — the EMS and the electricity, fuel, gas and
-  heating meters — still query participants by hard-coded tag literals through
-  `get_dynamic_inputs(tags=[...])`, while `DynamicComponent.get_channel_inputs(key)` was built to
-  make the `CHANNELS` declaration the single source of truth and has zero call sites. One dedicated
-  PR after the stack lands switches all five (behaviour-preserving by construction, per the
-  helper's own docstring), with the golden gates verifying. The electricity meter's per-building
-  queries carry extra tags no channel covers yet; they stay literal or get their own channels.
+- [x] **Migrate every aggregator's `i_simulate` lookup onto its channel declarations — done
+  2026-09-06 on `p3_channel_migration`** (decided 2026-09-05, #634 review round). All ten
+  participant lookups in the five aggregators — the EMS and the electricity, fuel, gas and heating
+  meters — now go through `DynamicComponent.get_channel_inputs(key)`, so the `CHANNELS` declaration
+  is the single source of truth for validation and for simulation alike and the two cannot drift.
+  Three lookups stay literal and say so in a comment, because their tag set matches no channel
+  exactly and forcing a near-match would change what they sum: the electricity meter's two
+  per-building queries, which narrow a channel with a buildings tag no channel declares, and the
+  EMS's per-participant dispatch-output query, whose first tag is the participant's own component
+  type. Both carve-outs want channels of their own, not a wider helper. Remove this entry once the
+  branch is on main; the two code comments point here, so retarget them in the same edit.
 
 ## Deferred by design (not P3's debt, listed so it is findable)
 

--- a/roadmap/p3_random_findings.md
+++ b/roadmap/p3_random_findings.md
@@ -256,6 +256,26 @@ Removing the duplicate occupancy feed from `household_gas_solar_thermal.py` (F-4
 regeneration ran. Regenerated. *The gates exist for exactly this: a setup and its twins move together, and a
 human will forget.*
 
+### F-36 — the imperative wiring path checks tags but never units **[reported]**
+The two build paths now share one participant vocabulary — every aggregator's ``CHANNELS``
+declaration — but only the declarative path enforces the whole declaration. A feed resolved from an
+energy-system file passes ``ChannelMatcher.match_and_validate``, which checks tags, carrier *and
+unit*: a power output feeding an energy channel is refused with ``EF-30``
+(``tests/test_meter_channels.py::test_the_matcher_refuses_a_feed_in_the_wrong_unit`` pins exactly
+that — a ``WATT`` feed into ``FuelMeter``'s ``WATT_HOUR`` consumption channel). The imperative
+path checks none of it: ``add_component_input_and_connect`` records tags and unit on the created
+port, and ``get_channel_inputs`` selects participants by tag subset alone, so the byte-identical
+wiring that the declarative path refuses is silently accepted when a setup writes it by hand.
+Concretely, using the repository's own pinned example: wire a heat source whose output is
+``HEAT_CONSUMPTION``-tagged but denominated in ``WATT`` into the fuel meter imperatively, and
+``i_simulate`` sums watts as watt-hours — at a 60-second resolution the priced fuel energy is
+overstated sixty-fold, a plausible-looking number that means nothing, which is precisely the
+failure mode the channel declarations were introduced to end. *To be fixed later, as its own
+change: the natural seam is unit/carrier validation at imperative wiring time (where the matched
+channel is known), not inside ``get_channel_inputs`` — a lookup that silently drops mismatched
+inputs would trade a wrong sum for a silently smaller one. The blast radius over existing setups
+is unknown until tried, which is why it is a finding and not a patch.*
+
 ### F-34 — a failed recording leaves an unbuildable file in the tree **[verified]**
 `record_all_setups.py` writes the file and then verifies it builds, and on failure leaves it "in place for
 inspection" — so after a failed run an untracked `energy_systems/<stem>.energy_system.yaml` sits there that


### PR DESCRIPTION
## Problem

Every aggregator — the energy management system and the electricity, fuel, gas and heating meters —
declares its dynamic inputs in a `CHANNELS` table and then queries them in `i_simulate` through
hard-coded tag literals: two spellings of one contract that can drift apart the day someone edits
one of them. `DynamicComponent.get_channel_inputs(key)` was built to make the declaration the
single source of truth and had zero call sites. Decided in the #634 review round; recorded in
`roadmap/p3_cleanup_todos.md`.

## Done

The ten lookups whose tag sets equal a channel's declaration exactly now go through
`get_channel_inputs`: three in the EMS, two each in the electricity, gas and heating meters, one in
the fuel meter. `tags_search_and_compare` is order-independent, so exact set equality is the whole
precondition — verified per call site.

Three lookups stay literal, each with a comment naming the todo entry: the electricity meter's two
district per-building queries carry a `BUILDINGS` tag no channel declares, and the EMS's
per-participant dispatch lookup varies its tag set per iteration and reads outputs rather than
inputs — a channel-key accessor for dispatch outputs is a design of its own, not a near-match to
force. The todo entry is ticked and records the three carve-outs.

## Result

Behavior-preserving, proven rather than assumed: `dynamic_components`,
`household_gas_building_sizer` and `household_oil_building_sizer` ran a full day before and after
the change and every result CSV, connection dump and realized record is byte-identical — 288 files
compared, no exceptions. 189 tests pass (one pre-existing, unrelated path-resolution failure in
`test_system_setups_dynamic_components` fails identically on an unmodified tree). One finding worth
knowing: the heating meter has no setup and no recorded twin anywhere, so it ships unexercised by
the golden fleet and is covered by its tests alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
