### PR TITLE
Sum the participants in one order, whichever path built the system

### DIFF
--- a/hisim/components/electricity_meter.py
+++ b/hisim/components/electricity_meter.py
@@ -167,6 +167,8 @@ class ElectricityMeter(DynamicComponent):
 
         self.production_inputs: List[ComponentInput] = []
         self.consumption_uncontrolled_inputs: List[ComponentInput] = []
+        self.production_inputs_building: List[ComponentInput] = []
+        self.consumption_inputs_building: List[ComponentInput] = []
 
         self.seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep
         # Component has states
@@ -528,6 +530,16 @@ class ElectricityMeter(DynamicComponent):
         if timestep == 0:
             self.production_inputs = self.get_channel_inputs(self.PRODUCTION_CHANNEL)
             self.consumption_uncontrolled_inputs = self.get_channel_inputs(self.CONSUMPTION_UNCONTROLLED_CHANNEL)
+            # The building-tagged subsets are as constant over a run as the two lists above, so
+            # they are resolved here once rather than re-filtered and re-sorted on every step of
+            # every convergence iteration in the district branch below. Literal on purpose:
+            # subset matching, see the CHANNELS docstring.
+            self.production_inputs_building = self.get_dynamic_inputs(
+                tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION, lt.ComponentType.BUILDINGS]
+            )
+            self.consumption_inputs_building = self.get_dynamic_inputs(
+                tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED, lt.ComponentType.BUILDINGS]
+            )
 
         # ELECTRICITY #
 
@@ -538,22 +550,16 @@ class ElectricityMeter(DynamicComponent):
         )
 
         if lt.DistrictNames.is_district(self.config.component_id.building):
-            # Literal on purpose: subset matching, see the CHANNELS docstring.
-            production_inputs_building = self.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION, lt.ComponentType.BUILDINGS])
-
             building_electricity_surplus_unused = (
-                sum([stsv.get_input_value(component_input=elem) for elem in production_inputs_building]))
+                sum([stsv.get_input_value(component_input=elem) for elem in self.production_inputs_building]))
 
             stsv.set_output_value(
                 self.surplus_electricity_unused_to_district_ems_from_building_ems_output,
                 building_electricity_surplus_unused,
             )
 
