### PR TITLE
The electrolyzer setup's two devices get cost models, so the all-options run survives to its KPIs

### DIFF
--- a/energy_systems/electrolyzer_with_renewables.energy_system.yaml
+++ b/energy_systems/electrolyzer_with_renewables.energy_system.yaml
@@ -8,6 +8,12 @@ components:
     class: hisim.components.transformer_rectifier.Transformer
     config:
       efficiency: 0.95
+      rated_power_in_kilowatt: 1028.225
+      device_co2_footprint_in_kg: null
+      investment_costs_in_euro: null
+      lifetime_in_years: null
+      maintenance_costs_in_euro_per_year: null
+      subsidy_as_percentage_of_investment_costs: null
     inputs:
       - input: Input1
         from: CSV.CSVProfile
@@ -46,6 +52,11 @@ components:
       i_cell_nom: 2.0
       ramp_up_rate: 0.03
       ramp_down_rate: 0.25
+      device_co2_footprint_in_kg: null
+      investment_costs_in_euro: null
+      lifetime_in_years: null
+      maintenance_costs_in_euro_per_year: null
+      subsidy_as_percentage_of_investment_costs: null
     inputs:
       - input: InputState
         from: L1ElectrolyzerController.CurrentMode

--- a/hisim/components/configuration.py
+++ b/hisim/components/configuration.py
@@ -319,6 +319,12 @@ Sources for capex techno-economic parameters:
         [45]: https://www.wko.at/netzwerke/infopoint-stromspeicher
         [46]: https://www.co2online.de/modernisieren-und-bauen/solarthermie/solarthermie-preise-kosten-amortisation/
         [47]: https://www.energieinstitut.at/privatpersonen/photovoltaik-und-solarthermie/solaranlagen
+        [48]: IRENA (2020), "Green Hydrogen Cost Reduction: Scaling up Electrolysers to Meet the
+        1.5C Climate Goal", https://www.irena.org/publications/2020/Dec/Green-hydrogen-cost-reduction
+        [49]: IEA (2023), "Global Hydrogen Review 2023", https://www.iea.org/reports/global-hydrogen-review-2023
+        [50]: ecoinvent-based life-cycle inventories for photovoltaic power electronics (inverter,
+        2500 W to 500 kW), used here as the closest published proxy for a rectifier's embodied
+        emissions: https://www.ecoinvent.org
         """
 capex_techno_economic_parameters = {
     "DE": {
@@ -392,6 +398,38 @@ capex_techno_economic_parameters = {
                 "subsidy_as_percentage_of_investment_costs": 0,
                 # there is a cheaper KfW loan for PV and batteries but it depends on several factors (bank, risk class etc.),
                 # that's why we assume 0% subsidy here, source: [31]
+            },
+            # PROPOSED VALUES, NOT YET REVIEWED BY THE COST OWNER (added 2026-09-07 so that a
+            # stock all-options run of electrolyzer_with_renewables reaches its KPIs instead of
+            # dying in COMPUTE_OPEX/COMPUTE_CAPEX). Every figure below is the midpoint of a
+            # published range for a megawatt-scale industrial installation, not a measurement, and
+            # the two devices are industrial equipment rather than the household appliances the
+            # rest of this table describes -- so the orders of magnitude differ by design.
+            ComponentType.ELECTROLYZER: {
+                # PEM system at the MW scale including balance of plant; [48] and [49] report
+                # 1400-1800 EUR/kW for European 2023-2024 installations, midpoint taken.
+                "investment_costs_in_euro_per_kw": 1500,
+                # 2-4 % of investment per year, stack replacement included, Source: [48, 49]
+                "maintenance_costs_as_percentage_of_investment_per_year": 0.03,
+                # System lifetime; the stack's shorter 10 years, which [19] records for the whole
+                # device, is carried by the maintenance share above rather than by a 10-year
+                # replacement of everything. Source: [48, 49]
+                "technical_lifetime_in_years": 15,
+                "co2_footprint_in_kg_per_kw": 190.5,  # Source: [19]
+                "subsidy_as_percentage_of_investment_costs": 0,
+            },
+            ComponentType.TRANSFORMER_AND_RECTIFIER: {
+                # Grid-side power supply of a large electrolyzer -- step-down transformer plus
+                # rectifier -- at 100-200 EUR/kW, which is the ~10 % share [48] attributes to the
+                # power supply of a MW-scale system; midpoint taken.
+                "investment_costs_in_euro_per_kw": 150,
+                "maintenance_costs_as_percentage_of_investment_per_year": 0.015,  # 1-2 %/year
+                # Grid transformers and industrial rectifiers are 25-30 year assets, Source: [23]
+                "technical_lifetime_in_years": 27,
+                # No published inventory for a rectifier was found; power electronics of the same
+                # duty (a PV inverter) carry roughly this, Source: [50]
+                "co2_footprint_in_kg_per_kw": 60,
+                "subsidy_as_percentage_of_investment_costs": 0,
             },
             # CAPEX per kWh
             ComponentType.BATTERY: {

--- a/hisim/components/generic_electrolyzer_h2.py
+++ b/hisim/components/generic_electrolyzer_h2.py
@@ -2,7 +2,7 @@
 
 # clean
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
 import json
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
@@ -11,9 +11,17 @@ import numpy as np
 import pandas as pd
 
 # Import modules from HiSim
-from hisim.component import SingleTimeStepValues, ComponentInput, ComponentOutput
+from hisim.component import (
+    CapexCostDataClass,
+    ComponentInput,
+    ComponentOutput,
+    OpexCostDataClass,
+    SingleTimeStepValues,
+)
 from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim import loadtypes as lt
+from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
+from hisim.postprocessing.cost_and_emission_computation.capex_computation import CapexComputationHelperFunctions
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiTagEnumClass
 from hisim import utils
 from hisim.simulationparameters import SimulationParameters
@@ -32,7 +40,15 @@ __status__ = "development"
 @dataclass_json
 @dataclass
 class ElectrolyzerConfig(ConfigBase):
-    """Configuration of the Electrolyzer."""
+    """Configuration of the Electrolyzer.
+
+    Besides the electrochemical parameters, the configuration carries the five cost fields every
+    costed component in the library declares. They are read as a set: while all five are ``None``
+    — which is the default and what both factories below produce — postprocessing looks the
+    figures up from the device database for the simulated year and country and scales them by
+    ``nom_load``, the electrolyzer's rating in kW. Setting all five overrides that lookup with
+    the values given here, for a specific quoted machine.
+    """
 
     @classmethod
     def get_main_classname(cls):
@@ -49,6 +65,16 @@ class ElectrolyzerConfig(ConfigBase):
     ramp_up_rate: float  # [%/s]
     ramp_down_rate: float  # [%/s]
     # H_s_h2 = 33.33 #kWh/kg
+    #: CO2 footprint of investment in kg
+    device_co2_footprint_in_kg: Optional[float] = None
+    #: cost for investment in Euro
+    investment_costs_in_euro: Optional[float] = None
+    #: lifetime in years
+    lifetime_in_years: Optional[float] = None
+    #: maintenance cost in euro per year
+    maintenance_costs_in_euro_per_year: Optional[float] = None
+    #: subsidies as percentage of investment costs
+    subsidy_as_percentage_of_investment_costs: Optional[float] = None
 
     @classmethod
     def get_default_alkaline_electrolyzer_config(
@@ -176,6 +202,17 @@ class Electrolyzer(cp.Component):
     ColdStartCycles = "ColdStartCycles"
     TotalRampUpTime = "TotalRampUpTime"
     TotalRampDownTime = "TotalRampDownTime"
+
+    #: The three outputs the component integrates itself, mapped to the KPI name, the KPI unit
+    #: string and the declared unit their column must carry. The unit is part of the key because
+    #: a component may publish the same quantity in two units, and reading the wrong column would
+    #: be off by a factor rather than absent. Both the KPI entries and the operating costs read
+    #: these, through :meth:`Electrolyzer.read_cumulative_totals`.
+    CUMULATIVE_TOTALS: ClassVar[Dict[str, Tuple[str, str, lt.Units]]] = {
+        TotalHydrogenProduced: ("Hydrogen produced", "kg", lt.Units.KG),
+        TotalEnergyConsumed: ("Electrical energy consumed", "kWh", lt.Units.KWH),
+        OperatingTime: ("Operating time", "h", lt.Units.HOURS),
+    }
 
     def __init__(
         self,
@@ -763,6 +800,54 @@ class Electrolyzer(cp.Component):
         else:
             stsv.set_output_value(self.current_efficiency_state, current_eff)
 
+    def read_cumulative_totals(
+        self,
+        all_outputs: List,
+        postprocessing_results: pd.DataFrame,
+    ) -> Dict[str, float]:
+        """Read the final value of each of the electrolyzer's three cumulative outputs.
+
+        The component integrates hydrogen, electricity and operating time per timestep itself, so
+        the total over the run is the last value of each column rather than its sum -- summing
+        would count every earlier timestep again. Both the KPI entries and the operating costs
+        need these totals, which is why they are read once here.
+
+        Args:
+            all_outputs: every output column of the run, searched for this component's outputs
+                by name.
+            postprocessing_results: the per-timestep values of those columns.
+
+        Returns:
+            Dict[str, float]: the total per output field name, keyed by the field names in
+            :attr:`CUMULATIVE_TOTALS`.
+
+        Raises:
+            ValueError: if one of the three columns is missing, empty or carries NaN — a value
+                pandas would otherwise drop silently — so a total is either read from complete
+                values or refused by name, never reported wrongly in silence.
+        """
+        found: Dict[str, float] = {}
+        for index, output in enumerate(all_outputs):
+            if output.component_name != self.component_name or output.field_name not in self.CUMULATIVE_TOTALS:
+                continue
+            name, _, expected_unit = self.CUMULATIVE_TOTALS[output.field_name]
+            if output.unit == expected_unit:
+                column = postprocessing_results.iloc[:, index]
+                if column.empty or bool(column.isna().any()):
+                    raise ValueError(
+                        f"The electrolyzer output for the KPI '{name}' of {self.component_name} is "
+                        f"{'empty' if column.empty else 'carrying NaN'}; the KPI would be silently "
+                        "wrong rather than absent, so it is refused instead."
+                    )
+                found[output.field_name] = float(column.iat[-1])
+        missing = [name for field, (name, _, _) in self.CUMULATIVE_TOTALS.items() if field not in found]
+        if missing:
+            raise ValueError(
+                f"The electrolyzer outputs for the KPI(s) {missing} were not found for "
+                f"{self.component_name}; they cannot be reported as absent silently."
+            )
+        return found
+
     def get_component_kpi_entries(
         self,
         all_outputs: List,
@@ -770,10 +855,9 @@ class Electrolyzer(cp.Component):
     ) -> List[KpiEntry]:
         """Calculates KPIs for the electrolyzer and returns all KPI entries as a list.
 
