### PR TITLE
Cost stack 9/9, slice 2 of 8: the layouts and the prose land first, because both renderers read them

### DIFF
--- a/hisim/economics/presentation_style.py
+++ b/hisim/economics/presentation_style.py
@@ -24,8 +24,10 @@ import-lint that pins that is `tests/test_economics_import_lint.py`.
 
 from __future__ import annotations
 
+import math
+import types
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
+from typing import Dict, List, Mapping, Tuple
 
 from hisim.economics.timeline import CostCategory
 
@@ -131,23 +133,29 @@ class ChromeColors:
     remembering a position in a list.
 
     Note for the renderer slices: `report_plots._Palette` and the `:root` block of
-    `reporting/sections.py` still carry their own copies of these four values. Rewiring both to
-    this namespace belongs with those modules and is deliberately not done here — this slice only
-    establishes the single source they will read.
+    `reporting/sections.py` carry their own copies of these four values until the slices that own
+    those modules rewire them to this namespace — that rewiring lives higher in this stack, not
+    here; this slice only establishes the single source they read.
+
+    Both maps are read-only proxies rather than plain dicts. A palette is a constant of the
+    document, and a renderer that reached in and assigned one role would change every chart drawn
+    after it in the same process — including the other renderer's — with nothing in the output
+    saying where the colour came from. Item access is unchanged, so `ChromeColors.LIGHT["surface"]`
+    reads exactly as it did; only assignment is refused, at the point that attempts it.
     """
 
-    LIGHT: Dict[str, str] = {
+    LIGHT: Mapping[str, str] = types.MappingProxyType({
         "surface": "#fcfcfb",
         "ink": "#0b0b0b",
         "muted": "#898781",
         "grid": "#e1e0d9",
-    }
-    DARK: Dict[str, str] = {
+    })
+    DARK: Mapping[str, str] = types.MappingProxyType({
         "surface": "#1a1a19",
         "ink": "#ffffff",
         "muted": "#898781",
         "grid": "#2c2c2a",
-    }
+    })
 
 
 def squarified_layout(
@@ -155,10 +163,25 @@ def squarified_layout(
 ) -> List[Tuple[float, float, float, float]]:
     """The classic squarified-treemap layout: one rectangle per value, in the input's order.
 
-    Lays descending areas out in rows (or columns, whichever the remaining rectangle is wider
-    in) so that the tiles stay as close to square as possible, which is what makes areas
-    comparable by eye at all. The returned rectangles tile the given box exactly, so a treemap's
-    "areas sum to the total" invariant survives the layout.
+    Lays the areas out in rows (or columns, whichever the remaining rectangle is wider in) so
+    that the tiles stay as close to square as possible, which is what makes areas comparable by
+    eye at all. The returned rectangles tile the given box exactly, so a treemap's "areas sum to
+    the total" invariant survives the layout.
+
+    **Descending order is a precondition of the near-square guarantee**, not something this
+    function arranges: it lays the values out in the order it is given, because the caller's order
+    is what pairs each rectangle with its label and its colour, and sorting here would silently
+    break that pairing. Squarify's quality argument assumes the largest areas are placed first —
+    hand it an ascending list and it still tiles the box exactly, still returns the rectangles in
+    input order, and still guarantees nothing about their aspect ratios. Callers that group tiles
+    by colour before sorting by size within the group therefore get near-square tiles per group
+    rather than over the whole box, which is the trade they are making knowingly.
+
+    **Every value has to be a positive, finite area** and a violation raises rather than drawing:
+    a zero or negative area has no rectangle, and a caller that passes one is either showing the
+    reader a tile that means nothing or has an amount whose sign it has not decided about. The
+    tiling arithmetic would not notice — a zero tile comes back as a zero-height rectangle and a
+    negative one eats into its row — so the wrong picture would be drawn in silence.
 
     It lives in this module — with the display grouping and the palette rather than with either
     renderer — for the same reason those do: the matplotlib PNG and the inline-SVG report both
