### PR TITLE
A config that cannot be read refuses, and a typo'd household names itself

### DIFF
--- a/hisim/building_sizer_utils/interface_configs/archetype_config.py
+++ b/hisim/building_sizer_utils/interface_configs/archetype_config.py
@@ -72,10 +72,13 @@ thermal model follows EN ISO 13790 (implemented in
 :class:`~hisim.components.building.Building`).
 """
 
+import difflib
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import ClassVar, List, Optional, Union
 
 from dataclasses_json import dataclass_json
+from utspclient.helpers.lpgdata import Households
+from utspclient.helpers.lpgpythonbindings import JsonReference
 
 
 @dataclass_json
@@ -188,3 +191,82 @@ class ArcheTypeConfig:
     window_area_in_m2: Optional[float] = None
     door_u_value_in_watt_per_m2_per_kelvin: Optional[float] = None
     door_area_in_m2: Optional[float] = None
+
+    #: Module path of the registry that defines every legal ``lpg_households`` entry, quoted in the
+    #: refusal below so a caller who mistyped a name is told where the valid ones live.
+    LPG_HOUSEHOLD_REGISTRY: ClassVar[str] = "utspclient.helpers.lpgdata.Households"
+
+    def resolve_lpg_households(self) -> Union[JsonReference, List[JsonReference]]:
+        """Turn the configured ``lpg_households`` profile names into LPG household references.
+
+        The names in ``lpg_households`` are attribute names of the Load Profile Generator's
+        ``Households`` registry; the occupancy component needs the ``JsonReference`` objects behind
+        them. A single configured name resolves to one reference, several names resolve to a list of
+        references that the occupancy component stacks into one building. Every building-sizer setup
+        calls this instead of resolving the names itself, so an unknown name is refused the same way
+        everywhere: the loop in those setups used to skip a name the registry did not know without
+        any diagnostic, which quietly built a household with fewer occupants than the configuration
+        asked for.
+
+        A minimal usage example::
+
+            >>> from hisim.building_sizer_utils.interface_configs.archetype_config import (
+            ...     ArcheTypeConfig,
+            ... )
+            >>> ArcheTypeConfig().resolve_lpg_households()  # doctest: +ELLIPSIS
+            JsonReference(...)
+
+        Returns:
+            Union[JsonReference, List[JsonReference]]: The single reference for a one-name
+            configuration, or the list of references, in configured order, for several names.
+
+        Raises:
+            ValueError: If ``lpg_households`` is empty, or if it names a household the registry does
+                not define. The refusal quotes the unknown name, names the registry that holds the
+                legal ones, and lists the closest known names when there are any.
+            TypeError: If ``lpg_households`` is not a list of strings.
+        """
+        if not isinstance(self.lpg_households, list):
+            raise TypeError(
+                f"Type {type(self.lpg_households)} is incompatible. Should be List[str]."
+            )
+        if not self.lpg_households:
+            raise ValueError(
+                "Config list with lpg household is empty. Name at least one household from "
+                f"{self.LPG_HOUSEHOLD_REGISTRY} in 'lpg_households'."
+            )
+
+        resolved = [self._resolve_one_lpg_household(name) for name in self.lpg_households]
+        if len(resolved) == 1:
+            return resolved[0]
+        return resolved
+
+    def _resolve_one_lpg_household(self, household_name: str) -> JsonReference:
+        """Look one LPG household profile name up in the registry, or refuse it.
+
+        Split out of :meth:`resolve_lpg_households` so the single-name and the multi-name case
+        cannot drift apart: both go through this lookup and therefore produce the same refusal for
+        an unknown name.
+
+        Args:
+            household_name: The configured profile name, an attribute name of the LPG ``Households``
+                registry such as ``"CHR01_Couple_both_at_Work"``.
+
+        Returns:
+            JsonReference: The registry entry the name stands for.
+
+        Raises:
+            ValueError: If the registry defines no household of that name.
+        """
+        known_names = [name for name in vars(Households) if not name.startswith("_")]
+        if household_name not in known_names:
+            suggestions = difflib.get_close_matches(household_name, known_names, n=3, cutoff=0.5)
+            hint = f" Did you mean {', '.join(suggestions)}?" if suggestions else ""
+            raise ValueError(
+                f"Unknown LPG household '{household_name}' in 'lpg_households'. The legal names are the "
+                f"{len(known_names)} household profiles defined in {self.LPG_HOUSEHOLD_REGISTRY}, for example "
+                f"'{known_names[0]}'.{hint} An unknown name used to be skipped without a word, which built a "
+                "household with fewer occupants than the configuration asked for."
+            )
+        registry_entry: JsonReference = getattr(Households, household_name)
+        return registry_entry

--- a/hisim/building_sizer_utils/interface_configs/archetype_config.py
+++ b/hisim/building_sizer_utils/interface_configs/archetype_config.py
@@ -143,7 +143,10 @@ class ArcheTypeConfig:
         ...     building_code="DE.N.MFH.05.Gen.ReEx.001.002",
         ...     conditioned_floor_area_in_m2=300.0,
         ...     number_of_dwellings_per_building=2,
-        ...     lpg_households=["CHR01_Couple_both_at_Work", "CHR03_Family"],
+        ...     lpg_households=[
+        ...         "CHR01_Couple_both_at_Work",
+        ...         "CHR03_Family_1_child_both_at_work",
+        ...     ],
         ... )
 
     """
@@ -202,11 +205,11 @@ class ArcheTypeConfig:
         The names in ``lpg_households`` are attribute names of the Load Profile Generator's
         ``Households`` registry; the occupancy component needs the ``JsonReference`` objects behind
         them. A single configured name resolves to one reference, several names resolve to a list of
-        references that the occupancy component stacks into one building. Every building-sizer setup
-        calls this instead of resolving the names itself, so an unknown name is refused the same way
-        everywhere: the loop in those setups used to skip a name the registry did not know without
-        any diagnostic, which quietly built a household with fewer occupants than the configuration
-        asked for.
+        references that the occupancy component stacks into one building. The eleven building-sizer
+        setups call this instead of resolving the names themselves, so an unknown name is refused
+        the same way everywhere: the loop in those setups used to skip a name the registry did not
+        know without any diagnostic, which quietly built a household with fewer occupants than the
+        configuration asked for.
 
         A minimal usage example::
 
@@ -224,7 +227,8 @@ class ArcheTypeConfig:
             ValueError: If ``lpg_households`` is empty, or if it names a household the registry does
                 not define. The refusal quotes the unknown name, names the registry that holds the
                 legal ones, and lists the closest known names when there are any.
-            TypeError: If ``lpg_households`` is not a list of strings.
+            TypeError: If ``lpg_households`` is not a list, or if any of its entries is not a
+                string. The refusal names the offending index and value.
         """
         if not isinstance(self.lpg_households, list):
             raise TypeError(
@@ -235,13 +239,25 @@ class ArcheTypeConfig:
                 "Config list with lpg household is empty. Name at least one household from "
                 f"{self.LPG_HOUSEHOLD_REGISTRY} in 'lpg_households'."
             )
+        for index, entry in enumerate(self.lpg_households):
+            if not isinstance(entry, str):
+                raise TypeError(
+                    f"lpg_households[{index}] is {entry!r}, of type {type(entry).__name__}. Every entry has "
+                    "to be a household profile name. Should be List[str]."
+                )
 
-        resolved = [self._resolve_one_lpg_household(name) for name in self.lpg_households]
+        # A bare string reaches this field as a list of its characters: dataclasses_json coerces
+        # "CHR01_..." into ["C", "H", "R", ...] rather than refusing it, and every character then
+        # looks like an unknown household. Detect the shape here so the refusal can say so.
+        looks_like_a_split_string = all(len(entry) == 1 for entry in self.lpg_households)
+        resolved = [
+            self._resolve_one_lpg_household(name, looks_like_a_split_string) for name in self.lpg_households
+        ]
         if len(resolved) == 1:
             return resolved[0]
         return resolved
 
-    def _resolve_one_lpg_household(self, household_name: str) -> JsonReference:
+    def _resolve_one_lpg_household(self, household_name: str, looks_like_a_split_string: bool) -> JsonReference:
         """Look one LPG household profile name up in the registry, or refuse it.
 
         Split out of :meth:`resolve_lpg_households` so the single-name and the multi-name case
@@ -251,6 +267,9 @@ class ArcheTypeConfig:
         Args:
             household_name: The configured profile name, an attribute name of the LPG ``Households``
                 registry such as ``"CHR01_Couple_both_at_Work"``.
+            looks_like_a_split_string: Whether every configured entry is a single character, which
+                is what a household name given as a bare string rather than a list decodes to. The
+                refusal then says so instead of complaining about each character on its own.
 
         Returns:
             JsonReference: The registry entry the name stands for.
@@ -262,6 +281,11 @@ class ArcheTypeConfig:
         if household_name not in known_names:
             suggestions = difflib.get_close_matches(household_name, known_names, n=3, cutoff=0.5)
             hint = f" Did you mean {', '.join(suggestions)}?" if suggestions else ""
