### PR TITLE
A deviation report is uploaded when a golden deviates, not when one passes

### DIFF
--- a/.github/workflows/golden-json-check.yml
+++ b/.github/workflows/golden-json-check.yml
@@ -86,8 +86,13 @@ jobs:
           python scripts/golden_check.py \
             --mode json \
             --setup "${{ matrix.setup }}" --param "${{ matrix.param }}"
+      # Only on failure, like golden-check, golden-year and golden_ref_spec.md's own listing:
+      # the report explains a deviation, so uploading it from a passing job stores something
+      # nobody reads and puts an artifact upload -- a network call to a service that can and does
+      # answer 403 -- inside the success path of a check that already passed. One such 403 on a
+      # green job failed this workflow's summary gate as if a JSON pair had diverged.
       - name: Upload deviation report
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v6
         with:
           name: golden-json-report-${{ matrix.setup }}-${{ matrix.param }}

--- a/.github/workflows/golden-yaml-check.yml
+++ b/.github/workflows/golden-yaml-check.yml
@@ -96,8 +96,9 @@ jobs:
           python scripts/golden_check.py \
             --mode yaml \
             --setup "${{ matrix.setup }}" --param "${{ matrix.param }}"
+      # Failure-only, for the reason spelled out in golden-json-check.yml.
       - name: Upload deviation report
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v6
         with:
           name: golden-yaml-report-${{ matrix.setup }}-${{ matrix.param }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,8 +87,13 @@ jobs:
           ret=0
         fi
         exit "$ret"
+    # The one upload that must stay unconditional, because the combine job below consumes it.
+    # It is diagnostics all the same, so a failure to store it must not turn a passing test
+    # matrix red: without continue-on-error a 403 from the artifact service is indistinguishable
+    # from a failing test, and it also fails the gate job that waits on this one.
     - name: Upload coverage data
       if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v6
       with:
         name: coverage-${{ matrix.name }}


### PR DESCRIPTION
## Problem

On #653, this appeared in `golden-json household_gas_solar_thermal_building_sizer / one_week_60s`:

```
Uploaded bytes 495
Finished uploading artifact content to blob storage!
Finalizing artifact upload
Error: Failed to FinalizeArtifact: Received non-retryable error: Failed request:
(403) Forbidden: Error from intermediary with HTTP status code 403 "Forbidden"
```

The KPI check in that job had **passed**. The only failing step was `Upload deviation report`, and because the job went red the `golden-json-check summary` gate failed too — so a GitHub storage hiccup was reported as "a JSON pair diverged", on a PR where nothing had diverged.

The cause is that `golden-json-check` and `golden-yaml-check` upload their deviation report with `if: always()`. An artifact upload is a network call to a service that answers 403 often enough to matter, and those two workflows made that call on the success path of every job — roughly 44 uploads per green run, for reports that only exist to explain a failure.

## Done

- **`golden-json-check` and `golden-yaml-check` upload the report only `if: failure()`.** That is already what `golden-check` and `golden-year` do, and what `golden_ref_spec.md`'s own listing of the job specifies — these two were the outliers.
- **The coverage upload in `tests.yml` gets `continue-on-error: true`.** It has to stay unconditional because the combine job consumes it, but it is diagnostics all the same: a failure to store it must not be indistinguishable from a failing test, and it currently also gates the job that the full-year golden run waits on.
- **`p3-parity` is deliberately unchanged.** Its verdicts are uploaded on success *because* the summary job downloads them, and that summary returns 1 when a verdict is missing — there, losing an upload must be loud.

I checked what consumes each artifact before changing anything. Only three are downloaded by any workflow: `golden-*` (assembled by `golden-update`'s PR-opening job), `coverage-*` (the combine job) and `p3-parity-verdict-*` (the parity summary). The four `golden-*-report-*` families and the `scenario-json-*` diagnostics have no machine consumer — a human downloads them when investigating a red check.

## Result

A 403 from the artifact service can no longer turn a passing golden check red, and the two workflows stop writing ~44 artifacts per green run. The repository currently holds **10,219 artifacts, none expired** in a 500-artifact sample; this is where most of them come from, so the pile stops growing. Clearing the backlog is a separate, admin-side action.

No test or script changes: this is CI hygiene only. Both edited workflows parse, and every upload step's condition is now consistent with the four-workflow family and with the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
