### PR TITLE
The renaming table catches up with the ports the fleet actually grows

### DIFF
--- a/scripts/p3_parity_renamings.py
+++ b/scripts/p3_parity_renamings.py
@@ -185,11 +185,15 @@ class DeclaredPortRenamings:
             # The battery target of the ten EMS sizers that pass this prefix. The legacy name is
             # that prefix, 'LoadingPowerInputForBattery_', plus the controller's fourteenth
             # output: the controller declares thirteen outputs before any setup adds a dispatch —
-            # seven of its own plus one per dynamic default connection it carries — so the first
-            # dispatch a setup adds is number fourteen. That count is the controller's, not the
-            # setup's: retiring one of those default connections moved every name here down by one
-            # (it read 'Output15' until the heat pump the retired connection served went away), and
-            # a test asserts the numbers against a live build so the next such move is caught here.
+            # seven of its own plus six grown by its default connections (one each for the
+            # occupancy and the solar-thermal pump, two each for the heat pump and the electric
+            # heater, none for PV or the battery) — so the first dispatch a setup adds is number
+            # fourteen. That count is the controller's, not the setup's, and this row was authored
+            # stale: retiring the old advanced heat pump (#604) had already removed one of those
+            # outputs when the table was first written, yet the row spelled the pre-retirement
+            # 'Output15', so every EMS setup failed the parity comparison from the table's first
+            # day. A test now asserts the numbers against a live build, so a wrong counter — born
+            # stale or moved later — is caught there instead of failing the whole fleet.
             "LoadingPowerInputForBattery_Output14": "DispatchToBattery_LoadingPowerInput",
             # The dynamic-components example steers four participants and names all four targets
             # 'ElectricityTargetOutput', so in the legacy spelling only the counter tells them

--- a/scripts/p3_parity_renamings.py
+++ b/scripts/p3_parity_renamings.py
@@ -81,6 +81,11 @@ class DeclaredPortRenamings:
             "Input_SolarThermalSystem_ElectricityConsumptionOutput_1": (
                 "ElectricityConsumptionOutputFromSolarThermalSystem"
             ),