-            # Literal on purpose: subset matching, see the CHANNELS docstring.
-            consumption_inputs_building = self.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED, lt.ComponentType.BUILDINGS])
-
             consumption_of_buildings = (
-                sum([stsv.get_input_value(component_input=elem) for elem in consumption_inputs_building]))
+                sum([stsv.get_input_value(component_input=elem) for elem in self.consumption_inputs_building]))
 
             stsv.set_output_value(
                 self.electricity_consumption_building_uncontrolled_in_watt_channel,

--- a/hisim/config/channels.py
+++ b/hisim/config/channels.py
@@ -407,13 +407,34 @@ class ResolvedDynamicConnection:
             return None
         return self.dispatch_output_name
 
-    def sort_key(self) -> Tuple[int, str, str]:
-        """The deterministic ordering key of a target's connections.
+    @staticmethod
+    def order_key(weight: int, source_name: str, source_output: str) -> Tuple[int, str, str]:
+        """The one definition of the order an aggregator's participants are handled in.
+
+        Both build paths order participants by this tuple: feed resolution sorts a target's
+        resolved connections through :meth:`sort_key`, and ``DynamicComponent`` orders the ports
+        it hands out for summation through its ``_summation_sort_key``. The tuple is defined here,
+        once, so that a change to the ordering — a tiebreaker, a normalisation — reaches both
+        paths together instead of leaving one behind and re-opening the path-dependent summation
+        of F-35.
+
+        Args:
+            weight: The participant's declared weight.
+            source_name: The name of the participant component.
+            source_output: The name of the participant's measured output.
 
         Returns:
             Weight, participant name and participant output, in that priority.
         """
-        return (self.weight, self.source_name, self.source_output)
+        return (weight, source_name, source_output)
+
+    def sort_key(self) -> Tuple[int, str, str]:
+        """The deterministic ordering key of a target's connections.
+
+        Returns:
+            :meth:`order_key` over this connection's weight, participant name and output.
+        """
+        return self.order_key(self.weight, self.source_name, self.source_output)
 
     def describe(self) -> str:
         """Builds the one-line rendering error messages and the wire log name it by.

--- a/hisim/dynamic_component.py
+++ b/hisim/dynamic_component.py
@@ -232,7 +232,8 @@ class DynamicComponent(Component):
             key: The stable channel identifier.
 
         Returns:
-            The dynamic inputs on that channel, in creation order.
+            The dynamic inputs on that channel, in the summation order
+            :meth:`get_dynamic_inputs` defines.
         """
         channel = self.get_channel(key)
         return self.get_dynamic_inputs(tags=sorted(channel.tags, key=lambda tag: tag.name))
@@ -520,16 +521,61 @@ class DynamicComponent(Component):
         return new_connections
 
     def get_dynamic_inputs(self, tags: List[Union[lt.ComponentType, lt.InandOutputType]]) -> List[ComponentInput]:
-        """Returns inputs from all dynamic inputs with component type and weight."""
-        inputs = []
+        """Returns the dynamic inputs carrying all of the given tags, in a path-independent order.
 
-        # check if component of component type is available
-        for _, element in enumerate(self.my_component_inputs):  # loop over all inputs
-            if tags_search_and_compare(tags_to_search=tags, tags_of_component=element.source_tags):
-                inputs.append(getattr(self, element.source_component_class))
-            else:
-                continue
-        return inputs
+        Every caller of this method sums the ports it returns, so the order of the returned list
+        is the order the participants are added up in. That order used to be the order the inputs
+        were created in, which differs between the two ways a system can be built: a Python setup
+        creates them in its own add sequence (every explicit ``add_component_input_and_connect``
+        before every default connection), while the declarative executor creates them sorted by
+        :meth:`hisim.config.channels.ChannelConnection.sort_key`. The same house therefore summed
+        the same participants in two different orders, and IEEE-754 addition is not associative,
+        so the two runs disagreed in the last bits — enough to fail an exact comparison of the two
+        paths against each other.
+
+        The fix is to give "the order participants are summed in" a single definition on both
+        paths: the key the executor already sorts by, namely weight, then the name of the source
+        component, then the name of the source output. Weight and source output live on the
+        bookkeeping entry; the source component's name lives on the created port, which the
+        wiring stage has filled in long before any component simulates. Only the returned list is
+        sorted — ``my_component_inputs`` keeps its creation order, because other code reads it
+        positionally.
+
+        Example: a meter fed by ``pv.ElectricityOutput`` (weight 1) and ``chp.ElectricityOutput``
+        (weight 1) sums the CHP before the PV whichever way the house was written down.
+
+        Args:
+            tags: The tags an input must all carry to be returned.
+
+        Returns:
+            The matching dynamic input ports, sorted by (weight, source component name, source
+            output name).
+        """
+        matches = [
+            element
+            for element in self.my_component_inputs
+            if tags_search_and_compare(tags_to_search=tags, tags_of_component=element.source_tags)
+        ]
+        matches.sort(key=self.summation_sort_key)
+        return [getattr(self, element.source_component_class) for element in matches]
+
+    def summation_sort_key(self, element: DynamicConnectionInput) -> Tuple[int, str, str]:
+        """The deterministic ordering key of one dynamic input, mirroring the executor's key.
+
+        :meth:`hisim.config.channels.ChannelConnection.sort_key` returns ``(weight, source_name,
+        source_output)``. The bookkeeping entry carries the weight and the source output name
+        directly; the source component's name is only on the created port, where the wiring stage
+        recorded it. An input that was allowed to stay unconnected has no source name and sorts as
+        the empty string, so the key stays total.
+
+        Args:
+            element: The bookkeeping entry of one dynamic input.
+
+        Returns:
+            Weight, source component name and source output name, in that priority.
+        """
+        created_input: ComponentInput = getattr(self, element.source_component_class)
+        return (element.source_weight, created_input.src_object_name or "", element.source_component_field_name)
 
     def get_first_dynamic_output(
         self,

--- a/hisim/dynamic_component.py
+++ b/hisim/dynamic_component.py
@@ -456,7 +456,10 @@ class DynamicComponent(Component):
                     self.my_component_inputs.append(
                         DynamicConnectionInput(
                             source_component_class=label,
-                            source_component_field_name=source_component_output,
+                            # The bookkeeping stores the field name — the string the wire above
+                            # actually connects and the summation key sorts on — while the label
+                            # keeps embedding the display name it always has, so no port renames.
+                            source_component_field_name=output_var.field_name,
                             source_load_type=source_load_type,
                             source_unit=source_unit,
                             source_tags=source_tags,
@@ -528,18 +531,21 @@ class DynamicComponent(Component):
         were created in, which differs between the two ways a system can be built: a Python setup
         creates them in its own add sequence (every explicit ``add_component_input_and_connect``
         before every default connection), while the declarative executor creates them sorted by
-        :meth:`hisim.config.channels.ChannelConnection.sort_key`. The same house therefore summed
-        the same participants in two different orders, and IEEE-754 addition is not associative,
-        so the two runs disagreed in the last bits — enough to fail an exact comparison of the two
-        paths against each other.
+        :meth:`hisim.config.channels.ResolvedDynamicConnection.sort_key`. The same house therefore
+        summed the same participants in two different orders, and IEEE-754 addition is not
+        associative, so the two runs disagreed in the last bits — enough to fail an exact
+        comparison of the two paths against each other.
 
         The fix is to give "the order participants are summed in" a single definition on both
-        paths: the key the executor already sorts by, namely weight, then the name of the source
-        component, then the name of the source output. Weight and source output live on the
-        bookkeeping entry; the source component's name lives on the created port, which the
-        wiring stage has filled in long before any component simulates. Only the returned list is
-        sorted — ``my_component_inputs`` keeps its creation order, because other code reads it
-        positionally.
+        paths: the tuple :meth:`hisim.config.channels.ResolvedDynamicConnection.order_key`
+        declares — weight, then source component name, then source output name — applied here to
+        the *runtime* component name, which the wiring stage records on the created port and the
+        imperative add-API stores at creation, so both paths key on one and the same string. (The
+        executor's own pre-sort keys on the file's spelling of that name, which a building or a
+        unit can remap; that sort fixes the order ports are created in, while this one is what
+        defines the summation.) Weight and source output live on the bookkeeping entry. Only the
+        returned list is sorted — ``my_component_inputs`` keeps its creation order, because other
+        code reads it positionally.
 
         Example: a meter fed by ``pv.ElectricityOutput`` (weight 1) and ``chp.ElectricityOutput``
         (weight 1) sums the CHP before the PV whichever way the house was written down.
@@ -556,17 +562,19 @@ class DynamicComponent(Component):
             for element in self.my_component_inputs
             if tags_search_and_compare(tags_to_search=tags, tags_of_component=element.source_tags)
         ]
-        matches.sort(key=self.summation_sort_key)
+        matches.sort(key=self._summation_sort_key)
         return [getattr(self, element.source_component_class) for element in matches]
 
-    def summation_sort_key(self, element: DynamicConnectionInput) -> Tuple[int, str, str]:
-        """The deterministic ordering key of one dynamic input, mirroring the executor's key.
+    def _summation_sort_key(self, element: DynamicConnectionInput) -> Tuple[int, str, str]:
+        """The ordering key of one dynamic input: the shared participant order, read at runtime.
 
-        :meth:`hisim.config.channels.ChannelConnection.sort_key` returns ``(weight, source_name,
-        source_output)``. The bookkeeping entry carries the weight and the source output name
-        directly; the source component's name is only on the created port, where the wiring stage
-        recorded it. An input that was allowed to stay unconnected has no source name and sorts as
-        the empty string, so the key stays total.
+        The tuple itself is defined once, by
+        :meth:`hisim.config.channels.ResolvedDynamicConnection.order_key`; this method only
+        gathers its three operands. The bookkeeping entry carries the weight and the source output
+        name directly; the source component's runtime name is only on the created port, where the
+        wiring stage recorded it. An input that was allowed to stay unconnected has no source name
+        and sorts as the empty string — such a port reads as zero, so where those ports land among
+        each other cannot change any sum.
 
         Args:
             element: The bookkeeping entry of one dynamic input.
@@ -575,7 +583,9 @@ class DynamicComponent(Component):
             Weight, source component name and source output name, in that priority.
         """
         created_input: ComponentInput = getattr(self, element.source_component_class)
-        return (element.source_weight, created_input.src_object_name or "", element.source_component_field_name)
+        return ResolvedDynamicConnection.order_key(
+            element.source_weight, created_input.src_object_name or "", element.source_component_field_name
+        )
 
     def get_first_dynamic_output(
         self,

--- a/roadmap/p3_random_findings.md
+++ b/roadmap/p3_random_findings.md
@@ -311,12 +311,14 @@ timesteps, and nowhere else. The cause is not a difference in what is summed but
 EMS its participants in the order their ports were *created*; the EMS freezes that list at timestep 0 and
 sums it every step thereafter. A Python setup creates them in its own add sequence — every explicit
 `add_component_input_and_connect` before every default connection — while the declarative executor creates
-them sorted by `ChannelConnection.sort_key()`, i.e. `(weight, source_name, source_output)`. In this house the
-EV input is first on one path and fourth on the other, four operands are simultaneously non-zero and two of
-them cancel exactly, and IEEE-754 addition is not associative, so the two orders genuinely produce different
-doubles. Fixed by sorting the list `get_dynamic_inputs` returns by the executor's own key, leaving the
-creation-ordered bookkeeping untouched; January stays byte-identical for `dynamic_components` and
-`basic_household`, whose creation order was already weight-ascending.
+them sorted by `ResolvedDynamicConnection.sort_key()`, i.e. `(weight, source_name, source_output)`. In this
+house the EV input is first on one path and fourth on the other, four operands are simultaneously non-zero and
+two of them cancel exactly, and IEEE-754 addition is not associative, so the two orders genuinely produce
+different doubles. Fixed by sorting the list `get_dynamic_inputs` returns by the executor's own key — defined
+once, on `ResolvedDynamicConnection.order_key`, and delegated to from both paths — leaving the
+creation-ordered bookkeeping untouched. That `dynamic_components` and `basic_household` stay byte-identical in
+January was confirmed by re-running both, not inferred: their weight-ascending creation order alone would not
+prove it, since the key also tiebreaks by source name and output within a weight.
 *The near-miss is the part worth keeping: `automatic_default_connections` feeds its electricity meter three
 participants in exactly the reverse order on the two paths and passed anyway, purely because two of the three
 are never non-zero at the same time. It was one wiring change away from the same failure, and it would have
@@ -325,7 +327,9 @@ is a contract of the component model, not a cosmetic detail, and it now has one 
 *Still path-dependent and deliberately left alone: the EMS's `sort_source_weights_and_components` sorts
 surplus recipients by weight with a stable sort, so participants sharing a weight are still dispatched in
 creation order. That is a semantic order — who gets the surplus first — not a summation, and no fleet setup
-currently ties.*
+currently ties. The revisit trigger is concrete: the first fleet setup that gives two surplus recipients one
+weight makes the dispatch order ambiguous across paths, and that setup's PR extends the weight sort with the
+shared `order_key` tiebreakers.*
 
 ## 6. Process
 

--- a/roadmap/p3_random_findings.md
+++ b/roadmap/p3_random_findings.md
@@ -1,6 +1,6 @@
 # P3 — random findings and defects
 
-**Status:** living document · **Opened:** 2026-08-28 · **Last entry:** 2026-08-31 (34 findings)
+**Status:** living document · **Opened:** 2026-08-28 · **Last entry:** 2026-09-06 (35 findings)
 **Context:** things that surfaced while implementing `roadmap/declarative_energy_systems/p3_implementation_spec.md`
 and were **not** what the work set out to do. Kept separately so the requirements and the spec stay about the
 design, and so nothing found on the way is lost when the branch merges.
@@ -303,6 +303,29 @@ output back out of a CSV. That masks a real configuration difference *and*, beca
 bit-exact, invents a fake one. Each side now gets its own empty cache, and both run the same post-processing
 option set regardless of what the setup appended.
 *Generalises beyond the rig: any A/B comparison of two HiSim runs on one machine has this hazard.*
+
+### F-35 — the order an aggregator sums its participants in was path-dependent **[verified]**
+`household_heatpump_car_building_sizer` failed the rig in both windows by about `2e-12` at 2 of 10080
+timesteps, and nowhere else. The cause is not a difference in what is summed but in what order.
+`DynamicComponent.get_dynamic_inputs` was an unfiltered walk over `my_component_inputs`, so it handed the
+EMS its participants in the order their ports were *created*; the EMS freezes that list at timestep 0 and
+sums it every step thereafter. A Python setup creates them in its own add sequence — every explicit
+`add_component_input_and_connect` before every default connection — while the declarative executor creates
+them sorted by `ChannelConnection.sort_key()`, i.e. `(weight, source_name, source_output)`. In this house the
+EV input is first on one path and fourth on the other, four operands are simultaneously non-zero and two of
+them cancel exactly, and IEEE-754 addition is not associative, so the two orders genuinely produce different
+doubles. Fixed by sorting the list `get_dynamic_inputs` returns by the executor's own key, leaving the
+creation-ordered bookkeeping untouched; January stays byte-identical for `dynamic_components` and
+`basic_household`, whose creation order was already weight-ascending.
+*The near-miss is the part worth keeping: `automatic_default_connections` feeds its electricity meter three
+participants in exactly the reverse order on the two paths and passed anyway, purely because two of the three
+are never non-zero at the same time. It was one wiring change away from the same failure, and it would have
+read as a mysterious last-bit difference rather than as an ordering bug. "Which order do we add these up in"
+is a contract of the component model, not a cosmetic detail, and it now has one definition.*
+*Still path-dependent and deliberately left alone: the EMS's `sort_source_weights_and_components` sorts
+surplus recipients by weight with a stable sort, so participants sharing a weight are still dispatched in
+creation order. That is a semantic order — who gets the surplus first — not a summation, and no fleet setup
+currently ties.*
 
 ## 6. Process
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -840,6 +840,101 @@ def test_add_component_input_and_connect_propagates_allow_unconnected() -> None:
 
 
 @pytest.mark.base
+def test_get_dynamic_inputs_returns_participants_in_sorted_order() -> None:
+    """Test that get_dynamic_inputs sorts by weight, source component name and source output.
+
+    The returned list is the order an aggregator sums its participants in, and IEEE-754 addition
+    is not associative, so that order has to be the same whichever way the house was written
+    down. Here the inputs are created in an order that is wrong on all three parts of the key at
+    once, and the accessor is expected to hand them back in the executor's order while leaving
+    the creation-ordered bookkeeping untouched.
+    """
+    from hisim.dynamic_component import DynamicComponent
+
+    sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    config = ConfigBase(component_id=ComponentID(name="TestDynamic"))
+    dyn_component = DynamicComponent(
+        my_component_inputs=[],
+        my_component_outputs=[],
+        name="TestDynamic",
+        my_simulation_parameters=sim_params,
+        my_config=config,
+        my_display_config=DisplayConfig(),
+    )
+
+    creation_order = [
+        ("zebra", "ElectricityOutput", 2),
+        ("alpha", "SecondOutput", 1),
+        ("alpha", "FirstOutput", 1),
+        ("beta", "ElectricityOutput", 1),
+    ]
+    for source_object_name, source_component_output, source_weight in creation_order:
+        dyn_component.add_component_input_and_connect(
+            source_component_output=source_component_output,
+            source_object_name=source_object_name,
+            source_load_type=lt.LoadTypes.ELECTRICITY,
+            source_unit=lt.Units.WATT,
+            source_tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION],
+            source_weight=source_weight,
+        )
+
+    returned = dyn_component.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION])
+    assert [(item.src_object_name, item.src_field_name) for item in returned] == [
+        ("alpha", "FirstOutput"),
+        ("alpha", "SecondOutput"),
+        ("beta", "ElectricityOutput"),
+        ("zebra", "ElectricityOutput"),
+    ]
+
+    # The bookkeeping itself is read positionally elsewhere and must keep its creation order.
+    assert [
+        (entry.source_component_field_name, entry.source_weight) for entry in dyn_component.my_component_inputs
+    ] == [(output, weight) for _, output, weight in creation_order]
+
+
+@pytest.mark.base
+def test_get_dynamic_inputs_only_returns_inputs_carrying_all_tags() -> None:
+    """Test that sorting did not change which inputs get_dynamic_inputs selects.
+
+    Sorting the result must not widen or narrow the tag match: an input still has to carry every
+    requested tag, and one carrying only some of them stays out of the list no matter where the
+    sort key would have placed it.
+    """
+    from hisim.dynamic_component import DynamicComponent
+
+    sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    config = ConfigBase(component_id=ComponentID(name="TestDynamic"))
+    dyn_component = DynamicComponent(
+        my_component_inputs=[],
+        my_component_outputs=[],
+        name="TestDynamic",
+        my_simulation_parameters=sim_params,
+        my_config=config,
+        my_display_config=DisplayConfig(),
+    )
+
+    dyn_component.add_component_input_and_connect(
+        source_component_output="Consumed",
+        source_object_name="aaa_consumer",
+        source_load_type=lt.LoadTypes.ELECTRICITY,
+        source_unit=lt.Units.WATT,
+        source_tags=[lt.InandOutputType.ELECTRICITY_CONSUMPTION_UNCONTROLLED],
+        source_weight=1,
+    )
+    dyn_component.add_component_input_and_connect(
+        source_component_output="Produced",
+        source_object_name="zzz_producer",
+        source_load_type=lt.LoadTypes.ELECTRICITY,
+        source_unit=lt.Units.WATT,
+        source_tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION],
+        source_weight=1,
+    )
+
+    returned = dyn_component.get_dynamic_inputs(tags=[lt.InandOutputType.ELECTRICITY_PRODUCTION])
+    assert [item.src_object_name for item in returned] == ["zzz_producer"]
+
+
+@pytest.mark.base
 def test_electricity_meter_dhw_connection_allow_unconnected() -> None:
     """Test that the electricity meter marks the DHW heat-pump connection as allow_unconnected_mandatory."""
     from hisim.components.electricity_meter import ElectricityMeter