-        Three indicators describe what the unit did over the simulated period, each read as the
-        final value of one of the electrolyzer's own cumulative outputs -- the component already
-        integrates them per timestep, so summing here would double-count: the hydrogen it
-        produced, the electrical energy it consumed doing so, and how long it actually operated.
+        Three indicators describe what the unit did over the simulated period, all three read by
+        :meth:`read_cumulative_totals`: the hydrogen it produced, the electrical energy it
+        consumed doing so, and how long it actually operated.
 
         Args:
             all_outputs: every output column of the run, searched for this component's outputs
@@ -784,35 +868,10 @@ class Electrolyzer(cp.Component):
             List[KpiEntry]: the three entries, tagged as Electrolyzer.
 
         Raises:
-            ValueError: if one of the three columns is missing, empty or carries NaN — a value
-                pandas would otherwise drop silently — so a KPI is either read from complete
-                values or refused by name, never reported wrongly in silence.
+            ValueError: if one of the three columns is missing, empty or carries NaN, via
+                :meth:`read_cumulative_totals`.
         """
-        wanted = {
-            Electrolyzer.TotalHydrogenProduced: ("Hydrogen produced", "kg", lt.Units.KG),
-            Electrolyzer.TotalEnergyConsumed: ("Electrical energy consumed", "kWh", lt.Units.KWH),
-            Electrolyzer.OperatingTime: ("Operating time", "h", lt.Units.HOURS),
-        }
-        found: Dict[str, float] = {}
-        for index, output in enumerate(all_outputs):
-            if output.component_name != self.component_name or output.field_name not in wanted:
-                continue
-            name, _, expected_unit = wanted[output.field_name]
-            if output.unit == expected_unit:
-                column = postprocessing_results.iloc[:, index]
-                if column.empty or bool(column.isna().any()):
-                    raise ValueError(
-                        f"The electrolyzer output for the KPI '{name}' of {self.component_name} is "
-                        f"{'empty' if column.empty else 'carrying NaN'}; the KPI would be silently "
-                        "wrong rather than absent, so it is refused instead."
-                    )
-                found[output.field_name] = float(column.iat[-1])
-        missing = [name for field, (name, _, _) in wanted.items() if field not in found]
-        if missing:
-            raise ValueError(
-                f"The electrolyzer outputs for the KPI(s) {missing} were not found for "
-                f"{self.component_name}; they cannot be reported as absent silently."
-            )
+        found = self.read_cumulative_totals(all_outputs, postprocessing_results)
         return [
             KpiEntry(
                 name=name,
@@ -822,8 +881,90 @@ class Electrolyzer(cp.Component):
                 description=self.component_name,
                 name_of_source_component=self.component_name,
             )
-            for field, (name, unit, _) in wanted.items()
+            for field, (name, unit, _) in self.CUMULATIVE_TOTALS.items()
         ]
+
+    @staticmethod
+    def get_cost_capex(
+        config: ElectrolyzerConfig, simulation_parameters: SimulationParameters
+    ) -> CapexCostDataClass:
+        """Return the electrolyzer's investment cost, embodied CO2, lifetime and maintenance cost.
+
+        The electrolyzer is priced per kilowatt of nominal electrical load
+        (``ComponentType.ELECTROLYZER``), which is how published electrolyzer costs are quoted.
+        The figures come from the device database for the simulated year and country unless all
+        five cost fields on the configuration carry values, in which case those are used verbatim;
+        that is the rule every other costed component follows, and it is why the database entry --
+        not this method -- is where the numbers are stated and sourced.
+
+        The device is deliberately *not* declared as modelling no device: it is real equipment
+        with a real price, so answering zero here would understate the system total silently
+        instead of naming what is missing.
+
+        Args:
+            config: the electrolyzer configuration, read for ``nom_load`` and its cost fields.
+            simulation_parameters: the simulated year, country and duration, which decide which
+                database row applies and what share of the investment falls in the run.
+
+        Returns:
+            CapexCostDataClass: the investment cost and embodied CO2, both in total and prorated
+            over the simulated period, tagged as Electrolyzer.
+        """
+        capex_cost_data_class = CapexComputationHelperFunctions.compute_capex_costs_and_emissions(
+            simulation_parameters=simulation_parameters,
+            component_type=lt.ComponentType.ELECTROLYZER,
+            unit=lt.Units.KILOWATT,
+            size_of_energy_system=config.nom_load,
+            config=config,
+            kpi_tag=KpiTagEnumClass.ELECTROLYZER,
+        )
+        CapexComputationHelperFunctions.overwrite_config_values_with_new_capex_values(
+            config=config, capex_cost_data_class=capex_cost_data_class
+        )
+        return capex_cost_data_class
+
+    def get_cost_opex(
+        self,
+        all_outputs: List,
+        postprocessing_results: pd.DataFrame,
+    ) -> OpexCostDataClass:
+        """Return the electrolyzer's operating cost: the electricity it drew, plus maintenance.
+
+        The electricity is the machine's own cumulative ``TotalEnergyConsumed`` output, which is
+        the load it was actually given rather than its rating, priced and carbon-accounted at the
+        electricity factors for the simulated year and country -- the same way every other
+        electricity consumer in the library prices what it draws. The water the process consumes
+        is not priced: no water tariff exists in the fuels table, so it would have to be invented
+        here, and inventing it silently is worse than leaving a named gap. Report it from the
+        component's ``TotalWaterDemand`` output when a tariff is added.
+
+        Args:
+            all_outputs: every output column of the run, searched for this component's outputs.
+            postprocessing_results: the per-timestep values of those columns.
+
+        Returns:
+            OpexCostDataClass: the cost, CO2 and consumption of the electricity drawn, plus the
+            maintenance cost for the simulated period, tagged as Electrolyzer.
+
+        Raises:
+            ValueError: if one of the cumulative columns is missing, empty or carries NaN, via
+                :meth:`read_cumulative_totals`.
+        """
+        totals = self.read_cumulative_totals(all_outputs, postprocessing_results)
+        consumption_in_kilowatt_hour = totals[Electrolyzer.TotalEnergyConsumed]
+        emissions_and_cost_factors = EmissionFactorsAndCostsForFuelsConfig.get_values_for_year(
+            self.my_simulation_parameters.year, self.my_simulation_parameters.country
+        )
+        return OpexCostDataClass(
+            opex_energy_cost_in_euro=consumption_in_kilowatt_hour
+            * emissions_and_cost_factors.electricity_costs_in_euro_per_kwh,
+            opex_maintenance_cost_in_euro=self.calc_maintenance_cost(),
+            co2_footprint_in_kg=consumption_in_kilowatt_hour
+            * emissions_and_cost_factors.electricity_footprint_in_kg_per_kwh,
+            total_consumption_in_kwh=consumption_in_kilowatt_hour,
+            loadtype=lt.LoadTypes.ELECTRICITY,
+            kpi_tag=KpiTagEnumClass.ELECTROLYZER,
+        )
 
     def write_to_report(self) -> List[str]:
         """Writes a report."""

--- a/hisim/components/transformer_rectifier.py
+++ b/hisim/components/transformer_rectifier.py
@@ -5,14 +5,25 @@ from __future__ import annotations
 
 # Import packages from standard library or the environment e.g. pandas, numpy etc.
 from dataclasses import dataclass
+from typing import Optional, Tuple
+
 from dataclasses_json import dataclass_json
 
 # Import modules from HiSim
 import pandas as pd
 
 from hisim.config import ConfigBase, ComponentID, DisplayConfig
-from hisim.component import StatelessComponent, SingleTimeStepValues, ComponentInput, ComponentOutput
+from hisim.component import (
+    CapexCostDataClass,
+    ComponentInput,
+    ComponentOutput,
+    OpexCostDataClass,
+    SingleTimeStepValues,
+    StatelessComponent,
+)
 from hisim import loadtypes as lt
+from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig
+from hisim.postprocessing.cost_and_emission_computation.capex_computation import CapexComputationHelperFunctions
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiHelperClass, KpiTagEnumClass
 from hisim.simulationparameters import SimulationParameters
 
@@ -32,6 +43,30 @@ class TransformerConfig(ConfigBase):
         by 100x — which is why the range is validated at construction: a
         percentage, a negative value or a zero is refused loudly instead of
         producing plausible but wrong outputs and negative loss indicators.
+    rated_power_in_kilowatt : float
+        Nameplate throughput of the unit in kW, i.e. the electrical power it is
+        built to convert continuously. It does not enter the simulation at all —
+        :meth:`Transformer.i_simulate` converts whatever it is fed — and exists
+        because a transformer and rectifier are priced per kilowatt of rating:
+        it is the only sizing figure :meth:`Transformer.get_cost_capex` can scale
+        by. A unit rated at zero would therefore cost nothing and be reported as
+        an answer, so a non-positive rating is refused at construction.
+    device_co2_footprint_in_kg : Optional[float]
+        CO2 emitted producing the device, in kg. ``None`` — the default — means
+        postprocessing looks the figure up from the device database for the
+        simulated year and country and scales it by ``rated_power_in_kilowatt``;
+        a number here overrides that lookup. The five cost fields are read as a
+        set: the lookup happens only when all five are ``None``.
+    investment_costs_in_euro : Optional[float]
+        Purchase cost of the device in EUR, or ``None`` for the database lookup.
+    lifetime_in_years : Optional[float]
+        Technical lifetime in years, over which the investment is written off,
+        or ``None`` for the database lookup.
+    maintenance_costs_in_euro_per_year : Optional[float]
+        Yearly maintenance cost in EUR, or ``None`` for the database lookup.
+    subsidy_as_percentage_of_investment_costs : Optional[float]
+        Share of the investment covered by a subsidy, as a fraction, or ``None``
+        for the database lookup.
     """
 
     @classmethod