+            # The air conditioner's draw, which air_conditioned_house likewise measures at the
+            # meter directly, inserted after the PV production and the household demand.
+            "Input_AirConditioner_ElectricalPowerConsumption_2": (
+                "ElectricalPowerConsumptionFromAirConditioner"
+            ),
             # In every EMS-controlled sizer the meter has exactly one participant — the
             # controller's residual — so the index is always zero.
             "Input_L2EMSElectricityController_TotalElectricityToOrFromGrid_0": (
@@ -92,15 +97,24 @@ class DeclaredPortRenamings:
         # last participant, so its index counts however many controlled heaters precede it, and
         # that is the whole reason four spellings of one wire appear below.
         "L2EMSElectricityController": {
-            # Household demand from the occupancy, weight 1 and therefore inserted early.
+            # Household demand from the occupancy, weight 1 and therefore inserted early. Index
+            # three is the car sizer, the one setup that inserts a participant before the demand.
             "Input_UTSPConnector_ElectricalPowerConsumption_2": "ElectricalPowerConsumptionFromUTSPConnector",
+            "Input_UTSPConnector_ElectricalPowerConsumption_3": "ElectricalPowerConsumptionFromUTSPConnector",
             # PV production, weight 999 and therefore inserted after the controlled loads.
             "Input_PVSystem_ElectricityOutput_2": "ElectricityOutputFromPVSystem",
             "Input_PVSystem_ElectricityOutput_3": "ElectricityOutputFromPVSystem",
+            "Input_PVSystem_ElectricityOutput_4": "ElectricityOutputFromPVSystem",
+            # The charge control of the electric car, which only the car sizer has. It is the
+            # first participant that setup wires, which is why every index of it counts one higher
+            # than the same participant's index in the sizers without a car.
+            "Input_L1EVChargeControl_1_BatteryChargingPowerToEMS_2": (
+                "BatteryChargingPowerToEMSFromL1EVChargeControl_1"
+            ),
             # The battery's realised charge or discharge, fed back so the controller sees what its
             # own dispatch achieved. Four indices: no controlled heater (district heating, gas,
             # hydrogen, pellets, wood chips), one (gas solar thermal), two (electric heating,
-            # heat pump) and three (heat pump plus solar thermal).
+            # heat pump) and three (heat pump plus solar thermal, and heat pump plus car).
             "Input_Battery_AcBatteryPowerUsed_4": "AcBatteryPowerUsedFromBattery",
             "Input_Battery_AcBatteryPowerUsed_5": "AcBatteryPowerUsedFromBattery",
             "Input_Battery_AcBatteryPowerUsed_6": "AcBatteryPowerUsedFromBattery",
@@ -112,11 +126,18 @@ class DeclaredPortRenamings:
             # The two CHPs of the same example.
             "Input_CHP1_ElectricityOutput_5": "ElectricityOutputFromCHP1",
             "Input_CHP2_ElectricityOutput_6": "ElectricityOutputFromCHP2",
-            # The hplib heat pump's two controlled draws in the heat-pump sizers.
+            # The hplib heat pump's two controlled draws in the heat-pump sizers, and the same two
+            # one index later in the car sizer, where the car's charge control precedes them.
             "Input_MoreAdvancedHeatPumpHPLib_ElectricalInputPowerSH_4": (
                 "ElectricalInputPowerSHFromMoreAdvancedHeatPumpHPLib"
             ),
             "Input_MoreAdvancedHeatPumpHPLib_ElectricalInputPowerDHW_5": (
+                "ElectricalInputPowerDHWFromMoreAdvancedHeatPumpHPLib"
+            ),
+            "Input_MoreAdvancedHeatPumpHPLib_ElectricalInputPowerSH_5": (
+                "ElectricalInputPowerSHFromMoreAdvancedHeatPumpHPLib"
+            ),
+            "Input_MoreAdvancedHeatPumpHPLib_ElectricalInputPowerDHW_6": (
                 "ElectricalInputPowerDHWFromMoreAdvancedHeatPumpHPLib"
             ),
             # The resistive heater's two controlled draws in the electric-heating sizer.
@@ -161,16 +182,33 @@ class DeclaredPortRenamings:
     #: happen to agree.
     DISPATCH_OUTPUTS: ClassVar[Mapping[str, Mapping[str, str]]] = {
         "L2EMSElectricityController": {
-            # The battery target of all nine EMS sizers. The legacy name is the prefix the setup
-            # passed, 'LoadingPowerInputForBattery_', plus the controller's fifteenth output.
-            "LoadingPowerInputForBattery_Output15": "DispatchToBattery_LoadingPowerInput",
+            # The battery target of the ten EMS sizers that pass this prefix. The legacy name is
+            # that prefix, 'LoadingPowerInputForBattery_', plus the controller's fourteenth
+            # output: the controller declares thirteen outputs before any setup adds a dispatch —
+            # seven of its own plus one per dynamic default connection it carries — so the first
+            # dispatch a setup adds is number fourteen. That count is the controller's, not the
+            # setup's: retiring one of those default connections moved every name here down by one
+            # (it read 'Output15' until the heat pump the retired connection served went away), and
+            # a test asserts the numbers against a live build so the next such move is caught here.
+            "LoadingPowerInputForBattery_Output14": "DispatchToBattery_LoadingPowerInput",
             # The dynamic-components example steers four participants and names all four targets
             # 'ElectricityTargetOutput', so in the legacy spelling only the counter tells them
-            # apart — which is exactly the fragility the declarative templates remove.
-            "ElectricityTargetOutput15": "DispatchToBattery1_LoadingPowerInput",
-            "ElectricityTargetOutput16": "DispatchToBattery2_LoadingPowerInput",
-            "ElectricityTargetOutput17": "DispatchToCHP1_ElectricityFromCHPTarget",
-            "ElectricityTargetOutput18": "DispatchToCHP2_ElectricityFromCHPTarget",
+            # apart — which is exactly the fragility the declarative templates remove. They start
+            # from the same fourteenth output and count up in the order the setup adds them.
+            "ElectricityTargetOutput14": "DispatchToBattery1_LoadingPowerInput",
+            "ElectricityTargetOutput15": "DispatchToBattery2_LoadingPowerInput",
+            "ElectricityTargetOutput16": "DispatchToCHP1_ElectricityFromCHPTarget",
+            "ElectricityTargetOutput17": "DispatchToCHP2_ElectricityFromCHPTarget",
+            # The car sizer steers two participants and passes a prefix of its own for each: the
+            # car's charge control first, so it takes the fourteenth output, then the house
+            # battery, which takes the fifteenth. That setup is therefore the one place where the
+            # battery target is not spelled 'LoadingPowerInputForBattery_' — the declarative name
+            # is the same either way, because it is derived from the participant and its input
+            # rather than from what a setup chose to call the channel.
+            "ElectricityToOrFromGridOfL1Controller_Output14": (
+                "DispatchToL1EVChargeControl_1_ElectricityTargetFromEMS"
+            ),
+            "ChargingPowerForBattery_Output15": "DispatchToBattery_LoadingPowerInput",
         },
     }
 

--- a/tests/test_p3_parity.py
+++ b/tests/test_p3_parity.py
@@ -23,12 +23,14 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
-from typing import ClassVar, Optional
+from typing import ClassVar, Optional, Tuple
 
 import pandas as pd
 import pytest
 
+from hisim.energy_system.parity import WiringParityHarness, WiringSnapshot
 from hisim.simulationparameters import SimulationParameters
+from hisim.simulator import Simulator
 
 # The rig's shared names are imported through the checker's namespace on purpose: the scripts are
 # importable both as ``p3_parity_*`` and as ``scripts.p3_parity_*``, and those are two separate
@@ -38,6 +40,7 @@ from hisim.simulationparameters import SimulationParameters
 from scripts.p3_parity_check import (
     DeclaredPortRenamings,
     ParityChecker,
+    ParitySide,
     ParityWindows,
     Report,
     RunOutcome,
@@ -89,6 +92,30 @@ class Rig:
     #: it — so the failure the test asserts comes from the wiring comparison, not from a crash.
     RENAMED_COMPONENT: ClassVar[str] = "RenamedTransformerAndRectifier"
 
+    #: The setup the staleness canary drives. It is the only in-scope setup that steers several
+    #: participants through one energy manager and needs no load profile from the LoadProfileGenerator,
+    #: so it exercises the counter-numbered dispatch names at a cost a base test can carry.
+    CANARY: ClassVar[str] = "dynamic_components"
+
+    #: The aggregator whose port names the canary checks. Every EMS setup grows its dispatch names
+    #: through this one component, which is why one setup can stand in for all of them.
+    CANARY_AGGREGATOR: ClassVar[str] = "L2EMSElectricityController"
+
+    #: Every legacy port the canary setup's energy manager grows, as the table declares them. The
+    #: numbers are the whole point: an input carries its insertion index and a dispatch output the
+    #: controller's output counter, so both move when anything before them is added or removed.
+    CANARY_LEGACY_PORTS: ClassVar[Tuple[str, ...]] = (
+        "Input_PVSystem_ElectricityOutput_2",
+        "Input_Battery1_AcBatteryPowerUsed_3",
+        "Input_Battery2_AcBatteryPowerUsed_4",
+        "Input_CHP1_ElectricityOutput_5",
+        "Input_CHP2_ElectricityOutput_6",
+        "ElectricityTargetOutput14",
+        "ElectricityTargetOutput15",
+        "ElectricityTargetOutput16",
+        "ElectricityTargetOutput17",
+    )
+
     @classmethod
     def triple(cls, work: Path, energy_system: Optional[Path] = None) -> TripleInputs:
         """Builds the triple the real tests run.
@@ -117,6 +144,56 @@ class Rig:
             A checker demanding exact equality and carrying the declared renamings.
         """
         return ParityChecker(Tolerance(), DeclaredPortRenamings.port_renaming())
+
+    @classmethod
+    def resolved_wiring(cls, simulator: Simulator) -> WiringSnapshot:
+        """Takes a built simulator through the two steps that resolve its wiring, and snapshots it.
+
+        A port name is only final once the automatic default connections have been applied, which
+        happens in ``prepare_calculation``, and once every input has found its source, which happens
+        in ``connect_all_components``. Those two are the beginning of ``run_all_timesteps`` and are
+        run here without the timesteps that follow, because the names are what this test is about
+        and simulating a week to read them would cost minutes rather than seconds.
+
+        Args:
+            simulator: A simulator whose components have been registered and wired.
+
+        Returns:
+            The canonical wiring snapshot of that simulator.
+        """
+        simulator.prepare_calculation()
+        simulator.connect_all_components()
+        return WiringSnapshot.from_simulator(simulator)
+
+    @classmethod
+    def canary_wiring(cls, work: Path) -> Tuple[WiringSnapshot, WiringSnapshot]:
+        """Builds the canary setup both ways, far enough to name every port, and snapshots each.
+
+        Both builds are given their own result and cache directory under the test's temporary
+        directory, for the same reason the rig gives each side of a triple its own: a shared cache
+        would let the second build read what the first one wrote.
+
+        Args:
+            work: Where the two builds may write; a test's own temporary directory.
+
+        Returns:
+            The Python setup's wiring and the recorded twin's wiring, in that order.
+        """
+        from hisim.energy_system.executor import build_energy_system  # noqa: PLC0415
+        from hisim.hisim_main import initialize_from_python  # noqa: PLC0415
+
+        legacy_parameters = ParityWindows.build(cls.WINDOW, work / "python", work / "python-cache")
+        ParitySide.reset_singletons()
+        legacy = cls.resolved_wiring(
+            initialize_from_python(str(cls.SETUPS / f"{cls.CANARY}.py"), legacy_parameters, None)
+        )
+
+        declared_parameters = ParityWindows.build(cls.WINDOW, work / "declarative", work / "declarative-cache")
+        ParitySide.reset_singletons()
+        declarative = cls.resolved_wiring(
+            build_energy_system(cls.ENERGY_SYSTEMS / f"{cls.CANARY}.energy_system.yaml", declared_parameters).simulator
+        )
+        return legacy, declarative
 
 
 @pytest.mark.base
@@ -165,11 +242,48 @@ def test_the_renaming_table_declares_one_meaning_per_legacy_port() -> None:
     assert pairs, "the table declares nothing, so every aggregator port would fail literally"
     assert pairs[("ElectricityMeter", "Input_PVSystem_ElectricityOutput_0")] == "ElectricityOutputFromPVSystem"
     assert (
-        pairs[("L2EMSElectricityController", "LoadingPowerInputForBattery_Output15")]
+        pairs[("L2EMSElectricityController", "LoadingPowerInputForBattery_Output14")]
         == "DispatchToBattery_LoadingPowerInput"
     )
     renaming = DeclaredPortRenamings.port_renaming()
     assert renaming.rename("ElectricityMeter", "SomethingNobodyDeclared") == "SomethingNobodyDeclared"
+
+
+@pytest.mark.base
+def test_the_table_still_spells_the_ports_the_dynamic_components_setup_actually_grows(tmp_path: Path) -> None:
+    """Catches a renaming table that has gone stale because a dispatch counter moved.
+
+    Every legacy dynamic port name in the table carries a number the two paths do not agree on: an
+    aggregator input carries its insertion index, and a dispatch output carries the aggregator's
+    running output counter, which counts the outputs the component had already declared when the
+    setup added the dispatch. That counter is not the setup's to control — an energy manager that
+    gains or loses one declared output renumbers every dispatch output of every setup that uses it —
+    so the table can be correct when it is written and wrong a month later without anyone touching
+    it. That is exactly what happened once: retiring one of the manager's default connections moved
+    all of them down by one, the table kept claiming the old numbers, and the whole fleet's dispatch
+    failed at once with a wiring difference that was nothing but a name.
+
+    This is the canary for that class of failure. One setup is enough because all thirteen energy
+    manager setups grow their names through the same machinery, and this one has no load profile to
+    generate, so it costs a base test seconds instead of minutes. It asserts both halves: that every
+    legacy name the table declares for this setup is a port the Python build really has — a name
+    nobody grows any more can never be exercised again — and that translating the Python wiring
+    through the table yields precisely the twin's wiring, which is the claim the rig makes fleet-wide.
+    """
+    legacy, declarative = Rig.canary_wiring(tmp_path)
+    grown = (
+        {wire.target_input for wire in legacy.wires if wire.target_component == Rig.CANARY_AGGREGATOR}
+        | {wire.source_output for wire in legacy.wires if wire.source_component == Rig.CANARY_AGGREGATOR}
+        | {port for component, port in legacy.unconnected_inputs if component == Rig.CANARY_AGGREGATOR}
+    )
+    declared = DeclaredPortRenamings.pairs()
+
+    for port in Rig.CANARY_LEGACY_PORTS:
+        assert port in grown, f"'{Rig.CANARY}' no longer grows '{port}', so the table declares a name nobody uses"
+        assert (Rig.CANARY_AGGREGATOR, port) in declared, f"the table stopped declaring '{port}'"
+
+    diff = WiringParityHarness.compare(DeclaredPortRenamings.port_renaming().apply_to(legacy), declarative)
+    assert diff.is_identical(), diff.describe()
 
 
 @pytest.mark.base

--- a/tests/test_p3_parity.py
+++ b/tests/test_p3_parity.py
@@ -21,9 +21,10 @@ Each test states the failure mode it catches.
 
 from __future__ import annotations
 
+import json
 import math
 from pathlib import Path
-from typing import ClassVar, Optional, Tuple
+from typing import ClassVar, Optional, Set, Tuple
 
 import pandas as pd
 import pytest
@@ -195,6 +196,40 @@ class Rig:
         )
         return legacy, declarative
 
+    @classmethod
+    def scenario_port_spellings(cls) -> Set[Tuple[str, str]]:
+        """Every ``(component name, port name)`` pair a committed scenario file spells out.
+
+        The ``.scenario.json`` files are regenerated from live builds of the Python setups
+        (``scripts/regenerate_scenario_jsons.py``), and every connection endpoint in them names its
+        component and its port — the same two strings that key the renaming table. Collecting the
+        endpoints of all of them therefore yields the fleet's legacy port names without building a
+        single setup, which is what lets a base test cross-check the whole table in milliseconds.
+
+        The walk is structural rather than schema-bound: any mapping that carries both a
+        ``component_name`` and a ``field_name`` string is an endpoint, wherever the file nests it,
+        so the collection survives a scenario format that moves its connection list.
+
+        Returns:
+            The set of ``(component_name, field_name)`` pairs found in all scenario files.
+        """
+        spellings: Set[Tuple[str, str]] = set()
+
+        def walk(node: object) -> None:
+            if isinstance(node, dict):
+                component, field = node.get("component_name"), node.get("field_name")
+                if isinstance(component, str) and isinstance(field, str):
+                    spellings.add((component, field))
+                for value in node.values():
+                    walk(value)
+            elif isinstance(node, list):
+                for item in node:
+                    walk(item)
+
+        for path in sorted(cls.SETUPS.glob("*.scenario.json")):
+            walk(json.loads(path.read_text(encoding="utf-8")))
+        return spellings
+
 
 @pytest.mark.base
 def test_one_week_july_is_the_first_week_of_july() -> None:
@@ -251,24 +286,28 @@ def test_the_renaming_table_declares_one_meaning_per_legacy_port() -> None:
 
 @pytest.mark.base
 def test_the_table_still_spells_the_ports_the_dynamic_components_setup_actually_grows(tmp_path: Path) -> None:
-    """Catches a renaming table that has gone stale because a dispatch counter moved.
+    """Catches a renaming table whose dispatch counter no longer matches the controller's build.
 
     Every legacy dynamic port name in the table carries a number the two paths do not agree on: an
     aggregator input carries its insertion index, and a dispatch output carries the aggregator's
     running output counter, which counts the outputs the component had already declared when the
     setup added the dispatch. That counter is not the setup's to control — an energy manager that
-    gains or loses one declared output renumbers every dispatch output of every setup that uses it —
-    so the table can be correct when it is written and wrong a month later without anyone touching
-    it. That is exactly what happened once: retiring one of the manager's default connections moved
-    all of them down by one, the table kept claiming the old numbers, and the whole fleet's dispatch
-    failed at once with a wiring difference that was nothing but a name.
+    gains or loses one declared output renumbers every dispatch output of every setup that uses
+    it — so a hand-authored number can be wrong without any setup changing. Exactly that once
+    failed the whole fleet's dispatch at once, with a wiring difference that was nothing but a
+    name; the table's own comment on the battery dispatch tells that story.
 
-    This is the canary for that class of failure. One setup is enough because all thirteen energy
-    manager setups grow their names through the same machinery, and this one has no load profile to
-    generate, so it costs a base test seconds instead of minutes. It asserts both halves: that every
-    legacy name the table declares for this setup is a port the Python build really has — a name
-    nobody grows any more can never be exercised again — and that translating the Python wiring
-    through the table yields precisely the twin's wiring, which is the claim the rig makes fleet-wide.
+    This is the canary for the counter class of that failure. One setup is enough for it because
+    the counter is the controller's: all twelve energy manager setups start their dispatch numbers
+    from the same thirteen constructor-declared outputs, so a shift moves this setup's names
+    exactly as it moves every other's. This setup also needs no load profile, so it costs a base
+    test seconds instead of minutes. The per-setup insertion indices of the setups the canary does
+    not build are outside its net; those are cross-checked against the recorded scenario files by
+    the next test and verified against live builds only by the fleet workflow. The canary asserts
+    both halves: that every legacy name the table declares for this setup is a port the Python
+    build really has — a name nobody grows any more can never be exercised again — and that
+    translating the Python wiring through the table yields precisely the twin's wiring, which is
+    the claim the rig makes fleet-wide.
     """
     legacy, declarative = Rig.canary_wiring(tmp_path)
     grown = (
@@ -284,6 +323,29 @@ def test_the_table_still_spells_the_ports_the_dynamic_components_setup_actually_
 
     diff = WiringParityHarness.compare(DeclaredPortRenamings.port_renaming().apply_to(legacy), declarative)
     assert diff.is_identical(), diff.describe()
+
+
+@pytest.mark.base
+def test_every_declared_legacy_port_is_spelled_by_a_committed_scenario_file() -> None:
+    """Catches a table entry whose legacy spelling no committed scenario file carries.
+
+    The canary above builds one setup live, so it can only vouch for that setup's ports; the
+    entries of every other setup — above all their insertion indices, which are per-setup and move
+    whenever a setup reorders its participants — would otherwise be guarded only by the manually
+    dispatched fleet workflow. This test closes that gap statically: every ``(aggregator, legacy
+    port)`` key the table declares must appear verbatim as a connection endpoint in some committed
+    ``.scenario.json``, because those files are regenerated from live builds and spell the exact
+    names the legacy add-API grew. A typo in a newly authored entry fails here immediately, and an
+    entry gone stale fails as soon as the scenario files are regenerated — cheaper and earlier than
+    the fleet workflow, though only that workflow proves an entry against a live build.
+    """
+    spelled = Rig.scenario_port_spellings()
+    assert spelled, "no scenario file spells any connection endpoint, so the cross-check checks nothing"
+    for key in DeclaredPortRenamings.pairs():
+        assert key in spelled, (
+            f"the table declares '{key[0]}.{key[1]}', but no committed scenario file spells that port — "
+            "either the entry has a typo, or the fleet stopped growing it and the entry is dead"
+        )
 
 
 @pytest.mark.base


### PR DESCRIPTION
## Problem

The parity rig's first fleet-wide dispatch (AC-P3.17) failed 26 of 44 triples — every setup with an
energy manager, both windows. The diagnosis is naming, not physics: retiring the old heat pump
(#604) deleted one of the EMS's constructor-time outputs, so every dispatch output the setups grow
moved down one counter. The hand-authored renaming table still spelled the old positions, so
`Output14` went untranslated and every translated name landed one participant late — the wiring and
result-column comparisons failed on names while every value that exists on both sides matched
exactly, and the KPI stage (keyed on input names, which did not shift) stayed green throughout.

## Done

- Derived the correct mappings from live prepare-and-connect snapshots of both paths for all 13
  affected setups — never guessed. Wire counts, component lists and unconnected-input sets are
  identical on both sides everywhere, so no genuinely different wire hides behind the shift.
- Corrected 5 stale entries (the battery dispatch prefix covering ten sizers; dynamic_components'
  four) and added 8 the table never had: `air_conditioned_house`'s meter input, and the car sizer's
  seven (its EV charge control is the first EMS participant, shifting every later index). The table
  stays hand-written and nested per aggregator; each corrected comment restates its derivation.
- Added the staleness canary the table lacked:
  `test_the_table_still_spells_the_ports_the_dynamic_components_setup_actually_grows` (base, ~52 s)
  builds `dynamic_components` both ways to prepare-and-connect, asserts every legacy name the setup
  grows is real and declared, and that the table maps the Python wiring onto the twin's exactly.
  All EMS setups share the naming machinery, so the next counter shift fails this test on every
  push instead of failing 26 CI triples after the fact. Restoring the old table makes it fail with
  the name it stopped declaring.

## Result

`dynamic_components` and `air_conditioned_house` reach parity in both windows (wiring, every result
column, KPIs — exact). A fleet re-dispatch should be green except for one known, deliberately
unpapered finding: `household_heatpump_car_building_sizer` still fails its results stage on a
single cell per window — `TotalElectricityConsumption` differing by 1.8e-12 (rel 4e-16), a
participant summation-order difference between the two paths. That is a real question for the
rig's exactness rule and gets its own investigation rather than a tolerance here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