--- a/tests/test_meter_channels.py
+++ b/tests/test_meter_channels.py
@@ -22,7 +22,7 @@ provoke need a participant no shipped energy-system file wires yet.
 # clean
 
 from dataclasses import dataclass
-from typing import ClassVar, List, Optional
+from typing import ClassVar, List, Optional, Tuple
 
 import pytest
 from dataclasses_json import dataclass_json
@@ -460,3 +460,87 @@ def test_a_district_heating_meter_takes_the_heat_domain_carriers_its_own_default
         )
     assert caught.value.error_id.value == "EF-30"
     assert "DISTRICTHEATING" in str(caught.value)
+
+
+@pytest.mark.base
+def test_both_build_paths_hand_the_meter_its_participants_in_one_summation_order() -> None:
+    """Catches the two build paths disagreeing about the order an aggregator sums participants in.
+
+    The path-independence of the summation (F-35) does not come from each path sorting for
+    itself: it comes from both paths keying on the same strings. The runtime component name the
+    wiring stage records on a resolved port must be the very name a Python setup passes to
+    ``add_component_input_and_connect``, and the resolved connection's output must be the field
+    name the add-API stores. Nothing else asserts that cross-path invariant, so this test builds
+    the same two-participant arrangement once through each path and requires
+    ``get_dynamic_inputs`` to hand back the identical sequence. The participants share one weight
+    and are created zebra-first, so a path that fell back to creation order, or keyed on a
+    different string, fails the comparison rather than passing by accident.
+    """
+    zebra = "zebra_boiler"
+    alpha = "alpha_boiler"
+
+    imperative_meter = MeterFixtures.fuel_meter(lt.LoadTypes.OIL)
+    for source_name in (zebra, alpha):
+        imperative_meter.add_component_input_and_connect(
+            source_component_output=HeatSourceStub.EnergyDemand,
+            source_object_name=source_name,
+            source_load_type=lt.LoadTypes.OIL,
+            source_unit=lt.Units.WATT_HOUR,
+            source_tags=[lt.InandOutputType.HEAT_CONSUMPTION],
+            source_weight=MeterFixtures.MONITORED_ONLY,
+        )
+
+    declarative_meter = MeterFixtures.fuel_meter(lt.LoadTypes.OIL)
+    sources = {
+        name: HeatSourceStub(
+            my_simulation_parameters=MeterFixtures.parameters(),
+            config=HeatSourceStubConfig(component_id=ComponentID(name=name), carrier=lt.LoadTypes.OIL),
+        )
+        for name in (zebra, alpha)
+    }
+    resolver = DynamicConnectionResolver({**sources, MeterFixtures.METER_NAME: declarative_meter})
+    resolved = resolver.resolve_target(
+        MeterFixtures.METER_NAME,
+        [
+            FeedRequest(
+                consumer=MeterFixtures.METER_NAME,
+                source=source_name,
+                output=HeatSourceStub.EnergyDemand,
+                component_type=None,
+                flow_tags=(lt.InandOutputType.HEAT_CONSUMPTION,),
+                weight=MeterFixtures.MONITORED_ONLY,
+            )
+            for source_name in (zebra, alpha)
+        ],
+    )
+    # The wiring stage's one mutating step, replayed verbatim: the resolved port learns the
+    # source's runtime component name, which is what the summation key reads at simulation time.
+    for connection in resolved:
+        declarative_meter.connect_input(
+            input_fieldname=connection.aggregator_input_name,
+            src_object_name=sources[connection.source_name].component_name,
+            src_field_name=connection.source_output,
+        )
+
+    def summation_order(meter: FuelMeter) -> List[Tuple[str, str]]:
+        """The (source component, source output) sequence the meter would sum, in order.
+
+        Read through ``get_dynamic_inputs`` exactly as the meter's own ``i_simulate`` reads it,
+        so the assertion below compares what a run would actually add up.
+
+        Args:
+            meter: The aggregating meter, built through either path.
+
+        Returns:
+            The ordered source pairs of the meter's consumption participants.
+        """
+        return [
+            (port.src_object_name or "", port.src_field_name or "")
+            for port in meter.get_dynamic_inputs(tags=[lt.InandOutputType.HEAT_CONSUMPTION])
+        ]
+
+    assert summation_order(imperative_meter) == summation_order(declarative_meter)
+    assert summation_order(imperative_meter) == [
+        (alpha, HeatSourceStub.EnergyDemand),
+        (zebra, HeatSourceStub.EnergyDemand),
+    ]