@@ -43,29 +78,59 @@ class TransformerConfig(ConfigBase):
     # my_simulation_parameters: SimulationParameters
     component_id: ComponentID
     efficiency: float  # conversion efficiency as a fraction in (0, 1] (not a percentage)
+    rated_power_in_kilowatt: float  # nameplate throughput in kW; the only figure the capex scales by
+    #: CO2 footprint of investment in kg
+    device_co2_footprint_in_kg: Optional[float] = None
+    #: cost for investment in Euro
+    investment_costs_in_euro: Optional[float] = None
+    #: lifetime in years
+    lifetime_in_years: Optional[float] = None
+    #: maintenance cost in euro per year
+    maintenance_costs_in_euro_per_year: Optional[float] = None
+    #: subsidies as percentage of investment costs
+    subsidy_as_percentage_of_investment_costs: Optional[float] = None
 
     def __post_init__(self) -> None:
-        """Refuses an efficiency outside the fraction range (0, 1].
+        """Refuses an efficiency outside the fraction range (0, 1] and a non-positive rating.
 
         A percentage (``95``) would silently scale the output a hundredfold, a negative value
         would invert it, and a zero would make the conversion-loss indicator a division by zero —
         all three run happily as simulations and only surface as wrong numbers in a report, so
-        the configuration is where they stop.
+        the configuration is where they stop. A rating of zero or less is refused for the same
+        reason one step later: the capex is the rating times a price per kilowatt, so an unrated
+        unit would be reported as costing nothing, which reads exactly like a device that is free.
 
         Raises:
-            ValueError: For an efficiency that is not in (0, 1].
+            ValueError: For an efficiency that is not in (0, 1], or a rated power that is not
+                strictly positive.
         """
         if not 0.0 < self.efficiency <= 1.0:
             raise ValueError(
                 f"The transformer efficiency must be a fraction in (0, 1], not {self.efficiency}. "
                 "Write 0.95 for 95 %, never a percentage."
             )
+        if self.rated_power_in_kilowatt <= 0.0:
+            raise ValueError(
+                f"The transformer rated power must be strictly positive, not {self.rated_power_in_kilowatt} kW. "
+                "It is what the investment cost is scaled by, so an unrated unit would be costed as free."
+            )
 
     @classmethod
     def get_default_transformer_config(cls) -> TransformerConfig:
-        """Gets a default ``TransformerConfig`` instance."""
+        """Gets a default ``TransformerConfig`` instance.
+
+        The default rating is the megawatt class, because the one setup that uses this component
+        feeds a megawatt-scale electrolyzer; the five cost fields stay ``None`` so that
+        postprocessing looks the figures up from the device database for the simulated year and
+        country rather than freezing them into every caller.
+
+        Returns:
+            TransformerConfig: a 95 %-efficient, 1000 kW unit with unset cost fields.
+        """
         return TransformerConfig(
-            component_id=ComponentID(name="GenericTransformerAndRectifier"), efficiency=0.95
+            component_id=ComponentID(name="GenericTransformerAndRectifier"),
+            efficiency=0.95,
+            rated_power_in_kilowatt=1000.0,
         )
 
 
@@ -156,31 +221,33 @@ class Transformer(StatelessComponent):
 
         stsv.set_output_value(self.electricity_output, float(input_power_in_kilowatt * efficiency))
 
-    def get_component_kpi_entries(
+    def delivered_and_lost_energy_in_kilowatt_hour(
         self,
         all_outputs: list,
         postprocessing_results: pd.DataFrame,
-    ) -> list[KpiEntry]:
-        """Calculates KPIs for the transformer/rectifier and returns all KPI entries as a list.
+    ) -> Tuple[float, float]:
+        """Integrate the delivered electrical energy over the run and derive the conversion losses.
 
-        Two indicators describe what the unit did over the simulated period: the electrical
-        energy it delivered, integrated from its output power, and the conversion losses. The
+        The energy the unit delivered is the integral of its single output power column. The
         losses are not observable as a column of their own -- the unit has one input and one
         output port -- but the output is by construction the input scaled by the configured
-        efficiency, so the loss follows exactly: ``delivered * (1/efficiency - 1)``.
+        efficiency, so the loss follows exactly: ``delivered * (1/efficiency - 1)``. Both the
+        KPI entries and the operating costs are these two numbers, which is why they are computed
+        once here instead of twice with two chances to disagree.
 
         Args:
-            all_outputs: every output column of the run, searched for this component's outputs
+            all_outputs: every output column of the run, searched for this component's output
                 by name.
             postprocessing_results: the per-timestep values of those columns.
 
         Returns:
-            list[KpiEntry]: the two entries, tagged as Transformer.
+            Tuple[float, float]: the delivered energy and the conversion losses, both in kWh,
+            each rounded to three decimals.
 
         Raises:
             ValueError: if the output column is missing, empty or carries NaN — a value pandas
-                would otherwise drop silently from the sum — so the KPIs are either computed from
-                complete values or refused, never reported wrongly in silence.
+                would otherwise drop silently from the sum — so the two figures are either
+                computed from complete values or refused, never reported wrongly in silence.
         """
         seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep
         delivered_in_kilowatt_hour = None
@@ -211,6 +278,35 @@ class Transformer(StatelessComponent):
         losses_in_kilowatt_hour = round(
             delivered_in_kilowatt_hour * (1.0 / self.transformerconfig.efficiency - 1.0), 3
         )
+        return delivered_in_kilowatt_hour, losses_in_kilowatt_hour
+
+    def get_component_kpi_entries(
+        self,
+        all_outputs: list,
+        postprocessing_results: pd.DataFrame,
+    ) -> list[KpiEntry]:
+        """Calculates KPIs for the transformer/rectifier and returns all KPI entries as a list.
+
+        Two indicators describe what the unit did over the simulated period: the electrical
+        energy it delivered and the conversion losses, both from
+        :meth:`delivered_and_lost_energy_in_kilowatt_hour`.
+
+        Args:
+            all_outputs: every output column of the run, searched for this component's outputs
+                by name.
+            postprocessing_results: the per-timestep values of those columns.
+
+        Returns:
+            list[KpiEntry]: the two entries, tagged as Transformer.
+
+        Raises:
+            ValueError: if the output column is missing, empty or carries NaN — a value pandas
+                would otherwise drop silently from the sum — so the KPIs are either computed from
+                complete values or refused, never reported wrongly in silence.
+        """
+        delivered_in_kilowatt_hour, losses_in_kilowatt_hour = self.delivered_and_lost_energy_in_kilowatt_hour(
+            all_outputs, postprocessing_results
+        )
         return [
             KpiEntry(
                 name="Electrical energy delivered",
@@ -229,6 +325,89 @@ class Transformer(StatelessComponent):
                 name_of_source_component=self.component_name,
             ),
         ]
