### PR TITLE
The child recorder becomes one class, and both drivers ask it

### DIFF
--- a/hisim/energy_system/recording/__init__.py
+++ b/hisim/energy_system/recording/__init__.py
@@ -29,8 +29,11 @@ is a judgement a person makes and not something one run can be asked about.
 That judgement has a second pass of its own, and it is built from the same three stages run several
 times over. :mod:`~hisim.energy_system.recording.probes` reads the authored list of module
 configurations a setup is recorded under; :mod:`~hisim.energy_system.recording.probe_session` records
-each of them in its own process; :mod:`~hisim.energy_system.recording.matrix` reduces the recordings
-to the three-state table a person is asked about;
+each of them in its own process, spawned through
+:mod:`~hisim.energy_system.recording.child_recorder`, which is where the recorder's child command
+line is stated for every caller that needs one;
+:mod:`~hisim.energy_system.recording.matrix` reduces the recordings to the three-state table a
+person is asked about;
 :mod:`~hisim.energy_system.recording.workbook` writes that table out as a spreadsheet and
 :mod:`~hisim.energy_system.recording.workbook_import` reads the answer back;
 :mod:`~hisim.energy_system.recording.grouping` is the answer as a value, with its committed form in
@@ -48,6 +51,7 @@ stay possible without importing HiSim's component tree, and a recorder necessari
 # clean
 
 from hisim.energy_system.recording.builder import EnergySystemBuilder, PortablePathGuard, build
+from hisim.energy_system.recording.child_recorder import ChildRecorder
 from hisim.energy_system.recording.configs import EntryConfigWriter
 from hisim.energy_system.recording.inputs import InputItemWriter
 from hisim.energy_system.recording.names import RecordedNames