+            if looks_like_a_split_string:
+                hint = (
+                    " This looks like one household name given as a bare string rather than a list of names,"
+                    " split into one entry per character."
+                )
             raise ValueError(
                 f"Unknown LPG household '{household_name}' in 'lpg_households'. The legal names are the "
                 f"{len(known_names)} household profiles defined in {self.LPG_HOUSEHOLD_REGISTRY}, for example "

--- a/hisim/building_sizer_utils/interface_configs/modular_household_config.py
+++ b/hisim/building_sizer_utils/interface_configs/modular_household_config.py
@@ -45,13 +45,16 @@ classmethods pair such a default archetype with each available heating system.
 Configurations are exchanged as :mod:`dataclasses_json` JSON objects whose structure
 mirrors the nested ``energy_system_config_`` and ``archetype_config_`` fields:
 :func:`write_config` serializes a configuration to the ``modular_example_config.json``
-file, and :func:`read_in_configs` reads a configuration from a caller-supplied JSON path.
+file, and :func:`read_in_configs` reads a configuration from a caller-supplied JSON path. That
+reader keeps "no config was given" apart from "a config was given but cannot be read": the first
+answers ``None`` so the calling setup falls back to its own default household, the second raises and
+names the path and the reason rather than letting the run simulate a household nobody asked for.
 """
 from __future__ import annotations
 
 # clean
 
-from typing import Optional
+from typing import Any, Dict, Optional, Union
 import json
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
@@ -336,39 +339,107 @@ def write_config(config: ModularHouseholdConfig) -> None:
         file.write(config.to_json())  # type: ignore
 
 
-def read_in_configs(pathname: Optional[str]) -> Optional[ModularHouseholdConfig]:
-    """Read a :class:`ModularHouseholdConfig` from a JSON file at the given path.
+def read_in_configs(pathname: Optional[Union[str, Dict[str, Any]]]) -> Optional[ModularHouseholdConfig]:
+    """Read a :class:`ModularHouseholdConfig` from a JSON file, or answer ``None`` if none was given.
 
-    The file is parsed with :meth:`ModularHouseholdConfig.from_dict`. If the file is read
-    successfully, the loaded configuration is returned and its presence is logged at information
-    level. If the file does not exist, cannot be parsed, or yields a configuration in which *both*
-    the energy system and archetype configs are ``None``, ``None`` is returned instead of raising.
+    The two outcomes are kept apart on purpose. *No config given* -- ``pathname`` is ``None``, an
+    empty string or a string of whitespace -- returns ``None``, which every calling system setup
+    reads as "use my own default household". *A config was given but cannot be read* -- the file is
+    missing or unreadable, its content is not valid JSON, it does not decode into a
+    :class:`ModularHouseholdConfig`, or it decodes into one that declares neither an energy system
+    nor an archetype -- raises :class:`ValueError` naming the path and the underlying reason. The
+    reader used to swallow every one of those failures and answer ``None``, so a typo'd path or a
+    stray comma silently simulated the shipped default household instead of the configured one and
+    the caller never learned that its configuration had not been read.
+
+    A ``dict`` is accepted in place of a path because the calling setups store the configuration
+    they used back into the very attribute that is handed here (``Simulator.my_module_config``), so
+    a second setup call on the same simulator passes an already-decoded configuration rather than a
+    path. Such a mapping is decoded directly and refused, with the same messages, when it does not
+    describe a usable configuration.
 
     Args:
-        pathname (str): Path to the JSON file containing a serialized :class:`ModularHouseholdConfig`.
-            Surrounding whitespace, carriage returns, and newlines are stripped before opening.
+        pathname: Path to the JSON file holding a serialized :class:`ModularHouseholdConfig`
+            (surrounding whitespace, carriage returns and newlines are stripped before opening), or
+            an already-decoded configuration mapping, or ``None``/``""`` for "no config given".
 
     Returns:
-        Optional[ModularHouseholdConfig]: The configuration read from ``pathname``, or ``None`` if
-        the file cannot be found, fails to parse, or contains no energy system and no archetype config.
+        Optional[ModularHouseholdConfig]: The configuration that was read, or ``None`` when no
+        configuration was given at all.
+
+    Raises:
+        ValueError: If a configuration was given but cannot be read -- missing or unreadable file,
+            invalid JSON, a payload that does not decode into a :class:`ModularHouseholdConfig`, or
+            a configuration carrying neither an energy system nor an archetype config. The message
+            names the source and the underlying reason.
     """
-    # try to read modular household config from path
-    household_config: Optional[ModularHouseholdConfig]
-    try:
-        if pathname is None:
-            raise ValueError("No modular household config path provided.")
+    if pathname is None or (isinstance(pathname, str) and not pathname.strip()):
+        log.information("No modular household config was given; the calling setup uses its own default config.")
+        return None
+
+    if isinstance(pathname, dict):
+        source = "the modular household config handed over as a dictionary"
+        household_config = _decode_module_config(pathname, source)
+    else:
         # use strip() in order to remove \r or \n signs from path
-        with open(pathname.strip(), encoding="utf8") as config_file:
-            household_config_dict = json.load(config_file)  # type: ignore
-            household_config = ModularHouseholdConfig.from_dict(household_config_dict)
+        stripped_pathname = pathname.strip()
+        source = f"the modular household config at '{stripped_pathname}'"
+        try:
+            with open(stripped_pathname, encoding="utf8") as config_file:
+                household_config_dict = json.load(config_file)
+        except OSError as error:
+            raise ValueError(
+                f"Could not open {source}: {error}. A module config was named, so the run refuses instead of "
+                "silently simulating the setup's default household. Fix the path, or pass no module config at "
+                "all to ask for the default on purpose."
+            ) from error
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                f"Could not parse {source}: it is not valid JSON ({error}). A module config was named, so the "
+                "run refuses instead of silently simulating the setup's default household."
+            ) from error
+        household_config = _decode_module_config(household_config_dict, source)
+        log.information(f"Read modular household config from {stripped_pathname}")
 
-        log.information(f"Read modular household config from {pathname}")
-        assert household_config is not None
-        if (household_config.energy_system_config_ is None) and (household_config.archetype_config_ is None):
-            raise ValueError("Energy system and archetype configs are None.")
+    return household_config
 
-    # get default modular household config
-    except Exception:
-        household_config = None
 
+def _decode_module_config(household_config_dict: Any, source: str) -> ModularHouseholdConfig:
+    """Turn an already-parsed JSON payload into a usable :class:`ModularHouseholdConfig`.
+
+    Shared by the file branch and the dictionary branch of :func:`read_in_configs` so both refuse a
+    payload that cannot be used with the same wording. A payload is usable only when it decodes into
+    a :class:`ModularHouseholdConfig` that declares at least one of its two modules; a configuration
+    with neither is indistinguishable from no configuration at all once the setups read it, which is
+    exactly the confusion this reader exists to prevent.
+
+    Args:
+        household_config_dict: The parsed JSON payload, normally a mapping of the two module fields.
+        source: Human-readable description of where the payload came from, used verbatim in the
+            refusal messages so the caller can tell which file or object was rejected.
+
+    Returns:
+        ModularHouseholdConfig: The decoded configuration.
+
+    Raises:
+        ValueError: If the payload does not decode into a :class:`ModularHouseholdConfig`, or the
+            decoded configuration carries neither an energy system nor an archetype config.
+    """
+    household_config: ModularHouseholdConfig
+    try:
+        household_config = ModularHouseholdConfig.from_dict(household_config_dict)  # type: ignore[attr-defined]
+    except Exception as error:  # dataclasses_json raises assorted types for a mismatched payload
+        raise ValueError(
+            f"Could not decode {source} into a ModularHouseholdConfig: {error}. A module config was named, so "
+            "the run refuses instead of silently simulating the setup's default household."
+        ) from error
+
+    if household_config is None or (
+        household_config.energy_system_config_ is None and household_config.archetype_config_ is None
+    ):
+        raise ValueError(
+            f"Read {source}, but it declares neither an energy system config nor an archetype config, so there "
+            "is nothing to simulate from it. Fill in at least one of 'energy_system_config_' and "
+            "'archetype_config_', or pass no module config at all to ask for the setup's default on purpose."
+        )
     return household_config

--- a/hisim/building_sizer_utils/interface_configs/modular_household_config.py
+++ b/hisim/building_sizer_utils/interface_configs/modular_household_config.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 
 # clean
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional
 import json
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
@@ -339,91 +339,104 @@ def write_config(config: ModularHouseholdConfig) -> None:
         file.write(config.to_json())  # type: ignore
 
 
-def read_in_configs(pathname: Optional[Union[str, Dict[str, Any]]]) -> Optional[ModularHouseholdConfig]:
+def read_in_configs(pathname: Optional[str]) -> Optional[ModularHouseholdConfig]:
     """Read a :class:`ModularHouseholdConfig` from a JSON file, or answer ``None`` if none was given.
 
     The two outcomes are kept apart on purpose. *No config given* -- ``pathname`` is ``None``, an
     empty string or a string of whitespace -- returns ``None``, which every calling system setup
     reads as "use my own default household". *A config was given but cannot be read* -- the file is
-    missing or unreadable, its content is not valid JSON, it does not decode into a
-    :class:`ModularHouseholdConfig`, or it decodes into one that declares neither an energy system
-    nor an archetype -- raises :class:`ValueError` naming the path and the underlying reason. The
+    missing or unreadable, its bytes are not UTF-8, its content is not valid JSON, it does not
+    decode into a :class:`ModularHouseholdConfig`, or it decodes into one that is missing either of
+    its two halves -- raises :class:`ValueError` naming the path and the underlying reason. The
     reader used to swallow every one of those failures and answer ``None``, so a typo'd path or a
     stray comma silently simulated the shipped default household instead of the configured one and
     the caller never learned that its configuration had not been read.
 
-    A ``dict`` is accepted in place of a path because the calling setups store the configuration
-    they used back into the very attribute that is handed here (``Simulator.my_module_config``), so
-    a second setup call on the same simulator passes an already-decoded configuration rather than a
-    path. Such a mapping is decoded directly and refused, with the same messages, when it does not
-    describe a usable configuration.
+    The config is named by a path, never handed over as an already-decoded object:
+    ``Simulator.my_module_config`` is declared ``Optional[str]`` and the setups that read it split
+    it on ``"/"`` to build their result path, so anything but a string is a caller error and is
+    refused as one rather than being decoded on the quiet.
 
     Args:
         pathname: Path to the JSON file holding a serialized :class:`ModularHouseholdConfig`
             (surrounding whitespace, carriage returns and newlines are stripped before opening), or
-            an already-decoded configuration mapping, or ``None``/``""`` for "no config given".
+            ``None``/``""`` for "no config given".
 
     Returns:
         Optional[ModularHouseholdConfig]: The configuration that was read, or ``None`` when no
         configuration was given at all.
 
     Raises:
+        TypeError: If ``pathname`` is neither a string nor ``None``.
         ValueError: If a configuration was given but cannot be read -- missing or unreadable file,
-            invalid JSON, a payload that does not decode into a :class:`ModularHouseholdConfig`, or
-            a configuration carrying neither an energy system nor an archetype config. The message
-            names the source and the underlying reason.
+            bytes that are not UTF-8, invalid JSON, a payload that does not decode into a
+            :class:`ModularHouseholdConfig`, or a configuration missing its energy system config,
+            its archetype config or both. The message names the source and the underlying reason.
     """
-    if pathname is None or (isinstance(pathname, str) and not pathname.strip()):
+    if pathname is None:
         log.information("No modular household config was given; the calling setup uses its own default config.")
         return None
 