+
+    @staticmethod
+    def get_cost_capex(
+        config: TransformerConfig, simulation_parameters: SimulationParameters
+    ) -> CapexCostDataClass:
+        """Return the unit's investment cost, embodied CO2, lifetime and maintenance cost.
+
+        A transformer and rectifier are bought, rated and replaced as one unit, so they are one
+        cost subject (``ComponentType.TRANSFORMER_AND_RECTIFIER``) priced per kilowatt of
+        nameplate rating. The figures come from the device database for the simulated year and
+        country unless all five cost fields on the configuration carry values, in which case
+        those are used verbatim; that is the same rule every other costed component follows, and
+        it is why the database entry -- not this method -- is where the numbers are stated and
+        sourced.
+
+        The unit is deliberately *not* declared as modelling no device: it is real industrial
+        equipment with a real price, so answering zero here would understate the system total
+        silently instead of naming what is missing.
+
+        Args:
+            config: the transformer configuration, read for its rating and its cost fields.
+            simulation_parameters: the simulated year, country and duration, which decide which
+                database row applies and what share of the investment falls in the run.
+
+        Returns:
+            CapexCostDataClass: the investment cost and embodied CO2, both in total and prorated
+            over the simulated period, tagged as Transformer.
+        """
+        capex_cost_data_class = CapexComputationHelperFunctions.compute_capex_costs_and_emissions(
+            simulation_parameters=simulation_parameters,
+            component_type=lt.ComponentType.TRANSFORMER_AND_RECTIFIER,
+            unit=lt.Units.KILOWATT,
+            size_of_energy_system=config.rated_power_in_kilowatt,
+            config=config,
+            kpi_tag=KpiTagEnumClass.TRANSFORMER,
+        )
+        CapexComputationHelperFunctions.overwrite_config_values_with_new_capex_values(
+            config=config, capex_cost_data_class=capex_cost_data_class
+        )
+        return capex_cost_data_class
+
+    def get_cost_opex(
+        self,
+        all_outputs: list,
+        postprocessing_results: pd.DataFrame,
+    ) -> OpexCostDataClass:
+        """Return the unit's operating cost: its conversion losses, plus maintenance.
+
+        The energy this unit consumes is exactly its conversion losses: everything else it passes
+        on, and the consumer downstream reports that share as its own. The two figures are
+        therefore disjoint and can be added, which is what the system total does -- reporting the
+        throughput here instead would count the same kilowatt-hours twice. The losses are priced
+        and carbon-accounted at the electricity factors for the simulated year and country, the
+        same way every other electricity consumer in the library prices what it draws.
+
+        Args:
+            all_outputs: every output column of the run, searched for this component's output.
+            postprocessing_results: the per-timestep values of those columns.
+
+        Returns:
+            OpexCostDataClass: the cost, CO2 and consumption of the conversion losses, plus the
+            maintenance cost for the simulated period, tagged as Transformer.
+
+        Raises:
+            ValueError: if the output column is missing, empty or carries NaN, via
+                :meth:`delivered_and_lost_energy_in_kilowatt_hour`.
+        """
+        _, losses_in_kilowatt_hour = self.delivered_and_lost_energy_in_kilowatt_hour(
+            all_outputs, postprocessing_results
+        )
+        emissions_and_cost_factors = EmissionFactorsAndCostsForFuelsConfig.get_values_for_year(
+            self.my_simulation_parameters.year, self.my_simulation_parameters.country
+        )
+        return OpexCostDataClass(
+            opex_energy_cost_in_euro=losses_in_kilowatt_hour
+            * emissions_and_cost_factors.electricity_costs_in_euro_per_kwh,
+            opex_maintenance_cost_in_euro=self.calc_maintenance_cost(),
+            co2_footprint_in_kg=losses_in_kilowatt_hour
+            * emissions_and_cost_factors.electricity_footprint_in_kg_per_kwh,
+            total_consumption_in_kwh=losses_in_kilowatt_hour,
+            loadtype=lt.LoadTypes.ELECTRICITY,
+            kpi_tag=KpiTagEnumClass.TRANSFORMER,
+        )
 
     def write_to_report(self) -> list[str]:
         """Return report lines describing this transformer.

--- a/hisim/loadtypes.py
+++ b/hisim/loadtypes.py
@@ -266,6 +266,9 @@ class ComponentType(str, enum.Enum):
     CAR = "Car"
     FUEL_CELL = "FuelCell"
     ELECTROLYZER = "Electrolyzer"
+    # The grid-side conversion stage in front of a DC load: the step-down transformer and the
+    # rectifier are bought, rated and replaced as one unit, so they are one cost subject here.
+    TRANSFORMER_AND_RECTIFIER = "TransformerAndRectifier"
     CHP = "CHP"
     H2_STORAGE = "H2Storage"
     ELECTRIC_VEHICLE = "ElectricVehicle"

--- a/system_setups/electrolyzer_with_renewables.py
+++ b/system_setups/electrolyzer_with_renewables.py
@@ -99,12 +99,18 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
     # Create new CSV loader object
     csv_loader = CSVLoader(my_csv_loader, my_simulation_parameters=my_simulation_parameters)
 
+    # The electrolyzer configuration is read first because the transformer and rectifier in front
+    # of it is rated for it: the conversion stage has to carry the machine's maximum load, which is
+    # also what its investment cost is scaled by.
+    my_electrolyzer_config = ElectrolyzerConfig.config_electrolyzer(electrolyzer_name)
+
     # Setup the transformer and rectifier unit
     my_transformer = Transformer(
         my_simulation_parameters=my_simulation_parameters,
         config=TransformerConfig(
             component_id=ComponentID(name=name),
             efficiency=efficiency,
+            rated_power_in_kilowatt=my_electrolyzer_config.max_load,
         ),
     )
 
@@ -116,7 +122,7 @@ def setup_function(my_sim: Simulator, my_simulation_parameters: Optional[Simulat
 
     # Setup the electrolyzer
     my_electrolyzer = Electrolyzer(
-        config=ElectrolyzerConfig.config_electrolyzer(electrolyzer_name),
+        config=my_electrolyzer_config,
         my_simulation_parameters=my_simulation_parameters,
     )
 

--- a/system_setups/electrolyzer_with_renewables.scenario.json
+++ b/system_setups/electrolyzer_with_renewables.scenario.json
@@ -11,7 +11,13 @@
                     "building": null,
                     "unit": null
                 },
-                "efficiency": 0.95
+                "efficiency": 0.95,
+                "rated_power_in_kilowatt": 1028.225,
+                "device_co2_footprint_in_kg": null,
+                "investment_costs_in_euro": null,
+                "lifetime_in_years": null,
+                "maintenance_costs_in_euro_per_year": null,
+                "subsidy_as_percentage_of_investment_costs": null
             },
             "config_full_classname": "hisim.components.transformer_rectifier.TransformerConfig",
             "inputs": [],
@@ -76,7 +82,12 @@
                 "faraday_eff": 0.999,
                 "i_cell_nom": 2.0,
                 "ramp_up_rate": 0.03,
-                "ramp_down_rate": 0.25
+                "ramp_down_rate": 0.25,
+                "device_co2_footprint_in_kg": null,
+                "investment_costs_in_euro": null,
+                "lifetime_in_years": null,
+                "maintenance_costs_in_euro_per_year": null,
+                "subsidy_as_percentage_of_investment_costs": null
             },
             "config_full_classname": "hisim.components.generic_electrolyzer_h2.ElectrolyzerConfig",
             "inputs": [],

--- a/tests/test_generic_electrolyzer_h2.py
+++ b/tests/test_generic_electrolyzer_h2.py
@@ -111,12 +111,23 @@ def test_electrolyzer() -> None:
     # python -m pytest ../tests/test_generic_electrolyzer_h2.py
 
 
-def _build_electrolyzer() -> generic_electrolyzer_h2.Electrolyzer:
-    """Construct the PEM electrolyzer of the tests above, for the KPI tests below."""
-    config = generic_electrolyzer_h2.ElectrolyzerConfig(
+def _build_config(nom_load: float = 987.0) -> generic_electrolyzer_h2.ElectrolyzerConfig:
+    """Build the PEM configuration of the tests above, optionally at another rating.
+
+    The rating is a parameter because the capex tests below assert that the cost scales with it,
+    and everything else about the machine is held fixed so that the rating is the only thing that
+    can explain a difference.
+
+    Args:
+        nom_load: nominal electrical load in kW, which is also what the investment cost scales by.
+
+    Returns:
+        ElectrolyzerConfig: the HTecME450 PEM configuration at that rating, cost fields unset.
+    """
+    return generic_electrolyzer_h2.ElectrolyzerConfig(
         component_id=ComponentID(name="HTecME450"),
         electrolyzer_type="PEM",
-        nom_load=987.0,
+        nom_load=nom_load,
         max_load=1028.225,
         nom_h2_flow_rate=18.875,
         faraday_eff=0.999,
@@ -124,8 +135,12 @@ def _build_electrolyzer() -> generic_electrolyzer_h2.Electrolyzer:
         ramp_up_rate=0.03,
         ramp_down_rate=0.25,
     )
+
+
+def _build_electrolyzer() -> generic_electrolyzer_h2.Electrolyzer:
+    """Construct the PEM electrolyzer of the tests above, for the KPI tests below."""
     return generic_electrolyzer_h2.Electrolyzer(
-        config=config, my_simulation_parameters=SimulationParameters.one_day_only(2021, 60)
+        config=_build_config(), my_simulation_parameters=SimulationParameters.one_day_only(2021, 60)
     )
 
 
@@ -197,3 +212,110 @@ def test_electrolyzer_kpi_entries_refuse_nan_instead_of_misreading() -> None:
 
     with pytest.raises(ValueError, match="Hydrogen produced"):
         electrolyzer.get_component_kpi_entries(outputs, frame)
+
+
+@pytest.mark.base
+def test_electrolyzer_config_leaves_the_cost_fields_unset_by_default() -> None:
+    """The five cost fields default to ``None``, which is what selects the database lookup.
+
+    They are read as a set: postprocessing looks the figures up from the device database for the
+    simulated year and country only while all five are ``None``. A default that accidentally
+    carried a number would silently pin every electrolyzer in the fleet to it.
+    """
+    config = _build_config()
+    assert config.device_co2_footprint_in_kg is None
+    assert config.investment_costs_in_euro is None
+    assert config.lifetime_in_years is None
+    assert config.maintenance_costs_in_euro_per_year is None
+    assert config.subsidy_as_percentage_of_investment_costs is None
+
+
+@pytest.mark.base
+def test_electrolyzer_capex_scales_with_the_nominal_load() -> None:
+    """The investment cost, embodied CO2 and maintenance cost are all linear in ``nom_load``.
+
+    Published electrolyzer costs are quoted per kilowatt, so doubling the rating has to double all
+    three figures exactly. Asserting the ratio rather than the euros keeps the test meaningful when
+    the owner revises the proposed price per kilowatt, while still catching a capex that ignores
+    the rating -- the failure this cost model exists to prevent -- or one that scales by the wrong
+    power of it.
+    """
+    mysim = SimulationParameters.one_day_only(2021, 60)
+    small = generic_electrolyzer_h2.Electrolyzer.get_cost_capex(_build_config(nom_load=500.0), mysim)
+    large = generic_electrolyzer_h2.Electrolyzer.get_cost_capex(_build_config(nom_load=1000.0), mysim)
+
+    assert small.capex_investment_cost_in_euro > 0.0
+    assert small.device_co2_footprint_in_kg > 0.0
+    assert small.maintenance_costs_in_euro > 0.0
+    assert 5.0 < small.lifetime_in_years < 30.0, "an electrolyzer system is a one- to two-decade asset"
+    assert large.capex_investment_cost_in_euro == pytest.approx(2 * small.capex_investment_cost_in_euro)
+    assert large.device_co2_footprint_in_kg == pytest.approx(2 * small.device_co2_footprint_in_kg)
+    assert large.maintenance_costs_in_euro == pytest.approx(2 * small.maintenance_costs_in_euro)
+    # The rating is stated in kilowatts, so the price per kilowatt has to land in the range the
+    # database entry cites (1400-1800 EUR/kW) rather than being off by a factor of a thousand.
+    assert 1400.0 <= small.capex_investment_cost_in_euro / 500.0 <= 1800.0
+
+
+@pytest.mark.base
+def test_electrolyzer_capex_prefers_explicit_config_values_over_the_database() -> None:
+    """A configuration carrying all five cost fields is used verbatim, with no database lookup.
+
+    This is the escape hatch for a specific quoted machine, and it is all-or-nothing: the helper
+    consults the database only while all five fields are ``None``. Pinning it here keeps a future
+    change to the shared helper from silently overriding a user's own numbers.
+    """
+    config = _build_config()
+    config.device_co2_footprint_in_kg = 5000.0
+    config.investment_costs_in_euro = 900000.0
+    config.lifetime_in_years = 12.0
+    config.maintenance_costs_in_euro_per_year = 20000.0
+    config.subsidy_as_percentage_of_investment_costs = 0.25
+
+    capex = generic_electrolyzer_h2.Electrolyzer.get_cost_capex(config, SimulationParameters.one_day_only(2021, 60))
+
+    assert capex.capex_investment_cost_in_euro == pytest.approx(900000.0)
+    assert capex.device_co2_footprint_in_kg == pytest.approx(5000.0)
+    assert capex.lifetime_in_years == pytest.approx(12.0)
+    assert capex.maintenance_costs_in_euro == pytest.approx(20000.0)
+    assert capex.subsidy_as_percentage_of_investment_costs == pytest.approx(0.25)
+
+
+@pytest.mark.base
+def test_electrolyzer_opex_prices_the_energy_it_actually_consumed() -> None:
+    """The operating cost is built from the machine's own cumulative consumption, plus maintenance.
+
+    The consumption is the final value of ``TotalEnergyConsumed`` -- the load the machine was
+    actually given, not its rating -- so a run that idled all day must cost almost nothing in
+    energy however large the device is. Summing that cumulative column instead of reading its last
+    value would double-count every earlier timestep, which the monotone series here would expose.
+    """
+    electrolyzer = _build_electrolyzer()
+    outputs = [
+        electrolyzer.total_hydrogen,
+        electrolyzer.total_energy_consumed,
+        electrolyzer.operating_time,
+    ]
+    frame = pd.DataFrame({0: [1.0, 2.5], 1: [40.0, 90.0], 2: [0.5, 1.25]})
+
+    opex = electrolyzer.get_cost_opex(outputs, frame)
+
+    assert opex.total_consumption_in_kwh == pytest.approx(90.0)
+    assert opex.loadtype == lt.LoadTypes.ELECTRICITY
+    # Both the cost and the footprint are those 90 kWh times a positive per-kWh factor, so each
+    # must be a plausible per-kWh multiple rather than zero or a thousandfold miss.
+    assert 0.0 < opex.opex_energy_cost_in_euro / 90.0 < 2.0
+    assert 0.0 < opex.co2_footprint_in_kg / 90.0 < 2.0
+    assert opex.opex_maintenance_cost_in_euro > 0.0
+
+
+@pytest.mark.base
+def test_electrolyzer_opex_refuses_a_missing_consumption_column() -> None:
+    """A missing cumulative column raises naming the KPI instead of costing the run as free.
+
+    The operating cost reads the same three columns the KPIs do, so an absent consumption column
+    would otherwise be reported as zero euros -- a run that looks free rather than unmeasured.
+    """
+    electrolyzer = _build_electrolyzer()
+
+    with pytest.raises(ValueError, match="Electrical energy consumed"):
+        electrolyzer.get_cost_opex([electrolyzer.total_hydrogen], pd.DataFrame({0: [1.0]}))

--- a/tests/test_system_setups_electrolyzer_with_renewables.py
+++ b/tests/test_system_setups_electrolyzer_with_renewables.py
@@ -10,9 +10,9 @@ import pytest
 
 from hisim import hisim_main
 from hisim.result_path_provider import ResultPathProviderSingleton
-from hisim.simulationparameters import SimulationParameters
 from hisim import utils
 
+from tests.functions_for_testing import SetupTestParameters
 from tests.testing_utils import TestingUtils
 
 
@@ -55,17 +55,10 @@ def fixture_isolated_result_directory() -> Iterator[str]:
             shutil.rmtree(directory)
 
 
-# This setup cannot yet be run with the KPI and cost options that
-# tests.functions_for_testing.SetupTestParameters switches on, and the omission is recorded here
-# rather than left as an absence. The transformer and rectifier unit refuses to report operating costs, and refusing is
-# correct: the cost exists and has not been modelled, so answering zero would understate the system
-# total silently. Component.MODELS_NO_DEVICE is only for components that genuinely have none.
-# Switch this test over once that cost model is written -- see the family-A entry in the setup
-# sweep.
 @pytest.mark.system_setups
 @utils.measure_execution_time
 def test_electrolyzer_with_renewables(isolated_result_directory: str) -> None:
-    """Test the electrolyzer with renewables system setup for a single day.
+    """Test the electrolyzer with renewables system setup for a single day, costs and KPIs included.
 
     Runs the system setup defined in ``system_setups/electrolyzer_with_renewables.py``
     using one-day simulation parameters (year=2021, 60 seconds per timestep) and verifies
@@ -74,10 +67,18 @@ def test_electrolyzer_with_renewables(isolated_result_directory: str) -> None:
     without explicit assertions a silent no-op would still pass; pinning the result
     directory, the ``finished.flag`` completion marker and the simulation log turns this
     into a real smoke test of the full run.
+
+    The parameters come from :class:`tests.functions_for_testing.SetupTestParameters`, which
+    switches on COMPUTE_OPEX, COMPUTE_CAPEX and the two KPI options. That matters here
+    specifically: those three run *before* the KPIs in post-processing, and until the
+    transformer/rectifier and the electrolyzer had cost models a stock all-options run of this
+    setup died in COMPUTE_OPEX before any KPI was computed. The cost tables asserted below are
+    what catches that regression -- the log and the flag alone would not, because they are
+    written even by a run whose cost stage was never asked to answer.
     """
     path = ELECTROLYZER_SETUP_PATH
 