@@ -168,7 +191,8 @@ def squarified_layout(
     deliberately not depended on (visualization spec §3, V8).
 
     Args:
-        values: Tile areas in any unit; non-positive values are the caller's to filter out.
+        values: Tile areas in any unit, every one of them positive and finite, largest first (see
+            above). An empty list is not an error and lays nothing out.
         x: Left edge of the box to fill.
         y: Bottom (or top — the caller's coordinate convention) edge of the box.
         width: Box width in the same units as `x`.
@@ -176,7 +200,19 @@ def squarified_layout(
 
     Returns:
         One `(x, y, width, height)` per input value, in input order.
+
+    Raises:
+        ValueError: If any value is zero, negative or not finite; the message names the index and
+            the value.
     """
+    for index, value in enumerate(values):
+        if not math.isfinite(value) or value <= 0.0:
+            raise ValueError(
+                f"squarified_layout needs positive, finite areas, but values[{index}] is {value!r}. "
+                "A treemap tile is an area: zero has no rectangle, a negative one has no meaning, "
+                "and either would be laid out without complaint. Filter or fix the amount at the "
+                "call site, where it is known whether it is an empty category or a sign error."
+            )
     total = sum(values) or 1.0
     scaled = [value * width * height / total for value in values]
     rectangles: List[Tuple[float, float, float, float]] = []
@@ -216,13 +252,18 @@ def _worst_aspect(row: List[float], side: float) -> float:
     """Worst width/height ratio of a candidate treemap row — squarify's quality measure.
 
     The algorithm keeps adding tiles to a row while this does not get worse and closes the row
-    the moment it does. A zero-area row is reported as infinitely bad so that it can never win a
-    comparison and stall the layout.
+    the moment it does. A zero-area row, or a row holding a zero-area tile, is reported as
+    infinitely bad so that it can never win a comparison and stall the layout. `squarified_layout`
+    already refuses a non-positive value before any row is built, so neither guard can fire on the
+    public path; they stay as defence in depth, because the alternative to an `inf` here is a
+    `ZeroDivisionError` from inside a layout, which says nothing about the amount that caused it.
     """
     total = sum(row)
     if total <= 0:
         return float("inf")
     largest, smallest = max(row), min(row)
+    if smallest <= 0:
+        return float("inf")
     return max(side * side * largest / (total * total), (total * total) / (side * side * smallest))
 
 
@@ -278,8 +319,10 @@ class RibbonSegment:
     leg, which is the shape every ribbon used to have.
 
     `out_anchor` is the offset of the leg's start above the bottom of the source node's right
-    face, `in_anchor` the same for the target node's left face — the same convention as
-    `SankeyGeometry.ribbon_anchors`, which is now the first and last leg of the chain.
+    face, `in_anchor` the same for the target node's left face. The two ends of the whole ribbon
+    are therefore the first leg's `out_anchor` and the last leg's `in_anchor`; there is no
+    separate projection of that pair, because a renderer that draws the chain already walks past
+    both and one that draws only the ends would draw a curve through whatever lies between.
     """
 
     source: str
@@ -318,26 +361,26 @@ class SankeyGeometry:
     maps a node id to `(x of its left edge, y of its bottom, height)` in the unit square;
     `unit_scale` is the height one unit of flow occupies — *the same number in every column*, which
     is what makes a ribbon keep its width from end to end (visualization spec rule 2.7); and
-    `ribbon_anchors` gives, per input ribbon and in the input's order, the offsets of its two ends
-    above the bottom of their node, so the ribbons on a face tile it exactly in the crossing-
-    minimizing order (Q19).
+    `ribbon_segments` gives, per input ribbon and in the input's order, the chain of legs it is
+    drawn as (Q29 R7): one leg per column gap, each carrying the offsets of its two ends above the
+    bottom of their node, so the ribbons on a face tile it exactly in the crossing-minimizing order
+    (Q19). A ribbon between neighbouring columns is a chain of one, which is the shape every ribbon
+    used to have; the ribbon's own two ends are the first leg's `out_anchor` and the last leg's
+    `in_anchor`.
 
     Handing the scale out rather than letting each renderer re-derive it from a node's height is
     the whole point: dividing a node's height by what it carries reproduces a per-node scale, and
     a middle column that carries each unit twice then gets a different one from its neighbours —
     which is exactly the defect this replaced.
 
-    `ribbon_segments` is the routed form of the same ribbons (Q29 R7): one leg per column gap, so
-    a renderer draws a chain rather than one curve across whatever lies between. `ribbon_anchors`
-    remains the (first out, last in) pair of each chain. `boxes` also contains the virtual nodes
-    the routing introduced — their ids start with `SankeyLayout.VIRTUAL_NODE_PREFIX` and they are
-    deliberately *not* in any caller's column list, so a renderer that draws the columns it was
-    handed never draws them. `net_stubs` closes the faces that ribbons do not fill.
+    `boxes` also contains the virtual nodes the routing introduced — their ids start with
+    `SankeyLayout.VIRTUAL_NODE_PREFIX` and they are deliberately *not* in any caller's column list,
+    so a renderer that draws the columns it was handed never draws them. `net_stubs` closes the
+    faces that ribbons do not fill.
     """
 
     boxes: Dict[str, Tuple[float, float, float]]
     unit_scale: float
-    ribbon_anchors: List[Tuple[float, float]]
     ribbon_segments: List[List[RibbonSegment]] = field(default_factory=list)
     net_stubs: List[NetStub] = field(default_factory=list)
 
@@ -458,6 +501,13 @@ def _crossing_count(
     positions and needs no geometry. It is what the ordering is now *scored* by — barycenter
     sweeps are a heuristic and can make a picture worse, as run 1's rented view showed, so the
     layout keeps the best-scoring pass rather than the last one.
+
+    Cost: every call recounts every crossing from scratch, and `_transposed` calls it once per
+    candidate swap, which is quadratic in a column's nodes and quadratic again in the legs of a
+    gap. That is the right trade for the diagrams this report draws — a dozen nodes and a couple
+    of dozen ribbons, where the whole layout is microseconds. The upgrade, if a diagram ever grows
+    past a few dozen nodes, is delta scoring: a single adjacent swap changes only the crossings
+    within that one gap pair, so the count can be updated rather than recomputed.
     """
     position = {node: index for nodes in order for index, node in enumerate(nodes)}
     by_gap: Dict[int, List[Tuple[str, str]]] = {}
@@ -484,6 +534,11 @@ def _transposed(
     last tangles, and it is the standard companion pass. Deterministic: columns are visited left
     to right, pairs bottom to top, and a swap is kept only on a strict improvement, so equal-cost
     alternatives never flip a re-render.
+
+    Cost: each candidate swap is scored by a full `_crossing_count` of the whole drawing rather
+    than by the change it makes in its own gap. Recounting is fine at report scale (a dozen nodes)
+    and delta scoring per gap is the upgrade when a diagram exceeds a few dozen; nothing here is
+    on a path where that has ever mattered.
     """
     current = [list(nodes) for nodes in order]
     score = _crossing_count(current, legs, column_of)
@@ -566,19 +621,41 @@ def sankey_node_boxes(
     Coordinates are fractions of a unit square with y growing upward; a renderer whose y grows
     downward (SVG) flips them itself.
 
+    **Bad input is refused, not drawn.** A ribbon amount has to be positive and finite, and both
+    of a ribbon's nodes have to be declared by some column. A zero-width ribbon is a flow the
+    reader cannot see but which still claims height on both faces it touches; a negative one is a
+    sign the caller has not resolved, and a Sankey encodes direction in the node pair rather than
+    in a sign; and a ribbon naming an undeclared node used to be kept, silently skipped by every
+    renderer, and yet counted into its source node's face height — a node drawn taller than the
+    ribbons that tile it, for a reason nothing in the picture states.
+
     Args:
         columns: Node ids per column, left to right. The order within a column is the sweep's
             starting point.
-        ribbons: `(source id, target id, amount)` triples; only the amounts are read here.
-            Amounts are expected non-negative — a Sankey ribbon has no sign, and the callers
-            encode direction in the node pair.
+        ribbons: `(source id, target id, amount)` triples; only the amounts are read here. Every
+            amount has to be positive and finite and both node ids have to appear in `columns`.
+            An empty list is not an error: the declared nodes are placed with height zero and
+            `unit_scale` comes back as `0.0`, which is the honest geometry of a diagram with
+            nothing in it.
 
     Returns:
-        A `SankeyGeometry` whose `ribbon_anchors` are index-aligned with `ribbons`. A node named
+        A `SankeyGeometry` whose `ribbon_segments` are index-aligned with `ribbons`. A node named
         in `columns` but carrying no flow gets height zero: under one global scale "no flow" is
         genuinely no height, and inventing a share for it would re-introduce a second scale
         through the back door.
+
+    Raises:
+        ValueError: If a ribbon amount is zero, negative or not finite, or if a ribbon names a
+            node no column declares; the message names the ribbon.
     """
+    for index, (source, target, amount) in enumerate(ribbons):
+        if not math.isfinite(amount) or amount <= 0.0:
+            raise ValueError(
+                f"Sankey ribbon {index} ({source!r} -> {target!r}) carries {amount!r}. A ribbon "
+                "amount has to be positive and finite: a Sankey has no sign — direction is the "
+                "node pair — and a zero-width ribbon is invisible while still claiming a slot on "
+                "both faces it touches. Drop or fix the flow where it is built."
+            )
     routed_columns, segments, legs_of_ribbon = _route_through_corridors(columns, ribbons)
     outgoing: Dict[str, float] = {}
     incoming: Dict[str, float] = {}
@@ -614,10 +691,6 @@ def sankey_node_boxes(
     return SankeyGeometry(
         boxes=boxes,
         unit_scale=unit_scale,
-        ribbon_anchors=[
-            (chain[0].out_anchor, chain[-1].in_anchor) if chain else (0.0, 0.0)
-            for chain in ribbon_segments
-        ],
         ribbon_segments=ribbon_segments,
         net_stubs=_net_stubs(columns, incoming, outgoing, unit_scale),
     )
@@ -639,13 +712,22 @@ def _route_through_corridors(
     function of the input and a re-render is byte-identical. They are appended to the intermediate
     column in ribbon order; where they end up vertically is the barycenter sweeps' business.
 
+    A ribbon naming a node no column declares is refused here rather than routed. It used to be
+    kept as a single leg with no geometry: every renderer skipped it, so the flow was invisible,
+    while its amount still counted into the source node's outgoing total and made that node taller
+    than the ribbons tiling it. A misspelt or unlisted node is a caller bug, and the only place it
+    is still identifiable is here, where the id is in hand.
+
     Args:
         columns: The caller's columns, left to right; read for membership and column index.
         ribbons: `(source, target, amount)` triples in the caller's order.
 
     Returns:
-        `(columns including the virtual nodes, legs, leg indices per ribbon)`. A ribbon naming a
-        node no column declares keeps its single leg, which the renderers skip as they always did.
+        `(columns including the virtual nodes, legs, leg indices per ribbon)`.
+
+    Raises:
+        ValueError: If a ribbon names a node that appears in no column; the message names both
+            the node and the ribbon it belongs to.
     """
     column_of = {node: index for index, nodes in enumerate(columns) for node in nodes}
     routed = [list(nodes) for nodes in columns]
@@ -653,7 +735,15 @@ def _route_through_corridors(
     legs_of_ribbon: List[List[int]] = []
     for index, (source, target, amount) in enumerate(ribbons):
         source_column, target_column = column_of.get(source), column_of.get(target)
-        if source_column is None or target_column is None or abs(target_column - source_column) <= 1:
+        if source_column is None or target_column is None:
+            missing = source if source_column is None else target
+            raise ValueError(
+                f"Sankey ribbon {index} ({source!r} -> {target!r}) names {missing!r}, which no "
+                "column declares. Such a ribbon has nowhere to be drawn, so every renderer used "
+                "to drop it while its amount still made the node it left taller than the ribbons "
+                "that tile it. List the node in a column, or do not emit the flow."
+            )
+        if abs(target_column - source_column) <= 1:
             legs_of_ribbon.append([len(segments)])
             segments.append((source, target, amount))
             continue
@@ -723,20 +813,19 @@ def _ribbon_anchors(
     cumulative and uses the global scale, which is what makes the ribbons tile the face exactly.
 
     Returns the anchors index-aligned with `ribbons`, so a renderer can iterate the flows in its
-    own order (colour, credit-versus-cost) without disturbing the geometry. A ribbon naming a node
-    the layout does not know gets `(0.0, 0.0)`; renderers skip those anyway.
+    own order (colour, credit-versus-cost) without disturbing the geometry. Every node named here
+    is in `boxes`: this runs on the routed legs, and `sankey_node_boxes` has already refused a
+    ribbon naming a node no column declares, so there is no unplaceable end left to skip.
     """
     def centre(node: str) -> float:
         """Vertical middle of a node, the key both stacking orders sort on."""
-        _x, y, height = boxes.get(node, (0.0, 0.0, 0.0))
+        _x, y, height = boxes[node]
         return y + height / 2.0
 
     anchors: List[Tuple[float, float]] = [(0.0, 0.0)] * len(ribbons)
     for is_outgoing in (True, False):
         by_node: Dict[str, List[int]] = {}
         for index, (source, target, _amount) in enumerate(ribbons):
-            if source not in boxes or target not in boxes:
-                continue
             by_node.setdefault(source if is_outgoing else target, []).append(index)
         for indices in by_node.values():
             offset = 0.0

--- a/hisim/economics/presentation_style.py
+++ b/hisim/economics/presentation_style.py
@@ -1,4 +1,4 @@
-"""Display grouping and the categorical palette, shared by every report output (W4.7).
+"""Display grouping, palette and layout geometry, shared by every report output (W4.7).
 
 The 16+ cost categories of `timeline.CostCategory` fold onto 8 display groups so a fixed
 categorical palette covers them and a group keeps its hue across the HTML report, the SVG
@@ -7,14 +7,24 @@ leaves on the presentation side (§2.4, stated exception): the grouping is a dis
 the group **sums** are not, and come from `views.fold_categories` / `views.fold_category_matrix`,
 into which presentation passes `CATEGORY_TO_GROUP`.
 
-This module exists so `report_plots.py` no longer imports `reporting.py` (and through it the
-engine) just to learn what colour "Energy" is. It imports nothing but `timeline.CostCategory`,
+Beside the grouping sit the things two renderers would otherwise each own a copy of: the four
+neutral chrome colours (`ChromeColors`) and the two layout algorithms every shared chart needs —
+`squarified_layout` for the treemap and `sankey_node_boxes` for the whole Sankey family. Both the
+matplotlib PNGs and the inline SVGs of the `reporting` package draw those charts, and a layout
+implemented twice eventually places the same tile or the same ribbon end in two different spots,
+which reads as two different charts of the same number. Geometry is not a computation in the
+seam-4 sense: nothing here reads a result or derives a figure, it only turns amounts a view
+already produced into rectangles.
+
+This module exists so `report_plots.py` no longer imports the `reporting` package (and through it
+the engine) just to learn what colour "Energy" is. It imports nothing but `timeline.CostCategory`,
 which makes it importable from either side of the seam without dragging anything along; the
-import-lint that pins that (`tests/test_economics_import_lint.py`) arrives with stack part 8/8.
+import-lint that pins that is `tests/test_economics_import_lint.py`.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
 from hisim.economics.timeline import CostCategory
@@ -101,6 +111,647 @@ class PresentationStyle:
     #: enforced, not defaulted: a category `DISPLAY_GROUPS` does not declare fails the import of
     #: this module by name rather than being folded into group 0 (see `_build_category_to_group`).
     CATEGORY_TO_GROUP: Dict[CostCategory, int] = _build_category_to_group(DISPLAY_GROUPS)
+
+
+class ChromeColors:
+    """The four neutral chrome roles of a chart — surface, ink, muted, grid — in one place.
+
+    The *non*-data colours: the background a chart sits on, the colour its text is set in, the
+    quieter tone of ticks and secondary labels, and the tone of the gridlines and spines. They are
+    here for the same reason `GROUP_COLORS_LIGHT` is: the HTML report declares them as CSS custom
+    properties and the matplotlib companions bake them into every PNG, and a report whose SVG
+    gridlines are a different grey from its PNG gridlines reads as two documents rather than one.
+    Keeping the values in this module makes that a fact of the build rather than of two people
+    copying the same hex string.
+
+    The two sets exist because the outputs differ in what they can do, not in what they mean: the
+    HTML report re-resolves the roles under `prefers-color-scheme: dark`, while a PNG is baked once
+    and may end up in a PDF or a slide, so it always takes the light values. `LIGHT` and `DARK` map
+    a role name to its hex value, so a caller reads `ChromeColors.LIGHT["surface"]` rather than
+    remembering a position in a list.
+
+    Note for the renderer slices: `report_plots._Palette` and the `:root` block of
+    `reporting/sections.py` still carry their own copies of these four values. Rewiring both to
+    this namespace belongs with those modules and is deliberately not done here — this slice only
+    establishes the single source they will read.
+    """
+
+    LIGHT: Dict[str, str] = {
+        "surface": "#fcfcfb",
+        "ink": "#0b0b0b",
+        "muted": "#898781",
+        "grid": "#e1e0d9",
+    }
+    DARK: Dict[str, str] = {
+        "surface": "#1a1a19",
+        "ink": "#ffffff",
+        "muted": "#898781",
+        "grid": "#2c2c2a",
+    }
+
+
+def squarified_layout(
+    values: List[float], x: float, y: float, width: float, height: float
+) -> List[Tuple[float, float, float, float]]:
+    """The classic squarified-treemap layout: one rectangle per value, in the input's order.
+
+    Lays descending areas out in rows (or columns, whichever the remaining rectangle is wider
+    in) so that the tiles stay as close to square as possible, which is what makes areas
+    comparable by eye at all. The returned rectangles tile the given box exactly, so a treemap's
+    "areas sum to the total" invariant survives the layout.
+
+    It lives in this module — with the display grouping and the palette rather than with either
+    renderer — for the same reason those do: the matplotlib PNG and the inline-SVG report both
+    draw the treemap, and two copies of a layout would eventually place the same tiles
+    differently. It needs no imports at all, which is what keeps this module importable from
+    either side of the seam. The `squarify` PyPI package implements the same algorithm and is
+    deliberately not depended on (visualization spec §3, V8).
+
+    Args:
+        values: Tile areas in any unit; non-positive values are the caller's to filter out.
+        x: Left edge of the box to fill.
+        y: Bottom (or top — the caller's coordinate convention) edge of the box.
+        width: Box width in the same units as `x`.
+        height: Box height.
+
+    Returns:
+        One `(x, y, width, height)` per input value, in input order.
+    """
+    total = sum(values) or 1.0
+    scaled = [value * width * height / total for value in values]
+    rectangles: List[Tuple[float, float, float, float]] = []
+    remaining = list(scaled)
+    origin_x, origin_y, box_w, box_h = x, y, width, height
+    while remaining:
+        row: List[float] = [remaining[0]]
+        rest = remaining[1:]
+        side = min(box_w, box_h) or 1.0
+        while rest and _worst_aspect(row + [rest[0]], side) <= _worst_aspect(row, side):
+            row.append(rest[0])
+            rest = rest[1:]
+        row_area = sum(row)
+        if box_w >= box_h:
+            row_width = row_area / box_h if box_h else 0.0
+            offset = origin_y
+            for area in row:
+                tile_height = area / row_width if row_width else 0.0
+                rectangles.append((origin_x, offset, row_width, tile_height))
+                offset += tile_height
+            origin_x += row_width
+            box_w = max(box_w - row_width, 0.0)
+        else:
+            row_height = row_area / box_w if box_w else 0.0
+            offset = origin_x
+            for area in row:
+                tile_width = area / row_height if row_height else 0.0
+                rectangles.append((offset, origin_y, tile_width, row_height))
+                offset += tile_width
+            origin_y += row_height
+            box_h = max(box_h - row_height, 0.0)
+        remaining = rest
+    return rectangles
+
+
+def _worst_aspect(row: List[float], side: float) -> float:
+    """Worst width/height ratio of a candidate treemap row — squarify's quality measure.
+
+    The algorithm keeps adding tiles to a row while this does not get worse and closes the row
+    the moment it does. A zero-area row is reported as infinitely bad so that it can never win a
+    comparison and stall the layout.
+    """
+    total = sum(row)
+    if total <= 0:
+        return float("inf")
+    largest, smallest = max(row), min(row)
+    return max(side * side * largest / (total * total), (total * total) / (side * side * smallest))
+
+
+class SankeyLayout:
+    """Shared geometry of the hand-drawn Sankeys (V1, V10, V11, V12).
+
+    All values are fractions of the unit square the diagram is laid out in, so the same numbers
+    work at any figure or viewBox size. `CURVATURE` is the share of the horizontal gap the Bézier
+    control points sit at — 0 would draw straight trapezoids, 1 makes every ribbon leave and
+    arrive perfectly horizontally, and the value here is the compromise that keeps crossing
+    ribbons distinguishable. It sits beside the palette because both renderers read it and a
+    ribbon that curves differently in the PNG than in the report would look like a different
+    chart.
+
+    There is deliberately no same-column geometry any more: owner decision Q23 gave every
+    internal party its own column, so an inter-actor transfer is an ordinary ribbon between two
+    adjacent columns and the looping band the levy used to be drawn as — with its own bulge
+    constant and its own width correction — is gone from both renderers.
+    """
+
+    NODE_WIDTH = 0.035
+    NODE_GAP = 0.012
+    CURVATURE = 0.42
+    #: Smallest usable fraction of the unit square a column may be squeezed into by its node gaps;
+    #: a diagram with more nodes than gaps fit keeps drawing rather than collapsing to nothing.
+    MINIMUM_USABLE_HEIGHT = 0.1
+    #: Alternating barycenter passes over the columns (Q19). Four is the usual stopping point for
+    #: this heuristic: the ordering is almost always stable after two, and more passes trade run
+    #: time for nothing while risking a two-cycle that never settles.
+    BARYCENTER_SWEEPS = 4
+    #: Passes of the adjacent-swap refinement after each barycenter sweep (Q29 R7). It stops as
+    #: soon as a full pass improves nothing, so the bound only caps a pathological input.
+    TRANSPOSE_ROUNDS = 8
+    #: Prefix of the virtual (dummy) nodes that give a column-skipping ribbon a corridor to route
+    #: through (Q29 R7). Renderers never draw a node they were not handed, and every id built here
+    #: starts with this, so a renderer can also assert on it.
+    VIRTUAL_NODE_PREFIX = "__via:"
+    #: Length of a net-position stub as a fraction of the horizontal column pitch. Long enough to
+    #: read as a flow leaving the face, far too short to be mistaken for a ribbon to a neighbour.
+    STUB_LENGTH = 0.28
+    #: Height (as a fraction of the unit square) below which a face remainder is float noise
+    #: rather than a net position, and no stub is emitted for it.
+    MINIMUM_STUB_HEIGHT = 1e-4
+
+
+@dataclass(frozen=True)
+class RibbonSegment:
+    """One column-to-column leg of a ribbon, with the offsets of its two ends (Q29 R7).
+
+    A ribbon that skips a column is no longer drawn as one long curve past whatever happens to sit
+    in between; it is cut at every intermediate column, where a virtual node reserves exactly its
+    width, and drawn as a chain of these legs. A ribbon between neighbouring columns has a single
+    leg, which is the shape every ribbon used to have.
+
+    `out_anchor` is the offset of the leg's start above the bottom of the source node's right
+    face, `in_anchor` the same for the target node's left face — the same convention as
+    `SankeyGeometry.ribbon_anchors`, which is now the first and last leg of the chain.
+    """
+
+    source: str
+    target: str
+    out_anchor: float
+    in_anchor: float
+
+
+@dataclass(frozen=True)
+class NetStub:
+    """The unmatched remainder of a node's face: its net position, drawn (Q29 R7).
+
+    A node is drawn as tall as the larger of what enters and what leaves it, so an actor who
+    receives more than it passes on has an outgoing face that its ribbons do not fill. That
+    remainder is not nothing: it is precisely the actor's net gain, and leaving it blank was the
+    defect — a third of the landlord's block was untiled and unexplained. Rendered as a short stub
+    off the deficient face it makes both faces tile at 100 %.
+
+    `amount` is the absolute imbalance in flow units (the renderer formats and signs it),
+    `anchor` its offset above the bottom of that face — always the top of the tiled part, since
+    ribbons stack from the bottom — and `is_outgoing` says which face is short: True when more
+    arrives than leaves (a net gain), False when the node pays out more than it takes in.
+    """
+
+    node: str
+    amount: float
+    anchor: float
+    is_outgoing: bool
+
+
+@dataclass(frozen=True)
+class SankeyGeometry:
+    """Where every Sankey node sits, how wide a unit is, and where each ribbon attaches.
+
+    The complete layout both Sankey renderers consume, so that a renderer only has to draw. `boxes`
+    maps a node id to `(x of its left edge, y of its bottom, height)` in the unit square;
+    `unit_scale` is the height one unit of flow occupies — *the same number in every column*, which
+    is what makes a ribbon keep its width from end to end (visualization spec rule 2.7); and
+    `ribbon_anchors` gives, per input ribbon and in the input's order, the offsets of its two ends
+    above the bottom of their node, so the ribbons on a face tile it exactly in the crossing-
+    minimizing order (Q19).
+
+    Handing the scale out rather than letting each renderer re-derive it from a node's height is
+    the whole point: dividing a node's height by what it carries reproduces a per-node scale, and
+    a middle column that carries each unit twice then gets a different one from its neighbours —
+    which is exactly the defect this replaced.
+
+    `ribbon_segments` is the routed form of the same ribbons (Q29 R7): one leg per column gap, so
+    a renderer draws a chain rather than one curve across whatever lies between. `ribbon_anchors`
+    remains the (first out, last in) pair of each chain. `boxes` also contains the virtual nodes
+    the routing introduced — their ids start with `SankeyLayout.VIRTUAL_NODE_PREFIX` and they are
+    deliberately *not* in any caller's column list, so a renderer that draws the columns it was
+    handed never draws them. `net_stubs` closes the faces that ribbons do not fill.
+    """
+
+    boxes: Dict[str, Tuple[float, float, float]]
+    unit_scale: float
+    ribbon_anchors: List[Tuple[float, float]]
+    ribbon_segments: List[List[RibbonSegment]] = field(default_factory=list)
+    net_stubs: List[NetStub] = field(default_factory=list)
+
+
+def _place_nodes(
+    columns: List[List[str]], values_by_node: Dict[str, float], unit_scale: float
+) -> Dict[str, Tuple[float, float, float]]:
+    """Turns a column ordering into node rectangles under a given global scale.
+
+    Factored out of `sankey_node_boxes` because the barycenter sweeps need the *positions* an
+    ordering produces in order to score the next one, and re-deriving them by hand would let the
+    heuristic optimize a layout that is not the one drawn. Columns are vertically centred, so a
+    column carrying less than the fullest one sits in the middle rather than sinking to the floor.
+    """
+    boxes: Dict[str, Tuple[float, float, float]] = {}
+    column_count = max(len(columns), 1)
+    for index, nodes in enumerate(columns):
+        if not nodes:
+            continue
+        x = index * (1.0 - SankeyLayout.NODE_WIDTH) / max(column_count - 1, 1)
+        gaps = SankeyLayout.NODE_GAP * max(len(nodes) - 1, 0)
+        column_height = unit_scale * sum(values_by_node.get(node, 0.0) for node in nodes) + gaps
+        y = max((1.0 - column_height) / 2.0, 0.0)
+        for node in nodes:
+            height = unit_scale * values_by_node.get(node, 0.0)
+            boxes[node] = (x, y, height)
+            y += height + SankeyLayout.NODE_GAP
+    return boxes
+
+
+def _barycenter_order(
+    columns: List[List[str]],
+    ribbons: List[Tuple[str, str, float]],
+    values_by_node: Dict[str, float],
+    unit_scale: float,
+) -> List[List[str]]:
+    """Reorders the nodes of each column to reduce ribbon crossings (Q19).
+
+    The standard barycenter heuristic of layered graph drawing: a node wants to sit at the
+    flow-weighted mean height of the nodes it is connected to in the neighbouring column, so
+    sorting each column by that value pulls connected pairs level with each other and untangles
+    the ribbons between them. Sweeps alternate left-to-right and right-to-left, because a single
+    direction only ever tidies one side of each column, and stop as soon as a full sweep changes
+    nothing or after `SankeyLayout.BARYCENTER_SWEEPS` passes.
+
+    Determinism is a requirement, not a nicety — a report re-rendered from the same result must
+    be byte-identical, so the sort key ends in the flow volume and the node id and nothing here
+    consults a hash order or a random seed. A node with no link into the reference column keeps
+    its current height as its barycenter, which leaves it where it was instead of collecting all
+    unconnected nodes at the floor.
+
+    Args:
+        columns: The caller's node order per column, left to right.
+        ribbons: `(source, target, amount)` triples; same-column links are ignored, since they
+            connect two nodes whose relative order this heuristic is deciding.
+        values_by_node: Node id -> flow volume, for the node heights the sweeps score against.
+        unit_scale: The global unit-to-height scale, so the sweeps see the drawn geometry.
+
+    Returns:
+        A new list of columns with the nodes reordered; the input is not mutated.
+    """
+    order = [list(nodes) for nodes in columns]
+    column_of = {node: index for index, nodes in enumerate(order) for node in nodes}
+    links: Dict[str, List[Tuple[str, float]]] = {}
+    for source, target, amount in ribbons:
+        if column_of.get(source) is None or column_of.get(target) is None:
+            continue
+        if column_of[source] == column_of[target]:
+            continue
+        links.setdefault(source, []).append((target, amount))
+        links.setdefault(target, []).append((source, amount))
+    legs = [
+        (source, target)
+        for source, target, _amount in ribbons
+        if column_of.get(source) is not None
+        and column_of.get(target) is not None
+        and column_of[source] != column_of[target]
+    ]
+    best = [list(nodes) for nodes in order]
+    best_score = _crossing_count(best, legs, column_of)
+    for sweep in range(SankeyLayout.BARYCENTER_SWEEPS):
+        centers = {
+            node: y + height / 2.0
+            for node, (_x, y, height) in _place_nodes(order, values_by_node, unit_scale).items()
+        }
+        left_to_right = sweep % 2 == 0
+        indices = range(1, len(order)) if left_to_right else range(len(order) - 2, -1, -1)
+        changed = False
+        for index in indices:
+            reference = index - 1 if left_to_right else index + 1
+            reordered = sorted(
+                order[index],
+                key=lambda node, reference=reference, centers=centers: (
+                    _barycenter_of(node, reference, links, column_of, centers),
+                    -values_by_node.get(node, 0.0),
+                    node,
+                ),
+            )
+            if reordered != order[index]:
+                order[index] = reordered
+                changed = True
+        order = _transposed(order, legs, column_of)
+        score = _crossing_count(order, legs, column_of)
+        if score < best_score:
+            best_score, best = score, [list(nodes) for nodes in order]
+        if not changed and order == best:
+            break
+    return best
+
+
+def _crossing_count(
+    order: List[List[str]], legs: List[Tuple[str, str]], column_of: Dict[str, int]
+) -> int:
+    """Edge crossings of a layered ordering: inverted pairs within each column gap (Q29 R7).
+
+    The exact count for a layered drawing, not a proxy: two edges of the same gap cross precisely
+    when their endpoints appear in opposite order in the two columns, which is a comparison of
+    positions and needs no geometry. It is what the ordering is now *scored* by — barycenter
+    sweeps are a heuristic and can make a picture worse, as run 1's rented view showed, so the
+    layout keeps the best-scoring pass rather than the last one.
+    """
+    position = {node: index for nodes in order for index, node in enumerate(nodes)}
+    by_gap: Dict[int, List[Tuple[str, str]]] = {}
+    for source, target in legs:
+        by_gap.setdefault(min(column_of[source], column_of[target]), []).append((source, target))
+    total = 0
+    for pairs in by_gap.values():
+        for first, (source_a, target_a) in enumerate(pairs):
+            for source_b, target_b in pairs[first + 1:]:
+                if (position[source_a] - position[source_b]) * (
+                    position[target_a] - position[target_b]
+                ) < 0:
+                    total += 1
+    return total
+
+
+def _transposed(
+    order: List[List[str]], legs: List[Tuple[str, str]], column_of: Dict[str, int]
+) -> List[List[str]]:
+    """The transpose step of the Sugiyama method: adjacent swaps while they reduce crossings.
+
+    Barycenter placement gets the columns roughly right and then stops improving; swapping
+    neighbours and keeping the swap only when the exact crossing count falls is what removes the
+    last tangles, and it is the standard companion pass. Deterministic: columns are visited left
+    to right, pairs bottom to top, and a swap is kept only on a strict improvement, so equal-cost
+    alternatives never flip a re-render.
+    """
+    current = [list(nodes) for nodes in order]
+    score = _crossing_count(current, legs, column_of)
+    for _round in range(SankeyLayout.TRANSPOSE_ROUNDS):
+        improved = False
+        for index, nodes in enumerate(current):
+            for position in range(len(nodes) - 1):
+                candidate = [list(column) for column in current]
+                candidate[index][position], candidate[index][position + 1] = (
+                    candidate[index][position + 1],
+                    candidate[index][position],
+                )
+                candidate_score = _crossing_count(candidate, legs, column_of)
+                if candidate_score < score:
+                    current, score, improved = candidate, candidate_score, True
+        if not improved:
+            break
+    return current
+
+
+def _barycenter_of(
+    node: str,
+    reference_column: int,
+    links: Dict[str, List[Tuple[str, float]]],
+    column_of: Dict[str, int],
+    centers: Dict[str, float],
+) -> float:
+    """Flow-weighted mean height of a node's partners in one neighbouring column.
+
+    The score the barycenter sweeps sort on. Weighting by flow rather than counting partners is
+    what makes the heuristic follow the picture: a node hanging off one fat ribbon and three
+    hairlines belongs next to the fat one. A node with no partner in the reference column falls
+    back to its own current height, which is the "leave it alone" answer rather than an arbitrary
+    zero that would sink every unconnected node to the floor of the column.
+    """
+    weighted, total = 0.0, 0.0
+    for partner, amount in links.get(node, []):
+        if column_of.get(partner) == reference_column and amount > 0.0:
+            weighted += amount * centers.get(partner, 0.0)
+            total += amount
+    return weighted / total if total else centers.get(node, 0.0)
+
+
+def sankey_node_boxes(
+    columns: List[List[str]], ribbons: List[Tuple[str, str, float]]
+) -> SankeyGeometry:
+    """Lays a Sankey out: one global scale, crossing-minimized order, per-ribbon anchors.
+
+    The shared layout of the whole Sankey family (V1, V10, V11, V12), used by the matplotlib
+    companions and by the inline-SVG report alike — both draw the same diagram, so both have to
+    place the same node and the same ribbon end in the same spot. A node's height is `unit_scale`
+    times the larger of what flows into it and what flows out of it, which makes a pass-through
+    node exactly as tall as what crosses it.
+
+    **One scale, all columns** (visualization spec rule 2.7). The scale is chosen so the *fullest*
+    column exactly fills the unit square once its inter-node gaps are taken out, and every other
+    column is then shorter — vertically centred, so the diagram stays balanced. Scaling each
+    column independently to fill the height, which this function used to do, is what made ribbons
+    change width in flight: a column carrying each unit twice (every actor in V1 is both a payer
+    and a payee) got roughly half the scale of its neighbours, so the same flow arrived narrower
+    than it left.
+
+    **Corridors** (Q29 R7). A ribbon that skips a column is cut into one leg per column gap, with
+    a virtual node reserving its width in every column it passes — the dummy nodes of the Sugiyama
+    method. They take part in the ordering and in the space a column claims, which is what turns
+    "the ribbon happens to miss the block" into "the ribbon has somewhere to go"; the invariant it
+    buys is that no ribbon path intersects any node rectangle, and it is tested as one.
+
+    **Net stubs** (Q29 R7). A node is as tall as the larger of its two faces, so an internal node
+    whose inflow and outflow differ has a face its ribbons cannot fill. That remainder is the
+    node's net position and is handed to the renderers as a `NetStub` to draw and label, which is
+    what makes both faces of every node tile at 100 %.
+
+    **Untangling** (Q19) is two steps, both standard and both here rather than in a renderer.
+    Nodes are reordered per column by barycenter sweeps (`_barycenter_order`), and the ribbons on
+    each node face are then stacked in the order of their *far* ends, so two correctly ordered
+    columns are not re-tangled by the ribbons between them. The caller's column lists are read for
+    membership only; their order is a starting point, not a constraint.
+
+    Coordinates are fractions of a unit square with y growing upward; a renderer whose y grows
+    downward (SVG) flips them itself.
+
+    Args:
+        columns: Node ids per column, left to right. The order within a column is the sweep's
+            starting point.
+        ribbons: `(source id, target id, amount)` triples; only the amounts are read here.
+            Amounts are expected non-negative — a Sankey ribbon has no sign, and the callers
+            encode direction in the node pair.
+
+    Returns:
+        A `SankeyGeometry` whose `ribbon_anchors` are index-aligned with `ribbons`. A node named
+        in `columns` but carrying no flow gets height zero: under one global scale "no flow" is
+        genuinely no height, and inventing a share for it would re-introduce a second scale
+        through the back door.
+    """
+    routed_columns, segments, legs_of_ribbon = _route_through_corridors(columns, ribbons)
+    outgoing: Dict[str, float] = {}
+    incoming: Dict[str, float] = {}
+    for source, target, amount in segments:
+        outgoing[source] = outgoing.get(source, 0.0) + amount
+        incoming[target] = incoming.get(target, 0.0) + amount
+    values_by_node = {
+        node: max(outgoing.get(node, 0.0), incoming.get(node, 0.0))
+        for nodes in routed_columns for node in nodes
+    }
+    candidates = [
+        max(1.0 - SankeyLayout.NODE_GAP * max(len(nodes) - 1, 0), SankeyLayout.MINIMUM_USABLE_HEIGHT)
+        / sum(values_by_node.get(node, 0.0) for node in nodes)
+        for nodes in routed_columns
+        if sum(values_by_node.get(node, 0.0) for node in nodes) > 0.0
+    ]
+    unit_scale = min(candidates) if candidates else 0.0
+    order = _barycenter_order(routed_columns, segments, values_by_node, unit_scale)
+    boxes = _place_nodes(order, values_by_node, unit_scale)
+    anchors = _ribbon_anchors(segments, boxes, unit_scale)
+    ribbon_segments = [
+        [
+            RibbonSegment(
+                source=segments[leg][0],
+                target=segments[leg][1],
+                out_anchor=anchors[leg][0],
+                in_anchor=anchors[leg][1],
+            )
+            for leg in legs
+        ]
+        for legs in legs_of_ribbon
+    ]
+    return SankeyGeometry(
+        boxes=boxes,
+        unit_scale=unit_scale,
+        ribbon_anchors=[
+            (chain[0].out_anchor, chain[-1].in_anchor) if chain else (0.0, 0.0)
+            for chain in ribbon_segments
+        ],
+        ribbon_segments=ribbon_segments,
+        net_stubs=_net_stubs(columns, incoming, outgoing, unit_scale),
+    )
+
+
+def _route_through_corridors(
+    columns: List[List[str]], ribbons: List[Tuple[str, str, float]]
+) -> Tuple[List[List[str]], List[Tuple[str, str, float]], List[List[int]]]:
+    """Cuts column-skipping ribbons into legs through virtual nodes (Q29 R7, Sugiyama).
+
+    The layered-graph-drawing answer to a ribbon that crosses a column it has no business in: give
+    it a *dummy node* in every column it skips, sized exactly as wide as the ribbon, and let that
+    node take part in the ordering and in the space the column reserves. The ribbon is then a
+    chain of ordinary neighbour-to-neighbour legs, and since a leg only ever occupies the gap
+    between two adjacent columns it cannot overlap a node rectangle — the invariant that used to
+    be violated by four source-to-landlord ribbons crossing straight through the tenant's block.
+
+    Virtual ids are built from the ribbon's index and the column, so the expansion is a pure
+    function of the input and a re-render is byte-identical. They are appended to the intermediate
+    column in ribbon order; where they end up vertically is the barycenter sweeps' business.
+
+    Args:
+        columns: The caller's columns, left to right; read for membership and column index.
+        ribbons: `(source, target, amount)` triples in the caller's order.
+
+    Returns:
+        `(columns including the virtual nodes, legs, leg indices per ribbon)`. A ribbon naming a
+        node no column declares keeps its single leg, which the renderers skip as they always did.
+    """
+    column_of = {node: index for index, nodes in enumerate(columns) for node in nodes}
+    routed = [list(nodes) for nodes in columns]
+    segments: List[Tuple[str, str, float]] = []
+    legs_of_ribbon: List[List[int]] = []
+    for index, (source, target, amount) in enumerate(ribbons):
+        source_column, target_column = column_of.get(source), column_of.get(target)
+        if source_column is None or target_column is None or abs(target_column - source_column) <= 1:
+            legs_of_ribbon.append([len(segments)])
+            segments.append((source, target, amount))
+            continue
+        step = 1 if target_column > source_column else -1
+        chain = [source]
+        for column in range(source_column + step, target_column, step):
+            virtual = f"{SankeyLayout.VIRTUAL_NODE_PREFIX}{index}:{column}"
+            routed[column].append(virtual)
+            chain.append(virtual)
+        chain.append(target)
+        legs = []
+        for leg_source, leg_target in zip(chain, chain[1:]):
+            legs.append(len(segments))
+            segments.append((leg_source, leg_target, amount))
+        legs_of_ribbon.append(legs)
+    return routed, segments, legs_of_ribbon
+
+
+def _net_stubs(
+    columns: List[List[str]],
+    incoming: Dict[str, float],
+    outgoing: Dict[str, float],
+    unit_scale: float,
+) -> List[NetStub]:
+    """The face remainders of internal nodes, as stubs to draw (Q29 R7).
+
+    Only *internal* nodes qualify — a node with flow on both faces. A first-column source or a
+    last-column sink has one empty face by definition, and closing that with a stub would draw a
+    payment nobody makes; the imbalance that needs explaining is the one inside the picture, where
+    a party keeps part of what it receives.
+
+    Emitted in column order, then in the caller's node order, so the list is deterministic and a
+    golden diff of the stubs reads top-to-bottom like the diagram.
+    """
+    stubs: List[NetStub] = []
+    for nodes in columns:
+        for node in nodes:
+            arrives, leaves = incoming.get(node, 0.0), outgoing.get(node, 0.0)
+            if arrives <= 0.0 or leaves <= 0.0:
+                continue
+            imbalance = abs(arrives - leaves)
+            if imbalance * unit_scale < SankeyLayout.MINIMUM_STUB_HEIGHT:
+                continue
+            is_outgoing = arrives > leaves
+            stubs.append(
+                NetStub(
+                    node=node,
+                    amount=imbalance,
+                    anchor=(leaves if is_outgoing else arrives) * unit_scale,
+                    is_outgoing=is_outgoing,
+                )
+            )
+    return stubs
+
+
+def _ribbon_anchors(
+    ribbons: List[Tuple[str, str, float]],
+    boxes: Dict[str, Tuple[float, float, float]],
+    unit_scale: float,
+) -> List[Tuple[float, float]]:
+    """Offsets of each ribbon's two ends above the bottom of their node face (Q19).
+
+    The second untangling step. Once the columns are ordered, the ribbons leaving a node are
+    stacked in the order of the heights their *targets* sit at, and the ribbons arriving at a node
+    in the order of the heights their *sources* sit at — so a ribbon going up stays above one
+    going down instead of the two crossing inside the gap between the columns. The stacking is
+    cumulative and uses the global scale, which is what makes the ribbons tile the face exactly.
+
+    Returns the anchors index-aligned with `ribbons`, so a renderer can iterate the flows in its
+    own order (colour, credit-versus-cost) without disturbing the geometry. A ribbon naming a node
+    the layout does not know gets `(0.0, 0.0)`; renderers skip those anyway.
+    """
+    def centre(node: str) -> float:
+        """Vertical middle of a node, the key both stacking orders sort on."""
+        _x, y, height = boxes.get(node, (0.0, 0.0, 0.0))
+        return y + height / 2.0
+
+    anchors: List[Tuple[float, float]] = [(0.0, 0.0)] * len(ribbons)
+    for is_outgoing in (True, False):
+        by_node: Dict[str, List[int]] = {}
+        for index, (source, target, _amount) in enumerate(ribbons):
+            if source not in boxes or target not in boxes:
+                continue
+            by_node.setdefault(source if is_outgoing else target, []).append(index)
+        for indices in by_node.values():
+            offset = 0.0
+            for index in sorted(
+                indices,
+                key=lambda i, is_outgoing=is_outgoing: (
+                    centre(ribbons[i][1] if is_outgoing else ribbons[i][0]),
+                    -ribbons[i][2],
+                    ribbons[i][1] if is_outgoing else ribbons[i][0],
+                ),
+            ):
+                out_anchor, in_anchor = anchors[index]
+                anchors[index] = (offset, in_anchor) if is_outgoing else (out_anchor, offset)
+                offset += ribbons[index][2] * unit_scale
+    return anchors
 
 
 def group_of(category: CostCategory) -> int:

--- a/hisim/economics/report_prose.py
+++ b/hisim/economics/report_prose.py
@@ -1,0 +1,1942 @@
+"""The authored explanation of every report section — the report's own prose, in one place.
+
+Every section of `lifecycle_report.html` opens with the same four parts: what the chart in front
+of the reader *shows*, what it *adds* that no other section covers, the terms of art it uses
+(defined at engineering-bachelor level), and how the numbers in it are calculated. This module
+holds that text and nothing else, so the renderers stay geometry and the wording stays reviewable
+as prose rather than as string fragments spread over the section builders of the `reporting`
+package.
+
+Two mappings live here: `SECTIONS`, the four-part explanation of every report section, and
+`CHAPTER_INTROS`, the short authored lead-in of each story chapter (owner decision Q24). A chapter
+intro is deliberately not four-part — a chapter has no chart to show, nothing to add and nothing
+to calculate; it is the sentence that says which of the reader's three questions the sections
+below it answer.
+
+**Verbatim.** The text is the owner-reviewed explanation copy, transcribed without rewording from
+the authoring document it was reviewed in (which is not in the tree — this module is the copy of
+record); a change here is an editorial decision, not a rendering one. It is deliberately
+**number-free**: every run-specific figure stays in the renderers' dynamic captions, so the prose
+is identical in every report and the golden file only moves when the wording is actually edited.
+Recurring terms are re-defined in every section that leans on them, because the report is read
+non-linearly and a reader landing mid-page must not have to find the primer first.
+
+**Markup.** The strings carry markdown emphasis (`*term*`, `**emphasis**`, `` `code` ``) rather
+than HTML, because both renderers need them: the `reporting` package turns them into `<em>` /
+`<strong>` / `<code>` with `to_html`, and `report_plots.py` strips them for the caption of the
+ledger heatmap with `to_plain_text`. The `<details>` summaries are constants here for the same
+reason a section name is a constant in `ReportSections`: the test suite asserts on them, and two
+spellings of "Terms used here" would make that assertion meaningless.
+"""
+
+# clean
+
+import html
+import re
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+
+@dataclass(frozen=True)
+class SectionProse:
+    """The four parts of one section's explanation.
+
+    `shows` and `adds` are the two visible paragraphs, `terms` the definition list behind the
+    "Terms used here" disclosure (one `(term, definition)` pair per entry, in the order they are
+    to be read, not alphabetically), and `calculation` the paragraphs behind "How this is
+    calculated". All of them carry markdown emphasis; see the module docstring.
+    """
+
+    shows: str
+    adds: str
+    terms: Tuple[Tuple[str, str], ...]
+    calculation: Tuple[str, ...]
+
+
+class ReportProse:
+    """Every section's explanation, keyed by the section name `ReportSections` publishes.
+
+    Keyed by name rather than by anchor so the mapping reads as the table of contents does, and
+    so a renamed section fails loudly in `for_section` instead of silently dropping its
+    explanation. `SECTIONS` covers every entry of `ReportSections.ORDER` plus `Ledger heatmap`,
+    which is a PNG in the audit outputs rather than an HTML section: only its `shows` paragraph
+    fits a matplotlib caption, and its terms and calculation are unreachable there — a limitation
+    recorded in the PR description rather than papered over.
+    """
+
+    TERMS_SUMMARY = "Terms used here"
+    CALCULATION_SUMMARY = "How this is calculated"
+    PRIMER_SECTION_NAME = "How to read this report"
+    LEDGER_HEATMAP_SECTION_NAME = "Ledger heatmap"
+
+    SECTIONS: Dict[str, SectionProse] = {
+        "How to read this report": SectionProse(
+            shows=(
+                "This report prices a simulated building over an observation period of several decades: every "
+                "euro that the simulated household, and the other parties around it, pays or receives because "
+                "of the installed technology. Three conventions run through every chart. **First**: money in "
+                "different years is not comparable, so future amounts are *discounted* — divided by (1 + "
+                "interest rate)ⁿ for a payment n years away — before they are summed. A sum of discounted "
+                "amounts is a *net present value* (NPV): the single figure that answers \"what does the whole "
+                "timeline cost in today's money\". **Second**: every input price is a three-value band — a low, "
+                "an average and a high estimate. The report evaluates three complete, internally consistent "
+                "worlds (everything cheap, everything average, everything expensive) and shows them as `avg "
+                "[min | max]`. The band edges are coherent scenarios, not statistical error bars: a wide band "
+                "means the assumptions matter, not that the arithmetic is shaky. **Third**: costs carry a "
+                "positive sign and plot upward or rightward; revenues and credits are negative and plot "
+                "downward or leftward. Nothing is silently netted."
+            ),
+            adds=(
+                "Everything below builds on these three conventions; this block exists so no section has to "
+                "re-derive them."
+            ),
+            terms=(
+                ("Interest rate (discount rate)",
+                 (
+                     "the annual return the money could earn elsewhere (a savings account, another investment)."
+                     " It is the exchange rate between money today and money later."
+                 )),
+                ("Discounting",
+                 (
+                     "converting a future amount into its today-equivalent by dividing by (1 + interest rate) "
+                     "once per year of distance. 100 EUR due in 10 years at 3 % is worth 100/1.03¹⁰ ≈ 74 EUR "
+                     "today."
+                 )),
+                ("Present value / net present value (NPV)",
+                 (
+                     "the sum of all discounted cash flows of a plan. \"Net\" means costs and revenues are both "
+                     "in, with their signs."
+                 )),
+                ("Nominal value",
+                 (
+                     "the amount actually paid or received in its year, price increases included, **not** "
+                     "discounted. Nominal answers \"what will the bank transfer say\"; discounted answers \"what "
+                     "is it worth today\"."
+                 )),
+                ("Band / worlds",
+                 (
+                     "the three-value notation `avg [min | max]`. Min and max are complete scenarios (every "
+                     "price at its cheap or expensive end at once), not per-number error bars."
+                 )),
+                ("Cost vs credit",
+                 (
+                     "a cost is money leaving the household (positive sign here); a credit is money arriving or"
+                     " being saved: revenue, a subsidy, a value refunded."
+                 )),
+                ("Horizon (observation period)",
+                 (
+                     "the number of years the evaluation covers. Everything after the horizon is out of scope "
+                     "except through the residual credit (see *Lifetimes*)."
+                 )),
+            ),
+            calculation=(
+                (
+                    "The engine walks a *timeline* of dated, categorized cash flows: year-0 purchases, annual "
+                    "energy bills and maintenance, replacement purchases when a device's service life ends "
+                    "inside the horizon, subsidies, loan payments, and at the end of the horizon a credit for "
+                    "hardware that still has remaining life. Prices escalate at configured annual rates before "
+                    "discounting, so \"nominal\" charts show the actual future bank-account amounts and "
+                    "\"discounted\" charts show their today-equivalent. Every figure in every chart is an "
+                    "aggregation of this one timeline — which is why the sections reconcile with each other, "
+                    "and why any number can be traced to its sources with the `explain` command named at the "
+                    "foot of the report."
+                ),
+            ),
+        ),
+        "At a glance": SectionProse(
+            shows=(
+                "The whole evaluation on one page: a shared year axis with one row per part of the story. The "
+                "top row carries computed milestones — the deepest out-of-pocket point, the payback range where"
+                " a comparison exists, the end of the observation period. Below it, one row per financing and "
+                "support instrument, then one row per installed component with its service periods (bars) and "
+                "its dated events (ticks): purchase, replacement, and the residual credit at the horizon. "
+                "Labels on the ticks carry the amounts."
+            ),
+            adds=(
+                "Orientation. Every number here is restated in full detail somewhere below — this chart adds no"
+                " new figures, it adds the *timing*: what happens when, over decades, in one picture. If a "
+                "replacement lands in a surprising year or a loan outlives a device, this is where it becomes "
+                "visible."
+            ),
+            terms=(
+                ("Milestone",
+                 (
+                     "a computed date worth remembering, derived from the results rather than configured: the "
+                     "worst cash position, the payback, the horizon."
+                 )),
+                ("Out-of-pocket",
+                 (
+                     "money actually paid from the household's own account, summed up over time. \"Deepest "
+                     "out-of-pocket\" is the moment the most of one's own money is tied up in the project, "
+                     "before savings and credits have won it back."
+                 )),
+                ("Payback",
+                 (
+                     "the year in which accumulated savings (relative to not renovating) have recovered the "
+                     "money spent. Shown as a range because the cheap and the expensive world reach that point "
+                     "in different years."
+                 )),
+                ("Service period",
+                 (
+                     "the span of years a specific installed unit is in operation, from its purchase to its "
+                     "replacement or the horizon."
+                 )),
+                ("Replacement",
+                 (
+                     "buying the same component again when its service life ends inside the horizon, at that "
+                     "future year's (escalated) price."
+                 )),
+                ("Residual credit (residual value)",
+                 (
+                     "the worth of hardware that has remaining life when the observation ends, credited back so"
+                     " an arbitrary end date does not punish recently bought equipment."
+                 )),
+                ("Horizon (observation period)",
+                 "the last year of the evaluation; the right edge of every time axis in this report."),
+            ),
+            calculation=(
+                (
+                    "The rows are read directly from the booked timeline, not from catalog assumptions — a "
+                    "component's service period spans from its actual purchase event to its actual replacement "
+                    "or the horizon. The payback milestone is drawn as a *range*, from the year the renovation "
+                    "has paid for itself in the optimistic world to the year it has in the pessimistic world; a"
+                    " single payback year would pretend a precision the input bands cannot support. The deepest"
+                    " out-of-pocket milestone is the maximum of the cumulative undiscounted cash curve (see "
+                    "*Cash curve*)."
+                ),
+            ),
+        ),
+        "Plausibility": SectionProse(
+            shows=(
+                "A table of automated sanity checks with their measured values and the expected ranges: totals "
+                "that must reconcile internally, ratios that experience says should fall inside a generous "
+                "corridor (effective energy prices, cost per square meter, maintenance relative to investment),"
+                " and structural invariants (a residual credit may never exceed the purchases it stems from). "
+                "`OK` means inside the corridor; `WARN` means outside it and worth a human look; `FAIL` means "
+                "an internal contradiction."
+            ),
+            adds=(
+                "The report's own error detector, run before you read anything else. A `WARN` here is not "
+                "necessarily a defect — an unusual configuration can legitimately sit outside a corridor (a "
+                "nearly self-sufficient house has a strange-looking effective electricity price, because a "
+                "fixed standing charge is divided by very few purchased kilowatt hours) — but it tells you "
+                "which number deserves scrutiny before you trust the headline."
+            ),
+            terms=(
+                ("Invariant",
+                 (
+                     "a relationship that must hold exactly, always: for example \"the parts sum to the total\". "
+                     "An invariant violation is a defect in the computation, never a property of the scenario."
+                 )),
+                ("Structural invariant",
+                 (
+                     "an invariant that follows from how the numbers are constructed (a residual credit is a "
+                     "fraction of a purchase, so it cannot exceed the purchases), as opposed to an empirical "
+                     "corridor that is merely usually true."
+                 )),
+                ("Corridor (expected range)",
+                 (
+                     "a generous value range from experience. Values outside are flagged for a look, not "
+                     "declared wrong."
+                 )),
+                ("Effective price",
+                 (
+                     "total annual bill divided by the energy actually bought, in EUR/kWh. It bundles "
+                     "consumption charges, fixed charges and taxes into one comparable number."
+                 )),
+                ("Reconcile",
+                 (
+                     "two independently computed figures agreeing exactly. The report leans on reconciliation "
+                     "everywhere: if the same money is shown twice, both views must match."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Each check recomputes its value from the published results, never from internal state, so "
+                    "the check proves what the report shows rather than what the engine intended. The corridors"
+                    " live in a data file (`plausibility_checks.json`), not in code, and are deliberately wide:"
+                    " they are tripwires for wiring mistakes — a price in the wrong unit, a missing component, "
+                    "a band typo — not judgments about the scenario's economics."
+                ),
+            ),
+        ),
+        "Input audit": SectionProse(
+            shows=(
+                "One row per priced item: what the engine believed about it (size, unit), the unit price it "
+                "resolved (as a low/average/high band), the price basis year, the data source behind it, and "
+                "the subsidies attached. This is the complete list of *inputs after resolution* — the numbers "
+                "the rest of the report is computed from."
+            ),
+            adds=(
+                "Traceability at the entry point. Every chart downstream aggregates; this is the only section "
+                "where each number is still attached to its origin. Configuration mistakes — a component priced"
+                " at the wrong size, a price resolved from an unexpected catalog year — surface here first, "
+                "before they blur into totals."
+            ),
+            terms=(
+                ("Unit price",
+                 (
+                     "the price per unit of size: EUR per kilowatt of heat pump, EUR per square meter of "
+                     "insulation, EUR per kilowatt hour of storage."
+                 )),
+                ("Band",
+                 "the low/average/high triple every price carries; see the primer."),
+                ("Price basis year",
+                 (
+                     "the year whose price level the cost data represents. All inputs are quoted at this basis "
+                     "and then escalated to their payment years."
+                 )),
+                ("Cost database (catalog)",
+                 (
+                     "the versioned data files of unit prices, service lives, maintenance rates and emission "
+                     "factors the engine prices from."
+                 )),
+                ("Resolution",
+                 (
+                     "the lookup step: matching an installed component to its database entry for the right "
+                     "country and basis year, and scaling the unit price by the size."
+                 )),
+                ("Source (citation)",
+                 (
+                     "where a number comes from: a study, a price survey, an estimate. Every resolved price "
+                     "keeps its source, so any figure can be traced."
+                 )),
+            ),
+            calculation=(
+                (
+                    "The simulation hands the cost engine a set of facts (what is installed, how large). The "
+                    "engine resolves each fact against a versioned cost database: it selects the database entry"
+                    " valid for the configured price-basis year, multiplies the unit price band by the size, "
+                    "and records the source citation. Items the database cannot resolve stop the whole "
+                    "evaluation with a named error rather than being silently skipped — an unpriced component "
+                    "would make every total quietly wrong."
+                ),
+            ),
+        ),
+        "Assumptions": SectionProse(
+            shows=(
+                "Every economic assumption the evaluation ran on, in one table: the interest rate, the "
+                "horizon, the price basis year, the annuity factor they imply; the escalation rate of every "
+                "price category and energy carrier; the tariffs — working price, standing charge and feed-in "
+                "rate per carrier; the building quantities the per-unit figures divide by (living area, "
+                "heated area, annual heat demand); and the CO2 damage-cost path where the society chapter "
+                "uses one. Each value carries its source."
+            ),
+            adds=(
+                "Reconstructability. The charts show consequences; this table is the complete set of causes. "
+                "Any nominal series in the report is a year-1 value compounded with one of these escalation "
+                "rates; any per-square-meter or per-kilowatt-hour figure divides by one of these quantities. "
+                "If a number elsewhere seems off, the first check is whether the assumption behind it is the "
+                "one you expected."
+            ),
+            terms=(
+                ("Escalation rate",
+                 (
+                     "the assumed annual price growth of one category (energy, devices, maintenance), "
+                     "compounded year by year; the reason later years cost more nominal euros."
+                 )),
+                ("Working price / standing charge / feed-in rate",
+                 (
+                     "the three parts of an energy tariff: per-kilowatt-hour price, fixed annual charge, and "
+                     "the price paid per exported kilowatt hour."
+                 )),
+                ("Annuity factor",
+                 (
+                     "the factor i(1+i)ⁿ/((1+i)ⁿ−1) that converts a present value into the constant annual "
+                     "payment with the same worth; fixed by the interest rate and horizon."
+                 )),
+                ("Price basis year",
+                 (
+                     "the year the input price level represents; escalation runs from here."
+                 )),
+                ("CO2 damage-cost path",
+                 (
+                     "the assumed societal cost per tonne of CO2 over the years, used only in the society "
+                     "chapter."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Nothing is calculated here — this is the boundary between input and result. Everything "
+                    "in the table is configuration or cost-database content, resolved for this run and cited; "
+                    "everything after this section is computed from it."
+                ),
+            ),
+        ),
+        "Investment build-up": SectionProse(
+            shows=(
+                "One horizontal bar per component: the gross purchase price in year 0 and, where support exists"
+                " in this perspective, the part covered by subsidies — so the visible split is \"what it costs\" "
+                "versus \"what the owner actually pays\"."
+            ),
+            adds=(
+                "The year-0 story per component. The cost-structure and breakdown sections show lifetime money;"
+                " this section isolates the single largest event, the initial purchase, and shows how far "
+                "support reduces it — including whether a subsidy cap has flattened the support below its "
+                "nominal percentage."
+            ),
+            terms=(
+                ("Gross purchase price / gross investment",
+                 (
+                     "the full price of buying and installing a component, before any subsidy is subtracted: "
+                     "device, installation labor, planning, removal of the old unit."
+                 )),
+                ("Net investment",
+                 (
+                     "the gross investment minus the subsidies granted for it: what actually leaves the owner's"
+                     " account. \"Gross\" and \"net\" in this report always mean before/after support, not "
+                     "before/after VAT."
+                 )),
+                ("Subsidy",
+                 (
+                     "money granted by a public program toward a measure; it reduces the owner's cost without "
+                     "reducing the measure's price."
+                 )),
+                ("Subsidy cap",
+                 (
+                     "an upper limit in a support program: a maximum eligible cost, a maximum percentage, or a "
+                     "maximum amount. A binding cap means the program's nominal percentage was clamped."
+                 )),
+                ("Perspective",
+                 (
+                     "one defined viewpoint on the same evaluation (see *Perspectives*). A *gross* perspective "
+                     "deliberately ignores subsidies to answer \"what does the technology cost\"; a *net* "
+                     "perspective answers \"what does the owner pay\"."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Gross investment is unit price × size from the input audit. The subsidy split comes from "
+                    "the subsidy solver (see *Subsidies*): each scheme's percentage applies to its eligible "
+                    "cost basis, and caps — per measure, per program, or as a share of cost — clamp the sum. "
+                    "Note the perspective in the section title: a *gross* perspective deliberately shows no "
+                    "subsidies, so an empty support split there is a definition, not a defect."
+                ),
+            ),
+        ),
+        "Funding": SectionProse(
+            shows=(
+                "A flow diagram of day one: where the money comes from (left — own capital, loans, each subsidy"
+                " program as its own block) and what it is spent on (right — each component's gross purchase). "
+                "Ribbon thickness is euros; both columns have the same total height by construction."
+            ),
+            adds=(
+                "The financing question, which no cost chart answers: \"how do I pay for this on day one\". "
+                "Because each subsidy program is its own block, you can see which program funds which measure —"
+                " and own capital is the balancing item, i.e. what remains after all support and debt is "
+                "counted."
+            ),
+            terms=(
+                ("Own capital (equity)",
+                 (
+                     "the owner's own money put into the project, as opposed to borrowed money or granted "
+                     "money."
+                 )),
+                ("Loan disbursement",
+                 (
+                     "the moment the bank pays out the borrowed amount; it appears as a funding source in year "
+                     "0 and is repaid over the following years (see *Loan*)."
+                 )),
+                ("Subsidy program (scheme)",
+                 (
+                     "one specific public support offer with its own rules; each is drawn as its own block so "
+                     "programs are distinguishable."
+                 )),
+                ("Balancing item",
+                 (
+                     "the quantity computed last so that an identity holds. Here: own capital = total spending "
+                     "− loans − subsidies."
+                 )),
+                ("Gross year-0 investment",
+                 (
+                     "the sum of all components' gross purchase prices in year 0 (see *Investment build-up* for"
+                     " \"gross\")."
+                 )),
+                ("Ribbon",
+                 (
+                     "a band in a flow diagram whose thickness is proportional to the amount flowing; the curve"
+                     " is only routing, the thickness is the number."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Sources are read from the year-0 timeline: loan disbursements, subsidy payouts, and own "
+                    "capital as the residual. The two column totals must equal each other and the gross year-0 "
+                    "investment; the report verifies this identity and treats support exceeding the investment "
+                    "(negative own capital) as a data defect rather than drawing it. The layout places "
+                    "connected blocks near each other and keeps every ribbon's thickness constant along its "
+                    "length."
+                ),
+            ),
+        ),
+        "Lifetimes": SectionProse(
+            shows=(
+                "One row per component: bars for its periods in service, ticks for its purchase and replacement"
+                " years with their prices, and at the right edge the residual credit — what the hardware is "
+                "still worth when the observation ends."
+            ),
+            adds=(
+                "The replacement schedule, which drives the mid-life cost spikes in every timeline chart, and "
+                "the *audit* of it: the service periods here are derived from the flows the engine actually "
+                "booked, never from the catalog's nominal service life. If a booked replacement interval "
+                "disagrees with the database — or a residual appears for something never purchased — it is "
+                "visible in this picture (and the second case refuses to render at all)."
+            ),
+            terms=(
+                ("Service life",
+                 (
+                     "how many years a component type lasts before it needs replacing; a property from the cost"
+                     " database (e.g. 18 years for a heat pump, 40 for wall insulation)."
+                 )),
+                ("Service period",
+                 "the actual span one purchased unit is in operation in this evaluation."),
+                ("Replacement",
+                 (
+                     "the repeat purchase when a service life ends inside the horizon, priced at that future "
+                     "year's escalated price."
+                 )),
+                ("Escalated price",
+                 (
+                     "a today-price projected to a future year by compounding an annual price-increase rate; "
+                     "the replacement in year 12 costs more nominal euros than the same device today."
+                 )),
+                ("Residual value / residual credit",
+                 (
+                     "the remaining worth of equipment at the horizon, credited back to the evaluation. See the"
+                     " depreciation rule below."
+                 )),
+                ("Straight-line depreciation",
+                 (
+                     "spreading a purchase price evenly over the service life, so after k of L years the "
+                     "remaining (\"book\") value is (L−k)/L of the price."
+                 )),
+            ),
+            calculation=(
+                (
+                    "A component bought in year 0 with a service life shorter than the horizon is re-purchased "
+                    "at its escalated future price when the life ends; the cycle repeats to the horizon. At the"
+                    " horizon, remaining value is credited back using straight-line depreciation: a device that"
+                    " has served k of its L years is worth (L − k)/L of its last purchase price. This "
+                    "convention prevents the arbitrary cutoff date from punishing recently replaced equipment —"
+                    " without it, a replacement in the horizon's final year would count as a total loss."
+                ),
+            ),
+        ),
+        "Cash-flow timeline": SectionProse(
+            shows=(
+                "The nominal money of each year as a stacked bar: costs above the zero line, revenues and "
+                "credits below, colored by cost group. Year 0 is dominated by the investment; ordinary years "
+                "show energy, maintenance and revenues; replacement years spike; the horizon year carries the "
+                "residual credit."
+            ),
+            adds=(
+                "The raw material of the whole report, before any discounting — the actual amounts that would "
+                "cross a bank account each year. The shape is the fastest plausibility read there is: do "
+                "replacements land in the right years, does energy drift upward at a believable rate, does "
+                "anything appear in a year where it has no business."
+            ),
+            terms=(
+                ("Nominal",
+                 (
+                     "the amount actually paid in its year, price increases included, not converted to "
+                     "today-money. The bank statement's view."
+                 )),
+                ("Escalation",
+                 (
+                     "the assumed annual price growth per kind of cost (energy prices, device prices, "
+                     "maintenance wages), compounded year by year."
+                 )),
+                ("Cost group",
+                 (
+                     "the report's small set of color-coded categories: investment & financing, energy, "
+                     "maintenance & operation, replacements, revenues, residual & anyway credits."
+                 )),
+                ("Anyway cost (like-for-like renovation)",
+                 (
+                     "cost the building would have caused even without the improvement: an old boiler at the "
+                     "end of its life must be replaced by *something*, a weathered facade must at least be "
+                     "repaired. The evaluation credits that unavoidable cost to the renovation in the year it "
+                     "would have occurred, so the renovation is only charged for what it truly adds."
+                 )),
+                ("Anyway share",
+                 (
+                     "the fraction of the new measure's cost that the counterfactual would really have spent. "
+                     "Replacing dead windows: close to all of it. Insulating a facade that was never "
+                     "insulated: only the repair share — scaffolding, render, paint — because the "
+                     "counterfactual would have repaired, not insulated. The applied share is stated with "
+                     "each credit."
+                 )),
+                ("Counterfactual",
+                 (
+                     "the hypothetical \"what would have happened without the measure\", against which such "
+                     "credits are computed."
+                 )),
+                ("Residual credit",
+                 "see *Lifetimes*: the horizon-year refund for remaining equipment value."),
+            ),
+            calculation=(
+                (
+                    "\"Nominal\" means escalated to the year of payment but *not* discounted: a bill n years out "
+                    "is this year's price times the carrier's escalation rate compounded n times. Where the "
+                    "evaluation credits an avoided like-for-like renovation, that credit is booked in the year "
+                    "the counterfactual replacement would have happened — the detail table below the chart "
+                    "attributes every flow to its origin."
+                ),
+            ),
+        ),
+        "Cash curve": SectionProse(
+            shows=(
+                "Two panels of the same running total. The upper panel accumulates the nominal flows: the "
+                "curve's highest point is the deepest out-of-pocket position — the most money that is ever tied"
+                " up. The lower panel accumulates the same flows discounted to today; its endpoint is, by "
+                "construction, the headline NPV. The shaded envelope spans the all-cheap and all-expensive "
+                "worlds; where a reference variant exists, the savings panel's zero crossing is the payback, "
+                "stated as a range across the worlds."
+            ),
+            adds=(
+                "Liquidity. Totals answer \"is it worth it\"; this section answers \"can I afford the path\" — how "
+                "deep the position gets, when it recovers, and how much of that timing shifts between the "
+                "optimistic and pessimistic world."
+            ),
+            terms=(
+                ("Cumulative",
+                 (
+                     "each year's value is the running sum of everything up to that year, not the year's own "
+                     "amount."
+                 )),
+                ("Out-of-pocket",
+                 (
+                     "one's own money actually spent so far; the curve's peak is the worst point of the "
+                     "household's cash position."
+                 )),
+                ("Liquidity",
+                 (
+                     "having the cash available when a payment is due, as opposed to the project being "
+                     "profitable overall. A profitable plan can still have a painful cash valley."
+                 )),
+                ("Discounting / present value",
+                 (
+                     "converting future money to today-money by dividing by (1 + interest rate) per year of "
+                     "distance; see the primer."
+                 )),
+                ("NPV (net present value)",
+                 "the discounted sum of all flows; the endpoint of the lower panel."),
+                ("Envelope (min/max band)",
+                 (
+                     "the region between the whole-horizon-cheap world and the whole-horizon-expensive world; "
+                     "two coherent scenarios, not error bars."
+                 )),
+                ("Payback",
+                 (
+                     "the first year cumulative discounted savings versus the reference reach zero; reported "
+                     "per world, hence a range."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Discounting divides a year-n amount by (1 + i)ⁿ, with i the evaluation's interest rate — "
+                    "the rate at which the decision-maker could otherwise invest (see *Bank benchmark* for that"
+                    " rate made visible). Cumulative curves are computed per world: the lower band edge is the "
+                    "*whole horizon* in the cheap world, not a per-year minimum. The payback year in each world"
+                    " is the first year its cumulative discounted savings reach zero; reporting the range "
+                    "across worlds replaces false single-year precision."
+                ),
+            ),
+        ),
+        "Loan": SectionProse(
+            shows=(
+                "The debt over time: annual debt service split into interest and principal repayment (bars), "
+                "and the outstanding balance falling as principal is repaid (line, same euro axis). An annuity "
+                "loan shows its signature shape — constant total payment, interest share falling, principal "
+                "share rising; a bullet loan shows interest-only years and one final repayment spike."
+            ),
+            adds=(
+                "The financed view. Every other chart books the investment when it happens; this section shows "
+                "what a financed owner actually experiences — a stream of payments — and whether the loan is "
+                "amortized before the horizon."
+            ),
+            terms=(
+                ("Principal",
+                 "the borrowed amount itself."),
+                ("Interest",
+                 "the price of borrowing: each year, the interest rate times the debt still outstanding."),
+                ("Debt service",
+                 "a year's total loan payment: interest plus principal repayment."),
+                ("Outstanding balance",
+                 "how much of the principal is still owed at a given time."),
+                ("Annuity loan",
+                 (
+                     "the common household loan: the same total payment every year, with the interest share "
+                     "shrinking and the repayment share growing as the debt falls."
+                 )),
+                ("Bullet loan (interest-only)",
+                 "only interest is paid during the term; the whole principal is repaid at once at the end."),
+                ("Term",
+                 "the agreed number of years of the loan."),
+                ("Amortized",
+                 "fully repaid; an amortizing loan's balance reaches zero by the end of its term."),
+            ),
+            calculation=(
+                (
+                    "The schedule is read off the booked timeline, not recomputed, so what you see is exactly "
+                    "the debt service inside the NPV. For an annuity loan the constant payment is "
+                    "P·i(1+i)ⁿ/((1+i)ⁿ−1) for principal P, rate i, term n; each year's interest is the rate "
+                    "times the remaining balance and the rest of the payment repays principal. The balance line"
+                    " is the disbursement minus cumulative repayments and must reach zero at the end of a fully"
+                    " amortizing term — a checked invariant."
+                ),
+            ),
+        ),
+        "Cost of credit": SectionProse(
+            shows=(
+                "The consumer-credit disclosure a loan document carries, as one stacked bar: total repaid, "
+                "split into borrowed principal, interest, and fees, with any repayment grant shown as money "
+                "coming back. The caption states the *effective annual rate* — the single interest rate that "
+                "summarizes the whole package."
+            ),
+            adds=(
+                "Comparability. \"What does the loan cost on top of the money itself\" and \"what rate is this "
+                "package really\" are the two numbers to hold against a bank's alternative offer, and neither is"
+                " visible in the amortization schedule directly."
+            ),
+            terms=(
+                ("Total cost of credit",
+                 (
+                     "everything paid back minus everything received: the loan's price on top of the borrowed "
+                     "money itself."
+                 )),
+                ("Fees",
+                 (
+                     "one-off charges of the loan (processing, commitment) that raise its true cost without "
+                     "appearing in the interest rate."
+                 )),
+                ("Repayment grant",
+                 (
+                     "support in loan form: a program forgives part of the debt, so less principal must be "
+                     "repaid than was disbursed."
+                 )),
+                ("Nominal rate",
+                 "the interest rate written in the contract."),
+                ("Effective annual rate",
+                 (
+                     "the single rate that reproduces the whole package — fees and grants included — when "
+                     "applied to the actual payment stream. This is the legally mandated comparison figure for "
+                     "consumer credit."
+                 )),
+                ("Internal rate of return (IRR)",
+                 (
+                     "the discount rate at which a payment stream's present value is exactly zero; the "
+                     "effective rate is the IRR of the loan's own flows."
+                 )),
+            ),
+            calculation=(
+                (
+                    "The effective rate is the internal rate of return of the loan's flow sequence: the rate at"
+                    " which the discounted disbursement (and any grant) exactly balances the discounted debt "
+                    "service. For a fee-free, grant-free annuity with annual payments it equals the nominal "
+                    "rate — a built-in self-test — and a repayment grant strictly lowers it."
+                ),
+            ),
+        ),
+        "Energy bill": SectionProse(
+            shows=(
+                "The first full year's energy cost per carrier: consumption charge, standing charge, taxes and "
+                "levies, with feed-in revenue as a negative entry, and the implied *effective price* — the "
+                "total bill divided by the kilowatt hours actually bought."
+            ),
+            adds=(
+                "The link between the simulation's physics and the priced result, one year deep. The effective "
+                "price is the fastest unit-mistake detector in the report: it should land near the tariff's "
+                "working price, and it drifts upward when a fixed standing charge is spread over few purchased "
+                "kilowatt hours — which is exactly what a nearly self-sufficient building looks like, and worth"
+                " recognizing rather than mistaking for a pricing error."
+            ),
+            terms=(
+                ("Carrier (energy carrier)",
+                 "the form energy is delivered in: electricity, natural gas, district heat, pellets, oil."),
+                ("Working price",
+                 "the per-kilowatt-hour part of a tariff: what each consumed unit costs."),
+                ("Standing charge",
+                 (
+                     "the fixed part of a tariff, due regardless of consumption (metering, grid connection), "
+                     "per month or year."
+                 )),
+                ("Levy / energy tax",
+                 "state-imposed components of an energy price (e.g. a CO2 price on fuel)."),
+                ("Feed-in",
+                 (
+                     "electricity exported to the grid, credited at the feed-in rate; appears as a negative "
+                     "(revenue) entry."
+                 )),
+                ("Effective price",
+                 (
+                     "total annual bill ÷ kilowatt hours bought. Compare it with the working price: the gap is "
+                     "the fixed and tax components spread over the volume."
+                 )),
+            ),
+            calculation=(
+                (
+                    "The simulation delivers the year's bought and sold energy per carrier; the tariff data "
+                    "prices them as working price × quantity plus fixed charges, minus feed-in revenue at the "
+                    "feed-in rate. All later years are this bill escalated at per-carrier rates — so a wrong "
+                    "year-1 bill propagates through the whole horizon, which is why it gets its own section."
+                ),
+            ),
+        ),
+        "Energy balance": SectionProse(
+            shows=(
+                "The building's energy flows for one year, in kilowatt hours end-to-end: generation and grid "
+                "import on the left, the battery as a pass-through, consumption and grid export on the right. "
+                "Money appears only as annotations on the grid nodes — import kWh × effective price = bill; "
+                "export kWh × feed-in rate = revenue. The caption states the self-consumption share and the "
+                "self-sufficiency of the building."
+            ),
+            adds=(
+                "The physical story the money charts price. Whether PV mostly exports or mostly substitutes "
+                "purchased electricity, and how hard the battery actually works, determines the bills — and "
+                "none of it is visible in euro charts."
+            ),
+            terms=(
+                ("Grid import",
+                 "electricity bought from the grid; *grid export* — electricity sold to it."),
+                ("Self-consumption share",
+                 (
+                     "the fraction of the building's own generation that the building uses itself (directly or "
+                     "via the battery) instead of exporting."
+                 )),
+                ("Self-sufficiency (autarky)",
+                 (
+                     "the fraction of the building's consumption covered by its own generation. The two shares "
+                     "answer different questions and only coincide by accident."
+                 )),
+                ("Pass-through node",
+                 (
+                     "a node whose inflow equals its outflow plus stated losses; the battery stores energy but "
+                     "is not a source or sink over a full year."
+                 )),
+                ("Battery losses",
+                 (
+                     "the energy lost between charging and discharging (efficiency below 100 %); stated "
+                     "explicitly rather than hidden in the flows."
+                 )),
+                ("Feed-in rate",
+                 "the price per exported kilowatt hour."),
+            ),
+            calculation=(
+                (
+                    "The flows come from the simulation's component outputs, aggregated to annual sums; flow "
+                    "conservation holds at every node. The diagram keeps one scale for every ribbon — thickness"
+                    " is kilowatt hours everywhere — which is why euros are annotations here rather than "
+                    "ribbons: a diagram that changed units midway would have no honest widths."
+                ),
+            ),
+        ),
+        "CO2": SectionProse(
+            shows=(
+                "The lifecycle greenhouse-gas masses, parallel to the money but never mixed with it: embodied "
+                "emissions at each purchase and replacement, and operational emissions per carrier per year, "
+                "undiscounted. A factors table under the chart states every conversion used — kilograms per "
+                "kilowatt hour for each carrier, embodied kilograms per device — so each mass is one visible "
+                "multiplication away from its inputs."
+            ),
+            adds=(
+                "The second bottom line. A renovation is usually argued on both euros and CO2; this section "
+                "keeps the CO2 argument honest by keeping it in kilograms — the *cost* of CO2 (a carbon price "
+                "on the bills, or a damage cost in the macroeconomic perspective) lives in the money charts "
+                "and is deliberately not added to these masses."
+            ),
+            terms=(
+                ("Lifecycle emissions",
+                 (
+                     "all greenhouse gases attributable to the installation over the horizon: those from "
+                     "manufacturing it and those from operating it."
+                 )),
+                ("Embodied emissions",
+                 (
+                     "the mass emitted producing and installing the hardware itself, booked at each purchase "
+                     "and replacement."
+                 )),
+                ("Operational emissions",
+                 (
+                     "the mass emitted by the energy the building consumes, year by year."
+                 )),
+                ("Emission factor",
+                 (
+                     "kilograms of CO2-equivalent per kilowatt hour of a carrier (or per unit of device); the "
+                     "conversion between energy and mass."
+                 )),
+                ("CO2 price vs damage cost",
+                 (
+                     "a CO2 *price* is a real cash flow (a tax on fuel); a *damage cost* is a societal "
+                     "valuation of the harm per tonne, used only in the macroeconomic perspective. Both are "
+                     "money and live in the money charts; this section is mass only."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Embodied masses are per-device factors from the cost database times the installed size, "
+                    "booked at each purchase. Operational masses are the simulated annual energy per carrier "
+                    "times that carrier's emission factor. Masses are not discounted: discounting encodes "
+                    "time preference of *money*, and applying it to physical emissions would claim a tonne "
+                    "emitted later matters less."
+                ),
+            ),
+        ),
+        "Subsidies": SectionProse(
+            shows=(
+                "Per measure, the support programs that were applied, with their amounts and — for non-cash "
+                "forms — their terms; and for measures where a program was checked but not applied, the failed "
+                "condition by name. Where the country has no subsidy catalog, a flat legacy share from the "
+                "device data is used instead, and this section says so."
+            ),
+            adds=(
+                "The audit trail for the least transparent numbers in the evaluation. Subsidy amounts are "
+                "decisions, not prices — eligibility conditions, percentages, bonuses and caps — and this is "
+                "the only place the *reasoning* is visible, including which condition disqualified a program "
+                "you expected to apply."
+            ),
+            terms=(
+                ("Measure",
+                 "the thing being supported: installing a heat pump, insulating a wall."),
+                ("Eligible cost basis",
+                 (
+                     "the part of a measure's cost a program is allowed to subsidize; percentages apply to this"
+                     " basis, not necessarily to the full price."
+                 )),
+                ("Eligibility condition",
+                 (
+                     "a requirement for a program to apply at all (building age, income, technology properties,"
+                     " replacing a functioning fossil system)."
+                 )),
+                ("Cap",
+                 (
+                     "an upper limit on support: maximum eligible cost, maximum percentage, or maximum combined"
+                     " support across programs. \"Binding\" means the limit actually clamped the amount."
+                 )),
+                ("Payout form",
+                 (
+                     "how support arrives: an *upfront grant* (cash at purchase), a *tax credit* (spread over "
+                     "several tax years), *subsidized loan terms* (below-market interest or a repayment grant),"
+                     " or *reduced VAT*."
+                 )),
+                ("Subsidy catalog",
+                 (
+                     "the data file describing a country's programs and rules; without one, a flat percentage "
+                     "from the device data is used as a stand-in (\"legacy share\")."
+                 )),
+            ),
+            calculation=(
+                (
+                    "The solver evaluates each program's conditions against the applicant and building context,"
+                    " stacks eligible percentages on the measure's eligible cost basis, and clamps at every "
+                    "declared cap. Each payout form is booked into the timeline in its own shape; a tax credit "
+                    "spread over years is worth slightly less than its nominal sum, because later instalments "
+                    "are discounted."
+                ),
+            ),
+        ),
+        "Perspectives": SectionProse(
+            shows=(
+                "The same evaluation through different eyes: one row per perspective, each with its *equivalent"
+                " annual cost* — the NPV converted into a constant per-year amount — and its band."
+            ),
+            adds=(
+                "The recognition that \"what does it cost\" has no single answer: the tenant's costs are partly "
+                "the landlord's income, subsidies vanish from society's view, financing moves money in time. "
+                "Reading differences between rows is reading who the technology is expensive *for* — and "
+                "several built-in inequalities (gross ≥ net; operating ≤ total) double as sanity checks."
+            ),
+            terms=(
+                ("Perspective",
+                 (
+                     "a defined viewpoint: which flows count and whose they are. The same timeline, filtered "
+                     "differently."
+                 )),
+                ("Gross perspective",
+                 "all costs, no subsidies: what the technology costs, regardless of who helps pay."),
+                ("Net perspective",
+                 "after subsidies: what the owner pays."),
+                ("Operating perspective",
+                 "running costs only, no purchase: the view of someone who already owns the system."),
+                ("Financed owner",
+                 (
+                     "the net perspective with a loan instead of upfront payment: the purchase becomes a "
+                     "payment stream."
+                 )),
+                ("Landlord / tenant perspectives",
+                 "the rental split: who bears which cost and who receives the levy (see *Who pays what*)."),
+                ("Macroeconomic perspective",
+                 (
+                     "society's view: transfers between parties (subsidies, taxes, levies) cancel out, and CO2 "
+                     "is charged at a damage cost instead of a market price."
+                 )),
+                ("Equivalent annual cost (EAC)",
+                 (
+                     "the constant yearly payment with the same present value as the whole plan; makes "
+                     "different horizons and technologies comparable per year."
+                 )),
+                ("Transfer",
+                 (
+                     "money changing hands between parties inside the evaluation without changing society's "
+                     "total: a subsidy, a tax, a levy."
+                 )),
+            ),
+            calculation=(
+                (
+                    "All perspectives read the same timeline through different filters. The equivalent annual "
+                    "cost is the NPV multiplied by the annuity factor i(1+i)ⁿ/((1+i)ⁿ−1) — the constant annual "
+                    "payment with the same present value — making horizons and technologies comparable per year"
+                    " instead of per lump sum."
+                ),
+            ),
+        ),
+        "Who pays what": SectionProse(
+            shows=(
+                "The landlord/tenant split of every cost group under the active allocation rules: who bears "
+                "energy, operation, investment, support — and the modernization levy the landlord may add to "
+                "the rent, which appears as the tenant's cost and the landlord's income. Negative totals are "
+                "net gains."
+            ),
+            adds=(
+                "The distributional answer for rental property. The owner-occupier perspectives cannot say who "
+                "wins or loses when landlord and tenant are different parties; this section carries exactly "
+                "that, including whether regulation (levy caps) shifts the balance."
+            ),
+            terms=(
+                ("Allocation",
+                 (
+                     "the rule-based assignment of each cost to a party (landlord or tenant), or its split "
+                     "between them; the rules are country- and year-specific."
+                 )),
+                ("Apportionable costs",
+                 (
+                     "operating costs a landlord may legally pass on to the tenant (many operating and metering"
+                     " costs); non-apportionable ones stay with the landlord."
+                 )),
+                ("Modernization levy",
+                 (
+                     "the legally capped annual rent increase a landlord may charge after improving the "
+                     "building: a share of the eligible modernization cost per year."
+                 )),
+                ("Levy cap",
+                 (
+                     "the legal ceiling on that rent increase, per square meter and month; heating measures "
+                     "have their own stricter ceiling."
+                 )),
+                ("Net gain",
+                 (
+                     "a party whose received money exceeds its paid money over the horizon shows a negative "
+                     "total: the evaluation is profitable *for that party*."
+                 )),
+                ("Zero-sum",
+                 (
+                     "the landlord's and tenant's flows must sum to the unallocated whole; allocation moves "
+                     "money between parties, it never creates or destroys any."
+                 )),
+            ),
+            calculation=(
+                (
+                    "An allocation ruleset assigns each timeline entry to a party or splits it. The "
+                    "modernization levy converts a share of eligible modernization cost into an annual rent "
+                    "increase, clamped by the legal caps, and is booked as a matched pair: tenant pays, "
+                    "landlord receives. The zero-sum property is a checked invariant."
+                ),
+            ),
+        ),
+        "Who pays whom": SectionProse(
+            shows=(
+                "The money as flows, left to right: external sources first, then this story's parties — each "
+                "in its own column, ordered so that payments between them also flow left to right — then the "
+                "external recipients: market, suppliers, state, bank, grid operator. Ribbon thickness is the "
+                "nominal sum over the whole horizon; the modernization levy is the ribbon running from the "
+                "tenant's column to the landlord's. A party that receives more than it pays out closes its "
+                "block with a short labeled stub — its net position — so every block's height is fully "
+                "accounted for: inflows on one face, outflows plus the net stub on the other."
+            ),
+            adds=(
+                "Direction. The tables above say how much each party pays in total; this picture says where "
+                "each euro comes from and where it ends up — including the state's double role as subsidy "
+                "source and tax recipient, and the direct tenant-to-landlord transfer."
+            ),
+            terms=(
+                ("Counterparty",
+                 (
+                     "the external party on the other side of a payment: the market (installers, vendors) for "
+                     "purchases, suppliers for energy and maintenance, the state for taxes and subsidies, the "
+                     "bank for the loan, the grid operator for exported electricity."
+                 )),
+                ("Party (actor)",
+                 "a participant inside the evaluation: household, landlord, tenant."),
+                ("Nominal lifetime sum",
+                 (
+                     "all of a flow's yearly nominal amounts added up over the horizon, without discounting; "
+                     "the quantity behind each ribbon's thickness."
+                 )),
+                ("Transfer",
+                 (
+                     "a payment between two internal parties, drawn as a direct ribbon; it cancels out in any "
+                     "total across all parties."
+                 )),
+                ("Flow conservation",
+                 (
+                     "at every block, inflow equals outflow; a diagram violating it would be inventing or "
+                     "losing money."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Each timeline entry is classified by its category into a counterparty and by its payer "
+                    "into a source. Flow conservation holds per node, ribbon thickness is constant along each "
+                    "ribbon, and matched transfer pairs must cancel exactly across the parties — all checked "
+                    "before rendering."
+                ),
+            ),
+        ),
+        "Uncertainty drivers": SectionProse(
+            shows=(
+                "One bar per subject: how far the total moves when the whole evaluation switches from the "
+                "average to the optimistic world (one direction) or the pessimistic one (the other), measured "
+                "for that subject alone. Bars are sorted by width; small contributors are folded into one row; "
+                "the bars sum exactly to the total band restated under the chart."
+            ),
+            adds=(
+                "Where the band comes from. The headline says the result is uncertain; this section says *which"
+                " assumptions* carry that uncertainty — and therefore which price research or which quote would"
+                " narrow the answer most. Arguing about a narrow bar is wasted effort."
+            ),
+            terms=(
+                ("Subject",
+                 (
+                     "one carrier of cost in this report: a component (heat pump, wall insulation) or an energy"
+                     " position (electricity, feed-in)."
+                 )),
+                ("Optimistic / pessimistic world",
+                 (
+                     "the all-cheap and all-expensive scenarios from the primer; every price at its favorable "
+                     "or unfavorable band edge at once."
+                 )),
+                ("Attribution",
+                 (
+                     "splitting an already computed total into the shares its parts contributed. Nothing is "
+                     "re-computed; the whole is decomposed."
+                 )),
+                ("Sensitivity analysis",
+                 (
+                     "the different thing this is **not**: varying one input at a time and re-evaluating to "
+                     "measure its isolated effect."
+                 )),
+                ("Fold (\"other\" row)",
+                 (
+                     "small contributors merged into one row to keep the chart readable; the merged row keeps "
+                     "their exact sum, so the total still reconciles."
+                 )),
+                ("Credit subject",
+                 (
+                     "a subject whose money flows toward the household (feed-in revenue, support). Its cheap "
+                     "world is the world where the credit is *small*, which is why both its bars can lie on the"
+                     " same side of the axis."
+                 )),
+            ),
+            calculation=(
+                (
+                    "The engine evaluates three complete worlds anyway; this chart decomposes the low and high "
+                    "totals into per-subject shares under the same rules as the totals themselves, which is why"
+                    " the parts must sum to the whole (a checked invariant)."
+                ),
+            ),
+        ),
+        "Component breakdown": SectionProse(
+            shows=(
+                "For each component, its lifetime money as a diverging bar: costs to the right of the zero line"
+                " (purchase, replacements, maintenance, energy), credits to the left (residual value, "
+                "subsidies, revenue, avoided-anyway costs), never netted into each other. The dot and whisker "
+                "mark the component's net NPV with its band."
+            ),
+            adds=(
+                "The per-device verdict with its composition intact. Two components with the same net figure "
+                "can have opposite structures — expensive-to-buy-cheap-to-run versus the reverse — and lumping "
+                "costs and credits into one smaller bar would hide exactly that."
+            ),
+            terms=(
+                ("Diverging bar",
+                 (
+                     "a bar growing in both directions from a shared zero line: costs one way, credits the "
+                     "other, so both magnitudes stay visible."
+                 )),
+                ("Netting",
+                 (
+                     "collapsing costs and credits into their difference. This chart deliberately does not net;"
+                     " the whisker marks the net so you get both."
+                 )),
+                ("Net NPV",
+                 "a component's costs minus its credits, in present value: its bottom line."),
+                ("Whisker",
+                 "the thin line through the dot marking the min/max band of the net figure."),
+                ("Anyway credit",
+                 (
+                     "the avoided cost of the renovation the building would have needed regardless (see "
+                     "*Cash-flow timeline*), credited to the components that replaced it — at the *anyway "
+                     "share*: only the fraction the counterfactual would truly have spent (full for a "
+                     "like-for-like replacement, the repair share for a first-time improvement)."
+                 )),
+                ("Residual value",
+                 "the horizon-year refund for remaining equipment life (see *Lifetimes*)."),
+            ),
+            calculation=(
+                (
+                    "All flows carry a subject tag, so this is the timeline pivoted by component in present "
+                    "value. Net = costs − credits per component, and the nets sum to the headline NPV — the "
+                    "reconciliation that makes the breakdown trustworthy."
+                ),
+            ),
+        ),
+        "Cost structure": SectionProse(
+            shows=(
+                "The lifetime present value as a mosaic: each rectangle is one cost group of one component, "
+                "area proportional to its share. Two panels: the left shows the cost side only (with total "
+                "credits stated in the caption); the right shrinks each component by the credits it attracted, "
+                "and names every component whose credits exceeded its costs."
+            ),
+            adds=(
+                "Proportion at a glance — the answer to \"where does the money actually go\" that bar charts give"
+                " less immediately. The two panels bracket the honest range: a mosaic cannot draw negative "
+                "areas, so showing gross-plus-caption *and* net-with-disclosure is the way to show composition "
+                "without hiding the credits."
+            ),
+            terms=(
+                ("Present value share",
+                 "a money's fraction of the discounted total; the quantity behind each rectangle's area."),
+                ("Treemap (mosaic)",
+                 (
+                     "a chart that divides a rectangle into tiles whose areas are the shares; good for "
+                     "proportion, incapable of negative areas."
+                 )),
+                ("Gross panel",
+                 "cost side only: what is spent, before credits."),
+                ("Net-of-credits panel",
+                 (
+                     "each component shrunk by its own credits (subsidies, revenue, residual): what it costs "
+                     "after everything it earns back."
+                 )),
+                ("Clamped",
+                 (
+                     "a component whose credits exceed its costs cannot be drawn smaller than zero; its tile is"
+                     " set to zero and the overshoot is disclosed in the caption instead of vanishing."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Areas are the same present values as everywhere else, laid out by a squarified treemap "
+                    "(rectangles kept near-square for readability). In the net panel each component's credits "
+                    "are subtracted from its own cost tiles proportionally; net-panel total minus disclosed "
+                    "clamping must equal the headline NPV — a checked identity."
+                ),
+            ),
+        ),
+        "Cost shapes": SectionProse(
+            shows=(
+                "Components on the left, kinds of cost on the right, ribbon thickness the lifetime present "
+                "value connecting them. Solid ribbons are costs; dashed translucent ribbons are credits; "
+                "nothing is netted, so a PV system visibly has both an investment ribbon and a revenue "
+                "ribbon. Because nothing is netted, a component's block stacks its costs and the magnitude "
+                "of its credits — deliberately larger than both its gross cost and its net figure — and the "
+                "block's label states both sides so the block can be checked against the component "
+                "breakdown: the solid side is that table's cost column, the dashed side its credits."
+            ),
+            adds=(
+                "The *shape* of each technology's cost, which every total hides: a cheap device with expensive "
+                "fuel and an expensive device with cheap fuel can have identical totals and completely "
+                "different ribbons. In a technology comparison, this shape is usually the actual argument."
+            ),
+            terms=(
+                ("Kind of cost (category)",
+                 (
+                     "what a payment is for: purchase, replacement, energy, maintenance, revenue, support, "
+                     "residual. The right-hand blocks of this chart."
+                 )),
+                ("Ribbon",
+                 (
+                     "a band whose thickness is the amount connecting a component to a kind of cost; thickness "
+                     "is the number, the curve is routing."
+                 )),
+                ("Present value",
+                 "discounted to today; see the primer."),
+                ("Netting",
+                 (
+                     "collapsing a component's costs and credits into one smaller number; refused here so both "
+                     "directions stay visible."
+                 )),
+            ),
+            calculation=(
+                (
+                    "The same subject-by-category pivot as the component breakdown, drawn as flows. Both "
+                    "margins reconcile with their tables — per-component sums with the breakdown, per-category "
+                    "sums with the cost-structure groups — and the geometry rules of every flow diagram in this"
+                    " report apply: one scale, constant ribbon thickness, nodes tiled exactly."
+                ),
+            ),
+        ),
+        "Equity build-up": SectionProse(
+            shows=(
+                "Two lines and the gap between them: the book value of the installed hardware, written down in "
+                "a straight line from every purchase and stepped back up at every replacement; and the "
+                "outstanding loan balance, falling as principal is repaid. The filled gap is the owner's equity"
+                " in the installation. An interval where the debt line is above the book-value line is marked: "
+                "the installation is worth less than what is owed on it."
+            ),
+            adds=(
+                "The lender's solvency picture. Payback and NPV say nothing about collateral; this section "
+                "shows whether debt outruns asset value at any point — the condition a bank checks — and when "
+                "the installation is fully owned."
+            ),
+            terms=(
+                ("Book value",
+                 (
+                     "the accounting worth of equipment: purchase price reduced by straight-line depreciation "
+                     "over its service life (after k of L years: (L−k)/L of the price)."
+                 )),
+                ("Straight-line depreciation",
+                 "spreading a purchase price evenly over the service life."),
+                ("Outstanding balance",
+                 "the loan principal still owed (see *Loan*)."),
+                ("Equity",
+                 "book value minus debt: the owned share of the installation."),
+                ("Negative equity (\"underwater\")",
+                 "debt exceeding book value; selling the asset would not repay the loan."),
+                ("Collateral",
+                 "the asset a lender can claim if the loan fails; its book value is what backs the debt."),
+                ("Solvency",
+                 "assets covering liabilities; the condition this chart makes visible over time."),
+            ),
+            calculation=(
+                (
+                    "Book value uses the same straight-line depreciation as the residual-value convention, "
+                    "which pins this chart to the rest of the report twice over: at the horizon the book value "
+                    "must equal the residual credit booked in the results, and at every purchase it must step "
+                    "by exactly the charged amount. The balance line is the loan section's series reused, not "
+                    "recomputed."
+                ),
+            ),
+        ),
+        "Scenarios": SectionProse(
+            shows=(
+                "The headline result re-evaluated under alternative assumptions — different interest rates, "
+                "energy-price escalations, technology-cost paths — one row per scenario, with the shift "
+                "against the central case. Each row states the assumption it changed and both values, the "
+                "central one and the scenario's own, so the swing is never a label without a cause."
+            ),
+            adds=(
+                "Structured what-if beyond the three built-in worlds. The band answers \"what if everything "
+                "is cheap or expensive at once\"; scenarios answer targeted questions — what if only the "
+                "interest rate doubles, what if electricity escalates fast while the rest stays put."
+            ),
+            terms=(
+                ("Scenario",
+                 (
+                     "one named alternative set of economic assumptions, evaluated in full."
+                 )),
+                ("Central case",
+                 (
+                     "the evaluation's main assumptions; the reference all scenario shifts are measured "
+                     "against."
+                 )),
+                ("Axis",
+                 (
+                     "the one assumption a scenario varies (interest rate, an escalation rate, a technology "
+                     "price), holding the rest at the central case."
+                 )),
+                ("Escalation path",
+                 (
+                     "the assumed trajectory of a price over the years (e.g. a fast-rising electricity price)."
+                 )),
+                ("Re-pricing",
+                 (
+                     "recomputing the money on the stored simulation results without re-running the building "
+                     "physics; prices do not change what the building did, only what it cost."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Each scenario re-runs the *pricing* of the stored evaluation with one axis changed — the "
+                    "simulation itself is not re-run. Scenario values are therefore exactly comparable to the "
+                    "central case: same building, same flows, different money."
+                ),
+            ),
+        ),
+        "Monthly burden": SectionProse(
+            shows=(
+                "The recurring cost per month, year by year: energy, maintenance, taxes, levies and debt "
+                "service, minus running credits such as feed-in revenue, stacked by cost group with the band as"
+                " a whisker. A dashed line above the bars adds the *replacement reserve* — the constant monthly"
+                " amount that would prefund all future replacements. Capital events themselves — the year-0 "
+                "investment and the replacement purchases — are deliberately not in the bars."
+            ),
+            adds=(
+                "The household's unit of account. NPVs decide, but budgets are monthly; this is the number to "
+                "hold against rent, current bills, or a bank's affordability calculation. Excluding capital "
+                "events keeps the definition consistent: purchases are financing events (shown in *Funding* and"
+                " the timeline), not monthly burden — and the reserve line is the honest monthly representation"
+                " of the replacements that would otherwise be invisible here."
+            ),
+            terms=(
+                ("Recurring cost",
+                 (
+                     "cost that arrives continually (bills, maintenance, loan payments), as opposed to one-off "
+                     "capital events."
+                 )),
+                ("Capital event",
+                 (
+                     "a purchase: the year-0 investment or a replacement. Large, rare, and typically financed "
+                     "rather than paid out of a monthly budget."
+                 )),
+                ("Replacement reserve",
+                 (
+                     "the constant monthly saving that would exactly prefund all future replacements; the "
+                     "budgeting equivalent of a building's maintenance reserve."
+                 )),
+                ("Prefund",
+                 "saving ahead of a known future expense so the money exists when it is due."),
+                ("Equivalent annual cost (EAC)",
+                 (
+                     "a lump sum converted into the constant yearly amount with the same present value; the "
+                     "reserve is the replacements' EAC divided by twelve."
+                 )),
+                ("Whisker",
+                 "the min/max band of the monthly total per year."),
+                ("Affordability",
+                 (
+                     "whether a household's monthly income supports the monthly burden; the bank's question, "
+                     "distinct from whether the project is profitable."
+                 )),
+            ),
+            calculation=(
+                (
+                    "The bars are the recurring categories of the timeline divided by twelve, per year, "
+                    "escalation included. The reserve is the equivalent annual cost of the replacement flows "
+                    "divided by twelve; it reconciles with the replacement present value via the annuity "
+                    "factor, and the year-one bar reconciles with the published monthly cost figure. Actual "
+                    "replacement *years* are visible in the cash-flow timeline and *At a glance*."
+                ),
+            ),
+        ),
+        "KPIs": SectionProse(
+            shows=(
+                "The published key figures in one table — NPV, equivalent annual cost, monthly cost, the system "
+                "cost per unit of heat, CO2, subsidies per program — each as average with its band. This table "
+                "is what the machine-readable export contains."
+            ),
+            adds=(
+                "The interface. Everything above explains; this section is what downstream tools, comparisons "
+                "and archives consume — the numbers of record, stated once, with their bands."
+            ),
+            terms=(
+                ("KPI (key performance indicator)",
+                 (
+                     "a headline figure chosen to summarize the evaluation; each has a fixed name and recipe so"
+                     " results are comparable across runs."
+                 )),
+                ("System cost per unit of heat",
+                 (
+                     "this evaluation's entire cost (everything in the perspective: heating, PV, battery, "
+                     "revenues) divided by the heat delivered. Deliberately **not** called a levelized cost of "
+                     "heat: an LCOH in the literature counts heating costs only, and this system has no "
+                     "heating-only attribution — so this figure runs high whenever the system contains more "
+                     "than heating, and it is comparable between variants of the same system, not against "
+                     "published LCOH values."
+                 )),
+                ("Machine-readable export",
+                 (
+                     "the same numbers as a data file (JSON) for programs rather than people; this table is its"
+                     " human-readable mirror."
+                 )),
+                ("Band",
+                 "the min/max world values around each average; see the primer."),
+            ),
+            calculation=(
+                (
+                    "Each KPI names its recipe: the system cost per unit of heat, for example, is the "
+                    "equivalent annual cost divided by the annual heat demand — equivalently the NPV divided "
+                    "by the discounted heat sum. Every KPI is an aggregation of the same timeline as every "
+                    "chart, so table and charts cannot disagree."
+                ),
+            ),
+        ),
+        "Comparison": SectionProse(
+            shows=(
+                "This evaluation against its reference variant: the per-component NPV differences (what the "
+                "switch adds, what it saves) and the cumulative discounted savings over time, whose zero "
+                "crossing is the payback."
+            ),
+            adds=(
+                "The decision frame. A single evaluation states a cost; only the comparison states whether the "
+                "*change* pays — against the do-nothing (or keep-the-old-system) baseline it was computed for."
+            ),
+            terms=(
+                ("Reference (baseline)",
+                 (
+                     "the counterfactual evaluation the change is measured against: keep the old system, do "
+                     "nothing. Note that a reference may still contain investments of its own; shared "
+                     "investments cancel in the comparison."
+                 )),
+                ("Variant",
+                 "the evaluation containing the change under decision."),
+                ("Delta",
+                 "variant minus reference, per component or per year; negative deltas are savings."),
+                ("Cumulative discounted savings",
+                 (
+                     "the running total of the yearly deltas, discounted; the curve whose zero crossing is the "
+                     "payback."
+                 )),
+                ("Payback",
+                 (
+                     "the first year the accumulated savings have repaid the extra investment; reported per "
+                     "world (see the primer's bands)."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Both variants are full evaluations under identical economic parameters; the comparison "
+                    "subtracts them component by component and year by year. If the reference also invests "
+                    "(keeping its own PV, say), those shared investments cancel and the comparison isolates the"
+                    " actual difference between the paths."
+                ),
+            ),
+        ),
+        "NPV bridge": SectionProse(
+            shows=(
+                "A waterfall from the reference total (left anchor) to this variant's total (right anchor): "
+                "each bar is one cost group's contribution to the difference — rightward bars add cost, "
+                "leftward bars save — and the bars sum exactly to the gap between the anchors. The anchors "
+                "carry the bands."
+            ),
+            adds=(
+                "The *why* of the comparison in one picture: which groups drive the verdict and which are "
+                "noise. Groups keep a fixed order and their usual colors — deliberately not red/green, because "
+                "whether a cost increase is \"bad\" depends on who pays it — so two reports can be laid side by "
+                "side."
+            ),
+            terms=(
+                ("Waterfall (bridge)",
+                 (
+                     "a chart that walks from one total to another through the individual contributions in "
+                     "between; the floating bars must sum exactly to the difference."
+                 )),
+                ("Anchor",
+                 (
+                     "the two solid end bars: the reference total and the variant total, the only actually "
+                     "evaluated figures in the picture."
+                 )),
+                ("Contribution",
+                 (
+                     "one cost group's share of the difference: its present value in the variant minus in the "
+                     "reference."
+                 )),
+                ("Cost group",
+                 "the report's color-coded categories (see *Cash-flow timeline*)."),
+                ("Band",
+                 (
+                     "shown on the anchors only: the middle bars are differences of scenarios, and the extremes"
+                     " of a difference are not the difference of extremes, so drawing bands on them would "
+                     "fabricate precision."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Each bar is the present-value difference of one cost group between the variants (folded "
+                    "over components). The middle bars carry no bands for the reason above; the anchors, which "
+                    "are real evaluated totals, show theirs."
+                ),
+            ),
+        ),
+        "Bank benchmark": SectionProse(
+            shows=(
+                "The renovation raced against a savings account. Upper panel: how far ahead the renovating "
+                "household is over time, one thin line per interest rate from one to ten percent, the "
+                "evaluation's own rate drawn heavy with its band — above zero, renovating is winning. Lower "
+                "panel: the final advantage at the horizon as a function of the rate; where that curve crosses "
+                "zero is the rate a bank account would need to beat the renovation."
+            ),
+            adds=(
+                "The everyday framing of discounting. The interest rate every NPV depends on stops being an "
+                "abstract parameter: this chart shows the verdict at *your* alternative rate, whatever it is — "
+                "and the crossing rate is the renovation's internal rate of return, the single number that "
+                "summarizes \"how good an investment is this\"."
+            ),
+            terms=(
+                ("Compounding",
+                 (
+                     "interest earning interest: a balance grows by (1 + rate) each year, the mirror image of "
+                     "discounting."
+                 )),
+                ("Opportunity cost",
+                 (
+                     "what the money could have earned in its best alternative use; the savings account here "
+                     "stands in for that alternative."
+                 )),
+                ("Terminal advantage",
+                 (
+                     "the difference between the two households' wealth at the horizon, per interest rate; the "
+                     "lower panel's y-axis."
+                 )),
+                ("Internal rate of return (IRR)",
+                 (
+                     "the interest rate at which the renovation and the savings account end exactly even; above"
+                     " it the account wins, below it the renovation does."
+                 )),
+                ("Nominal, pre-tax interest",
+                 (
+                     "the plain quoted rate: no inflation adjustment and no tax on the interest income, because"
+                     " capital-income taxation is country-specific and deliberately out of scope."
+                 )),
+            ),
+            calculation=(
+                (
+                    "For each rate, the year-by-year cost difference between doing nothing and renovating (the "
+                    "unspent investment on one side, the unspent bills on the other) is compounded forward like"
+                    " a bank balance. The construction is exactly discounting run in reverse — the final "
+                    "advantage equals (1+i)ⁿ times the NPV difference at rate i, an identity the report tests —"
+                    " which is why the verdict at the evaluation's own rate provably agrees with every NPV "
+                    "chart."
+                ),
+            ),
+        ),
+        "Owner statement": SectionProse(
+            shows=(
+                "The owner-occupier's position as a two-sided statement over the same categories as every "
+                "chart. On the cash side: the investment net of subsidies, the energy bills, maintenance and "
+                "replacements paid; the feed-in revenue received; the loan flows where the financed view "
+                "applies. On the accounting side: the residual value of the hardware at the horizon and the "
+                "anyway credit for renovation the building needed regardless — values, not payments. Each "
+                "side is subtotaled before they combine into the perspective's net figure."
+            ),
+            adds=(
+                "The decomposition of the owner rows in the perspectives table, which until here were single "
+                "numbers. It also carries the honest caveat in the same place as the figure: how much of the "
+                "owner's result is money that moved, and how much is book value and avoided hypothetical "
+                "cost."
+            ),
+            terms=(
+                ("Net investment",
+                 (
+                     "gross purchase prices minus the subsidies granted; what actually left the owner's "
+                     "account in year 0."
+                 )),
+                ("Cash flow vs accounting credit",
+                 (
+                     "cash moves through an account (bills, revenue, subsidies); an accounting credit values "
+                     "something without moving money (remaining equipment worth, an avoided hypothetical "
+                     "expense)."
+                 )),
+                ("Residual value",
+                 (
+                     "the book worth of the installation at the horizon (see *Lifetimes*)."
+                 )),
+                ("Anyway credit",
+                 (
+                     "the avoided counterfactual renovation cost at its anyway share (see *Cash-flow "
+                     "timeline*)."
+                 )),
+                ("Net position",
+                 (
+                     "both sides combined, in present value; the number the perspectives table reports for "
+                     "this view."
+                 )),
+            ),
+            calculation=(
+                (
+                    "The perspective's category totals, partitioned: cash categories on one side, the two "
+                    "accounting-credit categories on the other. No new arithmetic — the two subtotals must "
+                    "sum exactly to the perspective's NPV, and the report verifies that identity."
+                ),
+            ),
+        ),
+        "Landlord statement": SectionProse(
+            shows=(
+                "The landlord's business case, twice over the same numbers. The table is a two-sided "
+                "statement: on one side the money that actually moves — the investment, maintenance and "
+                "replacements paid; the levy income, the subsidies and the feed-in revenue received — and on "
+                "the other side the accounting credits that are *not* cash: the residual value of the "
+                "hardware at the horizon, and the anyway credit for renovation the building would have needed "
+                "regardless. The flow picture below it is the same statement drawn as an income Sankey: "
+                "income ribbons arrive from the left, expense ribbons leave to the right, and the ribbon left "
+                "over *is* the net position. Solid ribbons are cash; hatched ribbons are the accounting "
+                "credits — so the cash/accounting split is visible, not just stated."
+            ),
+            adds=(
+                "The explanation the headline number cannot carry. A landlord perspective can show a strongly "
+                "negative net position — a gain — while the landlord's bank account sees far less of it: part "
+                "of that gain is book value and avoided hypothetical cost, not income. Separating cash from "
+                "accounting is what makes the landlord row of the perspectives table honest, and it is where "
+                "to check which kind of advantage the renovation actually produces."
+            ),
+            terms=(
+                ("Levy income",
+                 (
+                     "the modernization levy from the tenant's side of the ledger: a permanent, legally capped "
+                     "rent increase after modernization; the landlord's largest recurring income item here."
+                 )),
+                ("§559 cap",
+                 (
+                     "the legal ceiling on that increase, per square meter and month; when it binds, the levy "
+                     "is set by the cap, not by the modernization cost."
+                 )),
+                ("Cash flow vs accounting credit",
+                 (
+                     "cash moves through an account (levy, subsidy, bill); an accounting credit values "
+                     "something without moving money (remaining equipment worth, an avoided hypothetical "
+                     "expense). Both belong in a lifecycle result; only one pays bills."
+                 )),
+                ("Residual value",
+                 (
+                     "the book worth of the installation at the horizon (see *Lifetimes*); real if the "
+                     "property is sold or the equipment keeps serving, but not a payment."
+                 )),
+                ("Anyway credit",
+                 (
+                     "the avoided counterfactual renovation cost, at its anyway share (see *Cash-flow "
+                     "timeline*); a comparison against a world that did not happen, by construction never a "
+                     "payment."
+                 )),
+                ("Net position",
+                 (
+                     "all of it combined, in present value; negative means the renovation is advantageous for "
+                     "the landlord on the stated basis."
+                 )),
+                ("Income Sankey (statement Sankey)",
+                 (
+                     "the standard flow rendering of an income statement: what comes in from the left, what "
+                     "goes out to the right, and the remaining ribbon is the profit or loss. Here with solid "
+                     "ribbons for cash and hatched ribbons for accounting credits."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Every item is the landlord's slice of the same timeline as everywhere else, under the "
+                    "active allocation rules: the levy pair books the tenant's payment and the landlord's "
+                    "receipt in equal size, the investment net of subsidies falls to the landlord, and the "
+                    "apportionable operating costs pass through to the tenant. The statement's split is by "
+                    "category, not new arithmetic: cash categories on one side, the two accounting-credit "
+                    "categories on the other, and the sides sum exactly to the landlord perspective's NPV."
+                ),
+            ),
+        ),
+        "Tenant statement": SectionProse(
+            shows=(
+                "The tenant's side of the rented-out story as a statement: the modernization levy added to "
+                "the rent, the energy bills, and the apportionable operating costs passed through by the "
+                "landlord — everything the tenant pays because of the renovation, year by year in present "
+                "value. The tenant receives nothing back in this ledger; where the renovation lowers the "
+                "energy bill, that relief appears as a smaller energy item, not as income."
+            ),
+            adds=(
+                "The tenant's number decomposed — and the fairness question made checkable: how much of the "
+                "tenant's burden is the levy (set by law and caps) versus energy (set by physics and prices). "
+                "A renovation that saves energy but carries a high levy can still be a net loss for the "
+                "tenant; this is the section where that verdict is visible."
+            ),
+            terms=(
+                ("Modernization levy",
+                 (
+                     "the legally capped permanent rent increase after modernization; the tenant's payment and "
+                     "the landlord's income, always booked as an equal pair."
+                 )),
+                ("Apportionable operating costs",
+                 (
+                     "running costs a landlord may legally pass to the tenant; the non-apportionable rest "
+                     "stays with the landlord."
+                 )),
+                ("Energy relief",
+                 (
+                     "the tenant's energy bill after the renovation is lower than before; in this statement it "
+                     "shows as a smaller cost, not as a credit line."
+                 )),
+                ("Net position",
+                 (
+                     "everything combined; for a tenant this is virtually always a cost, and the comparison "
+                     "that matters is against what the tenant would have paid without the renovation."
+                 )),
+            ),
+            calculation=(
+                (
+                    "The tenant's slice of the same timeline under the allocation rules: the levy pair's "
+                    "paying half, the energy bills of the occupant, and the apportioned share of operation. "
+                    "The items sum exactly to the tenant perspective's NPV — verified — and the levy line "
+                    "must mirror the landlord statement's levy income to the euro."
+                ),
+            ),
+        ),
+        "Society statement": SectionProse(
+            shows=(
+                "The macroeconomic position as a statement in two groups. Real resource costs and benefits: "
+                "the hardware bought, the maintenance performed, the energy consumed, the residual and anyway "
+                "values — things that use or preserve actual resources. And the transfers: subsidies, taxes, "
+                "levies — which appear here with both their halves so their sum is visibly zero. CO2 enters "
+                "as a cost at its damage-cost path, not at any market or legal price."
+            ),
+            adds=(
+                "The proof of what \"macroeconomic\" means, instead of the word: the transfers that dominate "
+                "the household stories cancel line by line, and what remains is what the renovation costs or "
+                "saves the economy — plus the emissions valued at their harm. Reading this section against "
+                "the owner and landlord statements shows exactly which private gains are society's transfers "
+                "and which are real."
+            ),
+            terms=(
+                ("Transfer",
+                 (
+                     "money moving between parties without using resources: a subsidy, a tax, a levy. In the "
+                     "society view every transfer appears twice with opposite signs and sums to zero."
+                 )),
+                ("Real resource cost",
+                 (
+                     "cost that consumes actual goods or labor: hardware, installation, maintenance, fuel."
+                 )),
+                ("CO2 damage cost",
+                 (
+                     "the societal harm per tonne of CO2, from the damage-cost path in the assumptions; "
+                     "distinct from any CO2 price a household pays, which is a transfer."
+                 )),
+                ("Macroeconomic NPV",
+                 (
+                     "the society perspective's bottom line: real resources plus valued emissions, transfers "
+                     "cancelled."
+                 )),
+            ),
+            calculation=(
+                (
+                    "The same timeline with every party included at once: transfer pairs cancel by "
+                    "construction (verified as an explicit zero line in the table), resource categories keep "
+                    "their values, and the emission masses from the CO2 section are multiplied by the "
+                    "damage-cost path and discounted like money. The statement sums exactly to the macroeconomic "
+                    "NPV."
+                ),
+            ),
+        ),
+        "Ledger heatmap": SectionProse(
+            shows=(
+                "The entire cash-flow ledger as a matrix: one row per cost category, one column per year, each "
+                "cell the nominal sum, colored on a diverging scale (costs warm, credits cool) with a "
+                "logarithmic-like ramp so small operational flows stay visible next to the year-0 investment."
+            ),
+            adds=(
+                "Completeness at a glance, for the auditor rather than the decision-maker: a stray flow in an "
+                "impossible year, a category that should be empty and is not, an escalation that flatlines — "
+                "patterns that stacked bars compress away."
+            ),
+            terms=(
+                ("Ledger",
+                 (
+                     "the complete list of dated, categorized cash flows behind the whole report; the timeline "
+                     "seen as a bookkeeping record."
+                 )),
+                ("Category",
+                 (
+                     "the fine-grained kind of a flow (investment, energy working price, standing charge, "
+                     "maintenance, residual value, …); finer than the color-coded cost groups."
+                 )),
+                ("Nominal",
+                 "the year's actual amount, escalated, not discounted (see the primer)."),
+                ("Diverging color scale",
+                 (
+                     "a scale with a neutral middle at zero and opposing hues for positive (cost) and negative "
+                     "(credit), so sign errors are visible as wrong-colored cells."
+                 )),
+                ("Symlog ramp",
+                 (
+                     "\"symmetric logarithmic\": linear near zero, logarithmic further out, so a hundred-euro fee"
+                     " and a hundred-thousand-euro purchase are both readable in one picture."
+                 )),
+            ),
+            calculation=(
+                (
+                    "Cells are the raw timeline aggregated by category and year, before discounting. Row sums "
+                    "reconcile with the per-category totals and column sums with the annual series — the same "
+                    "numbers as everywhere, arranged for pattern-spotting."
+                ),
+            ),
+        ),
+    }
+
+    #: The short authored lead-in of each story chapter (owner decision Q24). Chapter intros are
+    #: deliberately *not* four-part `SectionProse`: a chapter is not a chart, it has nothing to
+    #: show, add, define or calculate — it is the sentence that says which of the three questions
+    #: the sections below it answer. Keyed by the chapter names `ReportChapters` publishes, for
+    #: the same reason `SECTIONS` is keyed by section name: a renamed chapter fails loudly in
+    #: `for_chapter` instead of silently rendering an unexplained heading.
+    CHAPTER_INTROS: Dict[str, str] = {
+        "The building": (
+            "What the technology costs and does, before asking whose money it is: the priced inputs, the "
+            "flows over the years, the energy physics, the emissions, and where the uncertainty sits. "
+            "Everything here is on the gross basis — subsidies and the question of who pays come in the "
+            "story chapters that follow."
+        ),
+        "Owner-occupied": (
+            "The first story: the owner lives in the house. Support is subtracted, financing is real, and "
+            "the questions are a household's questions — how is day one paid for, how deep does the cash "
+            "position get, what does it cost per month, when is the installation owned outright."
+        ),
+        "Rented out": (
+            "The second story: the owner rents the house out. German law lets a landlord convert part of "
+            "the modernization cost into a permanent rent increase, capped by law — so the same "
+            "renovation splits into a landlord's business case and a tenant's monthly reality, and the "
+            "two do not sum to zero for either of them alone."
+        ),
+        "Society": (
+            "The third story: no parties, just the economy. Subsidies, taxes and levies are transfers — "
+            "one pocket to another — and cancel out; what remains is real resource use, and CO2 enters at "
+            "its damage cost rather than at whatever a market or a law currently charges for it."
+        ),
+    }
+
+    @classmethod
+    def for_chapter(cls, name: str) -> str:
+        """The authored lead-in of one chapter, by the name its heading carries (Q24).
+
+        Raises `KeyError` rather than returning an empty string, for the same reason
+        `for_section` does: a chapter heading with no lead-in is a silent editorial regression.
+        """
+        if name not in cls.CHAPTER_INTROS:
+            raise KeyError(f"No authored intro for report chapter {name!r}")
+        return cls.CHAPTER_INTROS[name]
+
+    @classmethod
+    def for_section(cls, name: str) -> SectionProse:
+        """The prose of one section, by the name its heading carries.
+
+        Raises `KeyError` with the offending name rather than returning an empty block: a section
+        that renders without its explanation is the failure this module exists to prevent, and it
+        would otherwise be invisible in a report that is thousands of lines long.
+        """
+        if name not in cls.SECTIONS:
+            raise KeyError(f"No authored explanation for report section {name!r}")
+        return cls.SECTIONS[name]
+
+    @classmethod
+    def to_html(cls, text: str) -> str:
+        """Markdown emphasis to HTML, with the text escaped first.
+
+        The only transformation the prose is allowed to undergo on its way into the report: the
+        markup characters become entities, `**x**` becomes `<strong>`, `*x*` becomes `<em>` and
+        `` `x` `` becomes `<code>`. Escaping runs first so a definition mentioning `<details>`
+        cannot open a tag, and the emphasis patterns are non-greedy and marker-free inside, so
+        they cannot span from one term to the next.
+
+        The escaping is `html.escape(..., quote=True)`, the same call the `reporting` package's
+        `_esc` makes, rather than a hand-rolled replacement of `&`, `<` and `>`. Two escapers in
+        one document is one escaper too many: the hand-rolled one left quotes alone, so a
+        paragraph that ever reached an attribute — a `title`, an SVG `aria-label` — would have
+        closed it, and the two would have had to be kept in step by hand forever.
+        """
+        escaped = html.escape(text, quote=True)
+        with_strong = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", escaped)
+        with_em = re.sub(r"\*([^*]+)\*", r"<em>\1</em>", with_strong)
+        return re.sub(r"`([^`]+)`", r"<code>\1</code>", with_em)
+
+    @classmethod
+    def to_plain_text(cls, text: str) -> str:
+        """The same prose with the emphasis markers removed and nothing else changed.
+
+        For the one renderer that cannot carry markup: the matplotlib caption of the ledger
+        heatmap. Dropping the markers rather than substituting anything keeps the caption
+        character-for-character comparable with the authored source.
+        """
+        return text.replace("**", "").replace("*", "").replace("`", "")

--- a/hisim/economics/report_prose.py
+++ b/hisim/economics/report_prose.py
@@ -11,7 +11,9 @@ Two mappings live here: `SECTIONS`, the four-part explanation of every report se
 `CHAPTER_INTROS`, the short authored lead-in of each story chapter (owner decision Q24). A chapter
 intro is deliberately not four-part — a chapter has no chart to show, nothing to add and nothing
 to calculate; it is the sentence that says which of the reader's three questions the sections
-below it answer.
+below it answer. Both are keyed by the names of registries — `ReportSections` and
+`ReportChapters` — that arrive with the renderer slices further up this stack, so the keys here
+are the strings those registries will publish rather than anything this slice can import.
 
 **Verbatim.** The text is the owner-reviewed explanation copy, transcribed without rewording from
 the authoring document it was reviewed in (which is not in the tree — this module is the copy of
@@ -24,9 +26,14 @@ non-linearly and a reader landing mid-page must not have to find the primer firs
 **Markup.** The strings carry markdown emphasis (`*term*`, `**emphasis**`, `` `code` ``) rather
 than HTML, because both renderers need them: the `reporting` package turns them into `<em>` /
 `<strong>` / `<code>` with `to_html`, and `report_plots.py` strips them for the caption of the
-ledger heatmap with `to_plain_text`. The `<details>` summaries are constants here for the same
-reason a section name is a constant in `ReportSections`: the test suite asserts on them, and two
-spellings of "Terms used here" would make that assertion meaningless.
+ledger heatmap with `to_plain_text` — both of those renderers arrive with later slices of this
+stack, and what lands here is the text plus the two conversions they will call. Markup that
+cannot be rendered is refused rather than passed through: an unbalanced or nested marker raises
+out of *both* conversions, and the test suite runs both over every authored string, so a stray
+asterisk fails in CI instead of reaching a reader as a literal one. The `<details>` summaries are
+constants for the same reason the section names are: they are the one source of the two
+disclosure titles the renderer slices read, and two spellings of "Terms used here" would put both
+of them in one report.
 """
 
 # clean
@@ -34,7 +41,7 @@ spellings of "Terms used here" would make that assertion meaningless.
 import html
 import re
 from dataclasses import dataclass
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 
 @dataclass(frozen=True)
@@ -1910,26 +1917,115 @@ class ReportProse:
             raise KeyError(f"No authored explanation for report section {name!r}")
         return cls.SECTIONS[name]
 
+    #: Code spans first, then strong, then emphasis — see `_rendered` for why the order matters.
+    _CODE_SPAN = re.compile(r"`([^`]+)`")
+    _STRONG = re.compile(r"\*\*([^*]+)\*\*")
+    _EMPHASIS = re.compile(r"\*([^*]+)\*")
+    #: Stands in for an already-rendered code span while the emphasis patterns run over the rest
+    #: of the text. NUL is the one character authored prose cannot contain — it is not typeable,
+    #: not in any of the transcribed source documents, and would not survive a JSON round trip —
+    #: so a slot can never collide with the text it is embedded in.
+    _SPAN_SLOT = "\x00{}\x00"
+    _SPAN_SLOT_PATTERN = re.compile("\x00(\\d+)\x00")
+
+    @classmethod
+    def _rendered(
+        cls,
+        text: str,
+        code: Tuple[str, str],
+        strong: Tuple[str, str],
+        emphasis: Tuple[str, str],
+    ) -> str:
+        """One markup pass with the three delimiter pairs the caller wants, validated at the end.
+
+        Both renderers run this, with tags for HTML and with empty strings for plain text, so the
+        two can never disagree about what the markup *is*: a string either renders in both or is
+        refused by both. Order is part of the contract. Code spans are substituted first and
+        their content parked in a slot, so an asterisk between backticks stays an asterisk instead
+        of being read as emphasis inside a `<code>` element; strong runs before emphasis, because
+        `**x**` would otherwise be consumed as two empty emphases.
+
+        The patterns are not "non-greedy" — they exclude their own marker character
+        (`[^*]+`, `` [^`]+ ``), which is stronger: a run cannot span from one term to the next
+        even where a lazy quantifier would have been allowed to. The price is that nested
+        emphasis (`**bold with *italic* inside**`) is not expressible, and rather than
+        rendering it as something the author did not write, it is refused: whatever the three
+        passes could not consume is left in the text, and a leftover marker raises.
+
+        Args:
+            text: The authored string, already escaped if the caller escapes.
+            code: `(opening, closing)` around the content of a code span.
+            strong: `(opening, closing)` around strong emphasis.
+            emphasis: `(opening, closing)` around ordinary emphasis.
+
+        Returns:
+            The text with all three markups replaced by the given delimiters.
+
+        Raises:
+            ValueError: If any marker character survives the three passes.
+        """
+        spans: List[str] = []
+
+        def stash(match: "re.Match[str]") -> str:
+            """Renders one code span and parks it, so emphasis cannot reach inside it."""
+            spans.append(f"{code[0]}{match.group(1)}{code[1]}")
+            return cls._SPAN_SLOT.format(len(spans) - 1)
+
+        parked = cls._CODE_SPAN.sub(stash, text)
+        rendered = cls._EMPHASIS.sub(
+            lambda match: f"{emphasis[0]}{match.group(1)}{emphasis[1]}",
+            cls._STRONG.sub(lambda match: f"{strong[0]}{match.group(1)}{strong[1]}", parked),
+        )
+        cls._refuse_unrendered_markup(rendered, text)
+        return cls._SPAN_SLOT_PATTERN.sub(lambda match: spans[int(match.group(1))], rendered)
+
+    @classmethod
+    def _refuse_unrendered_markup(cls, rendered: str, source: str) -> None:
+        """Raises when a markup character survived the substitutions of `_rendered`.
+
+        A leftover `*` or backtick means one of two things, and neither may reach a report: the
+        marker is unbalanced (`value *`, a footnote star, a multiplication sign) and would be
+        printed raw where the author meant nothing by it, or the emphasis is nested
+        (`**a *b* c**`) and the passes have already rendered part of it into something the
+        author did not write. Both are editorial mistakes in a module whose entire content is
+        authored text, and both are invisible in a rendered report that is thousands of lines
+        long — a raw asterisk reads as punctuation and a mis-nested one reads as emphasis. The
+        message quotes the offending string, because the string is the bug report.
+        """
+        leftover = [marker for marker in ("*", "`") if marker in rendered]
+        if leftover:
+            raise ValueError(
+                f"Report prose carries markup that cannot be rendered: {' and '.join(leftover)} "
+                f"left over after the code, strong and emphasis passes of {source!r}. Emphasis "
+                "markers have to be balanced and cannot be nested; write the literal character "
+                "inside a code span if it is meant literally."
+            )
+
     @classmethod
     def to_html(cls, text: str) -> str:
         """Markdown emphasis to HTML, with the text escaped first.
 
         The only transformation the prose is allowed to undergo on its way into the report: the
-        markup characters become entities, `**x**` becomes `<strong>`, `*x*` becomes `<em>` and
-        `` `x` `` becomes `<code>`. Escaping runs first so a definition mentioning `<details>`
-        cannot open a tag, and the emphasis patterns are non-greedy and marker-free inside, so
-        they cannot span from one term to the next.
+        markup characters become entities, `` `x` `` becomes `<code>`, `**x**` becomes `<strong>`
+        and `*x*` becomes `<em>` — in that order, and refusing anything the three passes cannot
+        consume; `_rendered` carries the reasoning for both. Escaping runs first, so a definition
+        mentioning `<details>` cannot open a tag.
 
         The escaping is `html.escape(..., quote=True)`, the same call the `reporting` package's
         `_esc` makes, rather than a hand-rolled replacement of `&`, `<` and `>`. Two escapers in
         one document is one escaper too many: the hand-rolled one left quotes alone, so a
         paragraph that ever reached an attribute — a `title`, an SVG `aria-label` — would have
         closed it, and the two would have had to be kept in step by hand forever.
+
+        Raises:
+            ValueError: If the markup is unbalanced or nested, exactly as in `to_plain_text`.
         """
-        escaped = html.escape(text, quote=True)
-        with_strong = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", escaped)
-        with_em = re.sub(r"\*([^*]+)\*", r"<em>\1</em>", with_strong)
-        return re.sub(r"`([^`]+)`", r"<code>\1</code>", with_em)
+        return cls._rendered(
+            html.escape(text, quote=True),
+            code=("<code>", "</code>"),
+            strong=("<strong>", "</strong>"),
+            emphasis=("<em>", "</em>"),
+        )
 
     @classmethod
     def to_plain_text(cls, text: str) -> str:
@@ -1938,5 +2034,13 @@ class ReportProse:
         For the one renderer that cannot carry markup: the matplotlib caption of the ledger
         heatmap. Dropping the markers rather than substituting anything keeps the caption
         character-for-character comparable with the authored source.
+
+        It runs the same pass `to_html` does, with empty delimiters, rather than three string
+        replacements. Stripping by `replace` accepted anything — `value *` came out as `value `,
+        silently — so the caption renderer would have printed prose that the HTML renderer
+        refuses. One validator, one verdict.
+
+        Raises:
+            ValueError: If the markup is unbalanced or nested, exactly as in `to_html`.
         """
-        return text.replace("**", "").replace("*", "").replace("`", "")
+        return cls._rendered(text, code=("", ""), strong=("", ""), emphasis=("", ""))

--- a/tests/test_economics_import_lint.py
+++ b/tests/test_economics_import_lint.py
@@ -7,7 +7,8 @@ recompute an engine figure, whatever it wanted to. This module parses the import
 the presentation modules with `ast` (so a local import inside a function counts exactly like a
 top-of-file one) and checks them against the surface below.
 
-**The allowed surface for presentation** — `reporting`, `report_plots`, `presentation_style`:
+**The allowed surface for presentation** — `reporting`, `report_plots`, `presentation_style`,
+`report_prose`:
 
 | Module              | Why presentation may import it                                        |
 |---------------------|-----------------------------------------------------------------------|
@@ -16,6 +17,7 @@ top-of-file one) and checks them against the surface below.
 | `plausibility`      | the typed findings and their check ids — **types only**, see below    |
 | `input_audit`       | the typed resolved-input rows `audit.py` produces (W4.6)              |
 | `presentation_style`| the display groups and palette shared by HTML and matplotlib (W4.7)   |
+| `report_prose`      | the authored four-part explanation every section opens with           |
 | `exports`           | `build_lifecycle_kpi_entries`, so the KPI table and lifecycle_kpis.json cannot disagree |
 | `timeline`          | `CostCategory` / `Actor` — the vocabulary of the result object        |
 | `uncertainty`       | `UncertainValue` / `Slot` — the type every money figure has           |
@@ -64,11 +66,12 @@ PACKAGE_DIRECTORY = os.path.join(
 )
 PACKAGE_PREFIX = "hisim.economics"
 
-#: The presentation layer: what renders, and nothing else.
-PRESENTATION_MODULES = ("reporting", "report_plots", "presentation_style")
+#: The presentation layer: what renders, and the prose it renders — nothing else.
+PRESENTATION_MODULES = ("reporting", "report_plots", "presentation_style", "report_prose")
 
 #: Modules the presentation layer may import from `hisim.economics` (see the table above).
 ALLOWED_FOR_PRESENTATION: Set[str] = {
+    "report_prose",
     "results",
     "views",
     "plausibility",

--- a/tests/test_economics_import_lint.py
+++ b/tests/test_economics_import_lint.py
@@ -196,9 +196,16 @@ class TestEngineDoesNotImportPresentation:
 
     @pytest.mark.parametrize("module_name", NON_PRESENTATION_MODULES)
     def test_no_engine_side_module_imports_a_renderer(self, module_name):
-        """A result serializer or a parity harness that renders is a seam violation."""
+        """A result serializer or a parity harness that renders is a seam violation.
+
+        The forbidden set is the presentation side of `PRESENTATION_MODULES` minus the one module
+        that is shared on purpose. `presentation_style` is deliberately importable from either
+        side — it is geometry and colour, and the whole point of W4.7 — but `report_prose` is not:
+        it is authored wording, and an engine-side module that reached for a section's explanation
+        would be formatting, which is exactly what this direction of the seam forbids.
+        """
         imported = {item.module for item in _economics_imports(module_name)}
-        assert not imported & {"reporting", "report_plots"}, (
+        assert not imported & {"reporting", "report_plots", "report_prose"}, (
             f"{module_name}.py imports a renderer; exports serialize and audit verifies — "
             "neither formats (cost-spec-v2 §2.4, W4.6)."
         )

--- a/tests/test_economics_layouts_prose.py
+++ b/tests/test_economics_layouts_prose.py
@@ -1,0 +1,340 @@
+"""Unit tests for the two shared dependencies of the report renderers: the layouts and the prose.
+
+`presentation_style.squarified_layout` / `sankey_node_boxes` and `report_prose.ReportProse` are
+consumed by both renderers — the inline SVGs of the `reporting` package and the matplotlib PNGs of
+`report_plots.py` — and by neither exclusively. They are therefore tested here, on their own
+inputs, rather than through a rendered report: a layout is a pure function from amounts to
+rectangles, and asserting on it directly says which of the two is at fault when a chart looks
+wrong. The renderers' own tests (`test_economics_reporting.py`, the goldens) assert that what is
+drawn matches what these return.
+
+**What a failure means.** Nothing about a number: no figure in any report comes from this module
+pair. A failure here means a chart would be *drawn* wrong — tiles that do not tile, ribbons that
+cross where they need not, a face left partly empty, or authored prose that reaches the document
+unescaped. The last of those is the only one with a security flavour, which is why the escaping is
+pinned by an assertion rather than by the goldens alone.
+"""
+
+# clean
+
+from typing import Dict, List, Tuple
+
+import pytest
+
+from hisim.economics.presentation_style import (
+    SankeyLayout,
+    _place_nodes,
+    sankey_node_boxes,
+    squarified_layout,
+)
+from hisim.economics.report_prose import ReportProse
+
+pytestmark = pytest.mark.base
+
+
+Rectangle = Tuple[float, float, float, float]
+
+
+def _overlap(first: Rectangle, second: Rectangle) -> float:
+    """Overlapping area of two `(x, y, width, height)` rectangles, zero when they only touch."""
+    first_x, first_y, first_w, first_h = first
+    second_x, second_y, second_w, second_h = second
+    horizontal = min(first_x + first_w, second_x + second_w) - max(first_x, second_x)
+    vertical = min(first_y + first_h, second_y + second_h) - max(first_y, second_y)
+    return max(horizontal, 0.0) * max(vertical, 0.0)
+
+
+class TestSquarifiedLayout:
+    """V8's treemap layout: the tiles have to tile, in the caller's order, at the caller's scale.
+
+    A treemap says "these areas are these amounts". That reading survives only if the rectangles
+    partition the box exactly — every gap is an amount the reader cannot see and every overlap is
+    one counted twice — so the three properties below are the chart's correctness, not its polish.
+    """
+
+    def sample(self):
+        """A deliberately uneven set of amounts: one dominant tile and a tail of small ones."""
+        return [50.0, 25.0, 12.0, 7.0, 4.0, 2.0]
+
+    def test_the_tiles_cover_the_box_exactly(self):
+        """Areas sum to the box area, and the union's bounding box is the box itself."""
+        values = self.sample()
+        tiles = squarified_layout(values, 10.0, 5.0, 40.0, 20.0)
+        assert len(tiles) == len(values)
+        assert sum(width * height for _x, _y, width, height in tiles) == pytest.approx(40.0 * 20.0)
+        assert min(x for x, _y, _w, _h in tiles) == pytest.approx(10.0)
+        assert min(y for _x, y, _w, _h in tiles) == pytest.approx(5.0)
+        assert max(x + width for x, _y, width, _h in tiles) == pytest.approx(50.0)
+        assert max(y + height for _x, y, _w, height in tiles) == pytest.approx(25.0)
+
+    def test_no_two_tiles_overlap(self):
+        """An overlap would draw one euro inside another; the areas would stop being readable."""
+        tiles = squarified_layout(self.sample(), 0.0, 0.0, 16.0, 9.0)
+        for first, tile in enumerate(tiles):
+            for other in tiles[first + 1:]:
+                assert _overlap(tile, other) == pytest.approx(0.0, abs=1e-9)
+
+    def test_each_tile_has_the_area_its_value_claims(self):
+        """The rectangles come back in input order, each scaled by its share of the total."""
+        values = self.sample()
+        tiles = squarified_layout(values, 0.0, 0.0, 16.0, 9.0)
+        total = sum(values)
+        for value, (_x, _y, width, height) in zip(values, tiles):
+            assert width * height == pytest.approx(value / total * 16.0 * 9.0)
+
+    def test_the_tiles_stay_roughly_square(self):
+        """The point of squarifying: no tile degenerates into a sliver the eye cannot compare."""
+        tiles = squarified_layout(self.sample(), 0.0, 0.0, 16.0, 9.0)
+        for _x, _y, width, height in tiles:
+            assert max(width / height, height / width) < 6.0
+
+    def test_an_empty_input_lays_nothing_out(self):
+        """A treemap of nothing is not an error — the caller filters, and gets an empty list."""
+        assert not squarified_layout([], 0.0, 0.0, 16.0, 9.0)
+
+
+class TestSankeyLayoutGeometry:
+    """The shared Sankey layout: one scale, corridors, closed faces, and fewer crossings (Q17/Q19).
+
+    Ported from the geometry half of the 9/9 chart tests; the halves that parse an SVG path or a
+    matplotlib patch belong with the renderers that emit them. What is asserted here is the
+    contract both of those renderers consume: `SankeyGeometry`.
+    """
+
+    def tangled_diagram(self):
+        """A three-column diagram whose given node order is deliberately the tangled one.
+
+        Every source feeds the actor whose listed position is furthest from its own, so the naive
+        layout crosses on both sides; the middle column carries each unit twice, which is exactly
+        the situation that produced two different per-column scales before Q17.
+        """
+        columns = [["bank", "state", "market"], ["landlord", "tenant"], ["fees", "energy", "works"]]
+        ribbons = [
+            ("bank", "tenant", 400.0),
+            ("state", "tenant", 300.0),
+            ("market", "landlord", 500.0),
+            ("landlord", "energy", 200.0),
+            ("landlord", "fees", 300.0),
+            ("tenant", "works", 500.0),
+            ("tenant", "energy", 200.0),
+        ]
+        return columns, ribbons
+
+    def skipping_diagram(self):
+        """Four columns in which two ribbons skip a column each, in both directions of imbalance.
+
+        The shape of the rented view reduced to its defect: sources paying a party two columns
+        along (their ribbons used to cross the intervening party's block), a party paying a sink
+        two columns along, and a middle party that receives more than it passes on (its outgoing
+        face used to be a third empty).
+        """
+        columns = [["bank", "state"], ["tenant"], ["landlord"], ["market", "suppliers"]]
+        ribbons = [
+            ("bank", "landlord", 600.0),
+            ("state", "landlord", 300.0),
+            ("tenant", "landlord", 500.0),
+            ("tenant", "suppliers", 200.0),
+            ("landlord", "market", 700.0),
+        ]
+        return columns, ribbons
+
+    def crossings(self, anchors, boxes, ribbons):
+        """Pairwise anchor-order inversions between ribbons sharing a column pair.
+
+        Two ribbons cross when their vertical order at the source end is the opposite of their
+        order at the target end. Counting inversions is the standard proxy for "how tangled is this
+        picture"; it is exact for straight ribbons and monotone in the same direction for the
+        Bezier ones actually drawn.
+        """
+        total = 0
+        for first, (source_a, target_a, _amount_a) in enumerate(ribbons):
+            for second, (source_b, target_b, _amount_b) in enumerate(ribbons[first + 1:], start=first + 1):
+                if boxes[source_a][0] != boxes[source_b][0] or boxes[target_a][0] != boxes[target_b][0]:
+                    continue
+                start = (boxes[source_a][1] + anchors[first][0]) - (boxes[source_b][1] + anchors[second][0])
+                end = (boxes[target_a][1] + anchors[first][1]) - (boxes[target_b][1] + anchors[second][1])
+                if start * end < 0:
+                    total += 1
+        return total
+
+    def naive_anchors(self, ribbons, unit_scale):
+        """Ribbon anchors without any ordering: stacked in the order the caller listed the flows.
+
+        The baseline the crossing-minimization test compares against — what the layout produced
+        before Q19, and what a renderer would do if it simply appended.
+        """
+        anchors: List[Tuple[float, float]] = []
+        out_offset: Dict[str, float] = {}
+        in_offset: Dict[str, float] = {}
+        for source, target, amount in ribbons:
+            anchors.append((out_offset.get(source, 0.0), in_offset.get(target, 0.0)))
+            out_offset[source] = out_offset.get(source, 0.0) + amount * unit_scale
+            in_offset[target] = in_offset.get(target, 0.0) + amount * unit_scale
+        return anchors
+
+    def test_one_global_unit_scale_across_all_columns(self):
+        """The defect itself: every node's height is the same euros-per-unit, column-independent."""
+        columns, ribbons = self.tangled_diagram()
+        geometry = sankey_node_boxes(columns, ribbons)
+        carried: Dict[str, float] = {}
+        incoming: Dict[str, float] = {}
+        for source, target, amount in ribbons:
+            carried[source] = carried.get(source, 0.0) + amount
+            incoming[target] = incoming.get(target, 0.0) + amount
+        for node, (_x, _y, height) in geometry.boxes.items():
+            value = max(carried.get(node, 0.0), incoming.get(node, 0.0))
+            assert height == pytest.approx(value * geometry.unit_scale)
+
+    def test_the_anchors_tile_the_fuller_face_of_every_node(self):
+        """The ribbons on a node's fuller face stack to its full height, with no overflow."""
+        columns, ribbons = self.tangled_diagram()
+        geometry = sankey_node_boxes(columns, ribbons)
+        for node, (_x, _y, height) in geometry.boxes.items():
+            outgoing = [
+                anchor[0] + amount * geometry.unit_scale
+                for anchor, (source, _target, amount) in zip(geometry.ribbon_anchors, ribbons)
+                if source == node
+            ]
+            incoming = [
+                anchor[1] + amount * geometry.unit_scale
+                for anchor, (_source, target, amount) in zip(geometry.ribbon_anchors, ribbons)
+                if target == node
+            ]
+            assert max(outgoing + incoming + [0.0]) == pytest.approx(height)
+
+    def test_ordering_reduces_crossings_against_the_unordered_layout(self):
+        """Q19: barycenter node order plus anchor sorting untangles a deliberately tangled input."""
+        columns, ribbons = self.tangled_diagram()
+        geometry = sankey_node_boxes(columns, ribbons)
+        naive_boxes = _place_nodes(
+            columns,
+            {
+                node: max(
+                    sum(amount for source, _target, amount in ribbons if source == node),
+                    sum(amount for _source, target, amount in ribbons if target == node),
+                )
+                for column in columns
+                for node in column
+            },
+            geometry.unit_scale,
+        )
+        before = self.crossings(self.naive_anchors(ribbons, geometry.unit_scale), naive_boxes, ribbons)
+        after = self.crossings(geometry.ribbon_anchors, geometry.boxes, ribbons)
+        assert before > 0
+        assert after <= before
+
+    def test_connected_nodes_end_up_near_each_other(self):
+        """What the barycenter sweeps are for: the fat ribbon's two ends sit at similar heights."""
+        columns, ribbons = self.tangled_diagram()
+        geometry = sankey_node_boxes(columns, ribbons)
+
+        def centre(node):
+            _x, y, height = geometry.boxes[node]
+            return y + height / 2.0
+
+        for source, target, amount in ribbons:
+            if amount < 500.0:
+                continue
+            assert abs(centre(source) - centre(target)) < 0.25
+
+    def test_layout_is_deterministic(self):
+        """A report re-rendered from the same result must be byte-identical; no hash order here."""
+        columns, ribbons = self.tangled_diagram()
+        first = sankey_node_boxes(columns, ribbons)
+        second = sankey_node_boxes(columns, ribbons)
+        assert first.boxes == second.boxes
+        assert first.ribbon_anchors == second.ribbon_anchors
+        assert first.ribbon_segments == second.ribbon_segments
+        assert first.net_stubs == second.net_stubs
+        assert first.unit_scale == second.unit_scale
+
+    def test_a_column_skipping_ribbon_is_routed_through_a_corridor(self):
+        """Q29 R7: it becomes one leg per column gap, with a virtual node holding the space."""
+        columns, ribbons = self.skipping_diagram()
+        geometry = sankey_node_boxes(columns, ribbons)
+        chains = geometry.ribbon_segments
+        assert [len(chain) for chain in chains] == [2, 2, 1, 2, 1]
+        virtual = [node for node in geometry.boxes if node.startswith(SankeyLayout.VIRTUAL_NODE_PREFIX)]
+        assert len(virtual) == 3
+        for node in virtual:
+            assert node not in [name for column in columns for name in column]
+        # A corridor node is exactly as tall as the ribbon it carries — that is what reserving
+        # the space means, and it is why the ribbon has somewhere to go.
+        for chain, (_source, _target, amount) in zip(chains, ribbons):
+            for leg in chain:
+                for node in (leg.source, leg.target):
+                    if node.startswith(SankeyLayout.VIRTUAL_NODE_PREFIX):
+                        assert geometry.boxes[node][2] == pytest.approx(amount * geometry.unit_scale)
+
+    def test_the_stub_is_the_nodes_own_net_position(self):
+        """Q29 R7: the face a node's ribbons cannot fill is handed out as its net position."""
+        columns, ribbons = self.skipping_diagram()
+        geometry = sankey_node_boxes(columns, ribbons)
+        stubs = {stub.node: stub for stub in geometry.net_stubs}
+        assert set(stubs) == {"landlord"}
+        assert stubs["landlord"].amount == pytest.approx(1400.0 - 700.0)
+        assert stubs["landlord"].is_outgoing
+        assert stubs["landlord"].anchor == pytest.approx(700.0 * geometry.unit_scale)
+
+    def test_a_transfer_is_an_ordinary_ribbon_between_distinct_columns(self):
+        """Q23: each party has its own column, so an inter-actor transfer travels left to right.
+
+        The levy used to connect two nodes of one shared middle column, which has no horizontal
+        extent, so both renderers drew it as a band looping out of the column and back. With the
+        payer's column placed before the payee's it is a ribbon like any other, and the payee is
+        as tall as what passes through it rather than as tall as the sum of both faces.
+        """
+        columns = [["market"], ["tenant"], ["landlord"], ["works"]]
+        ribbons = [
+            ("market", "landlord", 1000.0),
+            ("tenant", "landlord", 400.0),
+            ("landlord", "works", 1400.0),
+        ]
+        geometry = sankey_node_boxes(columns, ribbons)
+        assert geometry.boxes["landlord"][2] == pytest.approx(1400.0 * geometry.unit_scale)
+        assert geometry.boxes["tenant"][2] == pytest.approx(400.0 * geometry.unit_scale)
+        assert geometry.boxes["tenant"][0] < geometry.boxes["landlord"][0]
+        assert geometry.net_stubs == []
+
+
+class TestReportProse:
+    """The authored explanation text: complete, addressable by section name, and escaped on the way out."""
+
+    def test_prose_markup_is_escaped_before_it_is_emphasized(self):
+        """A definition mentioning a tag must not be able to open one."""
+        assert ReportProse.to_html("a *b* and **c** and `d`") == (
+            "a <em>b</em> and <strong>c</strong> and <code>d</code>"
+        )
+        assert ReportProse.to_html("<details> & <em>") == "&lt;details&gt; &amp; &lt;em&gt;"
+        assert ReportProse.to_plain_text("a *b* and **c** and `d`") == "a b and c and d"
+
+    def test_quotes_are_escaped_too_so_an_attribute_cannot_be_closed(self):
+        """`html.escape(..., quote=True)`, the same call the reporting package's `_esc` makes."""
+        assert ReportProse.to_html('a "quoted" word') == "a &quot;quoted&quot; word"
+        assert ReportProse.to_html("it's") == "it&#x27;s"
+
+    def test_every_authored_section_carries_all_four_parts(self):
+        """A section rendered without its terms or its calculation is a silent editorial gap."""
+        for name, prose in ReportProse.SECTIONS.items():
+            assert prose.shows, name
+            assert prose.adds, name
+            if name == ReportProse.LEDGER_HEATMAP_SECTION_NAME:
+                continue
+            assert prose.terms, name
+            assert prose.calculation, name
+            for term, definition in prose.terms:
+                assert term and definition, name
+
+    def test_every_chapter_carries_its_lead_in(self):
+        """Q24: a chapter heading with no authored intro would open the story with nothing."""
+        assert ReportProse.CHAPTER_INTROS
+        for name, intro in ReportProse.CHAPTER_INTROS.items():
+            assert intro.strip(), name
+
+    def test_an_unknown_name_raises_rather_than_rendering_empty(self):
+        """`for_section` / `for_chapter` fail loudly; an empty block would be invisible in a report."""
+        with pytest.raises(KeyError):
+            ReportProse.for_section("A section nobody wrote")
+        with pytest.raises(KeyError):
+            ReportProse.for_chapter("A chapter nobody wrote")
+        assert ReportProse.for_section(ReportProse.PRIMER_SECTION_NAME).shows

--- a/tests/test_economics_layouts_prose.py
+++ b/tests/test_economics_layouts_prose.py
@@ -13,15 +13,25 @@ pair. A failure here means a chart would be *drawn* wrong — tiles that do not 
 cross where they need not, a face left partly empty, or authored prose that reaches the document
 unescaped. The last of those is the only one with a security flavour, which is why the escaping is
 pinned by an assertion rather than by the goldens alone.
+
+**Refusals are part of the contract.** Both layouts and both prose renderers raise on input they
+cannot draw or cannot render, rather than producing a picture or a paragraph that is quietly
+wrong, and each of those refusals is asserted here — a zero-area tile, a signless ribbon, a
+ribbon naming a node no column declares, an unbalanced emphasis marker. The prose case is also
+asserted over the *whole* authored corpus, in both renderers, so a stray asterisk typed into a
+definition fails in CI rather than being printed to a reader as punctuation.
 """
 
 # clean
 
-from typing import Dict, List, Tuple
+import dataclasses
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
 from hisim.economics.presentation_style import (
+    ChromeColors,
+    SankeyGeometry,
     SankeyLayout,
     _place_nodes,
     sankey_node_boxes,
@@ -92,6 +102,26 @@ class TestSquarifiedLayout:
         """A treemap of nothing is not an error — the caller filters, and gets an empty list."""
         assert not squarified_layout([], 0.0, 0.0, 16.0, 9.0)
 
+    @pytest.mark.parametrize(
+        "values, offender",
+        [
+            ([50.0, 0.0, 12.0], 1),
+            ([50.0, -25.0], 1),
+            ([float("inf"), 3.0], 0),
+            ([3.0, float("nan")], 1),
+        ],
+    )
+    def test_a_value_that_is_not_a_positive_area_is_refused(self, values, offender):
+        """A zero tile has no rectangle and a negative one eats into its row — both raise.
+
+        The tiling arithmetic would not notice either: a zero area comes back as a zero-height
+        rectangle the reader cannot see, and a negative one shortens the row around it, so the
+        remaining tiles silently stop meaning what their areas claim. The message names the index
+        so the caller can find the amount it did not filter.
+        """
+        with pytest.raises(ValueError, match=rf"values\[{offender}\]"):
+            squarified_layout(values, 0.0, 0.0, 16.0, 9.0)
+
 
 class TestSankeyLayoutGeometry:
     """The shared Sankey layout: one scale, corridors, closed faces, and fewer crossings (Q17/Q19).
@@ -137,6 +167,15 @@ class TestSankeyLayoutGeometry:
             ("landlord", "market", 700.0),
         ]
         return columns, ribbons
+
+    def anchors(self, geometry: SankeyGeometry) -> List[Tuple[float, float]]:
+        """The two ends of every ribbon: the first leg's `out_anchor`, the last leg's `in_anchor`.
+
+        `SankeyGeometry` publishes the routed chain and nothing else, so the pair a crossing count
+        or a face tiling needs is read off the chain rather than from a second field holding a
+        projection of it — a field that could disagree with the legs it was derived from.
+        """
+        return [(chain[0].out_anchor, chain[-1].in_anchor) for chain in geometry.ribbon_segments]
 
     def crossings(self, anchors, boxes, ribbons):
         """Pairwise anchor-order inversions between ribbons sharing a column pair.
@@ -189,15 +228,16 @@ class TestSankeyLayoutGeometry:
         """The ribbons on a node's fuller face stack to its full height, with no overflow."""
         columns, ribbons = self.tangled_diagram()
         geometry = sankey_node_boxes(columns, ribbons)
+        anchors = self.anchors(geometry)
         for node, (_x, _y, height) in geometry.boxes.items():
             outgoing = [
                 anchor[0] + amount * geometry.unit_scale
-                for anchor, (source, _target, amount) in zip(geometry.ribbon_anchors, ribbons)
+                for anchor, (source, _target, amount) in zip(anchors, ribbons)
                 if source == node
             ]
             incoming = [
                 anchor[1] + amount * geometry.unit_scale
-                for anchor, (_source, target, amount) in zip(geometry.ribbon_anchors, ribbons)
+                for anchor, (_source, target, amount) in zip(anchors, ribbons)
                 if target == node
             ]
             assert max(outgoing + incoming + [0.0]) == pytest.approx(height)
@@ -219,9 +259,15 @@ class TestSankeyLayoutGeometry:
             geometry.unit_scale,
         )
         before = self.crossings(self.naive_anchors(ribbons, geometry.unit_scale), naive_boxes, ribbons)
-        after = self.crossings(geometry.ribbon_anchors, geometry.boxes, ribbons)
-        assert before > 0
-        assert after <= before
+        after = self.crossings(self.anchors(geometry), geometry.boxes, ribbons)
+        # The fixture is tangled on both sides on purpose: four crossings before the sweeps, and
+        # the two steps together remove all four. Both halves of that matter. `<=` passes even
+        # when nothing is reordered at all, and a strict `<` still passes with the barycenter
+        # sweeps disabled, because sorting the anchors alone gets the count down to two — only
+        # "no crossings left" fails when either step is taken out.
+        assert before == 4
+        assert after < before
+        assert after == 0
 
     def test_connected_nodes_end_up_near_each_other(self):
         """What the barycenter sweeps are for: the fat ribbon's two ends sit at similar heights."""
@@ -243,7 +289,6 @@ class TestSankeyLayoutGeometry:
         first = sankey_node_boxes(columns, ribbons)
         second = sankey_node_boxes(columns, ribbons)
         assert first.boxes == second.boxes
-        assert first.ribbon_anchors == second.ribbon_anchors
         assert first.ribbon_segments == second.ribbon_segments
         assert first.net_stubs == second.net_stubs
         assert first.unit_scale == second.unit_scale
@@ -296,6 +341,145 @@ class TestSankeyLayoutGeometry:
         assert geometry.boxes["tenant"][0] < geometry.boxes["landlord"][0]
         assert geometry.net_stubs == []
 
+    def test_the_scale_is_the_tightest_column_and_nothing_leaves_the_unit_square(self):
+        """One scale, chosen by the column that fits least comfortably, and no overflow.
+
+        `unit_scale` is the smallest of the per-column candidates — a column's usable height (the
+        unit square minus its inter-node gaps, floored at `MINIMUM_USABLE_HEIGHT`) divided by what
+        it carries — because the *binding* column is the one that decides how tall a unit may be.
+        Taking any other candidate would let that column overflow the square, which is the
+        assertion in the second half: the fullest column spans exactly [0, 1] and every node of
+        every column sits inside it.
+        """
+        columns, ribbons = self.tangled_diagram()
+        geometry = sankey_node_boxes(columns, ribbons)
+        values = {
+            node: max(
+                sum(amount for source, _target, amount in ribbons if source == node),
+                sum(amount for _source, target, amount in ribbons if target == node),
+            )
+            for column in columns
+            for node in column
+        }
+        assert geometry.unit_scale == pytest.approx(min(
+            max(1.0 - SankeyLayout.NODE_GAP * (len(nodes) - 1), SankeyLayout.MINIMUM_USABLE_HEIGHT)
+            / sum(values[node] for node in nodes)
+            for nodes in columns
+        ))
+        for node, (_x, y, height) in geometry.boxes.items():
+            assert y >= -1e-9, node
+            assert y + height <= 1.0 + 1e-9, node
+        spans = [
+            (min(geometry.boxes[node][1] for node in nodes),
+             max(geometry.boxes[node][1] + geometry.boxes[node][2] for node in nodes))
+            for nodes in columns
+        ]
+        assert any(
+            bottom == pytest.approx(0.0, abs=1e-9) and top == pytest.approx(1.0, abs=1e-9)
+            for bottom, top in spans
+        )
+
+    def test_the_ribbons_on_a_face_are_stacked_by_their_far_ends_height(self):
+        """The second untangling step: a face's ribbons are ordered by where they are going.
+
+        Stacking a node's outgoing ribbons in the order of their targets' heights (and its
+        incoming ones by their sources') is what stops two correctly ordered columns from being
+        re-tangled by the ribbons between them. Asserted as monotonicity rather than as a literal
+        anchor list, because the property is the ordering and not the arithmetic: read the anchors
+        of one face in ascending order and the far ends they lead to must ascend too.
+        """
+        columns, ribbons = self.tangled_diagram()
+        geometry = sankey_node_boxes(columns, ribbons)
+        anchors = self.anchors(geometry)
+
+        def centre(node):
+            """Vertical middle of a node — the height `_ribbon_anchors` sorts a face on."""
+            _x, y, height = geometry.boxes[node]
+            return y + height / 2.0
+
+        faces_checked = 0
+        for is_outgoing in (True, False):
+            face = 0 if is_outgoing else 1
+            by_node: Dict[str, List[int]] = {}
+            for index, (source, target, _amount) in enumerate(ribbons):
+                by_node.setdefault(source if is_outgoing else target, []).append(index)
+            for node, indices in by_node.items():
+                if len(indices) < 2:
+                    continue
+                faces_checked += 1
+                stacked = sorted(indices, key=lambda index, face=face: anchors[index][face])
+                far_ends = [
+                    centre(ribbons[index][1] if is_outgoing else ribbons[index][0])
+                    for index in stacked
+                ]
+                assert far_ends == sorted(far_ends), (node, is_outgoing)
+        assert faces_checked >= 4
+
+    def test_no_leg_passes_through_a_node_it_does_not_end_at(self):
+        """The invariant the corridors buy: a leg's horizontal span touches only its own two ends.
+
+        Every leg runs from the right face of a node in one column to the left face of a node in
+        the *next* column, so its x-extent is the open gap between two adjacent columns. Nothing
+        else can be in that gap: every node of the source column ends exactly where the leg starts
+        and every node of the target column starts exactly where it ends, and there is no third
+        column x in between. That is what makes "no ribbon path intersects a node rectangle" a
+        property of the layout rather than of the caller's luck — and it is the property the four
+        source-to-landlord ribbons of the rented view used to violate.
+        """
+        for columns, ribbons in (self.skipping_diagram(), self.tangled_diagram()):
+            geometry = sankey_node_boxes(columns, ribbons)
+            column_positions = sorted({x for x, _y, _height in geometry.boxes.values()})
+            for chain in geometry.ribbon_segments:
+                for leg in chain:
+                    source_x = geometry.boxes[leg.source][0]
+                    target_x = geometry.boxes[leg.target][0]
+                    left = min(source_x, target_x) + SankeyLayout.NODE_WIDTH
+                    right = max(source_x, target_x)
+                    assert left < right, leg
+                    assert not [x for x in column_positions if left <= x < right], leg
+                    for node, (x, _y, _height) in geometry.boxes.items():
+                        if node in (leg.source, leg.target):
+                            continue
+                        assert not (x < right and x + SankeyLayout.NODE_WIDTH > left), (leg, node)
+
+    @pytest.mark.parametrize("amount", [0.0, -400.0, float("inf"), float("nan")])
+    def test_a_ribbon_that_is_not_a_positive_flow_is_refused(self, amount):
+        """A Sankey has no sign — direction is the node pair — and a zero ribbon is invisible.
+
+        Both would still be laid out: the amount is added to both faces it touches, so the nodes
+        grow around a ribbon the reader either cannot see or would read backwards.
+        """
+        with pytest.raises(ValueError, match="Sankey ribbon 1"):
+            sankey_node_boxes([["a"], ["b"]], [("a", "b", 100.0), ("a", "b", amount)])
+
+    def test_a_ribbon_naming_an_undeclared_node_is_refused(self):
+        """It used to be dropped by the renderers while still inflating the node it left.
+
+        The ribbon had no column to be drawn in, so nothing drew it — but its amount still counted
+        into its source's outgoing total, and the source was therefore drawn taller than the
+        ribbons that tile it, for a reason nothing in the picture stated.
+        """
+        with pytest.raises(ValueError, match="'ghost'"):
+            sankey_node_boxes([["a"], ["b"]], [("a", "b", 100.0), ("a", "ghost", 50.0)])
+        with pytest.raises(ValueError, match="'ghost'"):
+            sankey_node_boxes([["a"], ["b"]], [("ghost", "b", 50.0)])
+
+
+class TestChromeColors:
+    """The four neutral chrome roles: the same roles in both modes, and not rewritable at runtime."""
+
+    def test_both_modes_define_exactly_the_same_four_roles(self):
+        """A role defined in one mode and missing in the other is a KeyError in dark mode only."""
+        assert set(ChromeColors.LIGHT) == {"surface", "ink", "muted", "grid"}
+        assert set(ChromeColors.DARK) == set(ChromeColors.LIGHT)
+
+    def test_a_palette_cannot_be_rewritten_in_place(self):
+        """A renderer that assigned a role would recolour every chart drawn after it, silently."""
+        palette: Any = ChromeColors.LIGHT
+        with pytest.raises(TypeError):
+            palette["surface"] = "#000000"
+        assert ChromeColors.LIGHT["surface"] == "#fcfcfb"
+
 
 class TestReportProse:
     """The authored explanation text: complete, addressable by section name, and escaped on the way out."""
@@ -330,6 +514,59 @@ class TestReportProse:
         assert ReportProse.CHAPTER_INTROS
         for name, intro in ReportProse.CHAPTER_INTROS.items():
             assert intro.strip(), name
+
+    def authored_strings(self):
+        """Every authored string in the module, named by where it was found.
+
+        Read off the dataclass fields rather than listed by hand, so a fifth part added to
+        `SectionProse` is covered the moment it exists instead of the day somebody remembers to
+        extend this helper.
+        """
+        found = []
+        for name, prose in ReportProse.SECTIONS.items():
+            for section_field in dataclasses.fields(prose):
+                value = getattr(prose, section_field.name)
+                if isinstance(value, str):
+                    found.append((f"{name}.{section_field.name}", value))
+                    continue
+                for item in value:
+                    parts = [item] if isinstance(item, str) else list(item)
+                    found.extend((f"{name}.{section_field.name}", part) for part in parts)
+        found.extend((f"chapter {name}", intro) for name, intro in ReportProse.CHAPTER_INTROS.items())
+        return found
+
+    def test_every_authored_string_renders_in_both_renderers(self):
+        """The corpus test: a stray asterisk anywhere in the module fails here rather than in a report.
+
+        Both renderers refuse markup they cannot render, so an unbalanced or nested marker typed
+        into a definition raises. Running both over every field of every section and every chapter
+        intro is what turns that refusal into a CI failure at the moment the text is edited,
+        instead of a traceback the first time somebody renders the report — or, worse, a raw
+        asterisk printed to a reader as punctuation.
+        """
+        strings = self.authored_strings()
+        assert len(strings) > 400
+        for where, text in strings:
+            assert ReportProse.to_html(text), where
+            assert ReportProse.to_plain_text(text), where
+
+    @pytest.mark.parametrize("text", ["**a*b**", "value *", "a ` b", "**bold *and* more**"])
+    def test_markup_that_cannot_be_rendered_is_refused_by_both_renderers(self, text):
+        """Nested or unbalanced markers raise, in HTML and in plain text alike.
+
+        `**a*b**` renders as neither strong nor emphasis; `value *` is a marker the author did not
+        close. Either way what is left over would be printed raw, and the plain-text renderer used
+        to strip it silently — so the caption and the HTML disagreed about what the prose said.
+        """
+        with pytest.raises(ValueError):
+            ReportProse.to_html(text)
+        with pytest.raises(ValueError):
+            ReportProse.to_plain_text(text)
+
+    def test_a_marker_inside_a_code_span_is_literal(self):
+        """Code spans are substituted first, so backticks protect what is between them."""
+        assert ReportProse.to_html("`*a*`") == "<code>*a*</code>"
+        assert ReportProse.to_plain_text("`*a*`") == "*a*"
 
     def test_an_unknown_name_raises_rather_than_rendering_empty(self):
         """`for_section` / `for_chapter` fail loudly; an empty block would be invisible in a report."""


### PR DESCRIPTION
﻿Second slice of the 9/9 port: the two shared dependencies of the HTML and matplotlib renderers, with no views, sections or plots. presentation_style gains the squarified treemap layout and the Sankey layout engine beside the existing group palette, plus a single ChromeColors source for the surface/ink/muted/grid colours the two renderers currently each hard-code (rewiring them is the renderer slices' job). report_prose is the authored "how to read this" text every chart section cites, ported whole with html.escape instead of a hand-rolled escaper, and registered with the seam-4 import lint. 18 new tests cover the layouts and the prose; no golden moves because nothing renders the prose yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