-    if isinstance(pathname, dict):
-        source = "the modular household config handed over as a dictionary"
-        household_config = _decode_module_config(pathname, source)
-    else:
-        # use strip() in order to remove \r or \n signs from path
-        stripped_pathname = pathname.strip()
-        source = f"the modular household config at '{stripped_pathname}'"
-        try:
-            with open(stripped_pathname, encoding="utf8") as config_file:
-                household_config_dict = json.load(config_file)
-        except OSError as error:
-            raise ValueError(
-                f"Could not open {source}: {error}. A module config was named, so the run refuses instead of "
-                "silently simulating the setup's default household. Fix the path, or pass no module config at "
-                "all to ask for the default on purpose."
-            ) from error
-        except json.JSONDecodeError as error:
-            raise ValueError(
-                f"Could not parse {source}: it is not valid JSON ({error}). A module config was named, so the "
-                "run refuses instead of silently simulating the setup's default household."
-            ) from error
-        household_config = _decode_module_config(household_config_dict, source)
-        log.information(f"Read modular household config from {stripped_pathname}")
+    if not isinstance(pathname, str):
+        raise TypeError(
+            f"A modular household config is named by a path string, or None for no config; got "
+            f"{type(pathname).__name__}. Simulator.my_module_config holds a path, not a decoded "
+            "configuration, so a config that already exists in memory has to be written to a file before "
+            "it can be read back."
+        )
 
+    # use strip() in order to remove \r or \n signs from path
+    stripped_pathname = pathname.strip()
+    if not stripped_pathname:
+        log.information("No modular household config was given; the calling setup uses its own default config.")
+        return None
+
+    source = f"the modular household config at '{stripped_pathname}'"
+    try:
+        with open(stripped_pathname, encoding="utf8") as config_file:
+            household_config_dict = json.load(config_file)
+    except OSError as error:
+        raise ValueError(
+            f"Could not open {source}: {error}. A module config was named, so the run refuses instead of "
+            "silently simulating the setup's default household. Fix the path, or pass no module config at "
+            "all to ask for the default on purpose."
+        ) from error
+    except UnicodeDecodeError as error:
+        raise ValueError(
+            f"Could not read {source}: its bytes are not valid UTF-8 ({error}). A module config was named, "
+            "so the run refuses instead of silently simulating the setup's default household."
+        ) from error
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            f"Could not parse {source}: it is not valid JSON ({error}). A module config was named, so the "
+            "run refuses instead of silently simulating the setup's default household."
+        ) from error
+
+    household_config = _decode_module_config(household_config_dict, source)
+    log.information(f"Read modular household config from {stripped_pathname}")
     return household_config
 
 
 def _decode_module_config(household_config_dict: Any, source: str) -> ModularHouseholdConfig:
     """Turn an already-parsed JSON payload into a usable :class:`ModularHouseholdConfig`.
 
-    Shared by the file branch and the dictionary branch of :func:`read_in_configs` so both refuse a
-    payload that cannot be used with the same wording. A payload is usable only when it decodes into
-    a :class:`ModularHouseholdConfig` that declares at least one of its two modules; a configuration
-    with neither is indistinguishable from no configuration at all once the setups read it, which is
-    exactly the confusion this reader exists to prevent.
+    Split out of :func:`read_in_configs` so that reading the file and judging what was read stay
+    separate. A payload is usable only when it decodes into a :class:`ModularHouseholdConfig` that
+    carries *both* of its halves: every calling system setup asserts both are present immediately
+    after reading, so a half-filled config used to die on a bare ``AssertionError`` that named
+    neither the file nor the missing half.
 
     Args:
         household_config_dict: The parsed JSON payload, normally a mapping of the two module fields.
         source: Human-readable description of where the payload came from, used verbatim in the
-            refusal messages so the caller can tell which file or object was rejected.
+            refusal messages so the caller can tell which file was rejected.
 
     Returns:
-        ModularHouseholdConfig: The decoded configuration.
+        ModularHouseholdConfig: The decoded configuration, with both halves present.
 
     Raises:
         ValueError: If the payload does not decode into a :class:`ModularHouseholdConfig`, or the
-            decoded configuration carries neither an energy system nor an archetype config.
+            decoded configuration is missing its energy system config, its archetype config or both.
     """
     household_config: ModularHouseholdConfig
     try:
@@ -434,12 +447,19 @@ def _decode_module_config(household_config_dict: Any, source: str) -> ModularHou
             "the run refuses instead of silently simulating the setup's default household."
         ) from error
 
-    if household_config is None or (
-        household_config.energy_system_config_ is None and household_config.archetype_config_ is None
-    ):
+    missing_halves = [
+        field_name
+        for field_name, value in (
+            ("energy_system_config_", household_config.energy_system_config_),
+            ("archetype_config_", household_config.archetype_config_),
+        )
+        if value is None
+    ]
+    if missing_halves:
         raise ValueError(
-            f"Read {source}, but it declares neither an energy system config nor an archetype config, so there "
-            "is nothing to simulate from it. Fill in at least one of 'energy_system_config_' and "
-            "'archetype_config_', or pass no module config at all to ask for the setup's default on purpose."
+            f"Read {source}, but it declares no {' and no '.join(missing_halves)}. A modular household config "
+            "needs both halves -- the energy system to build and the archetype to build it for -- and every "
+            f"system setup asserts both right after reading. Fill in {' and '.join(missing_halves)}, or pass "
+            "no module config at all to ask for the setup's default on purpose."
         )
     return household_config

--- a/roadmap/declarative_energy_systems/grouping_worklist.md
+++ b/roadmap/declarative_energy_systems/grouping_worklist.md
@@ -60,7 +60,9 @@ config, ignores all four of its fields, and reads one archetype value
   the typo, the registry that holds the legal names and the closest known spellings.
 - [ ] **Nine sizers mutate `my_sim.my_module_config` to a dict on the fallback path**; the two
   heat-pump sizers do not, so downstream readers see a different type depending on the sibling.
-  One behavior for all eleven.
+  One behavior for all eleven. `read_in_configs` is string-only by decision (review round of
+  2026-09-06: it refuses a non-string with a `TypeError`), so this repair has to settle what the
+  attribute is allowed to hold rather than widening the reader to accept both.
 - [ ] **Four sizers ignore `weather_filepath`/`weather_datasource`**
   (gas_solar_thermal_building_sizer, heatpump_car, heatpump_solar_thermal, hydrogen): the same
   archetype config yields a different weather source across the fleet. Either read them or refuse

--- a/roadmap/declarative_energy_systems/grouping_worklist.md
+++ b/roadmap/declarative_energy_systems/grouping_worklist.md
@@ -49,14 +49,15 @@ config, ignores all four of its fields, and reads one archetype value
   the battery and the energy manager as a side effect — existed verbatim in all eleven large
   sizers. Fixed for the heat pump first, then replicated across the other ten with one
   parametrized refusal test; done on this branch.
-- [ ] **The module-config probe swallows every read error.** `read_in_configs`
-  (`hisim/building_sizer_utils/interface_configs/modular_household_config.py`, the
-  catch-everything fallback) makes a missing file, a typo'd path, a JSON syntax error and a schema
-  mismatch indistinguishable from "no config given": the run silently simulates the shipped
-  default household with only a warning between them. Narrow it to "no config given" and let a
-  config that exists but cannot be read refuse.
-- [ ] **`hasattr(Households, name)` drops a typo'd LPG household silently** (sizer skeleton), so a
-  misspelled name quietly builds a smaller household. Refuse the unknown name instead.
+- [x] **The module-config probe swallows every read error** (fixed 2026-09-06). `read_in_configs`
+  now answers `None` only for "no config given" (`None`, `""`, whitespace) and raises `ValueError`
+  naming the source and the reason for a missing or unreadable file, invalid JSON, a payload that
+  does not decode, and a config declaring neither module; a config handed over as a dict is read
+  rather than refused. The thirteen setups' fallback warning no longer claims a failed read.
+- [x] **`hasattr(Households, name)` drops a typo'd LPG household silently** (fixed 2026-09-06).
+  The whole resolution moved to `ArcheTypeConfig.resolve_lpg_households`, beside the
+  `lpg_households` field it reads; all eleven sizers call it, and an unknown name is refused with
+  the typo, the registry that holds the legal names and the closest known spellings.
 - [ ] **Nine sizers mutate `my_sim.my_module_config` to a dict on the fallback path**; the two
   heat-pump sizers do not, so downstream readers see a different type depending on the sibling.
   One behavior for all eleven.
@@ -70,6 +71,12 @@ config, ignores all four of its fields, and reads one archetype value
 - [ ] **`air_conditioned_house` duplicates its location** (a `"Seville"` string for the PV beside
   `LocationEnum.SEVILLE` for the weather); one edit without the other silently desynchronizes the
   two. One spelling, one place.
+
+- [ ] **`ModularHouseholdConfig.get_hash()` is not round-trip stable** (found 2026-09-06 while
+  testing the reader). `pv_azimuth: float = 180` and `pv_tilt: float = 30` hold ints in memory and
+  come back as floats from any JSON round trip, so a config built from defaults and the same config
+  read from its own file hash differently — and the building sizer hashes configs. Normalise in
+  `get_hash()` (or make the defaults floats) and pin the round trip.
 
 ## Environment couplings a recording has to pin, not fix
 

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -10,9 +10,6 @@ sizer workflows for scenario evaluation.
 from typing import Optional, Any, Union, List
 import re
 import os
-from utspclient.helpers.lpgdata import (
-    Households,
-)
 from utspclient.helpers.lpgpythonbindings import JsonReference
 from hisim.simulator import SimulationParameters
 from hisim.config import SizingContext