-    sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    sim_params = SetupTestParameters.one_day_with_kpis(year=2021, seconds_per_timestep=60)
     # Route results into the isolated, test-scoped directory provided by the fixture so
     # that stale artefacts from a previous run cannot mask a regression and so the test
     # cleans up after itself.
@@ -98,12 +99,25 @@ def test_electrolyzer_with_renewables(isolated_result_directory: str) -> None:
     # The simulator always writes a simulation log (hisim_simulation.log) via
     # log.logger.setup at the start of run_all_timesteps, so its presence confirms the run
     # produced concrete output artifacts rather than merely not crashing.
-    # Note: CSV/JSON exports are gated behind post-processing options
-    # (EXPORT_TO_CSV / WRITE_KPIS_TO_JSON / ...) that SimulationParameters.one_day_only
-    # does not enable, so they cannot be asserted on here.
     assert (results_dir / "hisim_simulation.log").is_file(), (
         f"hisim_simulation.log missing in results directory: {results_dir}"
     )
     assert any(results_dir.iterdir()), (
         f"Result directory is empty: {results_dir}"
+    )
+    # The cost stages write one table each, and only if they were reached and answered. Both
+    # devices have to appear by name: a component whose cost model went missing again would
+    # either raise or drop out of the table, and this is what tells the two apart from a run
+    # that merely finished.
+    operational_costs = (results_dir / "operational_costs_co2_footprint.csv").read_text(encoding="utf-8")
+    investment_costs = (results_dir / "investment_cost_co2_footprint.csv").read_text(encoding="utf-8")
+    for table_name, table in (
+        ("operational_costs_co2_footprint.csv", operational_costs),
+        ("investment_cost_co2_footprint.csv", investment_costs),
+    ):
+        for component in ("StandardTransformerAndRectifier", "Electrolyzer"):
+            assert component in table, f"{component} is missing from {table_name}"
+    # WRITE_KPIS_TO_JSON is on, so the KPI stage after the cost stages ran too.
+    assert (results_dir / "all_kpis.json").is_file(), (
+        f"all_kpis.json missing in results directory: {results_dir}"
     )

