### PR TITLE
Fence the July window until a July window means July

### DIFF
--- a/.github/workflows/p3-parity.yml
+++ b/.github/workflows/p3-parity.yml
@@ -2,9 +2,15 @@
 #
 # For the duration of the P3 setup migration this workflow answers one question: does the
 # declarative file recorded from a Python setup reproduce that setup? It runs both paths inside
-# one container, at exact equality, over a January week and a July week, and it needs no golden
-# reference, so it covers the thirteen setups the permanent gate has no entry for and the seven
-# whose KPI layer crashes today (R11.1, R11.4).
+# one container, at exact equality, over every runnable window, and it needs no golden reference,
+# so it covers the thirteen setups the permanent gate has no entry for and the seven whose KPI
+# layer crashes today (R11.1, R11.4).
+#
+# R11.5 asked for a January week and a July week. Only the January week runs: HiSim has never
+# supported a mid-year start — every profile-driven component reads its year-long profile from
+# timestep 0 as if that were the 1st of January — so a July triple would compare two runs that
+# both simulate January. The July window is therefore fenced in scripts/p3_parity_matrix.py and
+# is not offered below; the mid-year-start epic (roadmap/midyear_start_epic.md) unfences it.
 #
 # It is dispatched by hand and never on push (R11.7). It blesses nothing and gates nothing.
 #
@@ -24,14 +30,13 @@ on:
         required: false
         default: ""
       window:
-        description: "Which window to run"
+        description: "Which window to run; 'all' is every window that is not fenced"
         required: false
-        default: "both"
+        default: "all"
         type: choice
         options:
-          - both
+          - all
           - january
-          - july
       rel_tol:
         description: "Relative slack; 0 demands exact equality, and any other value is a finding"
         required: false
@@ -62,7 +67,7 @@ jobs:
         run: |
           ARGS=""
           if [ -n "${{ inputs.setup }}" ]; then ARGS="$ARGS --setup ${{ inputs.setup }}"; fi
-          if [ "${{ inputs.window }}" != "both" ]; then ARGS="$ARGS --window ${{ inputs.window }}"; fi
+          if [ "${{ inputs.window }}" != "all" ]; then ARGS="$ARGS --window ${{ inputs.window }}"; fi
           echo "matrix=$(python3 scripts/p3_parity_matrix.py $ARGS)" >> "$GITHUB_OUTPUT"
 
   parity:

--- a/hisim/simulationparameters.py
+++ b/hisim/simulationparameters.py
@@ -211,17 +211,27 @@ class SimulationParameters:
 
     @classmethod
     def one_week_july(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
-        """Generates a parameter set for the first week of July, the summer counterpart of one_week_only.
+        """Generates a parameter set whose dates are the first week of July. It does not yet deliver July.
 
-        Every other short-horizon parameter set of this class starts on the first of January,
-        which puts them in the coldest, darkest week of the year. That window measures a cooling
+        The intent was a summer counterpart to ``one_week_only``: every other short-horizon
+        parameter set of this class starts on the first of January, which measures a cooling
         device, a solar-thermal collector or an air conditioner at its annual minimum, and a
-        component that does nothing for the whole run proves nothing about itself. (The
-        air-conditioner setup's KPI division by zero has a different cause — it has no occupancy
-        and no generation in any season — but its cooling path, too, only moves in summer.) This
-        set answers with the same seven days shifted into July, so a comparison that runs both
-        windows exercises the heating side once and the cooling side once; the parity rig of the
-        recording migration is that comparison.
+        component that does nothing for the whole run proves nothing about itself. Shifting the
+        same seven days into July was meant to exercise the cooling side.
+
+        **It does not do that today, and a caller must not assume it does.** HiSim has never
+        supported a mid-year start date. Every profile-driven component — the weather sources, the
+        PV model, the building, the LoadProfileGenerator occupancy, the cars, the smart devices,
+        the CSV loader, the price signal, the seasonal gates of the heat pump and the CHP — indexes
+        its year-long profile by the timestep number, so timestep 0 is read as the 1st of January
+        whatever this start date says. A run over these dates therefore reproduces January for
+        every component that reads a profile, and pairs a July sun position with January irradiance
+        in the few that do compute from the date, such as a solar-thermal collector's geometry.
+
+        The set is kept, and only the parity rig used it: the rig has fenced its July window
+        (``scripts/p3_parity_matrix.py``) until the mid-year-start epic makes the profiles follow
+        the start date, at which point this becomes the window it was meant to be. Until then it
+        belongs in nothing that reports physics.
 
         Args:
             year: Calendar year the week is taken from.

--- a/hisim/simulationparameters.py
+++ b/hisim/simulationparameters.py
@@ -213,20 +213,21 @@ class SimulationParameters:
     def one_week_july(cls, year: int, seconds_per_timestep: int) -> SimulationParameters:
         """Generates a parameter set whose dates are the first week of July. It does not yet deliver July.
 
-        The intent was a summer counterpart to ``one_week_only``: every other short-horizon
+        The intent was a summer counterpart to ``one_week_only``: every week- and day-sized
         parameter set of this class starts on the first of January, which measures a cooling
         device, a solar-thermal collector or an air conditioner at its annual minimum, and a
         component that does nothing for the whole run proves nothing about itself. Shifting the
-        same seven days into July was meant to exercise the cooling side.
+        same seven days into July was meant to exercise the cooling side. (The two three-month
+        sets do start mid-year — and are wrong in exactly the way described below.)
 
         **It does not do that today, and a caller must not assume it does.** HiSim has never
         supported a mid-year start date. Every profile-driven component — the weather sources, the
         PV model, the building, the LoadProfileGenerator occupancy, the cars, the smart devices,
-        the CSV loader, the price signal, the seasonal gates of the heat pump and the CHP — indexes
-        its year-long profile by the timestep number, so timestep 0 is read as the 1st of January
-        whatever this start date says. A run over these dates therefore reproduces January for
-        every component that reads a profile, and pairs a July sun position with January irradiance
-        in the few that do compute from the date, such as a solar-thermal collector's geometry.
+        the CSV loader, the seasonal gates of the heat pump and the CHP — indexes its year-long
+        profile by the timestep number, so timestep 0 is read as the 1st of January whatever this
+        start date says. A run over these dates therefore reproduces January for every component
+        that reads a profile, and pairs a July sun position with January irradiance in the few
+        that do compute from the date, such as a solar-thermal collector's geometry.
 
         The set is kept, and only the parity rig used it: the rig has fenced its July window
         (``scripts/p3_parity_matrix.py``) until the mid-year-start epic makes the profiles follow

--- a/roadmap/declarative_energy_systems/p3_recording_requirements.md
+++ b/roadmap/declarative_energy_systems/p3_recording_requirements.md
@@ -213,11 +213,11 @@ extension of the golden gate and it blesses nothing.
   January-only window is why the air-conditioner setup divides by zero in the scan.
   `[amended 2026-09-06]` **The July window is fenced; the rig runs the January week only.** HiSim has never supported
   a mid-year start date: every profile-driven component (all six weather sources and both cache branches, PV, the
-  building, the LPG occupancy, the cars, the smart devices, the CSV loader, the price signal, the seasonal heat-pump
-  and CHP gates) indexes its year-long profile from timestep 0 as if that were the 1st of January, so a July triple
-  compares two runs that both simulate January — byte-identical to the January triple for every setup without a
-  solar-thermal collector, and physically incoherent for the four with one, whose sun position follows the date while
-  its irradiance does not. `one_week_july` and the window name are kept and the fence is one refusal in
+  building, the LPG occupancy, the cars, the smart devices, the CSV loader, the seasonal heat-pump and CHP gates)
+  indexes its year-long profile from timestep 0 as if that were the 1st of January, so a July triple compares two
+  runs that both simulate January — the January triple's numbers under July timestamps for every setup without a
+  solar-thermal collector, and physically incoherent for the three with one, whose sun position follows the date
+  while its irradiance does not. `one_week_july` and the window name are kept and the fence is one refusal in
   `scripts/p3_parity_matrix.py`; the mid-year-start epic (`roadmap/midyear_start_epic.md`) fixes the profiles
   fleet-wide and unfences the window, at which point this requirement is met as first written.
 - R11.6 **One configuration axis.** The configurations are R10's probe list, so the rig, the grouping table and the

--- a/roadmap/declarative_energy_systems/p3_recording_requirements.md
+++ b/roadmap/declarative_energy_systems/p3_recording_requirements.md
@@ -211,6 +211,15 @@ extension of the golden gate and it blesses nothing.
 - R11.5 **Two windows.** Every triple runs a January week and a July week — `one_week_only` and a new `one_week_july`,
   both at 60 s. A single window measures the cooling and solar-thermal setups at their annual minimum, and the
   January-only window is why the air-conditioner setup divides by zero in the scan.
+  `[amended 2026-09-06]` **The July window is fenced; the rig runs the January week only.** HiSim has never supported
+  a mid-year start date: every profile-driven component (all six weather sources and both cache branches, PV, the
+  building, the LPG occupancy, the cars, the smart devices, the CSV loader, the price signal, the seasonal heat-pump
+  and CHP gates) indexes its year-long profile from timestep 0 as if that were the 1st of January, so a July triple
+  compares two runs that both simulate January — byte-identical to the January triple for every setup without a
+  solar-thermal collector, and physically incoherent for the four with one, whose sun position follows the date while
+  its irradiance does not. `one_week_july` and the window name are kept and the fence is one refusal in
+  `scripts/p3_parity_matrix.py`; the mid-year-start epic (`roadmap/midyear_start_epic.md`) fixes the profiles
+  fleet-wide and unfences the window, at which point this requirement is met as first written.
 - R11.6 **One configuration axis.** The configurations are R10's probe list, so the rig, the grouping table and the
   recorded files share one definition of the configurations a setup has.
 - R11.7 **Manual, aggregated and loud.** `workflow_dispatch` only, with filters for setup, window and configuration; a
@@ -264,7 +273,7 @@ extension of the golden gate and it blesses nothing.
 | AC-P3.14 | The prefilled workbook marks a component absent, identical or differing against the baseline, and the importer rejects a workbook with a differing component that carries no assignment, naming it. | R10.2, R10.3 |
 | AC-P3.15 | `<stem>.grouping.yaml` is committed and the workbook is not; regenerating the workbook from the probe runs and re-importing it yields the identical `.grouping.yaml`. | R10.4 |
 | AC-P3.16 | The grouping report lists the `override` differences as consumer knobs and names the fork combinations the probe list never exercised. | R10.5, R10.7 |
-| AC-P3.17 | One dispatch of the rig covers every in-scope (setup, configuration, window) triple and prints them as one table; the January and July windows both appear for every triple. | R11.1, R11.5, R11.7 |
+| AC-P3.17 `[amended 2026-09-06]` | One dispatch of the rig covers every in-scope (setup, configuration, window) triple and prints them as one table; every runnable window appears for every triple. That is the January window alone while the July one is fenced (R11.5 as amended, because a July window reads January's profiles today); a dispatch that asks for July is refused with that reason rather than quietly given January. The criterion returns to "both windows" when the mid-year-start epic unfences it. | R11.1, R11.5, R11.7 |
 | AC-P3.18 | Changing one config value in a recorded file makes its triple fail and the report names the columns or KPIs that moved; the comparison is exact, so no threshold can hide it. | R11.2, R11.3 |
 | AC-P3.19 `[amended 2026-09-05]` | The seven KPI-broken setups return a structural verdict — component set and wire set compared, KPI stage reported as unavailable — rather than an error. The unavailable stage fails the triple in the summary table (R11.4 as amended); what the criterion pins is that the failure is a named verdict with both structural comparisons made, never an exception. | R11.4, R11.3 |
 | AC-P3.20 `[deferred to P6, 2026-08-31]` | The phase-6 teardown deletes the workflow, its configuration and its scripts, and the repository contains no reference to them afterwards. It is an acceptance criterion of P6, not of P3 — P3 ships the rig, P6 removes it. | R11.8 |

--- a/roadmap/declarative_energy_systems/plan.md
+++ b/roadmap/declarative_energy_systems/plan.md
@@ -171,7 +171,8 @@ eight setups that have no KPI oracle at all.
 **Entry condition: P1, P2, P2.1, P3, P4 and P5 are all merged.** Until then the rig is dispatched by every
 batch that re-records, and its renaming tables are kept current as P4 renames the legacy aggregator ports.
 
-- [ ] Confirm the whole stack is green with the rig still in place, over both windows
+- [ ] Confirm the whole stack is green with the rig still in place, over every runnable window
+      (July is fenced pending `roadmap/midyear_start_epic.md`; R11.5 as amended 2026-09-06)
 - [ ] Decide which setups earned a place in the permanent gate, on the rig's accumulated evidence — the six the
       2026-08-28 scan cleared are the candidates, not the answer
 - [ ] Add those to `scripts/golden_config.json` and bless their references

--- a/roadmap/midyear_start_epic.md
+++ b/roadmap/midyear_start_epic.md
@@ -160,6 +160,20 @@ splits perfectly:
 - **The memoryless column set is discovered, not maintained:** run the full-year reference twice
   with a perturbed initial-state seed; the columns whose difference is identically zero ARE the
   exact-comparable set. Self-calibrating as components change.
+- **The seeded restart is the end state — the report tier exists to shrink to nothing.** Run the
+  full year once, read every stateful component's state at the window start (the battery's SOC on
+  the 1st of July, the storage temperatures, the thermal-mass temperature, the controllers' modes
+  and timers), hand those to the window run as startup values, and the *whole* comparison becomes
+  an exact gate: with its complete mid-cycle state handed over, even a bang-bang controller
+  continues on the very limit cycle the year run was on, so the one column no warm-up could ever
+  buy back joins the gate too. What that costs is completeness — a partially seeded component just
+  re-imports its transient — and not every component can express its state as configuration today
+  (controller idle timers, the meters' cumulative sums, the EMS's internals are not config
+  fields). So the seeded tier grows component by component: a column moves from the report to the
+  exact gate the moment its component's full state is expressible as startup configuration, and
+  the cumulative meter columns move immediately, gated on first differences instead of levels.
+  This is checkpoint handover at the configuration level, which is why it shares its
+  prerequisites with the `i_save_state` repairs below.
 
 The harness: `scripts/midyear_oracle.py`, modelled on the parity rig (per-run empty cache
 directory, one process, one printed verdict table, a tolerance flag that shouts when nonzero),
@@ -167,8 +181,9 @@ reusing `ResultComparison` verbatim — its index check refuses a misaligned sli
 both frames carry `start_date`-built indexes. Plus four unit anchors in `tests/`: first-timestep
 identity against the source's own labels; the DST phase pins (260 550 / 260 610 / 260 640, and a
 December mirror); each weather reader's `index[0]` pinned (the six sources use three different
-anchors — Berlin 00:30, Berlin 00:00 after padding, UTC 00:00 — which is exactly why "resolve
-against the delivered frame" is the rule); and the cold-then-warm cache equality assertion.
+anchors — Berlin 00:30, Berlin 00:00 after the padding row ``Weather.interpolate`` prepends,
+UTC 00:00 — which is exactly why "resolve against the delivered frame" is the rule); and the
+cold-then-warm cache equality assertion.
 
 ## The PR plan
 
@@ -184,14 +199,21 @@ PR1 (window contract; YEARLYFORECAST→window renames; plot labels; delete dead 
      │             or a July window heats the house)                          [epoch bump]
      └─ PR6 (solar thermal: drop its naive-UTC duplicate sun, consume the
              weather's published window — 3 solar-thermal goldens move)       [epoch bump]
-          └─ PR7 (lift the fence in its five sites; invert the fence test into
-                  "July differs from January"; bless the July goldens)
+          └─ PR7 (lift the fence in its five sites — the workflow's hand-kept window
+                  options among them, which nothing derives from the code; invert the
+                  fence test into "July differs from January"; bless the July goldens)
+              └─ PR8+ (startup-state configuration: every stateful component learns to
+                       express its complete state as startup values, one component per
+                       PR, and its columns move from the oracle's report tier to the
+                       seeded exact gate as it lands)
 ```
 
 Blast-radius rules: PR2 and PR4+5 must not move a single January golden (offset 0 on 1 January —
 each PR's own cheapest proof); PR3 is the deliberate January re-bless and ships alone so the
 golden diff has exactly one cause; PR7 adds the `july_week` parameter set to the golden config and
-blesses the first true July references.
+blesses the first true July references. The PR8+ series moves no golden at all: startup values
+default to today's constants, and each PR's proof is its component's columns going exactly to zero
+in the seeded oracle.
 
 ## Independent repairs surfaced by the analyses
 

--- a/roadmap/midyear_start_epic.md
+++ b/roadmap/midyear_start_epic.md
@@ -1,0 +1,214 @@
+# Mid-year simulation windows: the epic
+
+Written 2026-09-06 from three detailed analyses (irradiance/thermal chain; profile-file chain;
+cross-cutting), each of which verified its load-bearing claims by running probes rather than by
+reading alone. Line numbers are from the analysis date and will drift; the named constructs will
+not. The parity rig's July window is fenced pending this epic (`scripts/p3_parity_matrix.py`,
+R11.5 as amended 2026-09-06); this document is what unfences it.
+
+## The problem
+
+**Mid-year simulation windows are January in disguise, and always have been.** Every
+profile-driven component in HiSim — weather (all six data sources, cached and uncached), PV,
+building solar gains, LPG occupancy (deliberately, with a comment), the cars, the smart devices,
+the CSV loader, and the heating-season gates in the heat-pump and CHP controllers — indexes its
+year-long profile from timestep 0 as if that were the 1st of January, whatever `start_date` says.
+This has been so since the initial public release: `start_date` has never appeared in
+`weather.py`. The two places that *do* honour the date — the solar-thermal collector's own sun
+position, and the LPG connector's unused `USE_UTSP` mode — make a mid-year run incoherent rather
+than correct, because they move alone.
+
+The wrongness is silent and large. Measured: a July week in Aachen yields **37 kWh** of PV where
+the true July offset yields **426 kWh** — an 11.5× error — under a results index that is stamped
+with July timestamps (`simulator.py` builds the index from `start_date`), so the mislabelling is
+written to disk. The solar-thermal collector meanwhile sees a genuine July sun (apparent zenith
+27.7°) wired to January irradiance.
+
+**What is *not* affected:** every shipped parameter file, every golden reference, every recorded
+twin, RenoVisor and the freshness gates run January or full-year windows — no committed number is
+wrong. The latent exposure is the HPC harness's `three_months` option (starts 1 March) and anyone
+who ever hands a mid-year `start_date` to `hisim_main`.
+
+## The design: B′ — the profile owner resolves one offset against its own frame
+
+Four designs were assessed:
+
+- **A (absolute indexing)** — run the loop over year-absolute timesteps, keep profiles unchanged.
+  Rejected: every *window-sized* array in the fleet (result caches, per-timestep outputs,
+  window-scoped solar positions) breaks at once, so nothing can land independently; and it turns a
+  fleet-wide silent bug into a fleet-wide loud one that must be fixed everywhere before anything
+  runs.
+- **A′ (simulate the prefix, discard)** — solves initial states by construction, but costs up to
+  half a year of extra simulation per run (26× for a July week) and *enlarges* the cache problem:
+  every window-sized cache would grow to prefix+window. Rejected; a short warm-up is a separate,
+  later feature (see initial states).
+- **B (slice at load, everywhere)** — right idea, forfeits the weather cache's reuse and leaves
+  the offset logic scattered.
+- **B′ (chosen)** — **the profile-OWNING component keeps its year internally, resolves ONE window
+  offset by looking `start_date` up in the frame its source actually delivered, and publishes and
+  emits only the window. Downstream stays `[0, N)` and unchanged.**
+
+B′ has two shapes, and conflating them is the epic's most likely implementation error:
+
+1. **"Slice a kept year"** — weather (offset resolved against the resampled series' own
+   `DatetimeIndex`), the shipped predefined LPG profiles (their CSVs carry a real `Time` column
+   and the JSONs a `StartTime` — the data is self-describing and the code currently throws the
+   description away), the shipped wind CSV.
+2. **"Ask the source for the real window; the offset is zero"** — `USE_LOCAL_LPG` (send the real
+   `start_date` to the generator: this changes *content*, July household behaviour instead of
+   January's, which is the point) and `USE_UTSP` (already sends the truth; only the Jan-1
+   relabelling afterwards is wrong).
+
+**The invariant, verbatim, for every implementation and review:** *resolve the window against the
+frame the source actually delivered — never "skip N rows from January 1".* A blanket
+`skiprows=offset` double-shifts every source that already delivered the window.
+
+The payoff, verified rather than assumed: **PV, building and solar-thermal need zero functional
+lines** (PV's `[:timesteps]` truncation degenerates to a no-op; the building's solar gains have
+always come from its wired inputs — its own solar cache is dead code, see the repairs table; the
+collector already follows `start_date`), and the whole occupancy/car chain is fixed inside the LPG
+connector, which is the profile owner for both.
+
+## The two traps that decide success (write their tests before the code)
+
+1. **The offset must never be arithmetic.** The Berlin-anchored weather sources index elapsed
+   instants: for 1 July 2021, the correct row is **260 550**; naive minutes from the series' own
+   start give 260 610 (the March DST hour), naive minutes from Jan 1 give 260 640 (DST plus the
+   source's 00:30 anchor). The error is *energy-neutral over whole days* — no aggregate or KPI
+   test can ever catch it — and only a per-timestep phase test against wall-clock labels can. Pin
+   the three numbers, and pin a December window too (where the DST correction is zero again).
+   The LPG frame, by contrast, is gapless naive local time (uniform 1-minute diffs across all
+   525 600 rows, measured), so there the hazard is not the row arithmetic but the UTC↔local hop:
+   `convert_lpg_data_to_utc` hard-codes the winter +1 h, one hour short for CEST.
+2. **The warm cache makes the fix a silent no-op.** Every cache key already contains
+   `start_date`, so a pre-fix July entry holds January content under a key the fixed code
+   validates happily — and a staged rollout poisons its own caches between stages. The epoch
+   mechanism below is not optional, and the oracle runs cold-then-warm and asserts equality.
+
+## The window contract (one chokepoint)
+
+`SimulationParameters.__init__` is provably the only construction path (three external call sites,
+all keyword construction; every factory routes through it). It gains four validations: start at
+midnight; whole days; `start` and `end − 1 timestep` in the same year (a window crossing Dec 31
+has no single-year source and the DST surgery is keyed to one year — refuse loudly); duration
+divisible by `seconds_per_timestep` (today `timesteps` truncates silently). **Leap-year refusal
+does not live here** — whether an 8760-row source can serve 2020 is the source's answer, so it
+lands in the offset resolver, next to the lookup that discovers the missing label.
+
+The simulator core itself is clean: the loop is pure position, convergence is calendar-agnostic,
+the results index is already built from `start_date` (verified for six windows including DST-span
+and leap year), and KPI computation groups by the frame's index with no January assumption
+anywhere. Three plot/report sites do assume January (month tick labels on 365-point plots, the
+carpet's midnight anchor, the single-day chart titled "january 1st" whatever the day) — a small
+labelling PR, shipped with the epic so the first real July report does not say January.
+
+## Caches: the epoch
+
+All six caches route through one function, `utils.build_cache_key_string`, and it has **no
+version slot** — `hisim/caching/local.py` documents this exact gap in its own words. The
+structural fix (`hisim/caching/keys.py`'s `CacheKey`, which fingerprints the producer's import
+closure) has zero adopters and requires producer extraction first; that is the cache-service
+epic, not this one.
+
+The mechanism here: a class-scoped `CacheEpoch.CURRENT` constant prepended to the key material in
+`build_cache_key_string` (not in `get_unique_key`, which has a second, descriptive caller). One
+line to bump, invalidating *everything at once* — deliberately, because per-producer epochs are
+six constants and six chances to forget one, and the forgotten one reads green. Every PR of this
+epic that changes what a cached producer writes bumps it, with the PR number as the value so the
+history reads. CI never shares a cache across the epic's branches (the per-run empty cache
+directory pattern the parity rig already uses).
+
+## Initial states (storages, thermal mass, batteries)
+
+The inventory, measured and cited in the analyses, in one line each: building thermal mass starts
+at 22 °C (winter-typical; still 4.9 % off on day 7 after a 6 K perturbation — the largest and
+slowest transient); the buffer storage starts at a hard-coded 35 °C (winter-typical, and its
+dataclass default of 25 °C disagrees with the hard-coded value); DHW storage 60 °C
+(season-neutral, correct); battery SOC 0 (arbitrary, settles in a PV day); hydrogen storage 80 %
+full in one package and empty in the other (arbitrary twice over); ~25 controllers start "off"
+with their minimum idle time blocking the first 15–60 minutes (season-neutral start artefact);
+and one column (`WaterMassFlowHDS`, a bang-bang controller) never settles at all — it re-phases
+onto a different limit cycle, permanently 16.7 % out, which is why no warm-up length can buy
+exactness.
+
+**Decision:** keep the defaults and document the measured per-component transient (the validation
+design absorbs it), plus exactly one season-aware change — the buffer/space-heating storage seeds
+from the heating-season gate (outside the season it starts at ambient 20 °C instead of 35 °C: a
+buffer nobody has charged sits at room temperature — the one derivation defensible in a
+sentence). Warm-up prefixes are rejected on the measured evidence (weeks would be needed, and the
+limit-cycle columns never converge). Checkpoint handover is the honest follow-up but is blocked on
+repairs first: `i_save_state` is a convergence scratchpad, not a checkpoint contract, and two live
+bugs prove it (the EMS restores a reference, not a clone; the heat-distribution restore
+self-assigns) — fix those on their own merits before checkpointing is discussable. One blocker to
+untangle before any building-side seasonal default: `initial_internal_temperature_in_celsius`
+doubles as the *permanent* window-opening comfort floor in the building's free-cooling rule — a
+field named "initial" that is silently a model parameter.
+
+## Validation: the split oracle
+
+The strongest available truth: a full-year run is correct today, so a mid-year window must
+reproduce the same calendar slice of a full-year run. Measured on a real setup, the comparison
+splits perfectly:
+
+- **The memoryless half — weather, occupancy, solar gains, meters — agrees BIT-EXACTLY from
+  timestep 0** (verified: 30+ columns at exactly 0.0 deviation under a deliberately perturbed
+  initial state). This is precisely the layer the epic changes, so **the gate is exact, tolerance
+  zero, on those columns**.
+- **The stateful half** (thermal mass, storages, the boiler they drive) carries a days-long
+  transient and one permanent limit-cycle re-phasing — so it is a **report, never a gate**:
+  per-day deviation tables for days 1, 2, 3, 5, 7, read by a person.
+- **The memoryless column set is discovered, not maintained:** run the full-year reference twice
+  with a perturbed initial-state seed; the columns whose difference is identically zero ARE the
+  exact-comparable set. Self-calibrating as components change.
+
+The harness: `scripts/midyear_oracle.py`, modelled on the parity rig (per-run empty cache
+directory, one process, one printed verdict table, a tolerance flag that shouts when nonzero),
+reusing `ResultComparison` verbatim — its index check refuses a misaligned slice for free, since
+both frames carry `start_date`-built indexes. Plus four unit anchors in `tests/`: first-timestep
+identity against the source's own labels; the DST phase pins (260 550 / 260 610 / 260 640, and a
+December mirror); each weather reader's `index[0]` pinned (the six sources use three different
+anchors — Berlin 00:30, Berlin 00:00 after padding, UTC 00:00 — which is exactly why "resolve
+against the delivered frame" is the rule); and the cold-then-warm cache equality assertion.
+
+## The PR plan
+
+```
+PR1 (window contract; YEARLYFORECAST→window renames; plot labels; delete dead smart device)
+ └─ PR2 (offset primitive + weather adopts it; leap refusal; DWD_15MIN reader; delete dead
+         building solar cache; the four unit anchors; build the oracle)        [epoch bump]
+     ├─ PR3 (convert_lpg_data_to_utc rewritten: localize→convert→slice)       [epoch bump]
+     │        — changes January numbers too (the current code starts every window at source
+     │          row 60 and fabricates the final hour): GOLDEN RE-BLESS, alone, one cause
+     │   └─ PR4+5 (LPG connector owns occupancy + cars, all three modes;
+     │             seasonal gates go day-of-year — MUST SHIP TOGETHER,
+     │             or a July window heats the house)                          [epoch bump]
+     └─ PR6 (solar thermal: drop its naive-UTC duplicate sun, consume the
+             weather's published window — 3 solar-thermal goldens move)       [epoch bump]
+          └─ PR7 (lift the fence in its five sites; invert the fence test into
+                  "July differs from January"; bless the July goldens)
+```
+
+Blast-radius rules: PR2 and PR4+5 must not move a single January golden (offset 0 on 1 January —
+each PR's own cheapest proof); PR3 is the deliberate January re-bless and ships alone so the
+golden diff has exactly one cause; PR7 adds the `july_week` parameter set to the golden config and
+blesses the first true July references.
+
+## Independent repairs surfaced by the analyses
+
+In scope, batched as noted: the leap-year refusal (PR2 — the offset lookup is where "this source
+cannot serve this date" is decidable); the DWD_15MIN reader sizing its index from the *run's*
+duration instead of the file (PR2 — the one reader that cannot be sliced until anchored); the dead
+building solar-gain cache (PR2 — **delete, don't fix the `hasattr` typo**: repairing it would
+serve stale entries past every check and add a sixth window-sensitive cache); the solar-thermal
+naive-UTC sun and its duplicate sun position (PR6); the dead `generic_smart_device` (PR1 — zero
+references, raises `KeyError` on first call; deleting it also retires the independently broken
+`convert_lpg_timestep_to_utc` and the test that pins its wrong output).
+
+Out of scope, each with its trigger: `generic_price_signal` emits a constant (element `[0]`
+forever) — not profile-driven, cannot be made wrong by this epic; fix when a setup needs a
+time-varying tariff. The `i_save_state` reference/self-assignment bugs — live convergence-loop
+defects, prerequisite for checkpointing; on the cleanup list. The initial-state default
+contradictions (storage 25 vs 35 °C, EV SOC 0 vs 0.5, H₂ 0 vs 400 kg) — settle when the
+season-aware storage seed lands. The MPC's uninterpretable `10/15` Wh literal — flag for whoever
+touches the MPC. The building's dual-purpose `initial_internal_temperature_in_celsius` — split
+before any building-side seasonal default.

--- a/scripts/p3_parity_check.py
+++ b/scripts/p3_parity_check.py
@@ -2,16 +2,18 @@
 """Run one Python setup and its recorded twin side by side and prove they are the same simulation.
 
 TEMPORARY — this script is the P3 migration parity rig (requirements R11) and is deleted together
-with the rest of the rig in phase P6 (R11.8 amended and AC-P3.20 deferred to P6, 2026-08-31). It is not the permanent golden gate,
-it produces no reference and it blesses nothing: its only question is whether the declarative file
-recorded from a setup reproduces that setup.
+with the rest of the rig in phase P6 (R11.8 amended and AC-P3.20 deferred to P6, 2026-08-31). It is
+not the permanent golden gate, it produces no reference and it blesses nothing: its only question is
+whether the declarative file recorded from a setup reproduces that setup.
 
 Every requested ``(setup, window)`` triple is run through the three comparisons of R11.3 in order;
-one invocation covers the whole requested set — the entire fleet over both windows by default —
-and prints one table over all of it. First the component set and the wire set, through the
-declared port-renaming table, because two systems wired differently have nothing worth comparing
-numerically. Then **every** column of the result frame — the content of ``all_results.csv`` —
-since a difference the KPI layer happens to average away is still a difference. Then
+one invocation covers the whole requested set — the entire fleet over every runnable window by
+default, which is the January week alone while the July window is fenced (see
+``p3_parity_matrix.MatrixPaths.FENCED_WINDOWS``) — and prints one table over all of it. First the
+component set and the wire set, through the declared port-renaming table, because two systems
+wired differently have nothing worth comparing numerically. Then **every** column of the result
+frame — the content of ``all_results.csv`` — since a difference the KPI layer happens to average
+away is still a difference. Then
 ``all_kpis.json``, where KPI computation succeeds; a setup that crashes in that layer still
 receives a named verdict from the first two comparisons rather than an error, but its unavailable
 KPI stage fails the triple, so a new KPI regression cannot read green (R11.4 as amended
@@ -30,7 +32,7 @@ two runs themselves in ``p3_parity_runs.py``; what is here is the comparison and
 Examples
 --------
     python scripts/p3_parity_check.py --setup basic_household --window january
-    python scripts/p3_parity_check.py --setup household_gas_building_sizer --window july --rel-tol 1e-12
+    python scripts/p3_parity_check.py --setup household_gas_building_sizer --rel-tol 1e-12
 """
 
 from __future__ import annotations
@@ -53,7 +55,7 @@ from hisim.energy_system.parity import (
 )
 
 try:  # importable both as ``scripts.p3_parity_check`` (tests) and as a script from ``scripts/``
-    from p3_parity_matrix import covered_setups  # type: ignore[import-not-found]
+    from p3_parity_matrix import MatrixPaths, covered_setups  # type: ignore[import-not-found]
     from p3_parity_renamings import DeclaredPortRenamings  # type: ignore[import-not-found]
     from p3_parity_runs import (  # type: ignore[import-not-found]
         ColumnDifference,
@@ -73,7 +75,7 @@ try:  # importable both as ``scripts.p3_parity_check`` (tests) and as a script f
         last_line,
     )
 except ModuleNotFoundError:  # pragma: no cover - depends on how scripts/ is on the path
-    from scripts.p3_parity_matrix import covered_setups
+    from scripts.p3_parity_matrix import MatrixPaths, covered_setups
     from scripts.p3_parity_renamings import DeclaredPortRenamings
     from scripts.p3_parity_runs import (
         ColumnDifference,
@@ -425,11 +427,13 @@ def parse_arguments(argv: Optional[Sequence[str]]) -> argparse.Namespace:
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument("--setup", nargs="+", metavar="STEM", help="cover only these setups")
+    # Fenced windows stay valid choices so that asking for one is answered with the reason it is
+    # fenced rather than with argparse's bare "invalid choice"; main() refuses them before any run.
     parser.add_argument(
         "--window",
         nargs="+",
         choices=list(ParityWindows.names()),
-        help="cover only these windows (default: both)",
+        help=f"cover only these windows (default: {' '.join(ParityWindows.runnable())})",
     )
     parser.add_argument(
         "--rel-tol",
@@ -472,8 +476,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     Returns:
         ``0`` when every triple reached parity, ``1`` otherwise.
+
+    Raises:
+        SystemExit: If a fenced window was asked for. The refusal happens here, before the first
+            setup is imported, so that it costs nothing and cannot be mistaken for a run.
     """
     arguments = parse_arguments(argv)
+    try:
+        MatrixPaths.refuse_fenced(arguments.window or ())
+    except ValueError as refusal:
+        raise SystemExit(str(refusal)) from refusal
     if arguments.summarize is not None:
         table, covered, without_parity = Report.summarize(arguments.summarize)
         print(table)
@@ -485,7 +497,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     tolerance = Tolerance(arguments.rel_tol, arguments.abs_tol)
     checker = ParityChecker(tolerance, DeclaredPortRenamings.port_renaming())
     stems = discover(arguments.setup)
-    windows = list(arguments.window or ParityWindows.names())
+    windows = list(arguments.window or ParityWindows.runnable())
     print(f"Comparing {len(stems)} setup(s) over {len(windows)} window(s) at {tolerance.describe()}.\n")
 
     verdicts: List[TripleVerdict] = []

--- a/scripts/p3_parity_check.py
+++ b/scripts/p3_parity_check.py
@@ -478,14 +478,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ``0`` when every triple reached parity, ``1`` otherwise.
 
     Raises:
-        SystemExit: If a fenced window was asked for. The refusal happens here, before the first
-            setup is imported, so that it costs nothing and cannot be mistaken for a run.
+        SystemExit: If a fenced window was asked for, or if the window list came out empty. The
+            refusal happens before the first setup is imported, so that it costs nothing and
+            cannot be mistaken for a run — and only on the run path, because ``--summarize`` runs
+            no window and reads only what an earlier dispatch wrote.
     """
     arguments = parse_arguments(argv)
-    try:
-        MatrixPaths.refuse_fenced(arguments.window or ())
-    except ValueError as refusal:
-        raise SystemExit(str(refusal)) from refusal
     if arguments.summarize is not None:
         table, covered, without_parity = Report.summarize(arguments.summarize)
         print(table)
@@ -494,10 +492,18 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             return 1
         print(f"\n{without_parity} of {covered} triple(s) did not reach parity.")
         return 1 if without_parity else 0
+    try:
+        MatrixPaths.refuse_fenced(arguments.window or ())
+    except ValueError as refusal:
+        raise SystemExit(str(refusal)) from refusal
     tolerance = Tolerance(arguments.rel_tol, arguments.abs_tol)
     checker = ParityChecker(tolerance, DeclaredPortRenamings.port_renaming())
     stems = discover(arguments.setup)
     windows = list(arguments.window or ParityWindows.runnable())
+    if not windows:
+        # The matrix guards its empty product the same way: zero triples exiting 0 would read as
+        # a green table over coverage nobody checked.
+        raise SystemExit("No runnable window: every window is fenced, so this dispatch would cover nothing.")
     print(f"Comparing {len(stems)} setup(s) over {len(windows)} window(s) at {tolerance.describe()}.\n")
 
     verdicts: List[TripleVerdict] = []

--- a/scripts/p3_parity_matrix.py
+++ b/scripts/p3_parity_matrix.py
@@ -59,10 +59,10 @@ class MatrixPaths:
 
     #: The windows whose definition is kept but which the rig refuses to run. Mid-year start dates
     #: do not work anywhere in HiSim: every profile-driven component — weather, PV, building, the
-    #: LPG occupancy, cars, smart devices, the CSV loader, the price signal — indexes its year-long
-    #: profile from timestep 0 as if that were the 1st of January, whatever the start date says. A
-    #: July run therefore either reproduces January exactly or, where a component does honour the
-    #: date (a solar-thermal collector's sun position), pairs July sun with January irradiance. The
+    #: LPG occupancy, cars, smart devices, the CSV loader — indexes its year-long profile from
+    #: timestep 0 as if that were the 1st of January, whatever the start date says. A July run
+    #: therefore either reproduces January's numbers or, where a component does honour the date
+    #: (a solar-thermal collector's sun position), pairs July sun with January irradiance. The
     #: fence is a fence rather than a deletion because the mid-year-start epic removes it again.
     FENCED_WINDOWS = ("july",)
 
@@ -97,7 +97,7 @@ class MatrixPaths:
         if not fenced:
             return
         raise ValueError(
-            f"The window(s) {fenced} are fenced out of the parity rig: a July window reads "
+            f"The window(s) {fenced} are fenced out of the parity rig: a mid-year window reads "
             "January's profiles today, because every profile-driven component indexes its "
             "year-long profile from timestep 0 as if that were the 1st of January, whatever the "
             "start date says. The window definitions are kept for the mid-year-start epic, which "

--- a/scripts/p3_parity_matrix.py
+++ b/scripts/p3_parity_matrix.py
@@ -12,11 +12,14 @@ driver already fails and names it, so there is nothing for the rig to add.
 Deliberately standard-library only, like ``golden_matrix.py``: this runs in the lightweight
 discover job before any dependency is installed, so it cannot import HiSim. The price is that the
 window names appear here as well as in ``p3_parity_runs.py``, and a test asserts the two agree.
+Being the one module of the rig everything else may import, this is also where the window fence
+lives: :class:`MatrixPaths` knows which windows are runnable and refuses the rest with a reason,
+and the runner and the checker ask it rather than keeping a second answer.
 
 Examples
 --------
     python scripts/p3_parity_matrix.py
-    python scripts/p3_parity_matrix.py --setup basic_household --window july
+    python scripts/p3_parity_matrix.py --setup basic_household --window january
 """
 
 from __future__ import annotations
@@ -24,7 +27,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Tuple
 
 
 class MatrixPaths:
@@ -49,9 +52,58 @@ class MatrixPaths:
     #: The module of ``system_setups/`` that is not a setup.
     NOT_A_SETUP = "__init__.py"
 
-    #: The windows every triple is measured over. Mirrors ``ParityWindows.FACTORIES``; a test
-    #: asserts the two stay equal, because this module may not import HiSim to ask.
+    #: Every window the rig has a definition for, runnable or not. Mirrors
+    #: ``ParityWindows.FACTORIES``; a test asserts the two stay equal, because this module may not
+    #: import HiSim to ask.
     WINDOWS = ("january", "july")
+
+    #: The windows whose definition is kept but which the rig refuses to run. Mid-year start dates
+    #: do not work anywhere in HiSim: every profile-driven component — weather, PV, building, the
+    #: LPG occupancy, cars, smart devices, the CSV loader, the price signal — indexes its year-long
+    #: profile from timestep 0 as if that were the 1st of January, whatever the start date says. A
+    #: July run therefore either reproduces January exactly or, where a component does honour the
+    #: date (a solar-thermal collector's sun position), pairs July sun with January irradiance. The
+    #: fence is a fence rather than a deletion because the mid-year-start epic removes it again.
+    FENCED_WINDOWS = ("july",)
+
+    #: Where the fence's refusal sends the reader.
+    FENCE_ROADMAP = "roadmap/midyear_start_epic.md"
+
+    @classmethod
+    def runnable_windows(cls) -> Tuple[str, ...]:
+        """The windows a dispatch may actually run, in the order of :attr:`WINDOWS`.
+
+        Returns:
+            Every defined window that is not fenced.
+        """
+        return tuple(window for window in cls.WINDOWS if window not in cls.FENCED_WINDOWS)
+
+    @classmethod
+    def refuse_fenced(cls, windows: Sequence[str]) -> None:
+        """Refuses a request for a fenced window, saying what is broken and where it is tracked.
+
+        A fenced window is refused rather than quietly dropped, because a dispatch that silently
+        ran fewer triples than it was asked for would report a green table over coverage nobody
+        checked. The refusal is one sentence about the defect and one pointer, so whoever asked
+        for July learns why the answer would have been January's numbers.
+
+        Args:
+            windows: The windows a caller asked for.
+
+        Raises:
+            ValueError: If any of them is fenced.
+        """
+        fenced = sorted({window for window in windows if window in cls.FENCED_WINDOWS})
+        if not fenced:
+            return
+        raise ValueError(
+            f"The window(s) {fenced} are fenced out of the parity rig: a July window reads "
+            "January's profiles today, because every profile-driven component indexes its "
+            "year-long profile from timestep 0 as if that were the 1st of January, whatever the "
+            "start date says. The window definitions are kept for the mid-year-start epic, which "
+            f"unfences them; see {cls.FENCE_ROADMAP}. Runnable window(s): "
+            f"{list(cls.runnable_windows())}."
+        )
 
 
 def covered_setups(root: Optional[Path] = None) -> List[str]:
@@ -83,15 +135,16 @@ def build_matrix(
 
     Args:
         setups: Restrict to these setup stems; every covered setup when omitted or empty.
-        windows: Restrict to these windows; both when omitted or empty.
+        windows: Restrict to these windows; every runnable window when omitted or empty.
         root: Repository root to look in; the real one when omitted.
 
     Returns:
         ``{"include": [{"setup": ..., "window": ...}, ...]}``.
 
     Raises:
-        ValueError: If a named setup is not covered, or a named window does not exist — a typo in
-            a hand-dispatched run has to fail loudly rather than quietly run nothing.
+        ValueError: If a named setup is not covered, if a named window does not exist — a typo in
+            a hand-dispatched run has to fail loudly rather than quietly run nothing — or if a
+            named window is fenced, which :meth:`MatrixPaths.refuse_fenced` explains.
     """
     available = covered_setups(root)
     chosen = list(available) if not setups else [stem for stem in available if stem in set(setups)]
@@ -99,10 +152,11 @@ def build_matrix(
         unknown = sorted(set(setups) - set(available))
         if unknown:
             raise ValueError(f"No recorded twin for {unknown}; covered setups are {available}.")
-    chosen_windows = list(MatrixPaths.WINDOWS) if not windows else list(windows)
+    chosen_windows = list(MatrixPaths.runnable_windows()) if not windows else list(windows)
     unknown_windows = sorted(set(chosen_windows) - set(MatrixPaths.WINDOWS))
     if unknown_windows:
         raise ValueError(f"Unknown window(s) {unknown_windows}; choose from {list(MatrixPaths.WINDOWS)}.")
+    MatrixPaths.refuse_fenced(chosen_windows)
     return {
         "include": [
             {"setup": stem, "window": window} for stem in chosen for window in chosen_windows
@@ -123,8 +177,14 @@ def parse_arguments(argv: Optional[Sequence[str]]) -> argparse.Namespace:
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument("--setup", nargs="+", metavar="STEM", help="restrict to these setups")
+    # Every defined window stays a valid choice, fenced ones included: argparse would otherwise
+    # answer a request for July with "invalid choice", and the point of the fence is that whoever
+    # asks for July is told what is wrong with it and where that is being fixed.
     parser.add_argument(
-        "--window", nargs="+", choices=list(MatrixPaths.WINDOWS), help="restrict to these windows"
+        "--window",
+        nargs="+",
+        choices=list(MatrixPaths.WINDOWS),
+        help=f"restrict to these windows (default: {' '.join(MatrixPaths.runnable_windows())})",
     )
     return parser.parse_args(argv)
 
@@ -139,12 +199,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ``0``.
 
     Raises:
-        SystemExit: If the matrix is empty. GitHub reports a matrix job that expanded to zero
+        SystemExit: If the matrix is empty — GitHub reports a matrix job that expanded to zero
             cells as a success, so a dispatch over no recorded twins would otherwise turn the
-            whole workflow green while testing nothing.
+            whole workflow green while testing nothing — or if the request was refused, which a
+            discover job should read as one message rather than as a traceback.
     """
     arguments = parse_arguments(argv)
-    matrix = build_matrix(arguments.setup, arguments.window)
+    try:
+        matrix = build_matrix(arguments.setup, arguments.window)
+    except ValueError as refusal:
+        raise SystemExit(str(refusal)) from refusal
     if not matrix["include"]:
         raise SystemExit("The matrix is empty: no setup has a recorded twin, so the rig would cover nothing.")
     print(json.dumps(matrix, separators=(",", ":")))

--- a/scripts/p3_parity_runs.py
+++ b/scripts/p3_parity_runs.py
@@ -42,14 +42,15 @@ except ModuleNotFoundError:  # pragma: no cover - depends on how scripts/ is on 
 class ParityWindows:
     """The simulation windows every triple is defined over, which of them may run, and how.
 
-    R11.5 asked for two windows rather than one because every short parameter set HiSim ships
-    starts on the first of January, which measures each cooling device, air conditioner and
-    solar-thermal collector in the darkest week of the year, and the July week was meant to be the
-    answer. It is not one yet: HiSim has never supported a mid-year start, so every profile-driven
-    component reads its year-long profile from timestep 0 as if that were the 1st of January. A
-    July triple therefore compares two runs that both simulate January — byte-identical to the
-    January triple for most setups, and physically incoherent for the four with a solar-thermal
-    collector, whose sun position follows the date while its irradiance does not. The July window
+    R11.5 asked for two windows rather than one because every week- and day-sized parameter set
+    HiSim ships starts on the first of January, which measures each cooling device, air conditioner
+    and solar-thermal collector in the darkest week of the year, and the July week was meant to be
+    the answer. It is not one yet: HiSim has never supported a mid-year start, so every
+    profile-driven component reads its year-long profile from timestep 0 as if that were the 1st of
+    January. A July triple therefore compares two runs that both simulate January — the January
+    triple's numbers under July timestamps for most setups, and physically incoherent for the three
+    with a solar-thermal collector, whose sun position follows the date while its irradiance does
+    not. The July window
     is consequently **fenced**: its definition stays here for the mid-year-start epic that will fix
     the profiles and unfence it, and :meth:`runnable` is what a dispatch actually covers.
 
@@ -85,10 +86,14 @@ class ParityWindows:
     def runnable(cls) -> Tuple[str, ...]:
         """The window names a dispatch may actually ask for.
 
+        Delegates to :meth:`MatrixPaths.runnable_windows` rather than re-deriving the filter, so
+        the fence has exactly one implementation; the mirror test that keeps :meth:`names` equal
+        to ``MatrixPaths.WINDOWS`` is what makes the delegation safe.
+
         Returns:
             The defined names minus the fenced ones, in the same order.
         """
-        return tuple(name for name in cls.FACTORIES if name not in MatrixPaths.FENCED_WINDOWS)
+        return cast(Tuple[str, ...], MatrixPaths.runnable_windows())
 
     @classmethod
     def build(cls, window: str, result_directory: Path, cache_directory: Path) -> SimulationParameters:

--- a/scripts/p3_parity_runs.py
+++ b/scripts/p3_parity_runs.py
@@ -33,18 +33,34 @@ from hisim.energy_system.parity import WiringSnapshot
 from hisim.postprocessingoptions import PostProcessingOptions
 from hisim.simulationparameters import SimulationParameters
 
+try:  # importable both as ``p3_parity_runs`` (a script from ``scripts/``) and as ``scripts.p3_parity_runs``
+    from p3_parity_matrix import MatrixPaths  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - depends on how scripts/ is on the path
+    from scripts.p3_parity_matrix import MatrixPaths
+
 
 class ParityWindows:
-    """The simulation windows every triple is measured over, and how they are built.
+    """The simulation windows every triple is defined over, which of them may run, and how.
 
-    R11.5 asks for two windows rather than one because every short parameter set HiSim ships
+    R11.5 asked for two windows rather than one because every short parameter set HiSim ships
     starts on the first of January, which measures each cooling device, air conditioner and
-    solar-thermal collector in the darkest week of the year. The July week is the answer to that,
-    and both are named here so the checker, the matrix emitter and the workflow all spell them the
-    same way.
+    solar-thermal collector in the darkest week of the year, and the July week was meant to be the
+    answer. It is not one yet: HiSim has never supported a mid-year start, so every profile-driven
+    component reads its year-long profile from timestep 0 as if that were the 1st of January. A
+    July triple therefore compares two runs that both simulate January — byte-identical to the
+    January triple for most setups, and physically incoherent for the four with a solar-thermal
+    collector, whose sun position follows the date while its irradiance does not. The July window
+    is consequently **fenced**: its definition stays here for the mid-year-start epic that will fix
+    the profiles and unfence it, and :meth:`runnable` is what a dispatch actually covers.
+
+    Both names are still spelled here so the checker, the matrix emitter and the workflow agree on
+    them, and the fence itself is not repeated: it lives in ``p3_parity_matrix.MatrixPaths``, the
+    one module of the rig that imports nothing and can therefore be asked from anywhere.
     """
 
-    #: Window name to the ``SimulationParameters`` classmethod that builds it.
+    #: Window name to the ``SimulationParameters`` classmethod that builds it. Includes the fenced
+    #: windows: a definition that is kept has to stay buildable, or the epic would have to write it
+    #: again from scratch.
     FACTORIES: ClassVar[Dict[str, str]] = {
         "january": "one_week_only",
         "july": "one_week_july",
@@ -58,7 +74,7 @@ class ParityWindows:
 
     @classmethod
     def names(cls) -> Tuple[str, ...]:
-        """The window names a caller may ask for, in a stable order.
+        """Every window name this rig defines, fenced ones included, in a stable order.
 
         Returns:
             The names, January first.
@@ -66,11 +82,20 @@ class ParityWindows:
         return tuple(cls.FACTORIES)
 
     @classmethod
+    def runnable(cls) -> Tuple[str, ...]:
+        """The window names a dispatch may actually ask for.
+
+        Returns:
+            The defined names minus the fenced ones, in the same order.
+        """
+        return tuple(name for name in cls.FACTORIES if name not in MatrixPaths.FENCED_WINDOWS)
+
+    @classmethod
     def build(cls, window: str, result_directory: Path, cache_directory: Path) -> SimulationParameters:
         """Builds the parameters of one side of one triple.
 
         Args:
-            window: One of :meth:`names`.
+            window: One of :meth:`runnable`.
             result_directory: Where this side writes its results; created when missing.
             cache_directory: This side's private cache directory; created when missing.
 
@@ -78,12 +103,15 @@ class ParityWindows:
             The parameters, with the rig's post-processing option set already applied.
 
         Raises:
-            ValueError: If the window is not one this rig knows.
+            ValueError: If the window is not one this rig knows, or is one it refuses to run. The
+                refusal is repeated here rather than left to the command line because this is the
+                last point before a fenced window would cost a simulation.
         """
         if window not in cls.FACTORIES:
             raise ValueError(f"Unknown window {window!r}; choose from {sorted(cls.FACTORIES)}.")
+        MatrixPaths.refuse_fenced([window])
         factory = cast(
-            "Callable[[int, int], SimulationParameters]",
+            Callable[[int, int], SimulationParameters],
             getattr(SimulationParameters, cls.FACTORIES[window]),
         )
         parameters = factory(cls.YEAR, cls.SECONDS_PER_TIMESTEP)

--- a/tests/test_golden_matrix.py
+++ b/tests/test_golden_matrix.py
@@ -113,6 +113,12 @@ def test_a_parameter_set_factory_outside_the_vocabulary_is_refused() -> None:
     A factory without a horizon resolves to None, and ``None in horizons`` is False — restricted
     setups would silently skip the parameter set while unrestricted ones run it. A new factory
     has to enter the vocabulary consciously instead.
+
+    ``one_week_july`` is the example precisely because it is a factory the golden gate must not
+    gain today: a mid-year start date changes no profile in HiSim, so a July parameter set would
+    bless January's numbers under a summer name (R11.5 as amended, and the fence in
+    ``scripts/p3_parity_matrix.py``). The refusal here is about the vocabulary rather than about
+    that defect, and the two do not contradict each other — both refuse the factory.
     """
     config = _config()
     config["parameter_sets"].append({"id": "july_60s", "factory": "one_week_july"})

--- a/tests/test_p3_parity.py
+++ b/tests/test_p3_parity.py
@@ -245,7 +245,8 @@ def test_one_week_july_is_the_first_week_of_july() -> None:
     assert (parameters.start_date.month, parameters.start_date.day) == (7, 1)
     assert (parameters.end_date.month, parameters.end_date.day) == (7, 8)
     assert parameters.seconds_per_timestep == 60
-    assert parameters.timesteps == SimulationParameters.one_week_only(2021, 60).timesteps
+    # The literal, not one_week_only's count: a length bug both factories share must still fail.
+    assert parameters.timesteps == 7 * 24 * 60
 
 
 @pytest.mark.base
@@ -280,23 +281,28 @@ def test_the_july_window_is_fenced_out_of_every_default_dispatch() -> None:
     """
     assert "july" in MatrixPaths.WINDOWS, "the definition is kept; only the running of it is fenced"
     assert "july" in MatrixPaths.FENCED_WINDOWS
+    assert set(MatrixPaths.FENCED_WINDOWS) <= set(MatrixPaths.WINDOWS), (
+        "a fenced window that is not a defined window is a typo the fence would silently ignore"
+    )
     assert "july" not in MatrixPaths.runnable_windows()
     assert "july" not in ParityWindows.runnable()
     assert {entry["window"] for entry in build_matrix()["include"]} == {"january"}
 
 
 @pytest.mark.base
-def test_asking_for_the_fenced_window_is_refused_with_the_reason_and_the_pointer() -> None:
+def test_asking_for_the_fenced_window_is_refused_with_the_reason_and_the_pointer(tmp_path: Path) -> None:
     """Catches a fenced window being silently dropped, or refused without saying why.
 
     Silently running fewer triples than were asked for would report a green table over coverage
     nobody checked, and a bare "unknown window" would send whoever asked for July looking for a
     typo instead of at the defect. Every entry point is checked, because each of them is somebody's
-    first contact with the fence, and the last of them refuses before a simulation is started.
+    first contact with the fence, and the last of them refuses before a simulation is started. The
+    build call gets throwaway directories: the refusal fires before they are used today, but the
+    day the epic unfences July this test is edited, not allowed to write into the checkout.
     """
     for refused in (
         lambda: build_matrix(windows=["july"]),
-        lambda: ParityWindows.build("july", Rig.ROOT / "results" / "unused", Rig.ROOT / "results" / "unused"),
+        lambda: ParityWindows.build("july", tmp_path / "results", tmp_path / "cache"),
     ):
         with pytest.raises(ValueError, match="midyear_start_epic"):
             refused()

--- a/tests/test_p3_parity.py
+++ b/tests/test_p3_parity.py
@@ -51,6 +51,7 @@ from scripts.p3_parity_check import (
     Verdict,
     discover,
 )
+from scripts.p3_parity_check import main as parity_main
 from scripts.p3_parity_matrix import MatrixPaths, build_matrix
 
 
@@ -233,11 +234,12 @@ class Rig:
 
 @pytest.mark.base
 def test_one_week_july_is_the_first_week_of_july() -> None:
-    """Catches a summer window that is not seven days, or not in July.
+    """Catches a summer window whose dates are not seven days, or not in July.
 
-    The whole point of the second window is that it measures a cooling device somewhere other than
-    the annual minimum, so a set that silently stayed in January would defeat it without failing
-    anything else.
+    The definition is kept while the rig's July window is fenced (R11.5 as amended), because the
+    mid-year-start epic unfences it rather than writing it again, and a definition nobody runs is
+    exactly the kind that drifts. What this pins is the dates alone: what a run over those dates
+    currently simulates is January, which the fence tests below are about.
     """
     parameters = SimulationParameters.one_week_july(2021, 60)
     assert (parameters.start_date.month, parameters.start_date.day) == (7, 1)
@@ -247,22 +249,63 @@ def test_one_week_july_is_the_first_week_of_july() -> None:
 
 
 @pytest.mark.base
-def test_the_matrix_covers_every_recorded_setup_in_both_windows() -> None:
+def test_the_matrix_covers_every_recorded_setup_in_every_runnable_window() -> None:
     """Catches a dispatch that quietly covers less than the fleet.
 
-    R11.5 asks for both windows on every triple and R11.7 for one table covering all of them, so a
-    matrix that lost a setup or a window would make the rig's table an incomplete claim. The
-    windows are asserted against the runner's own list because the matrix script may not import
-    HiSim and therefore carries a second copy of them.
+    R11.7 asks for one table covering every triple, so a matrix that lost a setup or a runnable
+    window would make the rig's table an incomplete claim. The window vocabulary is asserted
+    against the runner's own list because the matrix script may not import HiSim and therefore
+    carries a second copy of it, and the runnable subset is asserted too so the fence cannot be
+    lifted on one side only.
     """
     assert tuple(MatrixPaths.WINDOWS) == ParityWindows.names()
+    assert MatrixPaths.runnable_windows() == ParityWindows.runnable()
     covered = discover(None)
     assert covered, "no setup has a recorded twin, so the rig would cover nothing"
     include = build_matrix()["include"]
-    assert len(include) == len(covered) * len(ParityWindows.names())
+    assert len(include) == len(covered) * len(ParityWindows.runnable())
     for stem in covered:
         windows = {entry["window"] for entry in include if entry["setup"] == stem}
-        assert windows == set(ParityWindows.names())
+        assert windows == set(ParityWindows.runnable())
+
+
+@pytest.mark.base
+def test_the_july_window_is_fenced_out_of_every_default_dispatch() -> None:
+    """Catches the fenced window creeping back into what a dispatch runs by default.
+
+    A July triple compares two runs that both simulate January, because every profile-driven
+    component indexes its profile from timestep 0 (R11.5 as amended). Until the mid-year-start epic
+    fixes that, no default path may reach the window: not the matrix the discover job emits, not
+    the checker's default window list, and not the runner's.
+    """
+    assert "july" in MatrixPaths.WINDOWS, "the definition is kept; only the running of it is fenced"
+    assert "july" in MatrixPaths.FENCED_WINDOWS
+    assert "july" not in MatrixPaths.runnable_windows()
+    assert "july" not in ParityWindows.runnable()
+    assert {entry["window"] for entry in build_matrix()["include"]} == {"january"}
+
+
+@pytest.mark.base
+def test_asking_for_the_fenced_window_is_refused_with_the_reason_and_the_pointer() -> None:
+    """Catches a fenced window being silently dropped, or refused without saying why.
+
+    Silently running fewer triples than were asked for would report a green table over coverage
+    nobody checked, and a bare "unknown window" would send whoever asked for July looking for a
+    typo instead of at the defect. Every entry point is checked, because each of them is somebody's
+    first contact with the fence, and the last of them refuses before a simulation is started.
+    """
+    for refused in (
+        lambda: build_matrix(windows=["july"]),
+        lambda: ParityWindows.build("july", Rig.ROOT / "results" / "unused", Rig.ROOT / "results" / "unused"),
+    ):
+        with pytest.raises(ValueError, match="midyear_start_epic"):
+            refused()
+
+    with pytest.raises(ValueError, match="January's profiles"):
+        build_matrix(windows=["january", "july"])
+
+    with pytest.raises(SystemExit, match="midyear_start_epic"):
+        parity_main(["--setup", Rig.FIXTURE, "--window", "july"])
 
 
 @pytest.mark.base


### PR DESCRIPTION
## Problem

The parity rig's July window (R11.5) has never delivered July: every profile-driven component in
HiSim indexes its year-long profile from timestep 0 as if that were the 1st of January, whatever
`start_date` says — since the initial public release. For every setup without a solar-thermal
collector the July triples compared two byte-identical January runs; for the four with one they
compared physically incoherent runs (the collector's sun honours the date, its wired irradiance is
January's). Measured size of the underlying defect: a July week yields 37 kWh of PV where July
yields 426 kWh, under a results index stamped with July timestamps. No shipped parameter file,
golden reference or twin uses a mid-year start, so no committed number is wrong — the rig's July
window was the only real consumer, and it claimed coverage that does not exist.

## Done

- **The July window is fenced, not deleted**: one fence in `p3_parity_matrix.py` (the stdlib-only
  module every rig module can ask), so a default dispatch covers the runnable windows alone and an
  explicit request for July is refused with the reason and a pointer at the epic, before any
  simulation starts. The workflow's window choices, the checker's defaults and every docstring
  that asserted July coverage now tell the truth; R11.5 and AC-P3.17 are amended in their own
  style. Two tests pin the fence; the coverage test asserts the vocabulary and the fence agree
  across modules.
- **`roadmap/midyear_start_epic.md`** — the epic the fence points at, condensed from three
  verified analyses: the B′ design (the profile-owning component resolves ONE window offset
  against the frame its source delivered, publishes the window, downstream unchanged — with its
  two shapes named, since conflating them double-shifts the sources that already deliver the
  window); the two traps that decide success (the DST-blind arithmetic offset, energy-neutral over
  whole days and thus invisible to every aggregate test; the warm cache serving pre-fix January
  content under post-fix July keys); the window contract in `SimulationParameters.__init__`; the
  cache-epoch mechanism; the initial-state inventory and decision (defaults kept and documented,
  one season-aware buffer-storage seed, warm-ups rejected on measured evidence); the split
  validation oracle (memoryless columns gate bit-exactly from timestep 0 — verified; stateful
  columns report per-day transients, never gate; the column split discovers itself); a seven-PR
  plan with each one's golden blast radius; and the independent repairs surfaced en route (dead
  building solar cache, dead smart device, leap years, the DWD_15MIN reader, the solar-thermal
  naive-UTC sun, the LPG UTC conversion that is off by an hour in January too).

## Result

The rig's runtime halves and its verdicts contain only claims that are true; a dispatch after this
merge is the honest AC-P3.17 baseline. The epic document is the reviewed plan for making a July
window mean July.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
