### PR TITLE
The CHP gets a cost model, so the dynamic_components gate survives its cost stages

### DIFF
--- a/energy_systems/dynamic_components.energy_system.yaml
+++ b/energy_systems/dynamic_components.energy_system.yaml
@@ -53,6 +53,11 @@ components:
       eff_th_max: 0.55
       temperature_max: 80.0
       delta_temperature: 10.0
+      device_co2_footprint_in_kg: null
+      investment_costs_in_euro: null
+      lifetime_in_years: null
+      maintenance_costs_in_euro_per_year: null
+      subsidy_as_percentage_of_investment_costs: null
   CHP2:
     class: hisim.components.advanced_fuel_cell.CHP
     config:
@@ -72,6 +77,11 @@ components:
       eff_th_max: 0.55
       temperature_max: 80.0
       delta_temperature: 10.0
+      device_co2_footprint_in_kg: null
+      investment_costs_in_euro: null
+      lifetime_in_years: null
+      maintenance_costs_in_euro_per_year: null
+      subsidy_as_percentage_of_investment_costs: null
   L2EMSElectricityController:
     class: hisim.components.controller_l2_energy_management_system.L2GenericEnergyManagementSystem
     preset: optimize_own_consumption

--- a/hisim/components/advanced_fuel_cell.py
+++ b/hisim/components/advanced_fuel_cell.py
@@ -5,16 +5,24 @@ import os
 from dataclasses import dataclass
 import math
 
-from typing import Optional, ClassVar, List
+from typing import Dict, Optional, ClassVar, List, Tuple
 import copy
 from dataclasses_json import dataclass_json
 
 import pandas as pd
 from hisim.config import ConfigBase, ComponentID, DisplayConfig
-from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput
+from hisim.component import (
+    CapexCostDataClass,
+    Component,
+    ComponentInput,
+    ComponentOutput,
+    OpexCostDataClass,
+    SingleTimeStepValues,
+)
 from hisim import loadtypes as lt
 
-from hisim.components.configuration import PhysicsConfig
+from hisim.components.configuration import EmissionFactorsAndCostsForFuelsConfig, PhysicsConfig
+from hisim.postprocessing.cost_and_emission_computation.capex_computation import CapexComputationHelperFunctions
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiEntry, KpiHelperClass, KpiTagEnumClass
 from hisim import utils
 from hisim.simulationparameters import SimulationParameters
@@ -37,7 +45,16 @@ SPECIFIC_HEAT_CAPACITY_WATER = 4182  # J/(kg·K)
 @dataclass_json
 @dataclass
 class CHPConfig(ConfigBase):
-    """CHP Config class."""
+    """CHP Config class.
+
+    Besides the machine's operating parameters, the configuration carries the five cost fields
+    every costed component in the library declares. They are read as a set: while all five are
+    ``None`` -- the default, and what the config-building classmethod below produces --
+    postprocessing looks the figures up from the device database for the simulated year and
+    country and scales them by ``p_el_max``, the unit's electrical rating, which is what a
+    micro-CHP's price is quoted per. Setting all five overrides that lookup with the values given
+    here, for a specific quoted machine.
+    """
 
     @classmethod
     def get_main_classname(cls) -> str:
@@ -55,12 +72,38 @@ class CHPConfig(ConfigBase):
     eff_el_min: float  # [-]
     eff_th_min: float  # [-]
     mass_flow_max: float  # kg/s
-    p_el_max: float  # [W]
+    p_el_max: float  # [W]; the electrical rating, and the only figure the capex scales by
     p_th_max: float  # [W]
     eff_el_max: float  # [-]
     eff_th_max: float  # [-]
     temperature_max: float
     delta_temperature: float