--- a/tests/test_transformer_rectifier.py
+++ b/tests/test_transformer_rectifier.py
@@ -34,6 +34,14 @@ def test_get_default_transformer_config_returns_config_with_documented_defaults(
     assert config.component_id.building is None
     assert config.component_id.name == "GenericTransformerAndRectifier"
     assert config.efficiency == pytest.approx(0.95)
+    assert config.rated_power_in_kilowatt == pytest.approx(1000.0)
+    # All five cost fields stay unset so that postprocessing looks the figures up from the device
+    # database for the simulated year and country instead of freezing them into every caller.
+    assert config.device_co2_footprint_in_kg is None
+    assert config.investment_costs_in_euro is None
+    assert config.lifetime_in_years is None
+    assert config.maintenance_costs_in_euro_per_year is None
+    assert config.subsidy_as_percentage_of_investment_costs is None
 
 
 @pytest.mark.base
@@ -155,7 +163,9 @@ def test_transformer_simulate_scales_input_by_efficiency() -> None:
     and i_simulate is called without an external orchestrator.
     """
     mysim = SimulationParameters.full_year(year=2021, seconds_per_timestep=60)
-    config = TransformerConfig(component_id=ComponentID(name="Transformer"), efficiency=0.9)
+    config = TransformerConfig(
+        component_id=ComponentID(name="Transformer"), efficiency=0.9, rated_power_in_kilowatt=100.0
+    )
     transformer = Transformer(my_simulation_parameters=mysim, config=config)
 
     # Create a source output that feeds the transformer's single input.
@@ -193,8 +203,15 @@ def test_transformer_config_refuses_an_efficiency_outside_the_fraction_range() -
     """
     for wrong in (0.0, -0.5, 1.5, 95.0):
         with pytest.raises(ValueError, match="fraction"):
-            TransformerConfig(component_id=ComponentID(name="Transformer"), efficiency=wrong)
-    assert TransformerConfig(component_id=ComponentID(name="Transformer"), efficiency=1.0).efficiency == 1.0
+            TransformerConfig(
+                component_id=ComponentID(name="Transformer"), efficiency=wrong, rated_power_in_kilowatt=100.0
+            )
+    assert (
+        TransformerConfig(
+            component_id=ComponentID(name="Transformer"), efficiency=1.0, rated_power_in_kilowatt=100.0
+        ).efficiency
+        == 1.0
+    )
 
 
 @pytest.mark.base
@@ -210,7 +227,9 @@ def test_transformer_kpi_entries_integrate_output_and_derive_losses() -> None:
     run's outputs over, so the component_name filter is load-bearing here too.
     """
     mysim = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    config = TransformerConfig(component_id=ComponentID(name="Transformer"), efficiency=0.8)
+    config = TransformerConfig(
+        component_id=ComponentID(name="Transformer"), efficiency=0.8, rated_power_in_kilowatt=100.0
+    )
     transformer = Transformer(my_simulation_parameters=mysim, config=config)
     foreign = ComponentOutput(
         object_name="OtherUnit",
@@ -245,7 +264,9 @@ def test_transformer_kpi_entries_refuse_nan_instead_of_understating() -> None:
     from complete values or refused by name.
     """
     mysim = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    config = TransformerConfig(component_id=ComponentID(name="Transformer"), efficiency=0.8)
+    config = TransformerConfig(
+        component_id=ComponentID(name="Transformer"), efficiency=0.8, rated_power_in_kilowatt=100.0
+    )
     transformer = Transformer(my_simulation_parameters=mysim, config=config)
     frame = pd.DataFrame({0: [100.0, float("nan")]})
 
@@ -261,3 +282,111 @@ def test_transformer_kpi_entries_refuse_a_missing_output() -> None:
 
     with pytest.raises(ValueError, match="transformer output column"):
         transformer.get_component_kpi_entries([], pd.DataFrame())
+
+
+@pytest.mark.base
+def test_transformer_config_refuses_a_non_positive_rated_power() -> None:
+    """A rating of zero or less is refused at construction, by value.
+
+    The investment cost is the rating times a price per kilowatt, so an unrated unit would be
+    costed at zero euros and reported as an answer -- a device that reads as free rather than as
+    unsized. The configuration is where that stops.
+    """
+    for wrong in (0.0, -1.0):
+        with pytest.raises(ValueError, match="rated power"):
+            TransformerConfig(
+                component_id=ComponentID(name="Transformer"), efficiency=0.95, rated_power_in_kilowatt=wrong
+            )
+
+
+@pytest.mark.base
+def test_transformer_capex_scales_with_the_rated_power() -> None:
+    """The investment cost, embodied CO2 and maintenance cost are all linear in the rating.
+
+    The device database prices this unit per kilowatt of nameplate rating, so doubling the rating
+    has to double all three figures exactly. Asserting the ratio rather than the euros keeps the
+    test meaningful when the owner revises the proposed price per kilowatt, while still catching
+    a capex that ignores the rating (the failure this whole cost model exists to prevent) or one
+    that scales by a squared or halved rating.
+    """
+    mysim = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    small = Transformer.get_cost_capex(
+        TransformerConfig(
+            component_id=ComponentID(name="Small"), efficiency=0.95, rated_power_in_kilowatt=500.0
+        ),
+        mysim,
+    )
+    large = Transformer.get_cost_capex(
+        TransformerConfig(
+            component_id=ComponentID(name="Large"), efficiency=0.95, rated_power_in_kilowatt=1000.0
+        ),
+        mysim,
+    )
+
+    assert small.capex_investment_cost_in_euro > 0.0
+    assert small.device_co2_footprint_in_kg > 0.0
+    assert small.maintenance_costs_in_euro > 0.0
+    assert 20.0 < small.lifetime_in_years < 40.0, "a transformer and rectifier are a multi-decade asset"
+    assert large.capex_investment_cost_in_euro == pytest.approx(2 * small.capex_investment_cost_in_euro)
+    assert large.device_co2_footprint_in_kg == pytest.approx(2 * small.device_co2_footprint_in_kg)
+    assert large.maintenance_costs_in_euro == pytest.approx(2 * small.maintenance_costs_in_euro)
+    # The rating is stated in kilowatts, so the price per kilowatt has to land in the range the
+    # database entry cites (100-200 EUR/kW) rather than being off by a factor of a thousand.
+    assert 100.0 <= small.capex_investment_cost_in_euro / 500.0 <= 200.0
+
+
+@pytest.mark.base
+def test_transformer_capex_prefers_explicit_config_values_over_the_database() -> None:
+    """A configuration carrying all five cost fields is used verbatim, with no database lookup.
+
+    This is the escape hatch for a specific quoted unit, and it is all-or-nothing: the helper
+    consults the database only while all five fields are ``None``. Pinning it here keeps a future
+    change to the shared helper from silently overriding a user's own numbers.
+    """
+    mysim = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    config = TransformerConfig(
+        component_id=ComponentID(name="Quoted"),
+        efficiency=0.95,
+        rated_power_in_kilowatt=500.0,
+        device_co2_footprint_in_kg=1234.0,
+        investment_costs_in_euro=45000.0,
+        lifetime_in_years=30.0,
+        maintenance_costs_in_euro_per_year=900.0,
+        subsidy_as_percentage_of_investment_costs=0.1,
+    )
+
+    capex = Transformer.get_cost_capex(config, mysim)
+
+    assert capex.capex_investment_cost_in_euro == pytest.approx(45000.0)
+    assert capex.device_co2_footprint_in_kg == pytest.approx(1234.0)
+    assert capex.lifetime_in_years == pytest.approx(30.0)
+    assert capex.maintenance_costs_in_euro == pytest.approx(900.0)
+    assert capex.subsidy_as_percentage_of_investment_costs == pytest.approx(0.1)
+
+
+@pytest.mark.base
+def test_transformer_opex_prices_the_conversion_losses_only() -> None:
+    """The operating cost covers the losses, not the throughput, and carries a maintenance share.
+
+    Everything the unit does not lose it passes on, and the consumer downstream reports that
+    share as its own consumption, so the two are disjoint and the system total may add them.
+    Reporting the throughput here instead would count the same kilowatt-hours twice, which is the
+    failure this test catches: two timesteps of 60 s at 100 kW are 3.333 kWh delivered, and at
+    80 % efficiency the losses are 0.833 kWh -- the consumption reported must be the latter.
+    """
+    mysim = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    config = TransformerConfig(
+        component_id=ComponentID(name="Transformer"), efficiency=0.8, rated_power_in_kilowatt=500.0
+    )
+    transformer = Transformer(my_simulation_parameters=mysim, config=config)
+    frame = pd.DataFrame({0: [100.0, 100.0]})
+
+    opex = transformer.get_cost_opex([transformer.electricity_output], frame)
+
+    assert opex.total_consumption_in_kwh == pytest.approx(0.833)
+    assert opex.loadtype == lt.LoadTypes.ELECTRICITY
+    # Both the cost and the footprint are the same kilowatt-hours times a positive per-kWh
+    # factor, so each must be a positive fraction of a euro / kilogram rather than zero.
+    assert 0.0 < opex.opex_energy_cost_in_euro < 1.0
+    assert 0.0 < opex.co2_footprint_in_kg < 1.0
+    assert opex.opex_maintenance_cost_in_euro > 0.0


### PR DESCRIPTION
## Problem
A bare `hisim_main.py electrolyzer_with_renewables.py` falls back to `full_year_all_options`, and COMPUTE_OPEX/COMPUTE_CAPEX run before COMPUTE_KPIS — so the stock run died before the KPIs #641 added ever computed. Both devices in the setup are real (MODELS_NO_DEVICE would be a lie) but had no `get_cost_opex`/`get_cost_capex`. (Noted 2026-09-05, #641 review round; `roadmap/p3_cleanup_todos.md`.)

## Done
- Both configs carry the five standard cost fields (default `None`); both classes implement the two cost methods through the shared helpers; the device database gains its two missing rows under an explicit **PROPOSED VALUES, NOT YET REVIEWED BY THE COST OWNER** header.
- **The numbers, for review:** electrolyzer 1500 EUR/kW (IRENA 2020 / IEA GHR 2023 midpoint of 1400–1800), 3 %/yr maintenance, 15-year system life, embodied CO2 190.5 kgCO2eq/kW from the existing WHY row. Transformer/rectifier 150 EUR/kW, 1.5 %/yr, 27 years (VDI 2067-1), 60 kgCO2eq/kW from inverter inventories as the closest published proxy (stated in place). Sources cited as [48]–[50] in `configuration.py`.
- Opex boundary: the electrolyzer prices what it consumes, the transformer only what it loses — disjoint, so the system total adds. Water stays unpriced; the docstring names the gap instead of inventing a tariff.
- `TransformerConfig` gains `rated_power_in_kilowatt` (refused when non-positive); the setup rates it for the electrolyzer it feeds. Config change → the setup's two twins re-recorded; nothing else builds either class, so no other twin moves.

## Result
The setup test now runs a day with the full option set and asserts both devices appear in the cost tables and `all_kpis.json`; 10 new unit tests pin linearity in the rating, config-over-database precedence, loss-only opex and the refusals. 29 tests green across the three touched files; golden check OK with an unchanged reference; twin freshness check clean; pylint 10.00; mypy clean.

**Found on the way, deliberately not touched:** `CapexComputationHelperFunctions.compute_capex_costs_and_emissions` divides the per-year maintenance figure by the technical lifetime, understating maintenance for every costed component — a fleet-wide fix with its own result diffs, its own PR. Also: the two new database rows exist for DE only, matching the table's existing AT sparseness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
