### PR TITLE
The freshness gate earns its blocking bit

### DIFF
--- a/.github/workflows/energy-system-freshness.yml
+++ b/.github/workflows/energy-system-freshness.yml
@@ -23,13 +23,14 @@
 # On failure the fix is: run 'python scripts/record_all_setups.py' locally,
 # resolve any recorder errors, and commit what it writes.
 #
-# Gate: ADVISORY for its burn-in (continue-on-error below). The step itself
-# still exits non-zero on drift, a missing twin, a setup that cannot be
-# recorded, or two parameter files describing the same run, and the drift diff
-# is still uploaded — but a failure does not block a merge yet. Byte-identical
-# re-recording is proven by test for one setup and by design for the rest, so
-# the fleet earns the blocking bit empirically: after a week of green runs on
-# main, delete the continue-on-error line and this gate is blocking.
+# Gate: BLOCKING. The step exits non-zero on drift, a missing twin, a setup that
+# cannot be recorded, or two parameter files describing the same run, and the drift
+# diff is uploaded with the failure, so a PR that leaves a twin stale cannot be
+# merged. The gate was advisory for a burn-in first: byte-identical re-recording is
+# proven by test for one setup and only by design for the other twenty-one, so the
+# fleet earned the blocking bit empirically — eleven green runs on main between
+# 2026-09-06 and 2026-09-08, none of them a failure, which was judged enough to grant
+# the bit without waiting out the nominal week.
 #
 # Note: this is heavy, like the scenario-JSON gate, because it constructs every
 # setup (occupancy setups trigger LPG) and then builds each recorded file back
@@ -58,9 +59,6 @@ concurrency:
 jobs:
   freshness:
     name: re-record every setup and check for drift
-    # Burn-in: failures are reported, uploaded and annotated, but do not block. Delete this
-    # line after a week of green runs on main to make the gate blocking (see the header).
-    continue-on-error: true
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/fzj-iek3-vsa/hisim-test:py311

--- a/roadmap/p3_cleanup_todos.md
+++ b/roadmap/p3_cleanup_todos.md
@@ -48,13 +48,6 @@ open, so nothing survives only in a conversation. Items are removed when done, n
   variable and run the same subprocess shape — deliberate duplication while the two lived on
   different stack branches. The helper's home is the recording package, with the script importing
   it.
-- [ ] **Flip `energy-system-freshness` from advisory to blocking after its burn-in** (decided
-  2026-09-05, #636 review round). The gate merged with `continue-on-error: true` because
-  byte-identical re-recording is proven by test for one setup and only by design for the other
-  twenty-one; after a week of green runs on main (first green run 2026-09-06, so due around
-  2026-09-13), delete that one line (the workflow header carries the same instruction) and the
-  gate blocks. That first green run on development-box twins is also AC-P3.4's cross-machine
-  evidence; the week of them is the confidence.
 
 ## Deferred by design (not P3's debt, listed so it is findable)
 
@@ -71,3 +64,6 @@ Rig headers say P6: #637. Channel migration: #645. Requirements doc R5.1/R5.2/R5
 AC-P3.10, AC-P3.11 and Q-P3.5 amended to the twenty-two-setup reality: 2026-09-07, this commit.
 The #625 fleet re-record: satisfied by #636 recording all twenty-two after #625, first freshness
 run green on main 2026-09-06. AC-P3.4 evidence: same run. #598 closed: 2026-09-07.
+The freshness gate flipped to blocking: 2026-09-08, #654 — eleven green runs on main
+across 2026-09-06..08 (one cancelled by a newer push, none failed), which the owner judged
+sufficient to grant the bit ahead of the nominal week.


### PR DESCRIPTION
## Problem

`energy-system-freshness` merged advisory on purpose. Byte-identical re-recording is proven by test for one setup and only by design for the other twenty-one, so the fleet had to earn the blocking bit empirically rather than by assertion — the workflow shipped with `continue-on-error: true` and an inline instruction to delete it once main had shown a run of green.

## Done

Deletes `continue-on-error: true` and the note telling the next reader to delete it, and rewrites the header's gate paragraph in the `Gate: BLOCKING` convention the golden gates already use, recording what the burn-in actually was rather than what was planned.

**The evidence:** eleven green runs on main between 2026-09-06 and 2026-09-08, no failures (one run cancelled by a newer push, which is not a failure). The nominal burn-in was a week; three days of an unbroken fleet-wide green was judged enough to grant the bit now.

The todo entry is **removed rather than ticked**, which is what `roadmap/p3_cleanup_todos.md` asks for — *"Items are removed when done, not ticked and kept"* — with the removal recorded in that file's dated ledger. This branch was cut before that convention landed on main, which is where its merge conflict came from; the conflict is resolved main's way.

## Result

A PR that leaves a recorded twin stale can no longer be merged. The step already exited non-zero on drift, a missing twin, an unrecordable setup, or two parameter files describing the same run, and already uploaded the drift diff — only the `continue-on-error` line stood between that and a blocked merge.

No `continue-on-error` remains anywhere under `.github/`. Rebased onto current main and merges cleanly; the workflow parses and the job carries no `continue-on-error` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