@@ -112,7 +109,7 @@ def setup_function(
         my_config = ModularHouseholdConfig().get_default_config_for_household_district_heating()
         my_sim.my_module_config = my_config.to_dict()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the district heating household default config instead."
+            "No modular household config was given. Using the district heating household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None
@@ -220,21 +217,7 @@ def setup_function(
         cache_dir_path_utsp = None
 
     # get household attribute jsonreferences from list of strings
-    lpg_households: Union[JsonReference, List[JsonReference]]
-    if isinstance(arche_type_config_.lpg_households, list):
-        if len(arche_type_config_.lpg_households) == 1:
-            lpg_households = getattr(Households, arche_type_config_.lpg_households[0])
-        elif len(arche_type_config_.lpg_households) > 1:
-            lpg_households = []
-            for household_string in arche_type_config_.lpg_households:
-                if hasattr(Households, household_string):
-                    lpg_household = getattr(Households, household_string)
-                    lpg_households.append(lpg_household)
-                    print(lpg_household)
-        else:
-            raise ValueError("Config list with lpg household is empty.")
-    else:
-        raise TypeError(f"Type {type(arche_type_config_.lpg_households)} is incompatible. Should be List[str].")
+    lpg_households: Union[JsonReference, List[JsonReference]] = arche_type_config_.resolve_lpg_households()
 
     # =================================================================================================================================
     # Build Basic Components

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -12,9 +12,6 @@ Configuration is loaded from modular household config files or defaults are used
 from typing import Optional, Any, Union, List
 import re
 import os
-from utspclient.helpers.lpgdata import (
-    Households,
-)
 from utspclient.helpers.lpgpythonbindings import JsonReference
 from hisim.simulator import SimulationParameters
 from hisim.components import loadprofilegenerator_utsp_connector
@@ -79,7 +76,7 @@ def setup_function(
         my_config = ModularHouseholdConfig().get_default_config_for_household_electric_heating()
         my_sim.my_module_config = my_config.to_dict()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the electric heating household default config instead."
+            "No modular household config was given. Using the electric heating household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None
@@ -178,21 +175,7 @@ def setup_function(
         cache_dir_path_utsp = None
 
     # get household attribute jsonreferences from list of strings
-    lpg_households: Union[JsonReference, List[JsonReference]]
-    if isinstance(arche_type_config_.lpg_households, list):
-        if len(arche_type_config_.lpg_households) == 1:
-            lpg_households = getattr(Households, arche_type_config_.lpg_households[0])
-        elif len(arche_type_config_.lpg_households) > 1:
-            lpg_households = []
-            for household_string in arche_type_config_.lpg_households:
-                if hasattr(Households, household_string):
-                    lpg_household = getattr(Households, household_string)
-                    lpg_households.append(lpg_household)
-                    print(lpg_household)
-        else:
-            raise ValueError("Config list with lpg household is empty.")
-    else:
-        raise TypeError(f"Type {type(arche_type_config_.lpg_households)} is incompatible. Should be List[str].")
+    lpg_households: Union[JsonReference, List[JsonReference]] = arche_type_config_.resolve_lpg_households()
 
     # =================================================================================================================================
     # Build Basic Components

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -5,9 +5,6 @@
 from typing import Optional, Any, Union, List
 import re
 import os
-from utspclient.helpers.lpgdata import (
-    Households,
-)
 from utspclient.helpers.lpgpythonbindings import JsonReference
 from hisim.simulator import SimulationParameters
 from hisim.config import SizingContext
@@ -79,7 +76,7 @@ def setup_function(
         my_config = ModularHouseholdConfig().get_default_config_for_household_gas()
         my_sim.my_module_config = my_config.to_dict()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the gas household default config instead."
+            "No modular household config was given. Using the gas household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None
@@ -187,21 +184,7 @@ def setup_function(
         cache_dir_path_utsp = None
 
     # get household attribute jsonreferences from list of strings
-    lpg_households: Union[JsonReference, List[JsonReference]]
-    if isinstance(arche_type_config_.lpg_households, list):
-        if len(arche_type_config_.lpg_households) == 1:
-            lpg_households = getattr(Households, arche_type_config_.lpg_households[0])
-        elif len(arche_type_config_.lpg_households) > 1:
-            lpg_households = []
-            for household_string in arche_type_config_.lpg_households:
-                if hasattr(Households, household_string):
-                    lpg_household = getattr(Households, household_string)
-                    lpg_households.append(lpg_household)
-                    print(lpg_household)
-        else:
-            raise ValueError("Config list with lpg household is empty.")
-    else:
-        raise TypeError(f"Type {type(arche_type_config_.lpg_households)} is incompatible. Should be List[str].")
+    lpg_households: Union[JsonReference, List[JsonReference]] = arche_type_config_.resolve_lpg_households()
 
     # =================================================================================================================================
     # Build Basic Components

--- a/system_setups/household_gas_solar_thermal.py
+++ b/system_setups/household_gas_solar_thermal.py
@@ -66,13 +66,12 @@ def setup_function(
     year = 2021
     seconds_per_timestep = 60 * 15
 
-    config_filename = my_sim.my_module_config
     # try reading energ system and archetype configs
     my_config = read_in_configs(my_sim.my_module_config)
     if my_config is None:
         my_config = ModularHouseholdConfig().get_default_config_for_household_gas_solar_thermal()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the gas ans solar thermal household default config instead."
+            "No modular household config was given. Using the gas ans solar thermal household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None

--- a/system_setups/household_gas_solar_thermal.py
+++ b/system_setups/household_gas_solar_thermal.py
@@ -71,7 +71,7 @@ def setup_function(
     if my_config is None:
         my_config = ModularHouseholdConfig().get_default_config_for_household_gas_solar_thermal()
         log.warning(
-            "No modular household config was given. Using the gas ans solar thermal household default config instead."
+            "No modular household config was given. Using the gas and solar thermal household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None

--- a/system_setups/household_gas_solar_thermal_building_sizer.py
+++ b/system_setups/household_gas_solar_thermal_building_sizer.py
@@ -3,9 +3,6 @@
 from typing import Optional, Any, Union, List
 import os
 import re
-from utspclient.helpers.lpgdata import (
-    Households,
-)
 from utspclient.helpers.lpgpythonbindings import JsonReference
 from hisim.building_sizer_utils.interface_configs.modular_household_config import (
     ModularHouseholdConfig,
@@ -77,7 +74,7 @@ def setup_function(
         my_config = ModularHouseholdConfig().get_default_config_for_household_gas_solar_thermal()
         my_sim.my_module_config = my_config.to_dict()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the gas and solar thermal household default config instead."
+            "No modular household config was given. Using the gas and solar thermal household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None
@@ -176,21 +173,7 @@ def setup_function(
         cache_dir_path_utsp = None
 
     # get household attribute jsonreferences from list of strings
-    lpg_households: Union[JsonReference, List[JsonReference]]
-    if isinstance(arche_type_config_.lpg_households, List):
-        if len(arche_type_config_.lpg_households) == 1:
-            lpg_households = getattr(Households, arche_type_config_.lpg_households[0])
-        elif len(arche_type_config_.lpg_households) > 1:
-            lpg_households = []
-            for household_string in arche_type_config_.lpg_households:
-                if hasattr(Households, household_string):
-                    lpg_household = getattr(Households, household_string)
-                    lpg_households.append(lpg_household)
-                    print(lpg_household)
-        else:
-            raise ValueError("Config list with lpg household is empty.")
-    else:
-        raise TypeError(f"Type {type(arche_type_config_.lpg_households)} is incompatible. Should be List[str].")
+    lpg_households: Union[JsonReference, List[JsonReference]] = arche_type_config_.resolve_lpg_households()
 
     # =================================================================================================================================
     # Build Basic Components

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -5,9 +5,6 @@
 from typing import Optional, Any, Union, List
 import re
 import os
-from utspclient.helpers.lpgdata import (
-    Households,
-)
 from utspclient.helpers.lpgpythonbindings import JsonReference
 from hisim.simulator import SimulationParameters
 from hisim.config import SizingContext
@@ -77,7 +74,7 @@ def setup_function(
     if my_config is None:
         my_config = ModularHouseholdConfig().get_default_config_for_household_heatpump()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the heatpump household default config instead."
+            "No modular household config was given. Using the heatpump household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None
@@ -182,21 +179,7 @@ def setup_function(
         cache_dir_path_utsp = None
 
     # get household attribute jsonreferences from list of strings
-    lpg_households: Union[JsonReference, List[JsonReference]]
-    if isinstance(arche_type_config_.lpg_households, list):
-        if len(arche_type_config_.lpg_households) == 1:
-            lpg_households = getattr(Households, arche_type_config_.lpg_households[0])
-        elif len(arche_type_config_.lpg_households) > 1:
-            lpg_households = []
-            for household_string in arche_type_config_.lpg_households:
-                if hasattr(Households, household_string):
-                    lpg_household = getattr(Households, household_string)
-                    lpg_households.append(lpg_household)
-                    print(lpg_household)
-        else:
-            raise ValueError("Config list with lpg household is empty.")
-    else:
-        raise TypeError(f"Type {type(arche_type_config_.lpg_households)} is incompatible. Should be List[str].")
+    lpg_households: Union[JsonReference, List[JsonReference]] = arche_type_config_.resolve_lpg_households()
 
     # =================================================================================================================================
     # Build Basic Components

--- a/system_setups/household_heatpump_car_building_sizer.py
+++ b/system_setups/household_heatpump_car_building_sizer.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from utspclient.helpers.lpgpythonbindings import JsonReference
 from utspclient.helpers.lpgdata import (
     ChargingStationSets,
-    Households,
 )
 from hisim.simulator import SimulationParameters
 from hisim.config import ComponentID, SizingContext
@@ -87,7 +86,7 @@ def setup_function(
     if my_config is None:
         my_config = ModularHouseholdConfig().get_default_config_for_household_heatpump()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the heatpump household default config instead."
+            "No modular household config was given. Using the heatpump household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None
@@ -186,21 +185,7 @@ def setup_function(
         cache_dir_path_utsp = None
 
     # get household attribute jsonreferences from list of strings
-    lpg_households: Union[JsonReference, List[JsonReference]]
-    if isinstance(arche_type_config_.lpg_households, List):
-        if len(arche_type_config_.lpg_households) == 1:
-            lpg_households = getattr(Households, arche_type_config_.lpg_households[0])
-        elif len(arche_type_config_.lpg_households) > 1:
-            lpg_households = []
-            for household_string in arche_type_config_.lpg_households:
-                if hasattr(Households, household_string):
-                    lpg_household = getattr(Households, household_string)
-                    lpg_households.append(lpg_household)
-                    print(lpg_household)
-        else:
-            raise ValueError("Config list with lpg household is empty.")
-    else:
-        raise TypeError(f"Type {type(arche_type_config_.lpg_households)} is incompatible. Should be List[str].")
+    lpg_households: Union[JsonReference, List[JsonReference]] = arche_type_config_.resolve_lpg_households()
 
     # Set electric car, if it will accept surplus charging or not
     car_surplus_charging = True

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.py
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.py
@@ -3,9 +3,6 @@
 from typing import Optional, Union, List
 import os
 import re
-from utspclient.helpers.lpgdata import (
-    Households,
-)
 from utspclient.helpers.lpgpythonbindings import JsonReference
 from hisim.building_sizer_utils.interface_configs.modular_household_config import (
     ModularHouseholdConfig,
@@ -78,7 +75,7 @@ def setup_function(
         # repurposed here to hold the parsed config dict.
         my_sim.my_module_config = my_config.to_dict()  # type: ignore[assignment]
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the heatpump and solar thermal household default config instead."
+            "No modular household config was given. Using the heatpump and solar thermal household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None
@@ -178,21 +175,7 @@ def setup_function(
         cache_dir_path_utsp = None
 
     # get household attribute jsonreferences from list of strings
-    lpg_households: Union[JsonReference, List[JsonReference]]
-    if isinstance(arche_type_config_.lpg_households, list):
-        if len(arche_type_config_.lpg_households) == 1:
-            lpg_households = getattr(Households, arche_type_config_.lpg_households[0])
-        elif len(arche_type_config_.lpg_households) > 1:
-            lpg_households = []
-            for household_string in arche_type_config_.lpg_households:
-                if hasattr(Households, household_string):
-                    lpg_household = getattr(Households, household_string)
-                    lpg_households.append(lpg_household)
-                    print(lpg_household)
-        else:
-            raise ValueError("Config list with lpg household is empty.")
-    else:
-        raise TypeError(f"Type {type(arche_type_config_.lpg_households)} is incompatible. Should be List[str].")
+    lpg_households: Union[JsonReference, List[JsonReference]] = arche_type_config_.resolve_lpg_households()
 
     # =================================================================================================================================
     # Build Basic Components

--- a/system_setups/household_hydrogen_boiler_building_sizer.py
+++ b/system_setups/household_hydrogen_boiler_building_sizer.py
@@ -5,9 +5,6 @@
 from typing import Optional, Any, Union, List
 import re
 import os
-from utspclient.helpers.lpgdata import (
-    Households,
-)
 from utspclient.helpers.lpgpythonbindings import JsonReference
 from hisim.simulator import SimulationParameters
 from hisim.config import SizingContext
@@ -79,7 +76,7 @@ def setup_function(
         my_config = ModularHouseholdConfig().get_default_config_for_household_hydrogen()
         my_sim.my_module_config = my_config.to_dict()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the hydrogen household default config instead."
+            "No modular household config was given. Using the hydrogen household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None
@@ -178,20 +175,7 @@ def setup_function(
         cache_dir_path_utsp = None
 
     # get household attribute jsonreferences from list of strings
-    lpg_households: Union[JsonReference, List[JsonReference]]
-    if isinstance(arche_type_config_.lpg_households, list):
-        if len(arche_type_config_.lpg_households) == 1:
-            lpg_households = getattr(Households, arche_type_config_.lpg_households[0])
-        elif len(arche_type_config_.lpg_households) > 1:
-            lpg_households = []
-            for household_string in arche_type_config_.lpg_households:
-                if hasattr(Households, household_string):
-                    lpg_household = getattr(Households, household_string)
-                    lpg_households.append(lpg_household)
-        else:
-            raise ValueError("Config list with lpg household is empty.")
-    else:
-        raise TypeError(f"Type {type(arche_type_config_.lpg_households)} is incompatible. Should be List[str].")
+    lpg_households: Union[JsonReference, List[JsonReference]] = arche_type_config_.resolve_lpg_households()
 
     # =================================================================================================================================
     # Build Basic Components

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -31,9 +31,6 @@ default oil-household configuration is used instead.
 from typing import Optional, Any, Union, List
 import re
 import os
-from utspclient.helpers.lpgdata import (
-    Households,
-)
 from utspclient.helpers.lpgpythonbindings import JsonReference
 from hisim.simulator import SimulationParameters
 from hisim.config import SizingContext
@@ -105,7 +102,7 @@ def setup_function(
         my_config = ModularHouseholdConfig().get_default_config_for_household_oil()
         my_sim.my_module_config = my_config.to_dict()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the oil household default config instead."
+            "No modular household config was given. Using the oil household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None
@@ -210,21 +207,7 @@ def setup_function(
         cache_dir_path_utsp = None
 
     # get household attribute jsonreferences from list of strings
-    lpg_households: Union[JsonReference, List[JsonReference]]
-    if isinstance(arche_type_config_.lpg_households, List):
-        if len(arche_type_config_.lpg_households) == 1:
-            lpg_households = getattr(Households, arche_type_config_.lpg_households[0])
-        elif len(arche_type_config_.lpg_households) > 1:
-            lpg_households = []
-            for household_string in arche_type_config_.lpg_households:
-                if hasattr(Households, household_string):
-                    lpg_household = getattr(Households, household_string)
-                    lpg_households.append(lpg_household)
-                    print(lpg_household)
-        else:
-            raise ValueError("Config list with lpg household is empty.")
-    else:
-        raise TypeError(f"Type {type(arche_type_config_.lpg_households)} is incompatible. Should be List[str].")
+    lpg_households: Union[JsonReference, List[JsonReference]] = arche_type_config_.resolve_lpg_households()
 
     # =================================================================================================================================
     # Build Basic Components

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -5,9 +5,6 @@
 from typing import Optional, Any, Union, List
 import re
 import os
-from utspclient.helpers.lpgdata import (
-    Households,
-)
 from utspclient.helpers.lpgpythonbindings import JsonReference
 from hisim.simulator import SimulationParameters
 from hisim.config import SizingContext
@@ -79,7 +76,7 @@ def setup_function(
         my_config = ModularHouseholdConfig().get_default_config_for_household_pellet()
         my_sim.my_module_config = my_config.to_dict()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the pellets household default config instead."
+            "No modular household config was given. Using the pellets household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None
@@ -182,21 +179,7 @@ def setup_function(
         cache_dir_path_utsp = None
 
     # get household attribute jsonreferences from list of strings
-    lpg_households: Union[JsonReference, List[JsonReference]]
-    if isinstance(arche_type_config_.lpg_households, list):
-        if len(arche_type_config_.lpg_households) == 1:
-            lpg_households = getattr(Households, arche_type_config_.lpg_households[0])
-        elif len(arche_type_config_.lpg_households) > 1:
-            lpg_households = []
-            for household_string in arche_type_config_.lpg_households:
-                if hasattr(Households, household_string):
-                    lpg_household = getattr(Households, household_string)
-                    lpg_households.append(lpg_household)
-                    print(lpg_household)
-        else:
-            raise ValueError("Config list with lpg household is empty.")
-    else:
-        raise TypeError(f"Type {type(arche_type_config_.lpg_households)} is incompatible. Should be List[str].")
+    lpg_households: Union[JsonReference, List[JsonReference]] = arche_type_config_.resolve_lpg_households()
 
     # =================================================================================================================================
     # Build Basic Components

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -5,9 +5,6 @@
 from typing import Optional, Any, Union, List
 import re
 import os
-from utspclient.helpers.lpgdata import (
-    Households,
-)
 from utspclient.helpers.lpgpythonbindings import JsonReference
 from hisim.simulator import SimulationParameters
 from hisim.config import SizingContext
@@ -79,7 +76,7 @@ def setup_function(
         my_config = ModularHouseholdConfig().get_default_config_for_household_wood_chips()
         my_sim.my_module_config = my_config.to_dict()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. Using the woodchips household default config instead."
+            "No modular household config was given. Using the woodchips household default config instead."
         )
     assert my_config.archetype_config_ is not None
     assert my_config.energy_system_config_ is not None
@@ -183,21 +180,7 @@ def setup_function(
         cache_dir_path_utsp = None
 
     # get household attribute jsonreferences from list of strings
-    lpg_households: Union[JsonReference, List[JsonReference]]
-    if isinstance(arche_type_config_.lpg_households, list):
-        if len(arche_type_config_.lpg_households) == 1:
-            lpg_households = getattr(Households, arche_type_config_.lpg_households[0])
-        elif len(arche_type_config_.lpg_households) > 1:
-            lpg_households = []
-            for household_string in arche_type_config_.lpg_households:
-                if hasattr(Households, household_string):
-                    lpg_household = getattr(Households, household_string)
-                    lpg_households.append(lpg_household)
-                    print(lpg_household)
-        else:
-            raise ValueError("Config list with lpg household is empty.")
-    else:
-        raise TypeError(f"Type {type(arche_type_config_.lpg_households)} is incompatible. Should be List[str].")
+    lpg_households: Union[JsonReference, List[JsonReference]] = arche_type_config_.resolve_lpg_households()
 
     # =================================================================================================================================
     # Build Basic Components

--- a/system_setups/simple_air_conditioner_household_building_sizer.py
+++ b/system_setups/simple_air_conditioner_household_building_sizer.py
@@ -56,7 +56,7 @@ def setup_function(
     if my_config is None:
         my_config = ModularHouseholdConfig().get_default_config_for_household_heatpump()
         log.warning(
-            f"Could not read the modular household config from path '{config_filename}'. "
+            "No modular household config was given. "
             "Using the heatpump household default config instead."
         )
     assert my_config.archetype_config_ is not None

--- a/tests/building_sizer_utils/test_archetype_config.py
+++ b/tests/building_sizer_utils/test_archetype_config.py
@@ -1,0 +1,128 @@
+"""Tests for ``ArcheTypeConfig.resolve_lpg_households``.
+
+The eleven building-sizer setups used to resolve the configured LPG household profile
+names themselves, with a loop that skipped any name the Load Profile Generator's
+``Households`` registry did not define. A misspelled name therefore built a building with
+fewer occupants than the configuration asked for, without a warning. The resolution now
+lives on :class:`~hisim.building_sizer_utils.interface_configs.archetype_config.ArcheTypeConfig`,
+next to the ``lpg_households`` field it reads, and refuses an unknown name. These tests
+cover the resolver directly; that the eleven setups actually go through it is covered by
+``tests/test_system_setups_households_for_building_sizer.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from utspclient.helpers.lpgdata import Households
+from utspclient.helpers.lpgpythonbindings import JsonReference
+
+from hisim.building_sizer_utils.interface_configs.archetype_config import ArcheTypeConfig
+
+#: Two household profile names the LPG registry really defines, used wherever a test needs
+#: a name that has to resolve rather than be refused.
+KNOWN_HOUSEHOLD_NAMES: list[str] = [
+    "CHR01_Couple_both_at_Work",
+    "CHR03_Family_1_child_both_at_work",
+]
+
+
+@pytest.mark.base
+def test_single_configured_household_resolves_to_one_reference() -> None:
+    """A one-name configuration resolves to the single registry entry, not to a list.
+
+    The occupancy component distinguishes the two: one reference asks for one household,
+    a list asks for a stacked multi-household building.
+    """
+    resolved = ArcheTypeConfig(lpg_households=[KNOWN_HOUSEHOLD_NAMES[0]]).resolve_lpg_households()
+
+    assert isinstance(resolved, JsonReference)
+    assert resolved == getattr(Households, KNOWN_HOUSEHOLD_NAMES[0])
+
+
+@pytest.mark.base
+def test_several_configured_households_resolve_in_configured_order() -> None:
+    """A multi-name configuration resolves to the references in the order they were configured."""
+    resolved = ArcheTypeConfig(lpg_households=list(KNOWN_HOUSEHOLD_NAMES)).resolve_lpg_households()
+
+    assert isinstance(resolved, list)
+    assert resolved == [getattr(Households, name) for name in KNOWN_HOUSEHOLD_NAMES]
+
+
+@pytest.mark.base
+@pytest.mark.parametrize(
+    "configured_names",
+    [
+        ["CHR01_Couple_both_at_Wrok"],
+        ["CHR01_Couple_both_at_Work", "CHR01_Couple_both_at_Wrok"],
+        ["CHR01_Couple_both_at_Wrok", "CHR01_Couple_both_at_Work"],
+    ],
+    ids=["alone", "after_a_known_name", "before_a_known_name"],
+)
+def test_unknown_household_name_is_refused_wherever_it_stands(configured_names: list[str]) -> None:
+    """An unknown name is refused whether it stands alone or beside a known one.
+
+    The old loop only dropped names silently in the multi-name branch, so the position of
+    the typo decided whether the run failed loudly, failed obscurely or succeeded with the
+    wrong household. All three positions now produce the same refusal, and it names the
+    misspelled string and the registry that holds the legal names so the caller can find
+    the right spelling.
+    """
+    with pytest.raises(ValueError) as refusal:
+        ArcheTypeConfig(lpg_households=configured_names).resolve_lpg_households()
+
+    message = str(refusal.value)
+    assert "CHR01_Couple_both_at_Wrok" in message
+    assert "utspclient.helpers.lpgdata.Households" in message
+    # A near miss gets the closest known spellings named outright.
+    assert "CHR01_Couple_both_at_Work" in message
+
+
+@pytest.mark.base
+def test_empty_household_list_is_refused() -> None:
+    """An empty ``lpg_households`` list names no occupants at all and is refused."""
+    with pytest.raises(ValueError) as refusal:
+        ArcheTypeConfig(lpg_households=[]).resolve_lpg_households()
+
+    assert "empty" in str(refusal.value)
+
+
+@pytest.mark.base
+@pytest.mark.parametrize(
+    "configured_value",
+    ["CHR01_Couple_both_at_Work", None, 5],
+    ids=["bare_string", "none", "number"],
+)
+def test_non_list_household_field_is_refused_as_a_type_error(configured_value: Any) -> None:
+    """``lpg_households`` has to be a list of names; anything else is a ``TypeError``.
+
+    A bare string is the interesting case: it would iterate character by character and
+    resolve nothing, so it is rejected on its type rather than on its contents.
+    """
+    with pytest.raises(TypeError) as refusal:
+        ArcheTypeConfig(lpg_households=configured_value).resolve_lpg_households()
+
+    assert "List[str]" in str(refusal.value)
+
+
+@pytest.mark.base
+def test_default_configuration_resolves() -> None:
+    """The dataclass default names a household the registry defines.
+
+    Guards the default against drifting to a name the LPG no longer ships, which every
+    caller relying on the default would then hit as a refusal.
+    """
+    assert isinstance(ArcheTypeConfig().resolve_lpg_households(), JsonReference)
+
+
+@pytest.mark.base
+def test_registry_constant_names_the_module_the_names_come_from() -> None:
+    """The registry quoted in the refusals is the module the resolver really reads.
+
+    The refusal sends the caller to a module path spelled out as a string, so this pins
+    that string to the class the resolver imports rather than letting the two drift apart.
+    """
+    assert ArcheTypeConfig.LPG_HOUSEHOLD_REGISTRY == f"{Households.__module__}.{Households.__name__}"
+    # A ClassVar, not a dataclass field: it must not show up in the serialized config.
+    assert "LPG_HOUSEHOLD_REGISTRY" not in ArcheTypeConfig().to_dict()  # type: ignore[attr-defined]

--- a/tests/building_sizer_utils/test_archetype_config.py
+++ b/tests/building_sizer_utils/test_archetype_config.py
@@ -107,6 +107,55 @@ def test_non_list_household_field_is_refused_as_a_type_error(configured_value: A
 
 
 @pytest.mark.base
+@pytest.mark.parametrize(
+    "configured_names, offending_index, offending_repr",
+    [
+        ([5], 0, "5"),
+        ([None], 0, "None"),
+        (["CHR01_Couple_both_at_Work", 5], 1, "5"),
+        ([["CHR01_Couple_both_at_Work"]], 0, "['CHR01_Couple_both_at_Work']"),
+    ],
+    ids=["number", "none", "number_after_a_name", "nested_list"],
+)
+def test_non_string_entry_is_refused_as_a_type_error(
+    configured_names: list[Any], offending_index: int, offending_repr: str
+) -> None:
+    """A list carrying a non-string entry is a ``TypeError`` naming the index and the value.
+
+    The container check alone let ``[5]`` through into the registry lookup, where it died as
+    ``'int' object is not iterable`` from inside ``difflib`` -- a message about the diagnostics
+    machinery rather than about the configuration. The entries are checked up front instead, which
+    is also what the method's ``Raises`` section promises.
+    """
+    with pytest.raises(TypeError) as refusal:
+        ArcheTypeConfig(lpg_households=configured_names).resolve_lpg_households()
+
+    message = str(refusal.value)
+    assert f"lpg_households[{offending_index}]" in message
+    assert offending_repr in message
+    assert "List[str]" in message
+
+
+@pytest.mark.base
+def test_a_bare_string_split_into_characters_says_so() -> None:
+    """A household name that arrived as a bare string is diagnosed as such, not per character.
+
+    ``dataclasses_json`` coerces a bare ``"CHR01_..."`` in a JSON config into a list of its
+    characters rather than refusing it, so the type checks above never see it and every single
+    character then looks like an unknown household. The refusal names that shape outright.
+    """
+    split_name = list("CHR01_Couple_both_at_Work")
+    assert len(split_name) > 1 and all(len(character) == 1 for character in split_name)
+
+    with pytest.raises(ValueError) as refusal:
+        ArcheTypeConfig(lpg_households=split_name).resolve_lpg_households()
+
+    message = str(refusal.value)
+    assert "Unknown LPG household 'C'" in message
+    assert "bare string rather than a list" in message
+
+
+@pytest.mark.base
 def test_default_configuration_resolves() -> None:
     """The dataclass default names a household the registry defines.
 

--- a/tests/building_sizer_utils/test_modular_household_config.py
+++ b/tests/building_sizer_utils/test_modular_household_config.py
@@ -246,7 +246,17 @@ UNREADABLE_CONFIGS: list[tuple[str, str | None, list[str]]] = [
     (
         "both_modules_missing",
         "{}",
-        ["declares neither an energy system config nor an archetype config"],
+        ["declares no energy_system_config_ and no archetype_config_"],
+    ),
+    (
+        "archetype_missing",
+        '{"energy_system_config_": {}}',
+        ["declares no archetype_config_"],
+    ),
+    (
+        "energy_system_missing",
+        '{"archetype_config_": {}}',
+        ["declares no energy_system_config_"],
     ),
 ]
 
@@ -262,11 +272,12 @@ def test_read_in_configs_refuses_a_config_it_cannot_read(
 ) -> None:
     """A named config that cannot be read raises and names both the path and the reason.
 
-    A missing file, a syntax error, a payload of the wrong shape and a config declaring neither of
-    its two modules used to be indistinguishable from "no config given": all four answered ``None``
-    and the calling setup then simulated its shipped default household with only a warning. Each is
-    now a refusal that quotes the path so the caller can see which file was rejected, plus the
-    underlying reason so they can tell a typo'd path from a stray comma.
+    A missing file, a syntax error, a payload of the wrong shape and a config missing one or both of
+    its two halves used to be indistinguishable from "no config given": all of them answered ``None``
+    and the calling setup then simulated its shipped default household with only a warning -- or, for
+    a half-filled config, died on a bare assertion naming neither the file nor the missing half. Each
+    is now a refusal that quotes the path so the caller can see which file was rejected, plus the
+    underlying reason so they can tell a typo'd path from a stray comma from a missing half.
     """
     config_path = tmp_path / f"{case_name}.json"
     if file_body is not None:
@@ -339,25 +350,40 @@ def test_read_in_configs_answers_none_when_no_config_was_given(
 
 
 @pytest.mark.base
-def test_read_in_configs_accepts_an_already_decoded_config_dict() -> None:
-    """A configuration handed over as a dictionary is decoded instead of being refused.
+def test_read_in_configs_refuses_a_file_whose_bytes_are_not_utf8(tmp_path: Path) -> None:
+    """A config file that is not UTF-8 is refused with the same shape as the other read failures.
 
-    Nine of the building-sizer setups write the configuration they used back into
-    ``Simulator.my_module_config`` -- the very attribute that is passed to ``read_in_configs`` -- so
-    a second setup call on the same simulator hands over a decoded mapping rather than a path.
+    The decoding happens while the file is being read, so the ``UnicodeDecodeError`` escaped both
+    the missing-file and the invalid-JSON handler and reached the caller raw, naming no path.
     """
-    written = ModularHouseholdConfig.get_default_config_for_household_oil()
+    config_path = tmp_path / "not_utf8.json"
+    config_path.write_bytes(b"\xff\xfe garbage")
 
-    read_back = read_in_configs(written.to_dict())
+    with pytest.raises(ValueError) as refusal:
+        read_in_configs(str(config_path))
 
-    assert read_back is not None
-    assert read_back.to_dict() == written.to_dict()
+    message = str(refusal.value)
+    assert str(config_path) in message
+    assert "not valid UTF-8" in message
 
 
 @pytest.mark.base
-def test_read_in_configs_refuses_an_empty_config_dict() -> None:
-    """An empty mapping is a config that declares nothing, so it is refused rather than defaulted."""
-    with pytest.raises(ValueError) as refusal:
-        read_in_configs({})
+@pytest.mark.parametrize(
+    "not_a_path",
+    [{}, {"energy_system_config_": {}}, 5, ["a_path.json"]],
+    ids=["empty_dict", "config_dict", "number", "list"],
+)
+def test_read_in_configs_refuses_anything_that_is_not_a_path(not_a_path: object) -> None:
+    """A config has to be named by a path string; an already-decoded object is a caller error.
 
-    assert "declares neither an energy system config nor an archetype config" in str(refusal.value)
+    ``Simulator.my_module_config`` is declared ``Optional[str]`` and the setups that read it split
+    it on ``"/"`` to build their result path, so a decoded configuration cannot travel that route
+    end to end. Accepting one here would have hidden that, which is why the reader refuses it
+    outright and names the forms it does accept.
+    """
+    with pytest.raises(TypeError) as refusal:
+        read_in_configs(not_a_path)  # type: ignore[arg-type]
+
+    message = str(refusal.value)
+    assert "path string" in message
+    assert "None for no config" in message

--- a/tests/building_sizer_utils/test_modular_household_config.py
+++ b/tests/building_sizer_utils/test_modular_household_config.py
@@ -4,11 +4,20 @@ Covers GitLab issue #733: the deterministic, side-effect-free
 ``get_default_config_for_household_*`` classmethods and the ``get_hash``
 instance method of
 :class:`~hisim.building_sizer_utils.interface_configs.modular_household_config.ModularHouseholdConfig`
-were previously untested. The file-I/O helpers ``write_config`` and
-``read_in_configs`` are intentionally not exercised here.
+were previously untested. The file-writing helper ``write_config`` is intentionally
+not exercised here.
+
+The last family of tests covers ``read_in_configs`` and the line it draws between
+"no config was given" and "a config was given but cannot be read": the first answers
+``None`` so the calling setup uses its own default household, the second raises and
+names the source and the reason. The reader used to swallow every read failure and
+answer ``None`` either way, so a typo'd path silently simulated the default household.
 """
 
 from __future__ import annotations
+
+import json
+from pathlib import Path
 
 import pytest
 
@@ -18,6 +27,7 @@ from hisim.building_sizer_utils.interface_configs import (
 )
 from hisim.building_sizer_utils.interface_configs.modular_household_config import (
     ModularHouseholdConfig,
+    read_in_configs,
 )
 from hisim.loadtypes import ComponentType, HeatingSystems
 
@@ -217,3 +227,137 @@ def test_direct_construction_leaves_sub_configs_none() -> None:
     cfg = ModularHouseholdConfig()
     assert cfg.energy_system_config_ is None
     assert cfg.archetype_config_ is None
+
+
+#: The unreadable-config cases ``read_in_configs`` has to refuse, each as a file body to write
+#: (``None`` meaning "write no file at all", i.e. the path does not exist) paired with the
+#: fragments the refusal must contain. Every message has to name the source, so the file name is
+#: asserted separately for all of them and only the case-specific reason is listed here.
+UNREADABLE_CONFIGS: list[tuple[str, str | None, list[str]]] = [
+    ("missing_file", None, ["Could not open", "No such file"]),
+    ("invalid_json", "{not json at all", ["not valid JSON", "Expecting property name"]),
+    ("truncated_json", '{"archetype_config_": {', ["not valid JSON"]),
+    ("wrong_shape", "[1, 2, 3]", ["Could not decode", "ModularHouseholdConfig"]),
+    (
+        "wrong_field_type",
+        '{"archetype_config_": {"lpg_households": 5}}',
+        ["Could not decode", "ModularHouseholdConfig"],
+    ),
+    (
+        "both_modules_missing",
+        "{}",
+        ["declares neither an energy system config nor an archetype config"],
+    ),
+]
+
+
+@pytest.mark.base
+@pytest.mark.parametrize(
+    "case_name, file_body, expected_fragments",
+    UNREADABLE_CONFIGS,
+    ids=[case_name for case_name, _, _ in UNREADABLE_CONFIGS],
+)
+def test_read_in_configs_refuses_a_config_it_cannot_read(
+    case_name: str, file_body: str | None, expected_fragments: list[str], tmp_path: Path
+) -> None:
+    """A named config that cannot be read raises and names both the path and the reason.
+
+    A missing file, a syntax error, a payload of the wrong shape and a config declaring neither of
+    its two modules used to be indistinguishable from "no config given": all four answered ``None``
+    and the calling setup then simulated its shipped default household with only a warning. Each is
+    now a refusal that quotes the path so the caller can see which file was rejected, plus the
+    underlying reason so they can tell a typo'd path from a stray comma.
+    """
+    config_path = tmp_path / f"{case_name}.json"
+    if file_body is not None:
+        config_path.write_text(file_body, encoding="utf8")
+
+    with pytest.raises(ValueError) as refusal:
+        read_in_configs(str(config_path))
+
+    message = str(refusal.value)
+    assert str(config_path) in message
+    for fragment in expected_fragments:
+        assert fragment in message
+
+
+@pytest.mark.base
+def test_read_in_configs_reads_a_valid_config_file(tmp_path: Path) -> None:
+    """A well-formed config file is read back with both of its modules intact."""
+    written = ModularHouseholdConfig.get_default_config_for_household_gas()
+    config_path = tmp_path / "valid_config.json"
+    config_path.write_text(json.dumps(written.to_dict()), encoding="utf8")
+
+    read_back = read_in_configs(str(config_path))
+
+    assert read_back is not None
+    assert read_back.energy_system_config_ is not None
+    assert read_back.archetype_config_ is not None
+    assert read_back.energy_system_config_.heating_system == HeatingSystems.GAS_HEATING
+    assert read_back.to_dict() == written.to_dict()
+
+
+@pytest.mark.base
+def test_read_in_configs_strips_whitespace_around_the_path(tmp_path: Path) -> None:
+    """Carriage returns and newlines around the path are stripped before the file is opened.
+
+    The building sizer hands the path through shell plumbing that can append a line ending, so a
+    path with surrounding whitespace still has to name a readable file rather than refuse.
+    """
+    config_path = tmp_path / "valid_config.json"
+    config_path.write_text(
+        json.dumps(ModularHouseholdConfig.get_default_config_for_household_heatpump().to_dict()),
+        encoding="utf8",
+    )
+
+    read_back = read_in_configs(f" {config_path}\r\n")
+
+    assert read_back is not None
+    assert read_back.energy_system_config_ is not None
+    assert read_back.energy_system_config_.heating_system == HeatingSystems.HEAT_PUMP
+
+
+@pytest.mark.base
+@pytest.mark.parametrize(
+    "no_config",
+    [None, "", "   ", "\r\n"],
+    ids=["none", "empty_string", "blanks", "line_ending_only"],
+)
+def test_read_in_configs_answers_none_when_no_config_was_given(
+    no_config: str | None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Every spelling of "no config given" answers ``None`` and says so in the log.
+
+    ``None`` is the answer the eleven building-sizer setups read as "use my own default household",
+    so this is the one path that must keep working unchanged after the reader started refusing
+    unreadable configs. The logged line is asserted too: it is what tells a reader of the run log
+    that the default was chosen deliberately rather than fallen back to after a failed read.
+    """
+    assert read_in_configs(no_config) is None
+
+    assert "No modular household config was given" in capsys.readouterr().out
+
+
+@pytest.mark.base
+def test_read_in_configs_accepts_an_already_decoded_config_dict() -> None:
+    """A configuration handed over as a dictionary is decoded instead of being refused.
+
+    Nine of the building-sizer setups write the configuration they used back into
+    ``Simulator.my_module_config`` -- the very attribute that is passed to ``read_in_configs`` -- so
+    a second setup call on the same simulator hands over a decoded mapping rather than a path.
+    """
+    written = ModularHouseholdConfig.get_default_config_for_household_oil()
+
+    read_back = read_in_configs(written.to_dict())
+
+    assert read_back is not None
+    assert read_back.to_dict() == written.to_dict()
+
+
+@pytest.mark.base
+def test_read_in_configs_refuses_an_empty_config_dict() -> None:
+    """An empty mapping is a config that declares nothing, so it is refused rather than defaulted."""
+    with pytest.raises(ValueError) as refusal:
+        read_in_configs({})
+
+    assert "declares neither an energy system config nor an archetype config" in str(refusal.value)

--- a/tests/test_system_setups_households_for_building_sizer.py
+++ b/tests/test_system_setups_households_for_building_sizer.py
@@ -11,11 +11,12 @@ loaded and checked to contain finite numeric KPI values, including the
 tests verify real post-processing output rather than only that the run did not
 crash.
 
-Two test families in this file run no simulation at all. Every building-sizer setup
+Three test families in this file run no simulation at all. Every building-sizer setup
 refuses a zero rooftop photovoltaic share while the energy manager is switched on, and
 every one of them refuses an LPG household name the profile registry does not define
-instead of quietly dropping it. Both refusals are raised before any component is built,
-so each is checked by initializing every setup once and catching the error.
+instead of quietly dropping it; one setup also stands in for the fleet in refusing a
+module-config path it cannot read. All three refusals are raised before any component is
+built, so each is checked by initializing the setup once and catching the error.
 """
 # clean
 import json
@@ -401,3 +402,32 @@ def test_building_sizer_setup_refuses_an_unknown_lpg_household(
     message = str(refusal.value)
     assert "CHR01_Couple_both_at_Wrok" in message
     assert "utspclient.helpers.lpgdata.Households" in message
+
+
+@pytest.mark.base
+def test_building_sizer_setup_refuses_a_module_config_path_it_cannot_read(tmp_path: Path) -> None:
+    """Test that a setup handed a module-config path that does not exist refuses the run.
+
+    This is the headline behaviour of the fail-loud reader seen from where it matters: a run
+    driven through ``initialize_from_python`` with a typo'd module-config path used to simulate
+    the setup's shipped default household with only a warning, so the caller got a complete,
+    plausible result for a configuration that had never been read. The refusal happens on the
+    first statement of the setup, before any component is built, so no simulation runs here.
+
+    The heat-pump sizer stands in for all thirteen callers: the reading is done by the shared
+    ``read_in_configs``, not per setup, and the per-reason messages are covered directly in
+    ``tests/building_sizer_utils/test_modular_household_config.py``.
+    """
+    missing_config_path = tmp_path / "typo_in_the_path.json"
+    assert not missing_config_path.exists()
+
+    setup_path = Path(__file__).resolve().parents[1] / "system_setups" / "household_heatpump_building_sizer.py"
+    with pytest.raises(ValueError) as refusal:
+        hisim_main.initialize_from_python(
+            str(setup_path),
+            my_simulation_parameters=SimulationParameters.one_day_only(2021, 60 * 15),
+            my_module_config=str(missing_config_path),
+        )
+    message = str(refusal.value)
+    assert str(missing_config_path) in message
+    assert "Could not open" in message

--- a/tests/test_system_setups_households_for_building_sizer.py
+++ b/tests/test_system_setups_households_for_building_sizer.py
@@ -11,10 +11,11 @@ loaded and checked to contain finite numeric KPI values, including the
 tests verify real post-processing output rather than only that the run did not
 crash.
 
-One test family in this file runs no simulation at all: every building-sizer setup
-refuses a zero rooftop photovoltaic share while the energy manager is switched on,
-and that refusal is raised before any component is built, so it is checked by
-initializing each setup once and catching the error.
+Two test families in this file run no simulation at all. Every building-sizer setup
+refuses a zero rooftop photovoltaic share while the energy manager is switched on, and
+every one of them refuses an LPG household name the profile registry does not define
+instead of quietly dropping it. Both refusals are raised before any component is built,
+so each is checked by initializing every setup once and catching the error.
 """
 # clean
 import json
@@ -291,25 +292,34 @@ def test_household_heatpump_car(building_sizer_result_directory: str) -> None:
     _assert_kpi_artefacts_written(building_sizer_result_directory, path)
 
 
+#: The eleven building-sizer setups paired with the ``ModularHouseholdConfig`` factory whose
+#: heating system each one accepts. Every setup refuses a heating system other than its own before
+#: it reaches anything else, so a test that wants to drive a setup past that check has to start
+#: from this setup's own default configuration. Shared by the two configuration-refusal tests
+#: below so a new setup is added to both at once.
+BUILDING_SIZER_SETUPS_AND_DEFAULT_CONFIGS: list[tuple[str, str]] = [
+    ("household_district_heating_building_sizer.py", "get_default_config_for_household_district_heating"),
+    ("household_electric_heating_building_sizer.py", "get_default_config_for_household_electric_heating"),
+    ("household_gas_building_sizer.py", "get_default_config_for_household_gas"),
+    ("household_gas_solar_thermal_building_sizer.py", "get_default_config_for_household_gas_solar_thermal"),
+    ("household_heatpump_building_sizer.py", "get_default_config_for_household_heatpump"),
+    ("household_heatpump_car_building_sizer.py", "get_default_config_for_household_heatpump"),
+    (
+        "household_heatpump_solar_thermal_building_sizer.py",
+        "get_default_config_for_household_heatpump_solar_thermal",
+    ),
+    ("household_hydrogen_boiler_building_sizer.py", "get_default_config_for_household_hydrogen"),
+    ("household_oil_building_sizer.py", "get_default_config_for_household_oil"),
+    ("household_pellets_building_sizer.py", "get_default_config_for_household_pellet"),
+    ("household_wood_chips_building_sizer.py", "get_default_config_for_household_wood_chips"),
+]
+
+
 @pytest.mark.base
 @pytest.mark.parametrize(
     "setup_file_name, default_config_getter_name",
-    [
-        ("household_district_heating_building_sizer.py", "get_default_config_for_household_district_heating"),
-        ("household_electric_heating_building_sizer.py", "get_default_config_for_household_electric_heating"),
-        ("household_gas_building_sizer.py", "get_default_config_for_household_gas"),
-        ("household_gas_solar_thermal_building_sizer.py", "get_default_config_for_household_gas_solar_thermal"),
-        ("household_heatpump_building_sizer.py", "get_default_config_for_household_heatpump"),
-        ("household_heatpump_car_building_sizer.py", "get_default_config_for_household_heatpump"),
-        (
-            "household_heatpump_solar_thermal_building_sizer.py",
-            "get_default_config_for_household_heatpump_solar_thermal",
-        ),
-        ("household_hydrogen_boiler_building_sizer.py", "get_default_config_for_household_hydrogen"),
-        ("household_oil_building_sizer.py", "get_default_config_for_household_oil"),
-        ("household_pellets_building_sizer.py", "get_default_config_for_household_pellet"),
-        ("household_wood_chips_building_sizer.py", "get_default_config_for_household_wood_chips"),
-    ],
+    BUILDING_SIZER_SETUPS_AND_DEFAULT_CONFIGS,
+    ids=[setup_file_name for setup_file_name, _ in BUILDING_SIZER_SETUPS_AND_DEFAULT_CONFIGS],
 )
 def test_building_sizer_setup_refuses_zero_pv_share_with_energy_manager(
     setup_file_name: str, default_config_getter_name: str, tmp_path: Path
@@ -332,8 +342,9 @@ def test_building_sizer_setup_refuses_zero_pv_share_with_energy_manager(
     config_path = tmp_path / "zero_pv_share_with_ems.json"
     config_path.write_text(json.dumps(household_config.to_dict()), encoding="utf8")
 
-    # read_in_configs answers None for anything it cannot parse and the setup then falls back to the
-    # class defaults, which would make this test pass its configuration to nobody.
+    # read_in_configs now refuses a config it cannot read instead of answering None, but a config it
+    # reads only partially would still leave the setup with different values than this test wrote.
+    # Reading the file back confirms the two fields under test really reach the setup.
     written_config = read_in_configs(str(config_path))
     assert written_config is not None and written_config.energy_system_config_ is not None
     assert written_config.energy_system_config_.share_of_maximum_pv_potential == 0.0
@@ -349,3 +360,44 @@ def test_building_sizer_setup_refuses_zero_pv_share_with_energy_manager(
     message = str(refusal.value)
     assert "share_of_maximum_pv_potential" in message
     assert "use_battery_and_ems" in message
+
+
+@pytest.mark.base
+@pytest.mark.parametrize(
+    "setup_file_name, default_config_getter_name",
+    BUILDING_SIZER_SETUPS_AND_DEFAULT_CONFIGS,
+    ids=[setup_file_name for setup_file_name, _ in BUILDING_SIZER_SETUPS_AND_DEFAULT_CONFIGS],
+)
+def test_building_sizer_setup_refuses_an_unknown_lpg_household(
+    setup_file_name: str, default_config_getter_name: str, tmp_path: Path
+) -> None:
+    """Test that a misspelled LPG household name is refused instead of quietly dropped.
+
+    The occupancy block of every building-sizer setup used to skip any name the LPG household
+    registry did not define, so a config asking for two households and misspelling one of them
+    built a one-household building without a word about it. The name is now resolved by
+    ``ArcheTypeConfig.resolve_lpg_households`` for all eleven setups, which refuses the unknown
+    name. The refusal is raised before any component is built, so this test needs no simulation:
+    it takes each setup's own default config (its heating system is checked first, and a foreign
+    one would be refused before the households are read), adds a misspelled household beside a
+    real one, and asserts the refusal names the typo and the registry the legal names live in.
+    """
+    household_config = getattr(ModularHouseholdConfig, default_config_getter_name)()
+    assert household_config.archetype_config_ is not None
+    household_config.archetype_config_.lpg_households = [
+        "CHR01_Couple_both_at_Work",
+        "CHR01_Couple_both_at_Wrok",
+    ]
+    config_path = tmp_path / "unknown_lpg_household.json"
+    config_path.write_text(json.dumps(household_config.to_dict()), encoding="utf8")
+
+    setup_path = Path(__file__).resolve().parents[1] / "system_setups" / setup_file_name
+    with pytest.raises(ValueError) as refusal:
+        hisim_main.initialize_from_python(
+            str(setup_path),
+            my_simulation_parameters=SimulationParameters.one_day_only(2021, 60 * 15),
+            my_module_config=str(config_path),
+        )
+    message = str(refusal.value)
+    assert "CHR01_Couple_both_at_Wrok" in message
+    assert "utspclient.helpers.lpgdata.Households" in message


### PR DESCRIPTION
## Problem

Two silent substitutions found by the fleet-wide setup inventory
(`roadmap/declarative_energy_systems/grouping_worklist.md`). First, `read_in_configs` caught every
exception, so a missing file, a typo'd path, invalid JSON and a wrong-shaped payload were all
indistinguishable from "no config given": the run silently simulated the shipped default household,
with only a warning between the caller and a wrong result. Second, the sizer setups' occupancy loop
guarded LPG household names with `hasattr` and silently skipped unknown ones, so a typo built a
household with fewer occupants than configured — and only for lists of two or more; a single typo'd
name crashed as a bare `AttributeError` instead, so the position of the typo decided crash or wrong
result.

## Done

- `read_in_configs`: no config given (None, empty, whitespace) still yields the default, with an
  honest log line; a config that was named but cannot be opened, parsed or decoded — or that
  declares neither an energy-system nor an archetype half — raises `ValueError` naming the source,
  the underlying reason, and the alternative (fix the path, or pass no config to ask for the
  default on purpose). Mappings are accepted, since nine sizers write `to_dict()` back onto the
  attribute they read. Every caller checked: thirteen setups, `hisim_main`, the RenoVisor runner,
  the JSON converter, the executor, and the CI quality workflow's no-config invocation.
- The thirteen setups' fallback log line, which claimed an unreadable config had been replaced by
  the default, now says what is true: no config was given.
- The eleven sizers' thirteen-line occupancy blocks become one call each to a new
  `ArcheTypeConfig.resolve_lpg_households()`, beside the field it reads: the old contract exactly
  (one name a `JsonReference`, several a list in configured order, empty and non-list still
  refused), plus a refusal for unknown names that names the registry, offers a did-you-mean via
  `difflib`, and says what the silence used to cost.

## Result

Thirty-six new tests — the reader's refusal and no-config cases, the resolver's eleven behaviours,
and all eleven setups driven through the real path (the refusal fires before any component is
built, so the cases run in seconds) — passing identically from the repository root and from inside
`tests/`; 168 passed across the touched suites, all six RenoVisor suites green. One finding
recorded on the worklist rather than fixed here: `ModularHouseholdConfig.get_hash()` is not
round-trip stable (two int-valued float fields come back as floats from JSON), which matters
because the building sizer hashes configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