@@ -102,6 +106,7 @@ __all__ = [
     "Assignment",
     "AssignmentKind",
     "CellState",
+    "ChildRecorder",
     "ColumnRealizer",
     "ColumnVerdict",
     "CombinationSpace",

--- a/hisim/energy_system/recording/child_recorder.py
+++ b/hisim/energy_system/recording/child_recorder.py
@@ -1,0 +1,99 @@
+"""Spawning the recorder in a child interpreter: the one place that knows how it is invoked.
+
+Nothing records a setup in the process that asked for it. A setup mutates module state, HiSim
+singletons and the local load-profile-generator index, so two setups recorded in one interpreter
+would record each other's leftovers; every caller therefore spawns a child, and this module is the
+child's whole invocation. The child is this repository's own command line rather than a private
+worker module, so that a fleet-wide run, a probe of one setup and a contributor recording a single
+setup by hand all go through the same code and cannot drift apart.
+
+Two callers use it — the fleet-wide driver in ``scripts/record_all_setups.py`` and
+:class:`~hisim.energy_system.recording.probe_session.ProbeRunner` — and they share exactly three
+decisions: which command records, which environment variable must not reach the child, and how the
+subprocess is run. What comes back is the plain ``CompletedProcess``, because the two callers are
+answerable for different things: the driver turns a nonzero exit into a per-setup outcome the run
+summarises, the probe runner turns it into a refusal naming the column, and neither reading belongs
+to the spawn.
+"""
+
+# clean
+
+from __future__ import annotations
+
+import os
+import subprocess  # nosec B404 - the only child is this repository's own command line
+import sys
+from pathlib import Path
+from typing import ClassVar, Dict, Optional, Sequence, Tuple
+
+
+class ChildRecorder:
+    """The recorder's child command, its environment and the subprocess call that runs it.
+
+    Held as a class of constants and classmethods rather than as loose functions so that the
+    command line, the variable stripped from the environment and the call's settings are stated
+    once and read together. Callers supply what genuinely differs between them: the interpreter,
+    the argument tail after the verb, and the working directory.
+    """
+
+    #: The child command that records one setup or one probe, completed with the paths the caller
+    #: appends. Spelled as ``-m hisim.cli`` so that the child is the installed command line of this
+    #: checkout and not a copy of it.
+    COMMAND: ClassVar[Tuple[str, ...]] = ("-m", "hisim.cli", "energy-system", "record")
+
+    #: Environment variable naming the local load-profile-generator working directory. It is
+    #: cleared from every child's environment rather than set, so a machine with a stale setting
+    #: records the same thing as a clean one and no recording run is pinned to a fixed directory.
+    #: Cleared, ``PylpgWorkspace.default_base_index()`` derives the index from the child's own
+    #: process, which is what keeps a recording out of the way of anything else using local
+    #: profiles on the same machine -- the collisions #611 exists to prevent. Pinning it to a
+    #: constant would reintroduce them for the length of a fleet-wide run, the better part of an
+    #: hour.
+    LPG_INDEX_VARIABLE: ClassVar[str] = "HISIM_LOCAL_LPG_CALC_INDEX"
+
+    @classmethod
+    def environment(cls) -> Dict[str, str]:
+        """Builds the child's environment: this process's own, minus the local-profile index.
+
+        The parent's environment is inherited wholesale, because a recording has to see what a
+        hand run of the same setup sees — the load profile provider's settings among it — and only
+        :attr:`LPG_INDEX_VARIABLE` is removed.
+
+        Returns:
+            A copy of this process's environment without the local-profile index variable.
+        """
+        environment = dict(os.environ)
+        environment.pop(cls.LPG_INDEX_VARIABLE, None)
+        return environment
+
+    @classmethod
+    def run(
+        cls,
+        arguments: Sequence[str],
+        python: Optional[str] = None,
+        cwd: Optional[Path] = None,
+    ) -> "subprocess.CompletedProcess[str]":
+        """Runs the recorder in a child interpreter and hands back what the child did.
+
+        The output is captured as text so that a caller can quote the child in its own error
+        message, and a nonzero exit is not raised here: what a failed recording means is the
+        caller's decision.
+
+        Args:
+            arguments: Everything after the verb — the setup, the parameters file and the options
+                the caller wants, already stringified.
+            python: The interpreter to record with; this process's own when omitted.
+            cwd: The directory the child runs in; the caller's own working directory when omitted.
+
+        Returns:
+            The completed process, carrying the exit code and the captured output.
+        """
+        vector = [python or sys.executable, *cls.COMMAND, *arguments]
+        return subprocess.run(  # nosec B603 - fixed argument vector, no shell
+            vector,
+            cwd=None if cwd is None else str(cwd),
+            env=cls.environment(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )

--- a/hisim/energy_system/recording/probe_session.py
+++ b/hisim/energy_system/recording/probe_session.py
@@ -25,10 +25,7 @@ probes are recorded and afterwards removed.
 from __future__ import annotations
 
 import difflib
-import os
 import shutil
-import subprocess  # nosec B404 - the only child is this repository's own command line
-import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -37,6 +34,7 @@ from typing import ClassVar, Dict, Iterator, List, Optional, Tuple
 from hisim.energy_system.errors import EnergySystemErrorId, EnergySystemRecordingError
 from hisim.energy_system.loader import dump_energy_system, load_energy_system, parse_energy_system
 from hisim.energy_system.model import EnergySystemFile
+from hisim.energy_system.recording.child_recorder import ChildRecorder
 from hisim.energy_system.recording.grouping import Grouping
 from hisim.energy_system.recording.grouping_checks import check_grouping
 from hisim.energy_system.recording.grouping_report import (
@@ -53,20 +51,13 @@ from hisim.energy_system.recording.session import RecordedFileWriter, RecordingS
 class ProbeRunner:
     """Records one setup under each of its probe configurations, one interpreter each.
 
-    The runner exists as a class only so that the command it builds, the environment it sets and
-    the throwaway directory it uses are stated once. Everything else about it is the same decision
-    the fleet-wide recording driver already made: sequential rather than parallel, this
-    repository's own command line as the child, and the child's output kept for the message when it
-    fails.
+    The runner exists as a class only so that the probe-specific part of the invocation — which
+    options a probe adds to the recorder's command line and the throwaway directory it records
+    into — is stated once. The child itself comes from
+    :class:`~hisim.energy_system.recording.child_recorder.ChildRecorder`, shared with the
+    fleet-wide recording driver. What is left to the runner is the reading of the result: probes
+    are recorded sequentially, and the child's output is kept for the message when one fails.
     """
-
-    #: The child command that records one probe, completed with the paths.
-    COMMAND: ClassVar[Tuple[str, ...]] = ("-m", "hisim.cli", "energy-system", "record")
-
-    #: Environment variable naming the local load-profile-generator working directory. It is
-    #: removed from the child's environment: each probe then derives its index from its own process
-    #: id and cannot collide with other runs, and an exported value on the parent cannot leak in.
-    LPG_INDEX_VARIABLE: ClassVar[str] = "HISIM_LOCAL_LPG_CALC_INDEX"
 
     #: Prefix of the throwaway directory the probes are recorded into.
     WORK_PREFIX: ClassVar[str] = ".probes-"
@@ -151,22 +142,11 @@ class ProbeRunner:
             EnergySystemRecordingError: ``EF-R5`` when the child failed or wrote nothing.
         """
         module_config = ModuleConfigMaterialiser.write(probe_list, probe, work_dir)
-        arguments: List[str] = [
-            python or sys.executable,
-            *cls.COMMAND,
-            str(setup),
-            str(parameters),
-            "--out",
-            str(work_dir),
-        ]
+        arguments: List[str] = [str(setup), str(parameters), "--out", str(work_dir)]
         if module_config is not None:
             arguments += ["--module-config", str(module_config), "--probe", probe.column]
             arguments += ["--probes", probe_list.origin]
-        environment = dict(os.environ)
-        environment.pop(cls.LPG_INDEX_VARIABLE, None)
-        completed = subprocess.run(  # nosec B603 - fixed argument vector, no shell
-            arguments, env=environment, capture_output=True, text=True, check=False
-        )
+        completed = ChildRecorder.run(arguments, python=python)
         label = "" if probe.is_baseline else f".{probe.column}"
         path = work_dir / f"{Path(setup).stem}{label}{RecordedFileWriter.SUFFIX}"
         if completed.returncode != 0 or not path.exists():

--- a/scripts/record_all_setups.py
+++ b/scripts/record_all_setups.py
@@ -31,13 +31,19 @@ import argparse
 import difflib
 import os
 import shutil
-import subprocess  # nosec B404 - the only child is this repository's own CLI
 import sys
 import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import ClassVar, List, Optional, Sequence, Tuple
+
+# The repository root goes on the import path before anything from HiSim is imported: this script
+# is run as a file from a checkout, where the package need not be installed, and then only the
+# script's own directory is on the path.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from hisim.energy_system.recording import ChildRecorder  # noqa: E402  # pylint: disable=wrong-import-position
 
 
 class Paths:
@@ -167,28 +173,18 @@ class SetupDiscovery:
 class Recorder:
     """Runs one setup's recording in its own interpreter and reports what came back.
 
-    The child is this repository's own command line rather than a worker module of this script,
-    so that the fleet-wide run and a contributor recording a single setup by hand go through
-    exactly the same code and cannot drift apart.
+    The child comes from :class:`~hisim.energy_system.recording.child_recorder.ChildRecorder`,
+    shared with the probe runner, so that a fleet-wide run, a probe and a contributor recording a
+    single setup by hand all go through exactly the same command line. What this class adds is the
+    fleet's own concerns: how many children run at once, and how a failed child becomes a line in
+    the run's summary.
     """
-
-    #: The command that records one setup, completed with the three paths.
-    COMMAND = ("-m", "hisim.cli", "energy-system", "record")
 
     #: How many children record at once unless ``--jobs`` says otherwise. Capped at four rather
     #: than at the machine's core count because each child builds a complete system — occupancy
     #: profiles included — and holds it in memory; the CI runner has four cores and seven
     #: gigabytes, and four children fit both. A bigger machine can raise it on the command line.
     DEFAULT_JOBS: ClassVar[int] = min(4, os.cpu_count() or 1)
-
-    #: Environment variable naming the local load-profile-generator working directory. It is
-    #: cleared from every child's environment rather than set, so a machine with a stale setting
-    #: records the same thing as a clean one and no recording run is pinned to a fixed directory.
-    #: Cleared, PylpgWorkspace.default_base_index() derives the index from the child's own process,
-    #: which is what keeps a recording run out of the way of anything else using local profiles on
-    #: the same machine -- the collisions #611 exists to prevent. Pinning it to a constant would
-    #: reintroduce them for the length of a fleet-wide run, which is the better part of an hour.
-    LPG_INDEX_VARIABLE = "HISIM_LOCAL_LPG_CALC_INDEX"
 
     @classmethod
     def record(cls, setup: Path, parameters: Path, out_dir: Path, python: str) -> SetupOutcome:
@@ -203,15 +199,10 @@ class Recorder:
         Returns:
             The outcome, carrying the child's output when it failed.
         """
-        environment = dict(os.environ)
-        environment.pop(cls.LPG_INDEX_VARIABLE, None)
-        completed = subprocess.run(  # nosec B603 - fixed argument vector, no shell
-            [python, *cls.COMMAND, str(setup), str(parameters), "--out", str(out_dir)],
-            cwd=str(Paths.REPO_ROOT),
-            env=environment,
-            capture_output=True,
-            text=True,
-            check=False,
+        completed = ChildRecorder.run(
+            [str(setup), str(parameters), "--out", str(out_dir)],
+            python=python,
+            cwd=Paths.REPO_ROOT,
         )
         if completed.returncode == 0:
             return SetupOutcome(stem=setup.stem, ok=True)
@@ -389,7 +380,6 @@ class DuplicateParameterCheck:
         Returns:
             One message per offending pair; empty when the directory is clean.
         """
-        sys.path.insert(0, str(Paths.REPO_ROOT))
         from hisim.energy_system.recording.parameters import (  # noqa: PLC0415
             ParameterFileLibrary,
         )

--- a/tests/test_energy_system_grouping.py
+++ b/tests/test_energy_system_grouping.py
@@ -911,7 +911,7 @@ def test_the_grouping_probe_verb_drives_the_shared_recorder_child(monkeypatch: p
         captured.setdefault("argv", list(arguments))
         return subprocess.CompletedProcess(args=arguments, returncode=1, stdout="", stderr="stubbed refusal")
 
-    monkeypatch.setattr("hisim.energy_system.recording.probe_session.subprocess.run", fake_run)
+    monkeypatch.setattr("hisim.energy_system.recording.child_recorder.subprocess.run", fake_run)
 
     # Absolute paths, because the continuous-integration job runs pytest from tests/ and a
     # working-directory-relative fixture path would make the verb refuse with EF-03 before the

--- a/tests/test_energy_system_recording_fleet.py
+++ b/tests/test_energy_system_recording_fleet.py
@@ -27,6 +27,7 @@ import pytest
 
 from hisim.cli import build_parser
 from hisim.energy_system.executor import SimulationParametersReader
+from hisim.energy_system.recording.child_recorder import ChildRecorder
 from hisim.energy_system.recording.parameters import (
     ParameterFileLibrary,
     ParameterFileName,
@@ -452,8 +453,8 @@ def test_a_recording_child_picks_its_own_profile_directory(monkeypatch: pytest.M
     ``pylpg/C<index>`` directory as anything else using local profiles.
     """
     recorded = RecordedChildEnvironment()
-    monkeypatch.setattr("scripts.record_all_setups.subprocess.run", recorded)
-    monkeypatch.setenv(Recorder.LPG_INDEX_VARIABLE, "1")
+    monkeypatch.setattr("hisim.energy_system.recording.child_recorder.subprocess.run", recorded)
+    monkeypatch.setenv(ChildRecorder.LPG_INDEX_VARIABLE, "1")
 
     Recorder.record(
         setup=Fleet.SETUPS / f"{Fleet.CHEAPEST_SETUP}.py",
@@ -463,7 +464,7 @@ def test_a_recording_child_picks_its_own_profile_directory(monkeypatch: pytest.M
     )
 
     assert len(recorded.environments) == 1
-    assert Recorder.LPG_INDEX_VARIABLE not in recorded.environments[0], (
+    assert ChildRecorder.LPG_INDEX_VARIABLE not in recorded.environments[0], (
         "the recorder pinned or passed on a local-LPG calculation index; cleared, the child derives "
         "its own from its process and cannot collide with another run"
     )


### PR DESCRIPTION
## Problem
`scripts/record_all_setups.py::Recorder` and `hisim/energy_system/recording/probe_session.py::ProbeRunner` each carried the whole knowledge of how to spawn the recording child: the same command tuple, the same `HISIM_LOCAL_LPG_CALC_INDEX` strip with the same #611 rationale, the same fixed-vector subprocess call. Deliberate while the two lived on different stacked branches; with both on main, a change to the child contract would have to be made twice — or would silently be made once. (Decided 2026-09-05 in the #638 review round.)

## Done
- New `hisim/energy_system/recording/child_recorder.py`: `ChildRecorder` owns the command, the environment strip and the invocation shape, and returns the `CompletedProcess` untouched — outcome interpretation stays with the callers, which are answerable for different things.
- Both callers delegate; their duplicated constants are deleted, shared rationale moved to the helper, caller docstrings keep only what is theirs.
- The two mock-based argv tests re-target the helper and pin the command line unchanged.

## Result
Pure refactor: 79 recording/grouping tests pass, and both callers were exercised against real subprocesses (a fleet `--check` of one setup; a full five-configuration probe pass). No golden, twin or recorded file moved. pylint 10.00, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