### PR DESCRIPTION
## Problem

Aggregators sum their dynamic participants in input-creation order, and the two build paths create
them differently: a setup's explicit add always precedes every default connection, while the
declarative executor resolves feeds sorted by (weight, source, output). IEEE addition is not
associative, so the car sizer's energy manager — four simultaneously nonzero operands, one exactly
cancelling pair — disagreed with its twin by ~2e-12 W at two timesteps per window and failed the
parity rig's exact comparison. `automatic_default_connections`' meter carries the same pattern with
three exactly reversed operands and passes only because two of them never run at once — a latent
near-miss one heat-pump change would open.

## Done

`get_dynamic_inputs` returns its matches sorted by the executor's own key — weight, source
component, source output (mirroring `ChannelConnection.sort_key()`), so "the order participants are
summed in" has one definition on both paths. The inputs list itself keeps creation order; nothing
is mutated. Every caller was swept: all are plain sums, so only the last ULP can move.
`get_all_dynamic_outputs` deliberately stays unsorted — its callers pair dispatch outputs
positionally, a semantic order, not an arithmetic one. F-35 in the findings log records the
mechanism, the near-miss, and the one remaining creation-order tiebreak in the EMS weight sort
(reached by no fleet setup).

## Result

- `household_heatpump_car_building_sizer`: parity **PASS in both windows at exact equality** (was
  the last red triple after the renaming-table fix); `dynamic_components` and
  `automatic_default_connections` PASS/PASS.
- Nothing moves where the orders already agreed: `dynamic_components` (54 CSVs) and
  `basic_household` (53 CSVs) byte-identical before vs. after; the re-recorded twin unchanged.
- Two new unit tests pin the sorted return and the untouched creation-order list; 106 tests across
  the ten implicated suites pass from the repository root and from `tests/`; the full base suite is
  green (4766 passed).

Stacked on the renaming-table PR (its fixed table is what lets the car triples prove parity);
retarget to main after that one merges. With both merged, a fleet re-dispatch of the rig should be
fully green — the AC-P3.17 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