+    #: CO2 footprint of investment in kg
+    device_co2_footprint_in_kg: Optional[float] = None
+    #: cost for investment in Euro
+    investment_costs_in_euro: Optional[float] = None
+    #: lifetime in years
+    lifetime_in_years: Optional[float] = None
+    #: maintenance cost in euro per year
+    maintenance_costs_in_euro_per_year: Optional[float] = None
+    #: subsidies as percentage of investment costs
+    subsidy_as_percentage_of_investment_costs: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        """Refuses a non-positive maximum electrical power.
+
+        The investment cost is that rating times a price per kilowatt, so a unit rated at zero or
+        less would be costed at nothing and reported as an answer -- a machine that reads as free
+        rather than as unrated. The configuration is where that stops.
+
+        Raises:
+            ValueError: For a ``p_el_max`` that is not strictly positive.
+        """
+        if self.p_el_max <= 0.0:
+            raise ValueError(
+                f"The CHP maximum electrical power must be strictly positive, not {self.p_el_max} W. "
+                "It is what the investment cost is scaled by, so an unrated unit would be costed as free."
+            )
 
     @classmethod
     def get_default_config(
@@ -185,6 +228,22 @@ class CHP(Component):
     NumberofCycles: ClassVar[str] = "NumberofCycles"
     ThermalOutputPower: ClassVar[str] = "ThermalOutputPower"
     GasDemandReal: ClassVar[str] = "GasDemandReal"
+
+    # The names of the four totals the run is summarised by. They are constants because they are
+    # keys rather than prose: the KPI entries carry them, :meth:`CHP.read_run_totals` returns them,
+    # the operating cost looks the fuel up by one of them, and every refusal names the one it
+    # could not read.
+    ELECTRICAL_ENERGY_PRODUCED: ClassVar[str] = "Electrical energy produced"
+    THERMAL_ENERGY_PRODUCED: ClassVar[str] = "Thermal energy produced"
+    FUEL_CONSUMED: ClassVar[str] = "Fuel consumed"
+    NUMBER_OF_ACTIVATION_CYCLES: ClassVar[str] = "Number of activation cycles"
+    #: The four totals in the order their KPI entries are written, with the unit each declares.
+    RUN_TOTALS: ClassVar[Tuple[Tuple[str, str], ...]] = (
+        (ELECTRICAL_ENERGY_PRODUCED, "kWh"),
+        (THERMAL_ENERGY_PRODUCED, "kWh"),
+        (FUEL_CONSUMED, "kg"),
+        (NUMBER_OF_ACTIVATION_CYCLES, "-"),
+    )
 
     def __init__(
         self,
@@ -641,6 +700,63 @@ class CHP(Component):
         stsv.set_output_value(self.gas_demand_target_channel, gas_demand_target)  # CHP runs with
         stsv.set_output_value(self.gas_demand_real_used_channel, gas_demand_real_used)  # ThermalPowerOutput
 
+    def read_run_totals(
+        self,
+        all_outputs: List[ComponentOutput],
+        postprocessing_results: pd.DataFrame,
+    ) -> Dict[str, float]:
+        """Read the four totals that describe what the unit did over the simulated period.
+
+        The electrical and thermal energy are integrated from the two power outputs; the fuel
+        mass from the *real* fuel draw, not the requested one, which differs whenever the storage
+        could not deliver; and the cycle count is the final value of the cumulative counter, since
+        summing it would count every earlier timestep again. Both the KPI entries and the
+        operating costs need these totals, which is why they are read once here.
+
+        Args:
+            all_outputs: every output column of the run, searched for this component's by name.
+            postprocessing_results: the per-timestep values of those columns.
+
+        Returns:
+            Dict[str, float]: the four totals, keyed by the KPI names in :attr:`RUN_TOTALS`.
+
+        Raises:
+            ValueError: When one of the four output columns is not found for this component, is
+                empty, or carries NaN — pandas would silently drop NaN from a sum and an all-NaN
+                column would report zero, so a total is either computed from complete values or
+                refused by name, never reported wrongly in silence.
+        """
+        seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep
+        found: Dict[str, float] = {}
+        for index, output in enumerate(all_outputs):
+            if output.component_name != self.component_name:
+                continue
+            column = postprocessing_results.iloc[:, index]
+            if output.field_name == self.ElectricityOutput and output.unit == lt.Units.WATT:
+                found[self.ELECTRICAL_ENERGY_PRODUCED] = self._energy_in_kilowatt_hour(
+                    self._checked_column(column, self.ELECTRICAL_ENERGY_PRODUCED), seconds_per_timestep
+                )
+            elif output.field_name == self.ThermalOutputPower and output.unit == lt.Units.WATT:
+                found[self.THERMAL_ENERGY_PRODUCED] = self._energy_in_kilowatt_hour(
+                    self._checked_column(column, self.THERMAL_ENERGY_PRODUCED), seconds_per_timestep
+                )
+            elif output.field_name == self.GasDemandReal and output.unit == lt.Units.KG_PER_SEC:
+                found[self.FUEL_CONSUMED] = round(
+                    float(self._checked_column(column, self.FUEL_CONSUMED).sum()) * seconds_per_timestep, 6
+                )
+            elif output.field_name == self.NumberofCycles and output.unit == lt.Units.ANY:
+                found[self.NUMBER_OF_ACTIVATION_CYCLES] = float(
+                    self._checked_column(column, self.NUMBER_OF_ACTIVATION_CYCLES).iloc[-1]
+                )
+
+        for name, _ in self.RUN_TOTALS:
+            if name not in found:
+                raise ValueError(
+                    f"The CHP output for the KPI '{name}' was not found among the run's columns for "
+                    f"{self.component_name}; the KPI cannot be reported as absent silently."
+                )
+        return found
+
     def get_component_kpi_entries(
         self,
         all_outputs: List[ComponentOutput],
@@ -648,11 +764,9 @@ class CHP(Component):
     ) -> List[KpiEntry]:
         """Calculates KPIs for the CHP and returns all KPI entries as a list.
 
-        Four indicators describe what the unit did over the simulated period: the electrical
-        and thermal energy it produced, integrated from its power outputs; the fuel mass it
-        actually burned, integrated from the real fuel draw (not the requested one, which can
-        differ when the storage cannot deliver); and how many on/off cycles it went through,
-        read as the final value of its cumulative cycle counter. Cycles are an indicator of
+        Four indicators describe what the unit did over the simulated period, all four read by
+        :meth:`read_run_totals`: the electrical and thermal energy it produced, the fuel mass it
+        actually burned, and how many on/off cycles it went through. Cycles are an indicator of
         their own because wear grows with switching, not with runtime.
 
         Args:
@@ -663,58 +777,111 @@ class CHP(Component):
             List[KpiEntry]: the four entries, tagged as CHP.
 
         Raises:
-            ValueError: When one of the four output columns is not found for this component, is
-                empty, or carries NaN — pandas would silently drop NaN from a sum and an all-NaN
-                column would report zero, so a KPI is either computed from complete values or
-                refused by name, never reported wrongly in silence.
+            ValueError: When one of the four output columns is missing, empty or carries NaN, via
+                :meth:`read_run_totals`.
         """
-        seconds_per_timestep = self.my_simulation_parameters.seconds_per_timestep
-        electrical_energy_in_kilowatt_hour = None
-        thermal_energy_in_kilowatt_hour = None
-        fuel_consumed_in_kg = None
-        number_of_cycles = None
-        for index, output in enumerate(all_outputs):
-            if output.component_name != self.component_name:
-                continue
-            column = postprocessing_results.iloc[:, index]
-            if output.field_name == self.ElectricityOutput and output.unit == lt.Units.WATT:
-                electrical_energy_in_kilowatt_hour = self._energy_in_kilowatt_hour(
-                    self._checked_column(column, "Electrical energy produced"), seconds_per_timestep
-                )
-            elif output.field_name == self.ThermalOutputPower and output.unit == lt.Units.WATT:
-                thermal_energy_in_kilowatt_hour = self._energy_in_kilowatt_hour(
-                    self._checked_column(column, "Thermal energy produced"), seconds_per_timestep
-                )
-            elif output.field_name == self.GasDemandReal and output.unit == lt.Units.KG_PER_SEC:
-                fuel_consumed_in_kg = round(
-                    float(self._checked_column(column, "Fuel consumed").sum()) * seconds_per_timestep, 6
-                )
-            elif output.field_name == self.NumberofCycles and output.unit == lt.Units.ANY:
-                number_of_cycles = float(self._checked_column(column, "Number of activation cycles").iloc[-1])
-
-        entries = [
-            ("Electrical energy produced", "kWh", electrical_energy_in_kilowatt_hour),
-            ("Thermal energy produced", "kWh", thermal_energy_in_kilowatt_hour),
-            ("Fuel consumed", "kg", fuel_consumed_in_kg),
-            ("Number of activation cycles", "-", number_of_cycles),
-        ]
-        for name, unit, value in entries:
-            if value is None:
-                raise ValueError(
-                    f"The CHP output for the KPI '{name}' was not found among the run's columns for "
-                    f"{self.component_name}; the KPI cannot be reported as absent silently."
-                )
+        found = self.read_run_totals(all_outputs, postprocessing_results)
         return [
             KpiEntry(
                 name=name,
                 unit=unit,
-                value=value,
+                value=found[name],
                 tag=KpiTagEnumClass.CHP,
                 description=self.component_name,
                 name_of_source_component=self.component_name,
             )
-            for name, unit, value in entries
+            for name, unit in self.RUN_TOTALS
         ]
+
+    @staticmethod
+    def get_cost_capex(config: CHPConfig, simulation_parameters: SimulationParameters) -> CapexCostDataClass:
+        """Return the unit's investment cost, embodied CO2, lifetime and maintenance cost.
+
+        A fuel-cell CHP is bought, rated and replaced as one appliance and is priced per kilowatt
+        of electrical output (``ComponentType.CHP``), which is how micro-CHP costs are quoted, so
+        the figures scale by ``p_el_max`` — stated in watt on the configuration and converted here.
+        Where they come from is the all-or-nothing rule stated on :class:`CHPConfig`: the device
+        database unless all five cost fields carry values.
+
+        Args:
+            config: the CHP configuration, read for ``p_el_max`` and its cost fields.
+            simulation_parameters: the simulated year, country and duration, which decide which
+                database row applies and what share of the investment falls in the run.
+
+        Returns:
+            CapexCostDataClass: the investment cost and embodied CO2, both in total and prorated
+            over the simulated period, tagged as CHP.
+        """
+        capex_cost_data_class = CapexComputationHelperFunctions.compute_capex_costs_and_emissions(
+            simulation_parameters=simulation_parameters,
+            component_type=lt.ComponentType.CHP,
+            unit=lt.Units.KILOWATT,
+            size_of_energy_system=config.p_el_max / 1e3,
+            config=config,
+            kpi_tag=KpiTagEnumClass.CHP,
+        )
+        CapexComputationHelperFunctions.overwrite_config_values_with_new_capex_values(
+            config=config, capex_cost_data_class=capex_cost_data_class
+        )
+        return capex_cost_data_class
+
+    def get_cost_opex(
+        self,
+        all_outputs: List[ComponentOutput],
+        postprocessing_results: pd.DataFrame,
+    ) -> OpexCostDataClass:
+        """Return the unit's operating cost: the fuel it burned, plus maintenance.
+
+        The fuel is the mass the unit really drew, not the mass it asked for, and it is converted
+        to energy with the same lower heating value :meth:`i_simulate` divided by to turn power
+        into that mass — so the kilowatt-hours priced here are the ones the simulation burned.
+        Which fuel it is follows the configured gas type, and so does the tariff: a hydrogen CHP
+        is priced at the green-hydrogen factors, a methane one at the gas factors. A hydrogen unit
+        therefore reports zero operating CO2, not by omission but because the fuels table gives
+        green hydrogen a zero footprint per kWh -- its emissions sit with whatever produced it.
+
+        Args:
+            all_outputs: every output column of the run, searched for this component's outputs.
+            postprocessing_results: the per-timestep values of those columns.
+
+        Returns:
+            OpexCostDataClass: the cost, CO2 and consumption of the fuel burned, plus the
+            maintenance cost for the simulated period, tagged as CHP and carrying the fuel's own
+            load type.
+
+        Raises:
+            ValueError: When one of the run totals is missing, empty or carries NaN, via
+                :meth:`read_run_totals`; or when the configured gas type is neither hydrogen nor
+                methane, via :meth:`get_fuel_load_type`.
+        """
+        fuel_load_type = self.get_fuel_load_type()
+        fuel_consumed_in_kg = self.read_run_totals(all_outputs, postprocessing_results)[self.FUEL_CONSUMED]
+        lower_heating_value_in_kwh_per_kg = (
+            PhysicsConfig.get_properties_for_energy_carrier(
+                energy_carrier=fuel_load_type
+            ).lower_heating_value_in_joule_per_kg
+            / 3.6e6
+        )
+        fuel_consumed_in_kilowatt_hour = fuel_consumed_in_kg * lower_heating_value_in_kwh_per_kg
+        emissions_and_cost_factors = EmissionFactorsAndCostsForFuelsConfig.get_values_for_year(
+            self.my_simulation_parameters.year, self.my_simulation_parameters.country
+        )
+        # get_fuel_load_type admits these two carriers and refuses everything else, so the
+        # alternative below is the methane one rather than an unhandled case.
+        if fuel_load_type == lt.LoadTypes.GREEN_HYDROGEN:
+            euro_per_kilowatt_hour = emissions_and_cost_factors.green_hydrogen_gas_costs_in_euro_per_kwh
+            co2_in_kg_per_kilowatt_hour = emissions_and_cost_factors.green_hydrogen_gas_footprint_in_kg_per_kwh
+        else:
+            euro_per_kilowatt_hour = emissions_and_cost_factors.gas_costs_in_euro_per_kwh
+            co2_in_kg_per_kilowatt_hour = emissions_and_cost_factors.gas_footprint_in_kg_per_kwh
+        return OpexCostDataClass(
+            opex_energy_cost_in_euro=fuel_consumed_in_kilowatt_hour * euro_per_kilowatt_hour,
+            opex_maintenance_cost_in_euro=self.calc_maintenance_cost(),
+            co2_footprint_in_kg=fuel_consumed_in_kilowatt_hour * co2_in_kg_per_kilowatt_hour,
+            total_consumption_in_kwh=fuel_consumed_in_kilowatt_hour,
+            loadtype=fuel_load_type,
+            kpi_tag=KpiTagEnumClass.CHP,
+        )
 
     def _checked_column(self, column: pd.Series, kpi_name: str) -> pd.Series:
         """Returns a KPI's column only when every value in it is real.

--- a/hisim/components/configuration.py
+++ b/hisim/components/configuration.py
@@ -325,6 +325,9 @@ Sources for capex techno-economic parameters:
         [50]: ecoinvent-based life-cycle inventories for photovoltaic power electronics (inverter,
         2500 W to 500 kW), used here as the closest published proxy for a rectifier's embodied
         emissions: https://www.ecoinvent.org
+        [51]: Clean Hydrogen Partnership (FCH 2 JU), MAWP Key Performance Indicators, "Residential
+        micro-CHP for single family homes and small buildings (0.3-5 kW)", state of the art 2024:
+        https://www.clean-hydrogen.europa.eu/residential-micro-chp-single-family-homes-and-small-buildings-03-5-kw_en
         """
 capex_techno_economic_parameters = {
     "DE": {
@@ -429,6 +432,34 @@ capex_techno_economic_parameters = {
                 # No published inventory for a rectifier was found; power electronics of the same
                 # duty (a PV inverter) carry roughly this, Source: [50]
                 "co2_footprint_in_kg_per_kw": 60,
+                "subsidy_as_percentage_of_investment_costs": 0,
+            },
+            # PROPOSED VALUES, NOT YET REVIEWED BY THE COST OWNER (added 2026-09-08 so that a
+            # stock all-options run of dynamic_components reaches its KPIs instead of dying in
+            # COMPUTE_OPEX/COMPUTE_CAPEX). The device this row prices is the one the component
+            # models: a residential fuel-cell micro-CHP of a few kW electrical (the component's
+            # own reference machine is a BlueGen-class SOFC), not an engine CHP and not an
+            # industrial unit -- a fuel cell costs several times an engine of the same output, so
+            # the figure below is deliberately far above the household heaters above it.
+            ComponentType.CHP: {
+                # Per kW of *electrical* rating, which is how m-CHP costs are quoted. [51] states
+                # 5500 EUR/kW as the 2024 state of the art for the 0.3-5 kW class, which is the
+                # year and class this table row is for, so it is taken as it stands rather than as
+                # the midpoint of a range. [19] records 6767 EUR/kW for a hydrogen fuel cell,
+                # older and higher, and is what says this is the right order of magnitude.
+                "investment_costs_in_euro_per_kw": 5500,
+                # [51] quotes maintenance per kWh produced (3.5 EUR ct/kWh in 2024) rather than as
+                # a share of the investment, so the share is derived from that source's own
+                # figures: 60000 h of stack durability over a 14-year appliance life is about
+                # 4300 operating hours per year, and 4300 h * 1 kW * 0.035 EUR/kWh = 150 EUR per
+                # kW per year, which is 2.7 % of the 5500 EUR/kW above. Source: [51]
+                "maintenance_costs_as_percentage_of_investment_per_year": 0.027,
+                # Appliance lifetime with the stack replaced as maintenance, 2024 state of the
+                # art; the stack's own shorter life is carried by the maintenance share above.
+                # [19] records 5 years for the whole device, which is a stack life, not an
+                # appliance life. Source: [51]
+                "technical_lifetime_in_years": 14,
+                "co2_footprint_in_kg_per_kw": 405.5,  # hydrogen fuel cell, Source: [19]
                 "subsidy_as_percentage_of_investment_costs": 0,
             },
             # CAPEX per kWh

--- a/system_setups/dynamic_components.scenario.json
+++ b/system_setups/dynamic_components.scenario.json
@@ -78,7 +78,12 @@
                 "eff_el_max": 0.4,
                 "eff_th_max": 0.55,
                 "temperature_max": 80,
-                "delta_temperature": 10
+                "delta_temperature": 10,
+                "device_co2_footprint_in_kg": null,
+                "investment_costs_in_euro": null,
+                "lifetime_in_years": null,
+                "maintenance_costs_in_euro_per_year": null,
+                "subsidy_as_percentage_of_investment_costs": null
             },
             "config_full_classname": "hisim.components.advanced_fuel_cell.CHPConfig",
             "inputs": [],
@@ -108,7 +113,12 @@
                 "eff_el_max": 0.4,
                 "eff_th_max": 0.55,
                 "temperature_max": 80,
-                "delta_temperature": 10
+                "delta_temperature": 10,
+                "device_co2_footprint_in_kg": null,
+                "investment_costs_in_euro": null,
+                "lifetime_in_years": null,
+                "maintenance_costs_in_euro_per_year": null,
+                "subsidy_as_percentage_of_investment_costs": null
             },
             "config_full_classname": "hisim.components.advanced_fuel_cell.CHPConfig",
             "inputs": [],

--- a/tests/test_advanced_fuel_cell.py
+++ b/tests/test_advanced_fuel_cell.py
@@ -2,6 +2,7 @@
 
 # clean
 
+import dataclasses
 import json
 import math
 from typing import NamedTuple
@@ -345,3 +346,198 @@ def test_chp_kpi_entries_refuse_nan_instead_of_understating() -> None:
 
     with pytest.raises(ValueError, match="Electrical energy produced"):
         chp.get_component_kpi_entries(outputs, frame)
+
+
+def _build_config(p_el_max: float = 3_000.0, gas_type: str = "Hydrogen") -> advanced_fuel_cell.CHPConfig:
+    """Build the default CHP configuration, optionally at another rating or on another fuel.
+
+    The rating is a parameter because the capex tests below assert that the cost scales with it,
+    and everything else about the machine is held fixed so that the rating is the only thing that
+    can explain a difference. ``dataclasses.replace`` rather than an assignment, because the
+    rating is validated in ``__post_init__`` and an assignment afterwards would walk past it.
+
+    Args:
+        p_el_max: maximum electrical power in watt, which is also what the investment cost is
+            scaled by.
+        gas_type: the fuel the unit burns, which decides the load type and tariff of its opex.
+
+    Returns:
+        CHPConfig: the default configuration at that rating and fuel, cost fields unset.
+    """
+    return dataclasses.replace(
+        advanced_fuel_cell.CHPConfig.get_default_config(), p_el_max=p_el_max, gas_type=gas_type
+    )
+
+
+def _build_chp(gas_type: str) -> advanced_fuel_cell.CHP:
+    """Construct a default CHP on the given fuel, in a year the fuel tariffs cover.
+
+    The cost tests build their own unit rather than reusing :func:`build_chp_system`, whose 2017
+    parameters predate the emission and cost factors the operating cost reads.
+
+    Args:
+        gas_type: the fuel the unit burns.
+
+    Returns:
+        CHP: the component, whose output channels the cost tests read totals from.
+    """
+    return advanced_fuel_cell.CHP(
+        config=_build_config(gas_type=gas_type),
+        my_simulation_parameters=SimulationParameters.one_day_only(2021, 60),
+    )
+
+
+def _fuel_outputs(chp: advanced_fuel_cell.CHP) -> list[cp.ComponentOutput]:
+    """Return the four output channels the run totals are read from, in column order."""
+    return [
+        chp.el_power_channel,
+        chp.th_power_channel,
+        chp.gas_demand_real_used_channel,
+        chp.number_of_cycles_channel,
+    ]
+
+
+#: Two timesteps of 60 s at 0.001 kg/s, which is what the opex frames below burn.
+FUEL_BURNED_IN_KG: float = 0.12
+#: Lower heating values in kWh/kg, written out here rather than read from PhysicsConfig so that
+#: the tests check the conversion against published values instead of against the code under test.
+HYDROGEN_LOWER_HEATING_VALUE_IN_KWH_PER_KG: float = 33.3
+METHANE_LOWER_HEATING_VALUE_IN_KWH_PER_KG: float = 13.9
+
+
+@pytest.mark.base
+def test_chp_config_leaves_the_cost_fields_unset_by_default() -> None:
+    """The five cost fields default to ``None``, which is what selects the database lookup.
+
+    They are read as a set: postprocessing looks the figures up from the device database for the
+    simulated year and country only while all five are ``None``. A default that accidentally
+    carried a number would silently pin every CHP in the fleet to it.
+    """
+    config = _build_config()
+    assert config.device_co2_footprint_in_kg is None
+    assert config.investment_costs_in_euro is None
+    assert config.lifetime_in_years is None
+    assert config.maintenance_costs_in_euro_per_year is None
+    assert config.subsidy_as_percentage_of_investment_costs is None
+
+
+@pytest.mark.base
+def test_chp_capex_scales_with_the_electrical_rating() -> None:
+    """The investment cost, embodied CO2 and maintenance cost are all linear in ``p_el_max``.
+
+    Micro-CHP costs are quoted per kilowatt of electrical output, so doubling the rating has to
+    double all three figures exactly. Asserting the ratio rather than the euros keeps the test
+    meaningful when the owner revises the proposed price per kilowatt, while still catching a
+    capex that ignores the rating -- the failure this cost model exists to prevent -- or one that
+    scales by the wrong power of it.
+    """
+    mysim = SimulationParameters.one_day_only(2021, 60)
+    small = advanced_fuel_cell.CHP.get_cost_capex(_build_config(p_el_max=3_000.0), mysim)
+    large = advanced_fuel_cell.CHP.get_cost_capex(_build_config(p_el_max=6_000.0), mysim)
+
+    assert small.capex_investment_cost_in_euro > 0.0
+    assert small.device_co2_footprint_in_kg > 0.0
+    assert small.maintenance_costs_in_euro > 0.0
+    assert 5.0 < small.lifetime_in_years < 25.0, "a fuel-cell appliance is a one- to two-decade asset"
+    assert large.capex_investment_cost_in_euro == pytest.approx(2 * small.capex_investment_cost_in_euro)
+    assert large.device_co2_footprint_in_kg == pytest.approx(2 * small.device_co2_footprint_in_kg)
+    assert large.maintenance_costs_in_euro == pytest.approx(2 * small.maintenance_costs_in_euro)
+    # The rating is stated in watt and the price per kilowatt, so the conversion has to happen:
+    # a unit priced per watt would land a thousandfold below the 5500 EUR/kW the database cites.
+    assert 4000.0 <= small.capex_investment_cost_in_euro / 3.0 <= 7000.0
+
+
+@pytest.mark.base
+def test_chp_capex_prefers_explicit_config_values_over_the_database() -> None:
+    """A configuration carrying all five cost fields is used verbatim, with no database lookup.
+
+    This is the escape hatch for a specific quoted machine, and it is all-or-nothing: the helper
+    consults the database only while all five fields are ``None``. Pinning it here keeps a future
+    change to the shared helper from silently overriding a user's own numbers.
+    """
+    config = _build_config()
+    config.device_co2_footprint_in_kg = 900.0
+    config.investment_costs_in_euro = 21000.0
+    config.lifetime_in_years = 9.0
+    config.maintenance_costs_in_euro_per_year = 700.0
+    config.subsidy_as_percentage_of_investment_costs = 0.4
+
+    capex = advanced_fuel_cell.CHP.get_cost_capex(config, SimulationParameters.one_day_only(2021, 60))
+
+    assert capex.capex_investment_cost_in_euro == pytest.approx(21000.0)
+    assert capex.device_co2_footprint_in_kg == pytest.approx(900.0)
+    assert capex.lifetime_in_years == pytest.approx(9.0)
+    assert capex.maintenance_costs_in_euro == pytest.approx(700.0)
+    assert capex.subsidy_as_percentage_of_investment_costs == pytest.approx(0.4)
+
+
+@pytest.mark.base
+def test_chp_opex_prices_the_hydrogen_it_actually_burned() -> None:
+    """A hydrogen unit's operating cost is the fuel it really drew, priced as green hydrogen.
+
+    The fuel mass is the ``GasDemandReal`` column -- what the unit got, not what it asked for --
+    integrated over the run and converted with hydrogen's lower heating value, the same one
+    ``i_simulate`` divided by. The CO2 is zero on purpose: the fuels table gives green hydrogen a
+    zero footprint per kWh, so the emissions sit with whatever produced the hydrogen, and a test
+    that demanded a positive number here would be demanding double counting.
+    """
+    chp = _build_chp(gas_type="Hydrogen")
+    frame = pd.DataFrame({0: [3000.0, 3000.0], 1: [4000.0, 4000.0], 2: [0.001, 0.001], 3: [1.0, 2.0]})
+
+    opex = chp.get_cost_opex(_fuel_outputs(chp), frame)
+
+    expected_kilowatt_hours = FUEL_BURNED_IN_KG * HYDROGEN_LOWER_HEATING_VALUE_IN_KWH_PER_KG
+    assert opex.loadtype == lt.LoadTypes.GREEN_HYDROGEN
+    assert opex.total_consumption_in_kwh == pytest.approx(expected_kilowatt_hours, rel=0.01)
+    # Cost is those kilowatt-hours times a positive per-kWh tariff, so the euros per kWh have to
+    # be a plausible tariff rather than zero or a thousandfold miss.
+    assert 0.0 < opex.opex_energy_cost_in_euro / opex.total_consumption_in_kwh < 2.0
+    assert opex.co2_footprint_in_kg == pytest.approx(0.0)
+    assert opex.opex_maintenance_cost_in_euro > 0.0
+
+
+@pytest.mark.base
+def test_chp_opex_prices_a_methane_unit_at_the_gas_tariff() -> None:
+    """A methane unit is priced and carbon-accounted as natural gas, not as hydrogen.
+
+    The fuel is chosen by the configured gas type, and it decides three things at once: the load
+    type the row carries, the heating value the mass is converted with, and which tariff applies.
+    Methane's heating value is under half hydrogen's per kilogram, so a unit that priced the same
+    mass as hydrogen would report more than twice the energy -- which is what this catches.
+    """
+    chp = _build_chp(gas_type="Methan")
+    frame = pd.DataFrame({0: [3000.0, 3000.0], 1: [4000.0, 4000.0], 2: [0.001, 0.001], 3: [1.0, 2.0]})
+
+    opex = chp.get_cost_opex(_fuel_outputs(chp), frame)
+
+    expected_kilowatt_hours = FUEL_BURNED_IN_KG * METHANE_LOWER_HEATING_VALUE_IN_KWH_PER_KG
+    assert opex.loadtype == lt.LoadTypes.GAS
+    assert opex.total_consumption_in_kwh == pytest.approx(expected_kilowatt_hours, rel=0.01)
+    assert 0.0 < opex.opex_energy_cost_in_euro / opex.total_consumption_in_kwh < 2.0
+    assert 0.0 < opex.co2_footprint_in_kg / opex.total_consumption_in_kwh < 2.0
+
+
+@pytest.mark.base
+def test_chp_opex_refuses_a_missing_fuel_column() -> None:
+    """A missing output column raises naming the KPI instead of costing the run as free.
+
+    The operating cost reads the same four columns the KPIs do, so an absent fuel column would
+    otherwise be reported as zero euros -- a run that looks free rather than unmeasured.
+    """
+    chp = _build_chp(gas_type="Hydrogen")
+
+    with pytest.raises(ValueError, match="Electrical energy produced"):
+        chp.get_cost_opex([chp.gas_demand_real_used_channel], pd.DataFrame({0: [0.001]}))
+
+
+@pytest.mark.base
+def test_chp_config_refuses_a_non_positive_electrical_rating() -> None:
+    """A maximum electrical power of zero or less is refused at construction, by value.
+
+    The investment cost is that rating times a price per kilowatt, so an unrated machine would be
+    costed at zero euros and reported as an answer -- a device that reads as free rather than as
+    unsized. The configuration is where that stops.
+    """
+    for wrong in (0.0, -1.0):
+        with pytest.raises(ValueError, match="maximum electrical power"):
+            _build_config(p_el_max=wrong)

--- a/tests/test_system_setups_dynamic_components.py
+++ b/tests/test_system_setups_dynamic_components.py
@@ -1,54 +1,143 @@
 """Test for system setup dynamic component."""
 
-import os
+from pathlib import Path
+import shutil
+from typing import Iterator
+
+import pandas as pd
 import pytest
 
 from hisim import hisim_main
-from hisim.simulationparameters import SimulationParameters
 from hisim import utils
 from hisim.result_path_provider import ResultPathProviderSingleton
 
+from tests.functions_for_testing import SetupTestParameters
+from tests.testing_utils import TestingUtils
 
-# This setup cannot yet be run with the KPI and cost options that
-# tests.functions_for_testing.SetupTestParameters switches on, and the omission is recorded here
-# rather than left as an absence. The CHP refuses to report operating costs, and refusing is
-# correct: the cost exists and has not been modelled, so answering zero would understate the system
-# total silently. Component.MODELS_NO_DEVICE is only for components that genuinely have none.
-# Switch this test over once that cost model is written -- see the family-A entry in the setup
-# sweep.
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+DYNAMIC_COMPONENTS_SETUP_PATH: str = str(REPO_ROOT / "system_setups" / "dynamic_components.py")
+#: The runtime names the setup gives its two CHPs, which are also how they are written into the
+#: "Component" column of both cost tables.
+CHP_COMPONENT_NAMES: tuple[str, ...] = ("CHP1", "CHP2")
+
+
+@pytest.fixture(name="isolated_result_directory")
+def fixture_isolated_result_directory() -> Iterator[str]:
+    """Provide a clean, deterministic, test-scoped result directory and tear it down afterwards.
+
+    ``TestingUtils.get_result_directory`` configures the global
+    :class:`ResultPathProviderSingleton` into ``RunMode.TEST`` and returns a path under
+    ``<repo>/results/test/<test_name>`` (which is gitignored). The directory is removed before the
+    test, so stale artefacts from a previous run cannot mask a regression, and again afterwards --
+    also on failure -- so artefacts do not accumulate. The singleton is reset on both sides so the
+    TEST-mode configuration cannot leak into sibling tests.
+
+    Yields:
+        str: the result directory the run writes into.
+    """
+    directory = TestingUtils.get_result_directory()
+    # The simulator consumes the explicit ``result_directory`` set on the SimulationParameters
+    # directly, so the (TEST-mode) provider is not consulted during the run. Reset it so the
+    # global state does not leak while the test body runs.
+    ResultPathProviderSingleton.reset()
+    if Path(directory).is_dir():
+        shutil.rmtree(directory)
+    try:
+        yield directory
+    finally:
+        ResultPathProviderSingleton.reset()
+        if Path(directory).is_dir():
+            shutil.rmtree(directory)
+
+
+def _cost_row(table: pd.DataFrame, component_name: str, table_name: str) -> pd.Series:
+    """Return the one row of a cost table that belongs to ``component_name``.
+
+    The cost tables carry the component's runtime name -- and nothing else -- in their leading
+    "Component" column, so the row is matched on equality rather than on a substring: the two CHPs
+    are named CHP1 and CHP2, and a substring match on "CHP" would accept either of them for the
+    other. The separator and total rows the writer appends carry no component name and simply do
+    not match.
+
+    Args:
+        table: the parsed cost table.
+        component_name: the runtime component name whose row is wanted.
+        table_name: the file the table was read from, for the failure message.
+
+    Returns:
+        pd.Series: the single matching row, indexed by the table's column headers.
+    """
+    matching = table[table["Component"].astype(str).str.strip() == component_name]
+    assert len(matching) == 1, (
+        f"Expected exactly one {component_name} row in {table_name}, found {len(matching)}"
+    )
+    return matching.iloc[0]
+
+
 @pytest.mark.extendedbase
 @utils.measure_execution_time
-def test_dynamic_components_system_setup() -> None:
-    """Test dynamic components system setup.
+def test_dynamic_components_system_setup(isolated_result_directory: str) -> None:
+    """Test dynamic components system setup for a single day, costs and KPIs included.
 
-    Runs the dynamic-components setup for a single day and verifies that the
-    simulation runs to completion and writes its outputs to the result directory
-    selected by the ResultPathProvider.
+    Runs the dynamic-components setup for one day and verifies that the simulation runs to
+    completion and writes its outputs.
+
+    The parameters come from :class:`tests.functions_for_testing.SetupTestParameters`, which
+    switches on COMPUTE_OPEX, COMPUTE_CAPEX and the two KPI options. That matters here
+    specifically: those three run *before* the KPIs in post-processing, and until the CHP had a
+    cost model a stock all-options run of this setup died in COMPUTE_OPEX before any KPI was
+    computed. The cost tables asserted below are what catches that regression -- the log and the
+    flag alone would not, because they are written even by a run whose cost stage was never asked
+    to answer.
+
+    Args:
+        isolated_result_directory: the test-scoped result directory from the fixture.
     """
+    sim_params = SetupTestParameters.one_day_with_kpis(year=2021, seconds_per_timestep=60)
+    # Route results into the isolated, test-scoped directory provided by the fixture so that
+    # stale artefacts from a previous run cannot mask a regression and so the test cleans up
+    # after itself.
+    sim_params.result_directory = isolated_result_directory
 
-    dynamic_components_setup_path = "../system_setups/dynamic_components.py"
-    dynamic_components_setup_path = "../system_setups/dynamic_components.py"
-    mysimpar = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    hisim_main.main(dynamic_components_setup_path, mysimpar)
+    hisim_main.main(DYNAMIC_COMPONENTS_SETUP_PATH, sim_params)
 
-    # hisim_main.main runs the full simulation. The simulator writes its outputs into
-    # the directory provided by the ResultPathProvider (see Simulator.prepare_simulation_directory).
-    # Assert that a result directory was actually created and that the run produced
-    # outputs there, instead of only checking that nothing raised.
-    result_directory = ResultPathProviderSingleton().get_result_directory_name()
-    assert result_directory is not None, (
-        "ResultPathProvider did not provide a result directory after the simulation."
+    # `finished.flag` is written at the very end of a successful simulation run (see
+    # Simulator.run_all_timesteps), so it is a reliable signal that the setup ran to completion.
+    results_dir = Path(sim_params.result_directory)
+    assert results_dir.is_dir(), f"Result directory was not created: {results_dir}"
+    assert (results_dir / "finished.flag").is_file(), (
+        f"finished.flag missing in results directory: {results_dir}"
     )
-    assert os.path.isdir(result_directory), (
-        f"Result directory was not created: {result_directory}"
+    assert (results_dir / "hisim_simulation.log").is_file(), (
+        f"hisim_simulation.log missing in results directory: {results_dir}"
     )
-    assert os.listdir(result_directory), (
-        f"Result directory is empty: {result_directory}"
-    )
-    # `finished.flag` is written at the very end of a successful simulation run
-    # (see Simulator.run_all_timesteps), so it is a reliable signal that the
-    # dynamic-components setup ran to completion.
-    finished_flag = os.path.join(result_directory, "finished.flag")
-    assert os.path.isfile(finished_flag), (
-        f"Simulation did not write the completion flag: {finished_flag}"
+    # The cost stages write one table each (semicolon-separated, one header row, the component
+    # name in the leading "Component" column), and only if they were reached and answered. Both
+    # CHPs have to appear by name and with an investment above zero: a component whose cost model
+    # went missing again would either raise or drop out of the table, and one that answered zero
+    # would understate the system total while still looking like an answer.
+    operational_costs = pd.read_csv(results_dir / "operational_costs_co2_footprint.csv", sep=";")
+    investment_costs = pd.read_csv(results_dir / "investment_cost_co2_footprint.csv", sep=";")
+    for component in CHP_COMPONENT_NAMES:
+        capex_row = _cost_row(investment_costs, component, "investment_cost_co2_footprint.csv")
+        assert capex_row["Investment [EUR]"] > 0.0, (
+            f"{component} reports no investment in investment_cost_co2_footprint.csv"
+        )
+        assert capex_row["Device CO2-footprint [kg]"] > 0.0, (
+            f"{component} reports no device CO2 in investment_cost_co2_footprint.csv"
+        )
+        # The operating cost is asserted as a row that exists and is not negative rather than as a
+        # positive number: whether these two CHPs are dispatched at all on the simulated day is the
+        # energy management's decision, and a day on which they stayed off is a legitimate zero.
+        opex_row = _cost_row(operational_costs, component, "operational_costs_co2_footprint.csv")
+        assert opex_row["Costs of energy consumption [EUR]"] >= 0.0, (
+            f"{component} reports a negative energy cost in operational_costs_co2_footprint.csv"
+        )
+        assert opex_row["Maintenance costs per year [EUR]"] > 0.0, (
+            f"{component} reports no maintenance cost in operational_costs_co2_footprint.csv"
+        )
+    # WRITE_KPIS_TO_JSON is on, so the KPI stage after the cost stages ran too.
+    assert (results_dir / "all_kpis.json").is_file(), (
+        f"all_kpis.json missing in results directory: {results_dir}"
     )


### PR DESCRIPTION
The golden gate now runs COMPUTE_OPEX and COMPUTE_CAPEX (golden_gate_costs), and the dynamic_components run died in the first of them: the two CHPs are real appliances with no cost methods. Following #652 device for device, CHPConfig carries the five standard cost fields, refuses a non-positive electrical rating, and CHP implements get_cost_capex through the shared helpers and get_cost_opex on the fuel it actually burned, priced at the hydrogen or natural-gas factors per the configured gas type.

The device database gains a CHP row under its own proposed-values header: 5500 EUR/kW electrical, 2.7 %/yr maintenance derived from the same source's per-kWh figure, 14-year appliance life (Clean Hydrogen Partnership MAWP KPIs, 2024 state of the art, added as source [51]), embodied CO2 from the existing hydrogen fuel-cell row. The setup's two twins are re-recorded; the setup test runs the day with the full cost option set and matches both CHP rows in the cost tables. Seven unit tests pin linearity in the rating, config-over-database precedence, both fuel tariffs and the refusals.

Goldens are deliberately not re-blessed here; golden_gate_costs re-blesses everything once this lands. Note the CHPs are never dispatched on the simulated day, so their energy cost is legitimately zero and only maintenance and investment are asserted positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLee5wPmjPP77wSEQ1D9ZC