### PR TITLE
ReadTheDocs builds again: Python 3.12, the undeclared mermaid extension, and dot for the diagrams

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,10 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.12"
+  # sphinx.ext.graphviz and sphinx.ext.inheritance_diagram shell out to "dot"
+  apt_packages:
+    - graphviz
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ openpyxl
 pytest
 sphinx
 sphinx-rtd-theme
+# Documentation build (docs/conf.py extensions): renders the ```mermaid blocks
+sphinxcontrib-mermaid
 dataclasses_json
 hplib==1.9
 bslib==0.6


### PR DESCRIPTION
## Problem
The ReadTheDocs build fails at `pip install -r requirements.txt`: the RTD config pins Python 3.9 while the requirements pin pandas 3.0.5 (needs >=3.11) and resolve numpy into the >=3.12 range — and `setup.py` itself declares `python_requires>=3.10`, so even the `path: .` install step would refuse 3.9. Development runs on 3.12.

## Done
- `.readthedocs.yaml`: `build.tools.python` 3.9 → **3.12** (the file was already valid v2 schema; nothing else needed migrating).
- Second blocker found on the way: `docs/conf.py` loads `sphinxcontrib.mermaid`, which nothing ever declared (introduced by an earlier cleanup commit without a requirements entry) — Sphinx aborts hard on it. Added `sphinxcontrib-mermaid` next to the existing sphinx entries in `requirements.txt`. Note: `setup.py` reads `requirements.txt` for `install_requires` and there is no docs extra, so this also becomes a runtime install dependency — say the word if you'd rather introduce a docs-only requirements file instead.
- `build.apt_packages: [graphviz]`: `sphinx.ext.graphviz` and `sphinx.ext.inheritance_diagram` shell out to `dot`, which the RTD image does not ship — without it the diagrams silently degrade to warnings.

## Result
Local Sphinx build on Python 3.12: **build succeeded**, 228 files, HTML written (4330 pre-existing docstring/reST warnings, untouched — docs content is out of scope here). YAML parses to the expected v2 structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
