### PR TITLE
Cost stack 9/9, slice 3 of 8: the engine-side data the new charts read

### DIFF
--- a/hisim/economics/actors.py
+++ b/hisim/economics/actors.py
@@ -26,11 +26,11 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass, field
-from typing import FrozenSet, List, Optional, Protocol, Tuple
+from typing import Dict, FrozenSet, List, Optional, Protocol, Tuple
 
 from hisim.economics.catalog_entries import CostDataError
 from hisim.economics.timeline import Actor, CashFlowEntry, CashFlowTimeline, CostCategory
-from hisim.economics.uncertainty import UncertainValue
+from hisim.economics.uncertainty import Slot, UncertainValue
 from hisim.loadtypes import ComponentType
 
 #: One pool's levy basis facts: (modernization cost, subsidies received, avoided maintenance).
@@ -151,6 +151,17 @@ class AllocationRuleset(Protocol):
         """
         ...  # pylint: disable=unnecessary-ellipsis
 
+    def modernization_levy_outcome(self, ctx: AllocationContext) -> Optional["ModernizationLevyOutcome"]:
+        """The levy this ruleset would charge, or None where the country's law has no levy.
+
+        The read-only companion of :meth:`allocate`, added for the landlord statement. The levy's
+        *amount* is already on the timeline as a transfer pair, but the two facts a reader needs
+        beside it — whether a statutory ceiling decided it, and which ceiling — are not derivable
+        from a cash flow, and reconstructing them in a report would be exactly the second
+        implementation of a legal rule the seam exists to prevent.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
 
 class OwnerOccupierRuleset:
     """The trivial allocation: everything is paid by the owner-occupier.
@@ -168,6 +179,12 @@ class OwnerOccupierRuleset:
             entries=[entry.with_payer(Actor.OWNER_OCCUPIER) for entry in timeline.entries],
             validate=timeline.validate,
         )
+
+    def modernization_levy_outcome(  # pylint: disable=unused-argument
+        self, ctx: AllocationContext
+    ) -> Optional["ModernizationLevyOutcome"]:
+        """None: an owner-occupier charges no rent increase to themselves."""
+        return None
 
 
 @dataclass
@@ -207,6 +224,31 @@ class ModernizationLevyParameters:
     heating_measure_component_types: FrozenSet[str] = frozenset()
 
 
+class LevyBindingMechanism:
+    """The vocabulary of the per-world levy verdicts.
+
+    "The levy is 1,847 EUR a year" is two different statements depending on what produced it: at a
+    ceiling the figure is fixed by law and the same renovation costing more would yield the same
+    rent, below it the figure is a percentage and every extra euro spent raises the rent. The
+    ruleset already knew which of the two applied; the constants here are what let it *say* so, in
+    one spelling, for each of the three worlds separately.
+
+    `SLOT_NAMES` maps the band's own field names onto the slot vocabulary the rest of the package
+    uses (`Slot` values), so the verdict map is keyed like every other per-slot map.
+    """
+
+    GENERAL_CAP = "§559 general cap"
+    HEATING_CAP = "§559e heating cap"
+    RATE_BELOW_CAP = "of eligible cost, below cap"
+    #: Euro per year below which a cap counts as not having removed anything.
+    TOLERANCE_IN_EURO = 1e-6
+    SLOT_NAMES = {
+        "minimum": Slot.LOW.value,
+        "best_estimate": Slot.BEST_ESTIMATE.value,
+        "maximum": Slot.HIGH.value,
+    }
+
+
 @dataclass
 class ModernizationLevyOutcome:
     """One year's rent increase, split into its §559 and §559e legs after both caps (§6.4).
@@ -243,6 +285,20 @@ class ModernizationLevyOutcome:
     uncapped_heating_levy_in_euro: UncertainValue
     heating_cap_in_euro_per_year: Optional[float] = None
     total_cap_in_euro_per_year: Optional[float] = None
+    #: Whether a statutory cap actually bit in the BEST_ESTIMATE slot. The landlord statement has
+    #: to say which of the two regimes produced the levy — the modernization cost or the ceiling —
+    #: because they are different economic situations: below the cap the levy scales with what was
+    #: spent, at the cap it does not, and a landlord reading a levy figure cannot tell which
+    #: without being told. False when no cap could be evaluated at all (no living area).
+    cap_binding: bool = False
+    #: The general §559 Abs. 3a ceiling that applied, in EUR per m² and month, or None when no
+    #: living area was known and therefore no cap was evaluated.
+    cap_in_euro_per_m2_per_month: Optional[float] = None
+    #: Which mechanism set the levy in each world, keyed by `Slot` value. The caps are applied per
+    #: slot, so the same run can be cap-decided in the expensive world and rate-decided in the
+    #: cheap one; a single flag over the best-estimate slot states one of the three answers and
+    #: hides the other two. Empty when no living area was known and no cap could be evaluated.
+    binding_mechanism_by_slot: Dict[str, str] = field(default_factory=dict)
 
 
 def _ordered_band(slots: dict) -> UncertainValue:
@@ -671,12 +727,23 @@ class DE2024Ruleset:
             )
         months_of_area = 12.0 * ctx.living_area_in_m2
         heating_cap = self.levy.heating_cap_in_euro_per_m2_per_month * months_of_area
-        total_cap = self.general_cap_rate(ctx) * months_of_area
+        cap_rate = self.general_cap_rate(ctx)
+        total_cap = cap_rate * months_of_area
         capped = {}
+        mechanisms: Dict[str, str] = {}
         for slot in ("minimum", "best_estimate", "maximum"):
             heating_slot = min(getattr(heating, slot), heating_cap, total_cap)
             general_slot = min(getattr(general, slot), total_cap - heating_slot)
             capped[slot] = (heating_slot, general_slot)
+            mechanisms[LevyBindingMechanism.SLOT_NAMES[slot]] = self._binding_mechanism(
+                heating_raw=getattr(heating, slot),
+                general_raw=getattr(general, slot),
+                heating_capped=heating_slot,
+                general_capped=general_slot,
+                cap_rate=cap_rate,
+            )
+        uncapped_best_estimate = heating.best_estimate + general.best_estimate
+        capped_best_estimate = sum(capped["best_estimate"])
         return ModernizationLevyOutcome(
             general_levy_in_euro=_ordered_band({slot: values[1] for slot, values in capped.items()}),
             heating_levy_in_euro=_ordered_band({slot: values[0] for slot, values in capped.items()}),
@@ -687,7 +754,66 @@ class DE2024Ruleset:
             uncapped_heating_levy_in_euro=heating,
             heating_cap_in_euro_per_year=heating_cap,
             total_cap_in_euro_per_year=total_cap,
+            # "Did a ceiling decide this number" is the single most important thing to know about
+            # a levy, so it is recorded rather than left to be inferred from the amount.
+            cap_binding=capped_best_estimate < uncapped_best_estimate - LevyBindingMechanism.TOLERANCE_IN_EURO,
+            cap_in_euro_per_m2_per_month=cap_rate,
+            # The per-world verdict, because a cap applied per slot can decide one world and leave
+            # the next one to the percentage of the modernization cost.
+            binding_mechanism_by_slot=mechanisms,
         )
+
+    def _binding_mechanism(
+        self,
+        heating_raw: float,
+        general_raw: float,
+        heating_capped: float,
+        general_capped: float,
+        cap_rate: float,
+    ) -> str:
+        """Which of the three mechanisms actually set this world's levy.
+
+        Reads the same comparison the capping did, in the order the caps are applied (D27): the
+        §559e ceiling first, on the heating leg alone, then the general §559 Abs. 3a ceiling on the
+        two legs together. Whichever ceiling removed euros is the binding one; when neither did,
+        the levy is the statutory percentage of the eligible cost and the verdict says so with the
+        rate that produced it, since that is the case in which spending more would raise the rent.
+
+        Args:
+            heating_raw: The §559e leg before any cap, in euro per year.
+            general_raw: The §559 leg before any cap, in euro per year.
+            heating_capped: The §559e leg after both caps.
+            general_capped: The §559 leg after both caps.
+            cap_rate: The general ceiling in EUR per m² and month, for the verdict's wording.
+
+        Returns:
+            A short sentence naming the binding mechanism, ready to be rendered verbatim.
+        """
+        tolerance = LevyBindingMechanism.TOLERANCE_IN_EURO
+        heating_cut = heating_raw - heating_capped > tolerance
+        general_cut = general_raw - general_capped > tolerance
+        if heating_cut or general_cut:
+            if heating_cut and general_capped <= tolerance:
+                return (
+                    f"{LevyBindingMechanism.HEATING_CAP} "
+                    f"{self.levy.heating_cap_in_euro_per_m2_per_month:,.2f} EUR/m2*mo"
+                )
+            return f"{LevyBindingMechanism.GENERAL_CAP} {cap_rate:,.2f} EUR/m2*mo"
+        rate = (
+            self.levy.heating_levy_rate_per_year
+            if heating_capped > general_capped
+            else self.levy.levy_rate_per_year
+        )
+        return f"{rate:.0%} {LevyBindingMechanism.RATE_BELOW_CAP}"
+
+    def modernization_levy_outcome(self, ctx: AllocationContext) -> Optional[ModernizationLevyOutcome]:
+        """The §559/§559e outcome, for the landlord statement's caption.
+
+        Simply :meth:`compute_modernization_levy` under the protocol's name, so a caller with a
+        ruleset in hand can ask any country's implementation the same question without knowing
+        which one it holds.
+        """
+        return self.compute_modernization_levy(ctx)
 
     def modernization_levy_entries(self, ctx: AllocationContext) -> List[CashFlowEntry]:
         """The §559/§559e BGB levy: TENANT pays a rent increase, LANDLORD receives it (§6.4).

--- a/hisim/economics/actors.py
+++ b/hisim/economics/actors.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, List, Optional, Protocol, Tuple
 
 from hisim.economics.catalog_entries import CostDataError
+from hisim.economics.results import LevyBindingMechanism
 from hisim.economics.timeline import Actor, CashFlowEntry, CashFlowTimeline, CostCategory
 from hisim.economics.uncertainty import Slot, UncertainValue
 from hisim.loadtypes import ComponentType
@@ -224,31 +225,6 @@ class ModernizationLevyParameters:
     heating_measure_component_types: FrozenSet[str] = frozenset()
 
 
-class LevyBindingMechanism:
-    """The vocabulary of the per-world levy verdicts.
-
-    "The levy is 1,847 EUR a year" is two different statements depending on what produced it: at a
-    ceiling the figure is fixed by law and the same renovation costing more would yield the same
-    rent, below it the figure is a percentage and every extra euro spent raises the rent. The
-    ruleset already knew which of the two applied; the constants here are what let it *say* so, in
-    one spelling, for each of the three worlds separately.
-
-    `SLOT_NAMES` maps the band's own field names onto the slot vocabulary the rest of the package
-    uses (`Slot` values), so the verdict map is keyed like every other per-slot map.
-    """
-
-    GENERAL_CAP = "§559 general cap"
-    HEATING_CAP = "§559e heating cap"
-    RATE_BELOW_CAP = "of eligible cost, below cap"
-    #: Euro per year below which a cap counts as not having removed anything.
-    TOLERANCE_IN_EURO = 1e-6
-    SLOT_NAMES = {
-        "minimum": Slot.LOW.value,
-        "best_estimate": Slot.BEST_ESTIMATE.value,
-        "maximum": Slot.HIGH.value,
-    }
-
-
 @dataclass
 class ModernizationLevyOutcome:
     """One year's rent increase, split into its §559 and §559e legs after both caps (§6.4).
@@ -285,20 +261,19 @@ class ModernizationLevyOutcome:
     uncapped_heating_levy_in_euro: UncertainValue
     heating_cap_in_euro_per_year: Optional[float] = None
     total_cap_in_euro_per_year: Optional[float] = None
-    #: Whether a statutory cap actually bit in the BEST_ESTIMATE slot. The landlord statement has
-    #: to say which of the two regimes produced the levy — the modernization cost or the ceiling —
-    #: because they are different economic situations: below the cap the levy scales with what was
-    #: spent, at the cap it does not, and a landlord reading a levy figure cannot tell which
-    #: without being told. False when no cap could be evaluated at all (no living area).
-    cap_binding: bool = False
     #: The general §559 Abs. 3a ceiling that applied, in EUR per m² and month, or None when no
     #: living area was known and therefore no cap was evaluated.
     cap_in_euro_per_m2_per_month: Optional[float] = None
-    #: Which mechanism set the levy in each world, keyed by `Slot` value. The caps are applied per
-    #: slot, so the same run can be cap-decided in the expensive world and rate-decided in the
-    #: cheap one; a single flag over the best-estimate slot states one of the three answers and
-    #: hides the other two. Empty when no living area was known and no cap could be evaluated.
-    binding_mechanism_by_slot: Dict[str, str] = field(default_factory=dict)
+    #: Which mechanism set the levy in each world, keyed by `Slot`. The caps are applied per slot,
+    #: so the same run can be cap-decided in the expensive world and rate-decided in the cheap
+    #: one; a single flag over the best-estimate slot would state one of those answers and hide
+    #: the other two, which is why there is no such flag here — a caller wanting the headline
+    #: answer reads this map's BEST_ESTIMATE entry through
+    #: `LevyBindingMechanism.names_a_cap` (`ModernizationLevySummary` exposes it as
+    #: `cap_binding_in_best_estimate`). Empty when no living area was known and no cap could be
+    #: evaluated. A world cut by *both* ceilings names both, joined by
+    #: `LevyBindingMechanism.BOTH_CAPS_JOINER`.
+    binding_mechanism_by_slot: Dict[Slot, str] = field(default_factory=dict)
 
 
 def _ordered_band(slots: dict) -> UncertainValue:
@@ -730,7 +705,7 @@ class DE2024Ruleset:
         cap_rate = self.general_cap_rate(ctx)
         total_cap = cap_rate * months_of_area
         capped = {}
-        mechanisms: Dict[str, str] = {}
+        mechanisms: Dict[Slot, str] = {}
         for slot in ("minimum", "best_estimate", "maximum"):
             heating_slot = min(getattr(heating, slot), heating_cap, total_cap)
             general_slot = min(getattr(general, slot), total_cap - heating_slot)
@@ -740,10 +715,10 @@ class DE2024Ruleset:
                 general_raw=getattr(general, slot),
                 heating_capped=heating_slot,
                 general_capped=general_slot,
+                heating_cap=heating_cap,
+                total_cap=total_cap,
                 cap_rate=cap_rate,
             )
-        uncapped_best_estimate = heating.best_estimate + general.best_estimate
-        capped_best_estimate = sum(capped["best_estimate"])
         return ModernizationLevyOutcome(
             general_levy_in_euro=_ordered_band({slot: values[1] for slot, values in capped.items()}),
             heating_levy_in_euro=_ordered_band({slot: values[0] for slot, values in capped.items()}),
@@ -754,9 +729,6 @@ class DE2024Ruleset:
             uncapped_heating_levy_in_euro=heating,
             heating_cap_in_euro_per_year=heating_cap,
             total_cap_in_euro_per_year=total_cap,
-            # "Did a ceiling decide this number" is the single most important thing to know about
-            # a levy, so it is recorded rather than left to be inferred from the amount.
-            cap_binding=capped_best_estimate < uncapped_best_estimate - LevyBindingMechanism.TOLERANCE_IN_EURO,
             cap_in_euro_per_m2_per_month=cap_rate,
             # The per-world verdict, because a cap applied per slot can decide one world and leave
             # the next one to the percentage of the modernization cost.
@@ -769,36 +741,58 @@ class DE2024Ruleset:
         general_raw: float,
         heating_capped: float,
         general_capped: float,
+        heating_cap: float,
+        total_cap: float,
         cap_rate: float,
     ) -> str:
-        """Which of the three mechanisms actually set this world's levy.
+        """Which ceiling — or which rate — actually set this world's levy.
 
-        Reads the same comparison the capping did, in the order the caps are applied (D27): the
-        §559e ceiling first, on the heating leg alone, then the general §559 Abs. 3a ceiling on the
-        two legs together. Whichever ceiling removed euros is the binding one; when neither did,
-        the levy is the statutory percentage of the eligible cost and the verdict says so with the
-        rate that produced it, since that is the case in which spending more would raise the rent.
+        Each leg is classified by *the ceiling that produced its bound value*, which is the only
+        way to get the answer right when the two legs are decided differently. The §559e ceiling
+        is applied to the heating leg alone and the §559 Abs. 3a ceiling to the two legs together
+        (D27), so a heating leg can be cut by either — by its own cap when that is the lower of
+        the two, and by the general cap when the general cap alone is below it — while the general
+        leg, which is only ever limited by the room the general cap leaves, can only be cut by the
+        general one.
+
+        Both ceilings can remove euros in the same world, and then both are named: the earlier
+        rule reported the general cap whenever the general leg survived, so a run whose §559e cap
+        cut the heating leg was told the §559 cap had decided it, which points a landlord at the
+        wrong paragraph and at a ceiling that in the shipped parameters is six times higher.
+
+        When neither ceiling removed anything the levy is the statutory percentage of the eligible
+        cost, and the verdict says so with the rate that produced it, since that is the case in
+        which spending more would raise the rent.
 
         Args:
             heating_raw: The §559e leg before any cap, in euro per year.
             general_raw: The §559 leg before any cap, in euro per year.
             heating_capped: The §559e leg after both caps.
             general_capped: The §559 leg after both caps.
+            heating_cap: The §559e ceiling for this context, in euro per year — compared against
+                the general one to say which of them bound the heating leg.
+            total_cap: The general ceiling for this context, in euro per year.
             cap_rate: The general ceiling in EUR per m² and month, for the verdict's wording.
 
         Returns:
-            A short sentence naming the binding mechanism, ready to be rendered verbatim.
+            A short sentence naming every binding ceiling, or the rate verdict; ready to be
+            rendered verbatim.
         """
         tolerance = LevyBindingMechanism.TOLERANCE_IN_EURO
         heating_cut = heating_raw - heating_capped > tolerance
         general_cut = general_raw - general_capped > tolerance
-        if heating_cut or general_cut:
-            if heating_cut and general_capped <= tolerance:
-                return (
-                    f"{LevyBindingMechanism.HEATING_CAP} "
-                    f"{self.levy.heating_cap_in_euro_per_m2_per_month:,.2f} EUR/m2*mo"
-                )
-            return f"{LevyBindingMechanism.GENERAL_CAP} {cap_rate:,.2f} EUR/m2*mo"
+        clauses = []
+        # The §559e ceiling can only be what bound the heating leg when it is the lower of the
+        # two; above the general cap it is never reached, and the euros were removed by §559.
+        if heating_cut and heating_cap <= total_cap:
+            clauses.append(
+                f"{LevyBindingMechanism.HEATING_CAP} "
+                f"{self.levy.heating_cap_in_euro_per_m2_per_month:,.2f} EUR/m2*mo"
+            )
+        if general_cut or (heating_cut and heating_cap > total_cap):
+            clauses.append(f"{LevyBindingMechanism.GENERAL_CAP} {cap_rate:,.2f} EUR/m2*mo")
+        if clauses:
+            return LevyBindingMechanism.BOTH_CAPS_JOINER.join(clauses)
         rate = (
             self.levy.heating_levy_rate_per_year
             if heating_capped > general_capped

--- a/hisim/economics/adapter.py
+++ b/hisim/economics/adapter.py
@@ -386,34 +386,37 @@ class MeterOutputContracts:
     }
 
 
-def _meter_output_name(component: Any, constant_name: str) -> str:
-    """The output column a meter class publishes under the given constant.
+def _declared_output_name(component: Any, constant_name: str, table_name: str) -> str:
+    """The output column a component class publishes under the given constant.
 
-    Reads the constant off `type(component)` instead of repeating its value here, so the meter
+    Reads the constant off `type(component)` instead of repeating its value here, so the component
     class owns the name of the column it writes and the adapter can only ever ask for a column
-    that class actually declares.
+    that class actually declares. Both compatibility tables that name columns — the meter contracts
+    and the energy-balance specs — resolve through this one function, so a renamed output is the
+    same loud failure whichever table pointed at it.
 
     Args:
-        component: The meter instance; only its class is read.
+        component: The component instance; only its class is read.
         constant_name: Name of the class constant holding the output field name.
+        table_name: The adapter table that named the constant, for the error message.
 
     Returns:
         The output field name as the class states it.
 
     Raises:
-        CostDataError: If the class has no such constant. That is a renamed or deleted meter
-            output, and the alternative is billing a carrier from a column nothing writes;
-            `bridge.py` catches it per component and reports it as an unresolved subject, so the
-            run aborts through the D7 path instead of publishing a zero bill.
+        CostDataError: If the class has no such constant. That is a renamed or deleted output, and
+            the alternative is reading a column nothing writes; `bridge.py` catches it per
+            component and reports it as an unresolved subject, so the run aborts through the D7
+            path instead of publishing a zero bill or a flowless balance.
     """
-    meter_class = type(component)
-    field_name = getattr(meter_class, constant_name, None)
+    component_class = type(component)
+    field_name = getattr(component_class, constant_name, None)
     if not isinstance(field_name, str):
         raise CostDataError(
-            f"Meter class {meter_class.__name__} declares no output-name constant "
-            f"{constant_name!r}, so the cost engine cannot tell which results column carries its "
-            "metered energy. The constant was renamed or removed; update "
-            "adapter.MeterOutputContracts to match."
+            f"Component class {component_class.__name__} declares no output-name constant "
+            f"{constant_name!r}, so the cost engine cannot tell which results column that row of "
+            f"adapter.{table_name} refers to. The constant was renamed or removed; update "
+            f"adapter.{table_name} to match."
         )
     return field_name
 
@@ -427,7 +430,7 @@ def get_meter_spec(component: Any) -> Optional[MeterSpec]:
     calls this for every component; a non-None result makes it read the named output columns out
     of the results frame into `BillingDeterminants`.
 
-    The column names come from the meter class itself (`_meter_output_name`), which is what makes a
+    The column names come from the meter class itself (`_declared_output_name`), which makes a
     renamed meter output a loud failure rather than a carrier quietly billed from an empty series.
 
     Raises:
@@ -439,14 +442,19 @@ def get_meter_spec(component: Any) -> Optional[MeterSpec]:
     contract = MeterOutputContracts.BY_CLASS_NAME.get(type(component).__name__)
     if contract is None:
         return None
+    table = "MeterOutputContracts"
     return MeterSpec(
         carrier=contract.carrier_of(component),
-        bought_field=_meter_output_name(component, contract.bought_constant),
+        bought_field=_declared_output_name(component, contract.bought_constant, table),
         sold_field=(
-            _meter_output_name(component, contract.sold_constant) if contract.sold_constant else None
+            _declared_output_name(component, contract.sold_constant, table)
+            if contract.sold_constant
+            else None
         ),
         power_field=(
-            _meter_output_name(component, contract.power_constant) if contract.power_constant else None
+            _declared_output_name(component, contract.power_constant, table)
+            if contract.power_constant
+            else None
         ),
     )
 
@@ -521,11 +529,19 @@ class FactsExtraction:
 class DeviceEnergySpec:
     """How to read one energy-balance flow of a component out of the results frame.
 
-    The energy-balance counterpart of `MeterSpec`, and deliberately the same shape of contract: a
-    declarative "this class's output column *X* is that role", so `bridge.py` can collect the
-    household energy balance generically instead of special-casing devices. Where `MeterSpec`
-    describes the *billing* boundary, this describes the *physical* one — flows nobody is ever
-    charged for (PV generation, battery charging) belong here and never reach a price.
+    The energy-balance counterpart of `MeterOutputContract`, and deliberately the same shape of
+    contract: a declarative "this class's output constant *X* is that role", so `bridge.py` can
+    collect the household energy balance generically instead of special-casing devices. Where the
+    meter contracts describe the *billing* boundary, these describe the *physical* one — flows
+    nobody is ever charged for (PV generation, battery charging) belong here and never reach a
+    price.
+
+    `output_constant` is the **name of the class constant** that holds the column name, not the
+    column name itself, resolved through `_declared_output_name` exactly as a meter's is. The
+    difference matters: `MoreAdvancedHeatPumpHPLib.ElectricalInputPowerTotal` is the constant and
+    `"ElectricalInputPowerTotalHeatpump"` its value, and a table that spelled the value would keep
+    working after the class renamed the constant and stop working after it renamed the column —
+    the wrong way round.
 
     Units are not assumed: the summing side reads the declared unit of the output
     (`Units.WATT`, `Units.WATT_HOUR`, `Units.KWH`) and converts to kWh accordingly, because HiSim
@@ -539,6 +555,20 @@ class DeviceEnergySpec:
     """
 
     role: EnergyFlowRole
+    output_constant: str
+    positive_part: Optional[bool] = None
+
+
+@dataclass(frozen=True)
+class ResolvedDeviceEnergyFlow:
+    """One energy-balance flow with its column name resolved off the component class.
+
+    What `resolve_device_energy_flows` returns and `bridge.py` reads — the `MeterSpec` of the
+    physical side. Separating it from `DeviceEnergySpec` is what keeps the table a statement about
+    *constants* while the collector works with *columns*.
+    """
+
+    role: EnergyFlowRole
     field_name: str
     positive_part: Optional[bool] = None
 
@@ -549,22 +579,42 @@ class DeviceEnergySpecs:
     The compatibility table for energy the way `FactsExtractors.BY_CLASS_NAME` is the one for
     cost, and the honest answer to "where do the numbers on the energy-balance chart come from":
     every one of them is a named output column of a named component class, summed over the
-    simulated period. A class that is not in this table contributes nothing — the balance then
-    shows an unattributed remainder rather than inventing a flow for it.
+    simulated period.
+
+    **The table is total over the classes that move electricity.** Every component class that
+    declares an output with `LoadTypes.ELECTRICITY` in a unit the collector can convert has a row
+    here — a real one when its flow is a terminal of the balance, and an *explicit empty* one when
+    it is not. Absence therefore means "nobody has looked at this class", and `bridge.py` refuses
+    a run over it (D7) instead of quietly leaving the device out of a picture that claims to be a
+    balance of the house. That is the whole point of the empty rows: a controller that publishes a
+    setpoint in watts and a heat pump that publishes its consumption in watts are indistinguishable
+    to a scanner, and only a person can say which of them is energy crossing a node.
+
+    The empty rows fall into three groups, and the comments below say which group each row is in:
+    control and energy-management channels that are *instructions*, not flows; aggregates and
+    duplicate channels whose energy is already counted under another row; and real device flows
+    for which `carriers.EnergyFlowRole` has no terminal yet, which the balance therefore carries
+    inside its residual node rather than as a drawn terminal.
 
     The table is keyed by class name rather than by type so this module keeps importing no
-    component, which is what the import lint pins. Adding a device to the balance is adding a row
-    here; no chart, view or renderer changes with it.
+    component, which is what the import lint pins; `tests/test_economics_extraction.py` binds every
+    key and every constant to the real classes so the two cannot drift.
     """
 
     BY_CLASS_NAME: Dict[str, Tuple[DeviceEnergySpec, ...]] = {
+        # ---------------------------------------------------------------- drawn terminals
         "PVSystem": (DeviceEnergySpec(EnergyFlowRole.PV_GENERATION, "ElectricityEnergyOutput"),),
         "Battery": (
             DeviceEnergySpec(EnergyFlowRole.BATTERY_CHARGE, "AcBatteryPowerUsed", positive_part=True),
             DeviceEnergySpec(EnergyFlowRole.BATTERY_DISCHARGE, "AcBatteryPowerUsed", positive_part=False),
         ),
         "MoreAdvancedHeatPumpHPLib": (
-            DeviceEnergySpec(EnergyFlowRole.HEAT_PUMP_ELECTRICITY, "ElectricalInputPowerTotalHeatpump"),
+            DeviceEnergySpec(EnergyFlowRole.HEAT_PUMP_ELECTRICITY, "ElectricalInputPowerTotal"),
+        ),
+        # The older single-channel heat pump: one electricity output, flagged
+        # ELECTRICITY_CONSUMPTION_UNCONTROLLED, so it is the same terminal as its successor's.
+        "GenericHeatPump": (
+            DeviceEnergySpec(EnergyFlowRole.HEAT_PUMP_ELECTRICITY, "ElectricityOutput"),
         ),
         "UtspLpgConnector": (
             DeviceEnergySpec(EnergyFlowRole.HOUSEHOLD_ELECTRICITY, "ElectricalEnergyConsumption"),
@@ -573,18 +623,95 @@ class DeviceEnergySpecs:
             DeviceEnergySpec(EnergyFlowRole.GRID_IMPORT, "ElectricityFromGrid"),
             DeviceEnergySpec(EnergyFlowRole.GRID_EXPORT, "ElectricityToGrid"),
         ),
+        # ------------------------------------------------- control and energy management
+        # These publish setpoints, targets, surpluses and curtailment — an instruction to a
+        # device, or the arithmetic of one. The energy they refer to is metered at the device
+        # that follows the instruction, and counting both would count it twice.
+        "L2GenericEnergyManagementSystem": (),
+        "ExtendedController": (),
+        "FuelCellController": (),
+        "L1Controller": (),
+        "L1GenericElectrolyzerController": (),
+        "MpcController": (),
+        "PTXController": (),
+        "RsocBatteryController": (),
+        "XTPController": (),
+        # ------------------------------------------------------ examples and templates
+        # Shipped as documentation of the component API. They appear in no priced setup, and a
+        # row here is what keeps them from failing a run that happens to include one.
+        "ExampleComponent": (),
+        "ComponentName": (),
+        # -------------------------------- real device flows with no terminal in the vocabulary
+        # `carriers.EnergyFlowRole` names seven terminals, and none of them fits these. Their
+        # kilowatt hours are not lost: the balance's residual node carries whatever the drawn
+        # terminals do not account for, and the caption says so. Giving one of them a terminal
+        # means adding a role and teaching the layout to draw it — a change to the chart, not to
+        # this table, which is why the rows stay empty rather than borrowing a role that means
+        # something else.
+        #
+        # An EV battery is not a pass-through of the house bus (the car drives away with the
+        # energy), so it cannot be drawn under the battery's charge/discharge pair.
+        "CarBattery": (),
+        "Car": (),
+        # Wind generation would need a generation terminal of its own; PV_GENERATION is the PV
+        # array's, and a wind turbine drawn there would be labelled as solar.
+        "Windturbine": (),
+        # Electric heat and cooling: resistive space/DHW heat and air conditioning are neither the
+        # household base load nor a heat pump's electricity.
+        "ElectricHeating": (),
+        "AirConditioner": (),
+        "SimpleAirConditioner": (),
+        # A shiftable appliance whose profile may or may not already sit inside the household
+        # load profile, depending on how the LPG connector was configured — exactly the question
+        # a terminal would have to answer before it could be drawn.
+        "SmartDevice": (),
+        # Auxiliary pump electricity of a solar thermal loop.
+        "SolarThermalSystem": (),
+        # The hydrogen chain (electrolyzers, fuel cells, reversible cells, CHP and their storage):
+        # electricity that leaves or enters the bus as hydrogen. The balance has no hydrogen
+        # terminal, and half of these channels are the same energy seen twice (a load in W beside
+        # a cumulative total in kWh).
+        "AdvancedElectrolyzer": (),
+        "Electrolyzer": (),
+        "GenericElectrolyzer": (),
+        "HydrogenStorage": (),
+        "FuelCell": (),
+        "Rsoc": (),
+        "CHP": (),
+        "SimpleCHP": (),
     }
 
 
-def get_device_energy_specs(component: Any) -> Tuple[DeviceEnergySpec, ...]:
-    """The energy-balance flows this component class publishes, or an empty tuple.
+def resolve_device_energy_flows(component: Any) -> Optional[Tuple[ResolvedDeviceEnergyFlow, ...]]:
+    """The energy-balance flows this component class publishes, with their columns resolved.
 
     The lookup `bridge.py` calls for every wrapped component, whatever its cost relevance: the
     energy balance is a physical record, so a component that is free of cost or not declared at
-    all still contributes its kilowatt hours. Returning an empty tuple for an unknown class is the
-    normal case and never a warning — most components move no electricity across a balance node.
+    all still contributes its kilowatt hours.
+
+    Args:
+        component: The wrapped component; its class name selects the row and its class carries the
+            output-name constants that row refers to.
+
+    Returns:
+        The resolved flows for a class the table knows — possibly none, which is what an explicit
+        empty row means — and `None` for a class the table does not mention at all. The caller
+        distinguishes the two: an empty row is a decision, an absent one is an omission.
+
+    Raises:
+        CostDataError: If a row names an output constant the class does not declare.
     """
-    return DeviceEnergySpecs.BY_CLASS_NAME.get(type(component).__name__, ())
+    specs = DeviceEnergySpecs.BY_CLASS_NAME.get(type(component).__name__)
+    if specs is None:
+        return None
+    return tuple(
+        ResolvedDeviceEnergyFlow(
+            role=spec.role,
+            field_name=_declared_output_name(component, spec.output_constant, "DeviceEnergySpecs"),
+            positive_part=spec.positive_part,
+        )
+        for spec in specs
+    )
 
 
 # The eight returns are the precedence rule this function exists to state -- hook, declared

--- a/hisim/economics/adapter.py
+++ b/hisim/economics/adapter.py
@@ -54,11 +54,11 @@ agree (this is what closed issue #11 / §2.1 issue #21).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from hisim import log
 from hisim import loadtypes as lt
-from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.carriers import EnergyCarrier, EnergyFlowRole
 from hisim.economics.catalog_entries import CostDataError
 from hisim.economics.facts import ComponentCostFacts, CostRelevance, EnergyFlowFacts
 from hisim.loadtypes import ComponentType, Units
@@ -515,6 +515,76 @@ class FactsExtraction:
                 "unresolved_reason and not_installed_reason may be set, because the caller reads "
                 "them by branch order and would silently drop the rest."
             )
+
+
+@dataclass(frozen=True)
+class DeviceEnergySpec:
+    """How to read one energy-balance flow of a component out of the results frame.
+
+    The energy-balance counterpart of `MeterSpec`, and deliberately the same shape of contract: a
+    declarative "this class's output column *X* is that role", so `bridge.py` can collect the
+    household energy balance generically instead of special-casing devices. Where `MeterSpec`
+    describes the *billing* boundary, this describes the *physical* one — flows nobody is ever
+    charged for (PV generation, battery charging) belong here and never reach a price.
+
+    Units are not assumed: the summing side reads the declared unit of the output
+    (`Units.WATT`, `Units.WATT_HOUR`, `Units.KWH`) and converts to kWh accordingly, because HiSim
+    components publish power and energy channels side by side and guessing wrong is a factor of
+    3600 away from the truth.
+
+    `positive_part` handles the one channel that carries two roles: a battery's AC power is
+    signed, charging one way and discharging the other, so the charge role takes the positive
+    part of the series and the discharge role the negative part's magnitude. None means "sum the
+    whole column", which is what every single-direction channel needs.
+    """
+
+    role: EnergyFlowRole
+    field_name: str
+    positive_part: Optional[bool] = None
+
+
+class DeviceEnergySpecs:
+    """Which component classes contribute which flows to the household energy balance.
+
+    The compatibility table for energy the way `FactsExtractors.BY_CLASS_NAME` is the one for
+    cost, and the honest answer to "where do the numbers on the energy-balance chart come from":
+    every one of them is a named output column of a named component class, summed over the
+    simulated period. A class that is not in this table contributes nothing — the balance then
+    shows an unattributed remainder rather than inventing a flow for it.
+
+    The table is keyed by class name rather than by type so this module keeps importing no
+    component, which is what the import lint pins. Adding a device to the balance is adding a row
+    here; no chart, view or renderer changes with it.
+    """
+
+    BY_CLASS_NAME: Dict[str, Tuple[DeviceEnergySpec, ...]] = {
+        "PVSystem": (DeviceEnergySpec(EnergyFlowRole.PV_GENERATION, "ElectricityEnergyOutput"),),
+        "Battery": (
+            DeviceEnergySpec(EnergyFlowRole.BATTERY_CHARGE, "AcBatteryPowerUsed", positive_part=True),
+            DeviceEnergySpec(EnergyFlowRole.BATTERY_DISCHARGE, "AcBatteryPowerUsed", positive_part=False),
+        ),
+        "MoreAdvancedHeatPumpHPLib": (
+            DeviceEnergySpec(EnergyFlowRole.HEAT_PUMP_ELECTRICITY, "ElectricalInputPowerTotalHeatpump"),
+        ),
+        "UtspLpgConnector": (
+            DeviceEnergySpec(EnergyFlowRole.HOUSEHOLD_ELECTRICITY, "ElectricalEnergyConsumption"),
+        ),
+        "ElectricityMeter": (
+            DeviceEnergySpec(EnergyFlowRole.GRID_IMPORT, "ElectricityFromGrid"),
+            DeviceEnergySpec(EnergyFlowRole.GRID_EXPORT, "ElectricityToGrid"),
+        ),
+    }
+
+
+def get_device_energy_specs(component: Any) -> Tuple[DeviceEnergySpec, ...]:
+    """The energy-balance flows this component class publishes, or an empty tuple.
+
+    The lookup `bridge.py` calls for every wrapped component, whatever its cost relevance: the
+    energy balance is a physical record, so a component that is free of cost or not declared at
+    all still contributes its kilowatt hours. Returning an empty tuple for an unknown class is the
+    normal case and never a warning — most components move no electricity across a balance node.
+    """
+    return DeviceEnergySpecs.BY_CLASS_NAME.get(type(component).__name__, ())
 
 
 # The eight returns are the precedence rule this function exists to state -- hook, declared

--- a/hisim/economics/audit.py
+++ b/hisim/economics/audit.py
@@ -307,6 +307,9 @@ def write_cost_audit(audit: InputAuditReport, result_directory: str) -> str:
         "Subsidy max [EUR]",
         "Caps binding (slots)",
         "Anyway share",
+        # The share alone cannot be checked: the credit is share x basis, and without the basis a
+        # reader auditing "30 %" has no second number to multiply it by.
+        "Anyway basis [EUR]",
     ]
     for row in audit.rows:
         unit_price, gross, subsidy = (
@@ -334,6 +337,7 @@ def write_cost_audit(audit: InputAuditReport, result_directory: str) -> str:
                 subsidy.maximum if subsidy else "",
                 "; ".join(f"{scheme}:{','.join(slots)}" for scheme, slots in row.caps_binding_by_scheme.items()),
                 row.anyway_share if row.anyway_share is not None else "",
+                row.anyway_basis_in_euro if row.anyway_basis_in_euro is not None else "",
             ]
         )
     with open(path, "w", newline="", encoding="utf-8") as file:

--- a/hisim/economics/audit.py
+++ b/hisim/economics/audit.py
@@ -200,6 +200,16 @@ def build_input_audit(
                 subsidies_nominal_in_euro=breakdown.subsidies_nominal_in_euro if breakdown else None,
                 subsidy_scheme_ids=[award.scheme_id for award in decision.applied] if decision else [],
                 caps_binding_by_scheme=caps,
+                # The Sowieso share behind this subject's anyway credit, so the audit table
+                # states the credit's basis instead of only its euro amount, and the cost the
+                # share was applied to, so the audited credit is a multiplication the reader can
+                # carry out rather than a percentage in isolation.
+                anyway_share=(
+                    result.anyway_share_by_subject.get(subject_facts.subject) if result else None
+                ),
+                anyway_basis_in_euro=(
+                    result.anyway_basis_by_subject.get(subject_facts.subject) if result else None
+                ),
                 flags=flags,
             )
         )
@@ -296,6 +306,7 @@ def write_cost_audit(audit: InputAuditReport, result_directory: str) -> str:
         "Subsidy best_estimate [EUR]",
         "Subsidy max [EUR]",
         "Caps binding (slots)",
+        "Anyway share",
     ]
     for row in audit.rows:
         unit_price, gross, subsidy = (
@@ -322,6 +333,7 @@ def write_cost_audit(audit: InputAuditReport, result_directory: str) -> str:
                 subsidy.best_estimate if subsidy else "",
                 subsidy.maximum if subsidy else "",
                 "; ".join(f"{scheme}:{','.join(slots)}" for scheme, slots in row.caps_binding_by_scheme.items()),
+                row.anyway_share if row.anyway_share is not None else "",
             ]
         )
     with open(path, "w", newline="", encoding="utf-8") as file:

--- a/hisim/economics/bridge.py
+++ b/hisim/economics/bridge.py
@@ -55,7 +55,7 @@ independent of cost-database state (cost-spec-v2 W1.1).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Dict, List, Optional, Tuple
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
 
 import pandas as pd
 
@@ -91,6 +91,7 @@ from hisim.economics.perspectives import load_default_bundle, select_applicable
 from hisim.economics.scenarios import ScenarioSet
 from hisim.economics.serialization import write_inputs
 from hisim.economics.subsidies import SubsidyCatalog, SubsidyContext
+from hisim.loadtypes import Units
 
 
 #: The length of a reference year, used to turn a simulation's start/end dates into
@@ -207,22 +208,122 @@ class EconomicContext:
             )
 
 
+def _output_column_and_unit(
+    component_name: str, field_name: str, all_outputs: List[Any], results: pd.DataFrame
+) -> Optional[Tuple[pd.Series, str]]:
+    """One output's per-timestep column together with the unit it was declared in.
+
+    The results DataFrame has no named columns the engine could rely on, so an output is located
+    positionally: `all_outputs` and the frame's columns are in the same order, and this is the one
+    place in the bridge that knows it. The declared unit travels with the column because the energy
+    balance reads channels that are sometimes power and sometimes energy, so it has to see what the
+    component declared rather than assume the Wh the meter contract fixes.
+    """
+    for index, output in enumerate(all_outputs):
+        if output.component_name == component_name and output.field_name == field_name:
+            unit = getattr(output, "unit", None)
+            return results.iloc[:, index], str(getattr(unit, "value", unit))
+    return None
+
+
 def _output_column(
     component_name: str, field_name: str, all_outputs: List[Any], results: pd.DataFrame
 ) -> Optional[pd.Series]:
     """One output's per-timestep column, or None when the run declares no such output.
 
-    The results DataFrame has no named columns the engine could rely on, so an output is located
-    positionally: `all_outputs` and the frame's columns are in the same order, and this is the one
-    place in the bridge that knows it. Returning None rather than an empty series for a missing
-    output is what lets the callers distinguish "this meter measured nothing" from "this meter's
-    declared field does not exist" — the second is a broken extraction and they refuse the run
-    over it.
+    Returning None rather than an empty series for a missing output is what lets the callers
+    distinguish "this meter measured nothing" from "this meter's declared field does not exist" —
+    the second is a broken extraction and they refuse the run over it.
     """
-    for index, output in enumerate(all_outputs):
-        if output.component_name == component_name and output.field_name == field_name:
-            return results.iloc[:, index]
-    return None
+    found = _output_column_and_unit(component_name, field_name, all_outputs, results)
+    return None if found is None else found[0]
+
+
+class EnergyUnitConversion:
+    """Factors that turn a summed output column into kilowatt hours, keyed by its declared unit.
+
+    HiSim components publish power and energy channels side by side — a PV system has both
+    `ElectricityOutput` in W and `ElectricityEnergyOutput` in Wh — so the energy-balance collector
+    reads the *declared* unit of the column it found instead of assuming one. `WATT` needs the
+    timestep length as well, which is why it is a callable rather than a number.
+
+    A unit not in this table is not converted at all: the collector logs the column and skips it,
+    which keeps a mis-declared output out of the energy balance instead of putting a number three
+    orders of magnitude wrong on a chart.
+    """
+
+    WATT_HOURS_PER_KWH = 1000.0
+    SECONDS_PER_HOUR = 3600.0
+    #: Declared unit string (`loadtypes.Units` value) -> factor from the summed column to kWh,
+    #: given the timestep length in seconds.
+    BY_UNIT: Dict[str, Callable[[int], float]] = {
+        Units.WATT_HOUR.value: lambda seconds: 1.0 / EnergyUnitConversion.WATT_HOURS_PER_KWH,
+        Units.KWH.value: lambda seconds: 1.0,
+        Units.WATT.value: lambda seconds: seconds / (
+            EnergyUnitConversion.SECONDS_PER_HOUR * EnergyUnitConversion.WATT_HOURS_PER_KWH
+        ),
+    }
+
+
+def _device_energy_flows(
+    component: Any,
+    all_outputs: List[Any],
+    results: pd.DataFrame,
+    seconds_per_timestep: int,
+) -> Dict[str, float]:
+    """One component's energy-balance flows over the simulated period, as role -> kWh.
+
+    The physical counterpart of `_billing_determinants`, and the data behind the household energy
+    balance: for every `adapter.DeviceEnergySpec` this component's class declares, the named output
+    column is located positionally, summed, converted to kWh by its own declared unit and filed
+    under the spec's role. A battery's signed AC-power channel is split by sign so charging and
+    discharging come out as two roles rather than one net number that would hide the round trip.
+
+    Nothing here is priced and nothing here crosses the system boundary, which is why it is
+    separate from the billing path: the flows of a component that is free of cost or not declared
+    at all are just as real, and dropping them would leave the balance unattributed.
+
+    Args:
+        component: The finished simulation's component; its class name and `component_name` are
+            read.
+        all_outputs: The run's output declarations, in the frame's column order.
+        results: The per-timestep results frame.
+        seconds_per_timestep: Needed to integrate the columns declared in W.
+
+    Returns:
+        Role value -> kWh over the simulated period, positive magnitudes, zero-valued roles
+        omitted. Empty for a class with no declared specs and for a declared column this run did
+        not produce (warned about once, since a renamed output is a real defect).
+    """
+    flows: Dict[str, float] = {}
+    for spec in adapter.get_device_energy_specs(component):
+        column = _output_column_and_unit(component.component_name, spec.field_name, all_outputs, results)
+        if column is None:
+            log.warning(
+                f"Energy balance: component {component.component_name} declares output "
+                f"{spec.field_name!r} for role {spec.role.value}, which this run did not produce; "
+                "the flow is left out of the household energy balance."
+            )
+            continue
+        series, unit = column
+        factor = EnergyUnitConversion.BY_UNIT.get(unit)
+        if factor is None:
+            log.warning(
+                f"Energy balance: output {component.component_name}.{spec.field_name} is declared "
+                f"in {unit!r}, which is not an energy or power unit this collector converts; the "
+                "flow is left out of the household energy balance."
+            )
+            continue
+        if spec.positive_part is True:
+            total = float(series.clip(lower=0.0).sum())
+        elif spec.positive_part is False:
+            total = -float(series.clip(upper=0.0).sum())
+        else:
+            total = float(series.sum())
+        value = total * factor(seconds_per_timestep)
+        if value:
+            flows[spec.role.value] = flows.get(spec.role.value, 0.0) + value
+    return flows
 
 
 def _sum_output_column(
@@ -474,12 +575,15 @@ def build_evaluation_inputs(
     """Collects facts and billing determinants from a finished simulation.
 
     The extraction half of the cost-spec-v2 seam-1 cut: it walks every wrapped component once and
-    asks three questions — is this component priced, free of cost or a meter
-    (`effective_cost_relevance`); what are its `ComponentCostFacts`; and, for meters, what crossed
-    the boundary (`_billing_determinants`, hook first and `MeterSpec` second). A component can
-    answer more than one of them: a meter with capex contributes both billing determinants and
-    cost facts, which is why the two branches below are sequential rather than exclusive. The
-    result is the plain-data record that `write_inputs` persists and the evaluator prices — no
+    asks four questions — which energy-balance flows does it publish (`_device_energy_flows`); is
+    this component priced, free of cost or a meter (`effective_cost_relevance`); what are its
+    `ComponentCostFacts`; and, for meters, what crossed the boundary (`_billing_determinants`,
+    hook first and `MeterSpec` second). A component can answer more than one of them: a meter with
+    capex contributes billing determinants, cost facts *and* the grid import/export flows, which
+    is why the branches below are sequential rather than exclusive. The energy question is asked
+    first and unconditionally, because the household energy balance is physics rather than
+    accounting — a free-of-cost PV system and an undeclared load profile move real kilowatt hours.
+    The result is the plain-data record that `write_inputs` persists and the evaluator prices — no
     prices, no perspective, no economics of any kind are decided here.
 
     Five things it also decides, and none of them is silent. An `UNDECLARED` component becomes an
@@ -518,12 +622,25 @@ def build_evaluation_inputs(
     """
     cost_facts: List[SubjectCostFacts] = []
     billing: List[BillingDeterminants] = []
+    attribution: Dict[str, Dict[str, float]] = {}
     unresolved: List[UnresolvedSubject] = []
     not_installed: List[str] = []
     billing_intervals = _capacity_billing_intervals(wrapped_components)
     for wrapper in wrapped_components:
         component = wrapper.my_component
         subject = component.component_name
+        # The energy balance is a physical record, not a cost classification: it is collected for
+        # every component, before and independently of the cost-relevance branch below, because a
+        # PV system that is FREE_OF_COST or a load profile that is UNDECLARED still moves the
+        # kilowatt hours the household balance is made of.
+        energy_flows = _device_energy_flows(
+            component,
+            all_outputs,
+            postprocessing_results,
+            simulation_parameters.seconds_per_timestep,
+        )
+        if energy_flows:
+            attribution[subject] = energy_flows
         try:
             relevance = adapter.effective_cost_relevance(component)
             if relevance == CostRelevance.UNDECLARED:
@@ -623,6 +740,7 @@ def build_evaluation_inputs(
         simulated_period_fraction=fraction,
         cost_facts=cost_facts,
         billing=billing,
+        energy_attribution_by_subject_in_kwh=attribution,
         unresolved_subjects=unresolved,
     )
     context: Optional[EconomicContext] = getattr(simulation_parameters, "economic_context", None)

--- a/hisim/economics/bridge.py
+++ b/hisim/economics/bridge.py
@@ -62,7 +62,7 @@ import pandas as pd
 from hisim import log
 from hisim.economics import adapter
 from hisim.economics.audit import build_input_audit, write_cost_audit, write_parity_report
-from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.carriers import EnergyCarrier, validate_energy_attribution
 from hisim.economics.input_audit import write_input_audit
 from hisim.economics.database import CostDatabase, CostDataError
 from hisim.economics.evaluator import (
@@ -91,7 +91,7 @@ from hisim.economics.perspectives import load_default_bundle, select_applicable
 from hisim.economics.scenarios import ScenarioSet
 from hisim.economics.serialization import write_inputs
 from hisim.economics.subsidies import SubsidyCatalog, SubsidyContext
-from hisim.loadtypes import Units
+from hisim.loadtypes import LoadTypes, Units
 
 
 #: The length of a reference year, used to turn a simulation's start/end dates into
@@ -243,13 +243,20 @@ class EnergyUnitConversion:
     """Factors that turn a summed output column into kilowatt hours, keyed by its declared unit.
 
     HiSim components publish power and energy channels side by side — a PV system has both
-    `ElectricityOutput` in W and `ElectricityEnergyOutput` in Wh — so the energy-balance collector
-    reads the *declared* unit of the column it found instead of assuming one. `WATT` needs the
-    timestep length as well, which is why it is a callable rather than a number.
+    `ElectricityOutput` in W and `ElectricityEnergyOutput` in Wh — so every summing path reads the
+    *declared* unit of the column it found instead of assuming one. `WATT` needs the timestep
+    length as well, which is why it is a callable rather than a number.
 
-    A unit not in this table is not converted at all: the collector logs the column and skips it,
-    which keeps a mis-declared output out of the energy balance instead of putting a number three
-    orders of magnitude wrong on a chart.
+    **One table, both paths.** The billing side (`_sum_output_column`, which turns a meter column
+    into the kilowatt hours a carrier is charged for) and the energy-balance side
+    (`_device_energy_flows`) convert through this same table, so a column can never be worth one
+    number on the bill and another on the chart. The billing side used to carry its own hardcoded
+    `* 1e-3`, which was right only because every meter column happens to be declared in Wh.
+
+    A unit not in this table is not converted at all, and that is a refusal rather than a guess:
+    the caller reports the column as an unresolved subject and the run stops, because a
+    mis-declared output silently converted is a number three orders of magnitude wrong on a chart
+    or on a bill.
     """
 
     WATT_HOURS_PER_KWH = 1000.0
@@ -263,6 +270,33 @@ class EnergyUnitConversion:
             EnergyUnitConversion.SECONDS_PER_HOUR * EnergyUnitConversion.WATT_HOURS_PER_KWH
         ),
     }
+
+    @staticmethod
+    def to_kwh(total: float, unit: str, seconds_per_timestep: int, column: str) -> float:
+        """Converts one summed column to kWh by the unit it was declared in.
+
+        Args:
+            total: The summed column, in its declared unit (a power column integrates by the
+                timestep, so its sum is W-timesteps).
+            unit: The declared unit's value, as `_output_column_and_unit` reports it.
+            seconds_per_timestep: The simulation's resolution, needed for a power column.
+            column: `component.field` of the column, for the error message.
+
+        Returns:
+            The same quantity in kilowatt hours.
+
+        Raises:
+            CostDataError: If the unit is neither an energy nor a power unit this table converts.
+        """
+        factor = EnergyUnitConversion.BY_UNIT.get(unit)
+        if factor is None:
+            raise CostDataError(
+                f"Output {column} is declared in {unit!r}, which is neither an energy nor a power "
+                f"unit the cost engine converts ({', '.join(sorted(EnergyUnitConversion.BY_UNIT))}"
+                "). Converting it anyway would put a number orders of magnitude wrong into the "
+                "energy balance or onto a bill."
+            )
+        return total * factor(seconds_per_timestep)
 
 
 def _device_energy_flows(
@@ -292,46 +326,126 @@ def _device_energy_flows(
 
     Returns:
         Role value -> kWh over the simulated period, positive magnitudes, zero-valued roles
-        omitted. Empty for a class with no declared specs and for a declared column this run did
-        not produce (warned about once, since a renamed output is a real defect).
+        omitted. Empty for a class whose table row is explicitly empty, and for a class that moves
+        no electricity at all.
+
+    Raises:
+        CostDataError: For a table row naming a constant the class does not declare, for a
+            declared column this run did not produce, for a column in a unit the conversion table
+            does not know, and for a class the table does not mention at all that nevertheless
+            publishes electricity in a convertible unit. All four used to be a warning and a
+            dropped flow, which is a balance that looks complete and is not; `build_evaluation_inputs`
+            turns each of them into an `UnresolvedSubject` and the D7 check stops the run.
     """
+    specs = adapter.resolve_device_energy_flows(component)
+    if specs is None:
+        _require_no_unplaced_electricity(component, all_outputs)
+        return {}
     flows: Dict[str, float] = {}
-    for spec in adapter.get_device_energy_specs(component):
+    for spec in specs:
         column = _output_column_and_unit(component.component_name, spec.field_name, all_outputs, results)
         if column is None:
-            log.warning(
-                f"Energy balance: component {component.component_name} declares output "
-                f"{spec.field_name!r} for role {spec.role.value}, which this run did not produce; "
-                "the flow is left out of the household energy balance."
+            raise CostDataError(
+                f"Energy balance: component {component.component_name} is listed in "
+                f"adapter.DeviceEnergySpecs with output {spec.field_name!r} for role "
+                f"{spec.role.value}, which this run did not produce. Leaving the flow out would "
+                "publish a household balance whose residual node silently absorbs it."
             )
-            continue
         series, unit = column
-        factor = EnergyUnitConversion.BY_UNIT.get(unit)
-        if factor is None:
-            log.warning(
-                f"Energy balance: output {component.component_name}.{spec.field_name} is declared "
-                f"in {unit!r}, which is not an energy or power unit this collector converts; the "
-                "flow is left out of the household energy balance."
-            )
-            continue
         if spec.positive_part is True:
             total = float(series.clip(lower=0.0).sum())
         elif spec.positive_part is False:
             total = -float(series.clip(upper=0.0).sum())
         else:
             total = float(series.sum())
-        value = total * factor(seconds_per_timestep)
+        value = EnergyUnitConversion.to_kwh(
+            total, unit, seconds_per_timestep, f"{component.component_name}.{spec.field_name}"
+        )
         if value:
             flows[spec.role.value] = flows.get(spec.role.value, 0.0) + value
+    try:
+        # The same rule the annualization and the deserializer apply, stated once and checked here
+        # first: a role is a direction, so a magnitude that comes out negative means the column
+        # this row named runs the other way and the row is wrong about it.
+        validate_energy_attribution(
+            {component.component_name: flows}, f"Energy balance: {type(component).__name__}"
+        )
+    except ValueError as err:
+        raise CostDataError(str(err)) from err
     return flows
 
 
+def _require_no_unplaced_electricity(component: Any, all_outputs: List[Any]) -> None:
+    """Refuses a component class the energy-balance table has never been asked about.
+
+    `adapter.DeviceEnergySpecs` is meant to be the one statement of who is in the household
+    balance, which only holds if a class outside it is outside it *on purpose*. A class that
+    publishes electricity in a unit the collector could convert and has no row at all is the case
+    nobody decided: it might be a device whose flow belongs on the chart, or a controller whose
+    watts are an instruction rather than a flow, and only a maintainer can say which. Before this
+    check it was silently the second.
+
+    Args:
+        component: The wrapped component; its class name and `component_name` are read.
+        all_outputs: The run's output declarations, scanned for this component's own.
+
+    Raises:
+        CostDataError: If the class publishes at least one `LoadTypes.ELECTRICITY` output in a
+            unit `EnergyUnitConversion` converts.
+    """
+    columns = [
+        output.field_name
+        for output in all_outputs
+        if output.component_name == component.component_name
+        and getattr(output, "load_type", None) == LoadTypes.ELECTRICITY
+        and str(getattr(getattr(output, "unit", None), "value", "")) in EnergyUnitConversion.BY_UNIT
+    ]
+    if not columns:
+        return
+    raise CostDataError(
+        f"Component class {type(component).__name__} publishes electricity "
+        f"({', '.join(sorted(columns))}) but has no row in adapter.DeviceEnergySpecs, so the "
+        "household energy balance cannot say whether those kilowatt hours are a flow across a "
+        "balance node or a control signal. Add a row: the roles it contributes, or an explicit "
+        "empty tuple with a comment saying why it contributes none."
+    )
+
+
 def _sum_output_column(
-    component_name: str, field_name: str, all_outputs: List[Any], results: pd.DataFrame
+    component_name: str,
+    field_name: str,
+    all_outputs: List[Any],
+    results: pd.DataFrame,
+    seconds_per_timestep: int,
 ) -> Optional[float]:
-    """Sums one output column (Wh) to kWh; None if the output does not exist."""
-    column = _output_column(component_name, field_name, all_outputs, results)
-    return None if column is None else float(column.sum()) * 1e-3
+    """Sums one output column to kWh by its declared unit; None if the output does not exist.
+
+    Routed through `EnergyUnitConversion` rather than the `* 1e-3` it used to hardcode, so the
+    kilowatt hours a carrier is billed for and the kilowatt hours the energy balance draws are the
+    same conversion of the same column. Every meter column is declared in Wh, so no bill moves;
+    what changes is that a meter column redeclared in kW or kWh would now be converted correctly
+    instead of by a factor of a thousand.
+
+    Args:
+        component_name: The meter's runtime name.
+        field_name: The output column's name.
+        all_outputs: The run's output declarations, in the frame's column order.
+        results: The per-timestep results frame.
+        seconds_per_timestep: The simulation's resolution, needed for a power column.
+
+    Returns:
+        The column's total in kWh, or None when the run declares no such output.
+
+    Raises:
+        CostDataError: If the column is declared in a unit the conversion table does not know.
+    """
+    found = _output_column_and_unit(component_name, field_name, all_outputs, results)
+    if found is None:
+        return None
+    series, unit = found
+    return EnergyUnitConversion.to_kwh(
+        float(series.sum()), unit, seconds_per_timestep, f"{component_name}.{field_name}"
+    )
 
 
 def _power_series(
@@ -494,15 +608,24 @@ def _billing_determinants(
         determinants = BillingDeterminants.from_energy_flow(flows)
     else:
         assert meter_spec is not None
+        seconds = simulation_parameters.seconds_per_timestep
         bought_kwh: Optional[float] = _sum_output_column(
-            component.component_name, meter_spec.bought_field, all_outputs, postprocessing_results
+            component.component_name,
+            meter_spec.bought_field,
+            all_outputs,
+            postprocessing_results,
+            seconds,
         )
         if bought_kwh is None:
             raise missing_meter_column_error(component.component_name, meter_spec.bought_field, "bought energy")
         sold_kwh = 0.0
         if meter_spec.sold_field:
             sold_column = _sum_output_column(
-                component.component_name, meter_spec.sold_field, all_outputs, postprocessing_results
+                component.component_name,
+                meter_spec.sold_field,
+                all_outputs,
+                postprocessing_results,
+                seconds,
             )
             if sold_column is None:
                 raise missing_meter_column_error(component.component_name, meter_spec.sold_field, "sold energy")
@@ -586,7 +709,12 @@ def build_evaluation_inputs(
     The result is the plain-data record that `write_inputs` persists and the evaluator prices — no
     prices, no perspective, no economics of any kind are decided here.
 
-    Five things it also decides, and none of them is silent. An `UNDECLARED` component becomes an
+    Six things it also decides, and none of them is silent. A component whose **energy-balance
+    flows cannot be placed** becomes an `UnresolvedSubject`: a class the `DeviceEnergySpecs` table
+    has never been asked about that nevertheless publishes electricity, a listed class whose
+    declared column this run did not produce, and a column in a unit the conversion table does not
+    know. All three used to warn and drop the flow, which publishes a household balance whose
+    residual node has silently swallowed a terminal. An `UNDECLARED` component becomes an
     `UnresolvedSubject` naming its class: §9.2 makes the declaration mandatory, so a component
     that reaches the cost engine without one is a defect in that component, not a component
     outside the cost model, and the downstream D7 check aborts the evaluation on it. A component
@@ -633,12 +761,19 @@ def build_evaluation_inputs(
         # every component, before and independently of the cost-relevance branch below, because a
         # PV system that is FREE_OF_COST or a load profile that is UNDECLARED still moves the
         # kilowatt hours the household balance is made of.
-        energy_flows = _device_energy_flows(
-            component,
-            all_outputs,
-            postprocessing_results,
-            simulation_parameters.seconds_per_timestep,
-        )
+        try:
+            energy_flows = _device_energy_flows(
+                component,
+                all_outputs,
+                postprocessing_results,
+                simulation_parameters.seconds_per_timestep,
+            )
+        except CostDataError as err:
+            # A device whose flow cannot be placed is the same kind of failure as a subject whose
+            # cost cannot be resolved: the answer the run asked for would come out incomplete, and
+            # a chart missing a terminal reads as a house that does not use that energy.
+            unresolved.append(UnresolvedSubject(subject=subject, reason=str(err)))
+            continue
         if energy_flows:
             attribution[subject] = energy_flows
         try:

--- a/hisim/economics/calculators/aggregation.py
+++ b/hisim/economics/calculators/aggregation.py
@@ -110,6 +110,35 @@ def annual_energy_quantities(
     return quantities
 
 
+def annual_energy_attribution(
+    attribution: Dict[str, Dict[str, float]], simulated_period_fraction: float
+) -> Dict[str, Dict[str, float]]:
+    """Per-subject energy attribution, annualized with the carrier totals' own divisor.
+
+    The per-device counterpart of `annual_energy_quantities`, and it exists as a sibling of that
+    function precisely so the two use one annualization: the household energy balance checks its
+    grid nodes against the metered carrier quantities, and a device column annualized with a
+    different divisor would not agree with the meter it is compared to. Values are carried through
+    unchanged, because annualizing is a scaling, not an interpretation.
+
+    Args:
+        attribution: Subject -> energy-balance role -> simulated-period kWh, straight off
+            `EvaluationInputs`.
+        simulated_period_fraction: Simulated share of a year, dimensionless.
+
+    Returns:
+        The same shape in kWh per year. An empty input yields an empty map, which is the state
+        every run without per-component attribution is in and which the chart skips on.
+    """
+    return {
+        subject: {
+            role: annualize(value, simulated_period_fraction, guard_zero=True)
+            for role, value in by_role.items()
+        }
+        for subject, by_role in attribution.items()
+    }
+
+
 def build_breakdowns(
     scoped: CashFlowTimeline,
     facts_by_subject: Dict[str, ComponentCostFacts],

--- a/hisim/economics/calculators/aggregation.py
+++ b/hisim/economics/calculators/aggregation.py
@@ -28,6 +28,7 @@ from typing import ClassVar, Dict, List, Optional
 from hisim.economics.calculators.annualization import annualize
 from hisim.economics.calculators.categories import EngineCategoryRules
 from hisim.economics.calculators.subsidy_application import nominal_support_from_entries
+from hisim.economics.carriers import validate_energy_attribution
 from hisim.economics.facts import BillingDeterminants, ComponentCostFacts
 from hisim.economics.parameters import EconomicParameters
 from hisim.economics.perspectives import ActorScope
@@ -129,7 +130,15 @@ def annual_energy_attribution(
     Returns:
         The same shape in kWh per year. An empty input yields an empty map, which is the state
         every run without per-component attribution is in and which the chart skips on.
+
+    Raises:
+        ValueError: If the extract carries a negative quantity. Annualizing is a positive scaling,
+            so a magnitude that arrives negative leaves negative, and the check belongs where the
+            map changes hands rather than at the chart that would draw it.
     """
+    validate_energy_attribution(
+        attribution, "annual_energy_attribution(EvaluationInputs.energy_attribution_by_subject_in_kwh)"
+    )
     return {
         subject: {
             role: annualize(value, simulated_period_fraction, guard_zero=True)

--- a/hisim/economics/calculators/co2.py
+++ b/hisim/economics/calculators/co2.py
@@ -112,6 +112,12 @@ def accumulate_operational_emissions(
         annual = carrier_emissions.annual_emissions_in_kg
         for projection_year in range(1, horizon + 1):
             co2_result.operational_co2_by_year_in_kg[projection_year] += annual
+        # The factor travels with the mass so the report can print the multiplication. Assigned
+        # rather than accumulated — it is a price-entry property, identical for every meter of the
+        # same carrier, not a quantity that adds up.
+        co2_result.emission_factor_by_carrier_in_kg_per_kwh[carrier_emissions.carrier_value] = (
+            carrier_emissions.emission_factor_in_kg_per_kwh
+        )
         # Accumulated, not assigned: a carrier can be billed by more than one meter, and the
         # per-year series above sums those records too — the two views must describe one quantity.
         co2_result.operational_co2_by_carrier_in_kg[carrier_emissions.carrier_value] = (

--- a/hisim/economics/calculators/co2.py
+++ b/hisim/economics/calculators/co2.py
@@ -32,10 +32,17 @@ from __future__ import annotations
 from typing import Iterable, List
 
 from hisim.economics.calculators.energy import EnergyFlowResult
+from hisim.economics.catalog_entries import CostDataError
 from hisim.economics.parameters import EconomicParameters
 from hisim.economics.results import LifecycleCo2Result
 from hisim.economics.timeline import CashFlowEntry, CostCategory
 from hisim.economics.uncertainty import UncertainValue
+
+
+#: Difference in kg per kWh below which two records of the same carrier count as carrying the
+#: same emission factor. Both come from the same price entry, so the only difference that can
+#: legitimately appear is float noise.
+EMISSION_FACTOR_TOLERANCE_IN_KG_PER_KWH = 1e-12
 
 
 class Co2Constants:
@@ -107,14 +114,36 @@ def accumulate_operational_emissions(
             accumulate across records, so two meters buying the same carrier add up in the
             carrier map exactly as they do in the yearly series.
         horizon: Observation period T in years.
+
+    Raises:
+        CostDataError: If two records of the same carrier carry different emission factors, which
+            would leave the published per-carrier factor unable to reproduce the published mass.
     """
     for carrier_emissions in energy_result.emissions:
         annual = carrier_emissions.annual_emissions_in_kg
         for projection_year in range(1, horizon + 1):
             co2_result.operational_co2_by_year_in_kg[projection_year] += annual
-        # The factor travels with the mass so the report can print the multiplication. Assigned
-        # rather than accumulated — it is a price-entry property, identical for every meter of the
-        # same carrier, not a quantity that adds up.
+        # The factor travels with the mass so the report can print the multiplication. It is a
+        # price-entry property, identical for every meter of the same carrier, not a quantity that
+        # adds up — so a second meter of the same carrier must arrive with the same factor. When
+        # it does not, the mass below is a sum over two different factors and no single published
+        # factor reproduces it; assigning last-wins would publish a multiplication that does not
+        # come out.
+        known_factor = co2_result.emission_factor_by_carrier_in_kg_per_kwh.get(
+            carrier_emissions.carrier_value
+        )
+        if (
+            known_factor is not None
+            and abs(known_factor - carrier_emissions.emission_factor_in_kg_per_kwh)
+            > EMISSION_FACTOR_TOLERANCE_IN_KG_PER_KWH
+        ):
+            raise CostDataError(
+                f"Carrier {carrier_emissions.carrier_value} was billed under two different "
+                f"emission factors ({known_factor:g} and "
+                f"{carrier_emissions.emission_factor_in_kg_per_kwh:g} kg/kWh). The CO2 section "
+                "publishes one factor per carrier and states the mass as factor x kWh, which no "
+                "single factor would reproduce here."
+            )
         co2_result.emission_factor_by_carrier_in_kg_per_kwh[carrier_emissions.carrier_value] = (
             carrier_emissions.emission_factor_in_kg_per_kwh
         )

--- a/hisim/economics/calculators/context_resolution.py
+++ b/hisim/economics/calculators/context_resolution.py
@@ -149,6 +149,15 @@ class ReplacedAssetOutcome:
     sunk_cost: UncertainValue
     credit_entry: Optional[CashFlowEntry] = None
     credit_amount: UncertainValue = UncertainValue.exact(0.0)
+    #: The Sowieso share the credit was computed at, for the audit trail and the report's
+    #: captions. 1.0 — a genuine like-for-like replacement — whenever the register declares none.
+    anyway_share: float = 1.0
+    #: The cost the share was applied to, in nominal euro of the credit year, BEST_ESTIMATE slot:
+    #: the escalated like-for-like replacement price, or — on the Q7 coupled-cost branch — the
+    #: non-energy share of the new measure that would have been spent anyway. `share x this =
+    #: credit`, which is the multiplication the report has to show rather than assert. 0.0 when no
+    #: credit is due.
+    credit_basis_in_euro: float = 0.0
 
 
 def resolve_device(
@@ -370,6 +379,7 @@ def resolve_replaced_asset(
     database: CostDatabase,
     parameters: EconomicParameters,
     price_basis_year: int,
+    ledger: Optional[ProvenanceLedger] = None,
 ) -> ReplacedAssetOutcome:
     """Sunk cost and anyway-cost credit for the asset this measure replaces (§4.1, Q7).
 
@@ -392,14 +402,26 @@ def resolve_replaced_asset(
     `credit_year` (the old asset's remaining life, rounded) with its own asset class's investment
     escalation rate.
 
+    **The anyway share** scales whichever of the two applies:
+    `credit = anyway_share × like-for-like cost @ credit_year`. It is the Sowieso-Kosten question
+    the previous version answered with an implicit 1.0 for everything — "how much of this measure
+    would the counterfactual really have paid?" Replacing dead windows with windows: all of it.
+    Insulating a facade that was never insulated: only the repair share, because the world without
+    the renovation would have rendered and painted, not insulated. Crediting the full insulation
+    price there was crediting money nobody would ever have spent, and it made every first-time
+    envelope improvement look tens of thousands of euros cheaper than it is.
+
     Args:
-        costing: The replacing measure's resolved costing; supplies `replaced_asset`, the
-            coupled-cost share and the anyway threshold that applies to this class.
+        costing: The replacing measure's resolved costing; supplies `replaced_asset` (with its
+            anyway share), the coupled-cost share and the anyway threshold for this class.
         gross: The measure's own gross investment (euro band), used only for the coupled-cost
             branch.
         database: Loaded cost database, for the replaced asset's price and service life.
         parameters: Economic parameters — country and the escalation-rate fallback chains.
         price_basis_year: The economic "today" the replaced asset's age is measured against.
+        ledger: Provenance ledger; the applied anyway share is recorded into it so the credit's
+            basis is traceable with `explain`. Optional only because the tests that exercise the
+            arithmetic alone do not carry one.
 
     Returns:
         A `ReplacedAssetOutcome`. `sunk_cost` is always present (possibly zero); `credit_entry` is
@@ -442,6 +464,7 @@ def resolve_replaced_asset(
         return ReplacedAssetOutcome(sunk_cost=sunk_cost)
 
     credit_year = int(round(remaining))
+    anyway_share = replaced.anyway_share
     share = costing.energy_related_cost_share
     if share.best_estimate < 1.0:
         # Coupled-cost credit (Q7): the non-energy share of the measure
@@ -460,8 +483,31 @@ def resolve_replaced_asset(
         credit = escalate(like_for_like, old_rate, credit_year)
     else:
         credit = UncertainValue.exact(0.0)
+    # The Sowieso share is applied to whichever branch produced the credit, last, so that the
+    # escalated like-for-like cost stays the stated basis and the share stays a visible factor on
+    # top of it rather than something folded into a price. That basis is captured here, before the
+    # share scales it, because it is exactly the number the report multiplies out.
+    credit_basis = credit.best_estimate
+    credit = credit.scale(anyway_share)
     if credit.maximum <= 0:
         return ReplacedAssetOutcome(sunk_cost=sunk_cost)
+    provenance_ids = costing.provenance_ids
+    if ledger is not None:
+        provenance_ids = provenance_ids + (
+            ledger.record(
+                ParameterProvenance(
+                    parameter=f"{costing.subject}.anyway_share",
+                    value=anyway_share,
+                    origin=ParameterOrigin.CONFIG_OVERRIDE,
+                    source_ids=("inline:existing-asset register (Sowieso-Kosten share, §4.1)",),
+                    detail=(
+                        f"anyway credit = {anyway_share:.0%} x like-for-like cost of "
+                        f"{replaced.asset_class.value} @ year {credit_year} "
+                        f"({credit_basis:,.2f} EUR) = {credit.best_estimate:,.2f} EUR"
+                    ),
+                )
+            ),
+        )
     return ReplacedAssetOutcome(
         sunk_cost=sunk_cost,
         credit_entry=CashFlowEntry(
@@ -469,7 +515,9 @@ def resolve_replaced_asset(
             amount_in_euro=credit.as_revenue(),
             category=CostCategory.ANYWAY_COST_CREDIT,
             subject=costing.subject,
-            provenance_ids=costing.provenance_ids,
+            provenance_ids=provenance_ids,
         ),
         credit_amount=credit,
+        anyway_share=anyway_share,
+        credit_basis_in_euro=credit_basis,
     )

--- a/hisim/economics/calculators/context_resolution.py
+++ b/hisim/economics/calculators/context_resolution.py
@@ -488,6 +488,15 @@ def resolve_replaced_asset(
     # top of it rather than something folded into a price. That basis is captured here, before the
     # share scales it, because it is exactly the number the report multiplies out.
     credit_basis = credit.best_estimate
+    # What the basis *is* differs by branch, and the provenance detail has to say which: on the
+    # coupled-cost branch it is the non-energy share of the measure being built now, on the other
+    # it is the escalated like-for-like cost of the device being replaced. One wording for both
+    # would describe the wrong quantity in one of them.
+    credit_basis_description = (
+        "non-energy share of the measure"
+        if share.best_estimate < 1.0
+        else f"like-for-like cost of {replaced.asset_class.value}"
+    )
     credit = credit.scale(anyway_share)
     if credit.maximum <= 0:
         return ReplacedAssetOutcome(sunk_cost=sunk_cost)
@@ -501,8 +510,8 @@ def resolve_replaced_asset(
                     origin=ParameterOrigin.CONFIG_OVERRIDE,
                     source_ids=("inline:existing-asset register (Sowieso-Kosten share, §4.1)",),
                     detail=(
-                        f"anyway credit = {anyway_share:.0%} x like-for-like cost of "
-                        f"{replaced.asset_class.value} @ year {credit_year} "
+                        f"anyway credit = {anyway_share:.0%} x {credit_basis_description} "
+                        f"@ year {credit_year} "
                         f"({credit_basis:,.2f} EUR) = {credit.best_estimate:,.2f} EUR"
                     ),
                 )

--- a/hisim/economics/calculators/energy.py
+++ b/hisim/economics/calculators/energy.py
@@ -75,6 +75,9 @@ class CarrierEmissions:
     #: The factor the mass above was computed with, in kg per kWh bought. Carried alongside the
     #: product so the CO2 section can state the multiplication instead of asserting its result; it
     #: is the price entry's `emission_factor_in_kg_per_kwh`, constant over the horizon in v1.
+    #: Revisit when an energy price entry carries a per-year factor: cost_spec.md §3.8 asks for a
+    #: per-carrier emission trend, and at that point this single float becomes a path and the
+    #: report's "factor x kWh" line becomes one row per year rather than one per carrier.
     emission_factor_in_kg_per_kwh: float = 0.0
 
 

--- a/hisim/economics/calculators/energy.py
+++ b/hisim/economics/calculators/energy.py
@@ -72,6 +72,10 @@ class CarrierEmissions:
 
     carrier_value: str
     annual_emissions_in_kg: float
+    #: The factor the mass above was computed with, in kg per kWh bought. Carried alongside the
+    #: product so the CO2 section can state the multiplication instead of asserting its result; it
+    #: is the price entry's `emission_factor_in_kg_per_kwh`, constant over the horizon in v1.
+    emission_factor_in_kg_per_kwh: float = 0.0
 
 
 @dataclass
@@ -94,6 +98,11 @@ class EnergyFlowResult:
     emissions: List[CarrierEmissions] = field(default_factory=list)
     #: Carrier value -> unclamped `TariffBill.flexibility_value_in_euro` of the year-1 bill.
     raw_flexibility_value_by_carrier: Dict[str, float] = field(default_factory=dict)
+    #: The contract each carrier was actually billed under, in carrier order — the explicit one
+    #: where the run supplied it and the generated flat contract otherwise. The assumptions table
+    #: publishes its working price, standing charge and feed-in rate, and only the calculator
+    #: knows which of the two contracts won.
+    tariffs_applied: List[TariffContract] = field(default_factory=list)
 
 
 def contract_from_price_entry(entry: EnergyPriceEntry, country: str) -> TariffContract:
@@ -340,6 +349,11 @@ def build_energy_flows(
                         )
                     )
         result.emissions.append(
-            CarrierEmissions(carrier_value=carrier.value, annual_emissions_in_kg=annual_emissions)
+            CarrierEmissions(
+                carrier_value=carrier.value,
+                annual_emissions_in_kg=annual_emissions,
+                emission_factor_in_kg_per_kwh=emission_factor,
+            )
         )
+        result.tariffs_applied.append(contract)
     return result

--- a/hisim/economics/calculators/escalation.py
+++ b/hisim/economics/calculators/escalation.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 from hisim.economics.carriers import EnergyCarrier
 from hisim.economics.database import CostDatabase
 from hisim.economics.parameters import EconomicParameters
+from hisim.economics.results import RateOrigin, ResolvedRate
 from hisim.economics.uncertainty import UncertainValue
 from hisim.loadtypes import ComponentType
 
@@ -99,12 +100,42 @@ def carrier_escalation_rate(
     Returns:
         A nominal annual rate as a fraction.
     """
+    return resolve_carrier_escalation_rate(carrier, parameters, database).rate
+
+
+def resolve_carrier_escalation_rate(
+    carrier: EnergyCarrier, parameters: EconomicParameters, database: CostDatabase
+) -> ResolvedRate:
+    """The same chain as :func:`carrier_escalation_rate`, but saying which step won.
+
+    The rate alone cannot be cited: 2 %/a on electricity is a configured assumption in one run and
+    the country defaults file's reviewed figure in the next, and the report's assumptions section
+    has to name the source of every value it publishes. The chain is implemented here once and the
+    plain-rate function above delegates to it, so the two can never disagree about which value
+    wins.
+
+    Args:
+        carrier: The energy carrier being priced.
+        parameters: The run's economic parameters.
+        database: Loaded cost database, consulted for `escalation_defaults_<COUNTRY>.json`.
+
+    Returns:
+        The rate with the origin that produced it and, for a defaults hit, that file's source ids.
+    """
     if carrier in parameters.energy_price_escalation_rates:
-        return parameters.energy_price_escalation_rates[carrier]
+        return ResolvedRate(
+            rate=parameters.energy_price_escalation_rates[carrier], origin=RateOrigin.CONFIGURATION
+        )
     defaults = database.get_escalation_defaults(parameters.country)
     if carrier in defaults.carrier_rates:
-        return defaults.carrier_rates[carrier]
-    return parameters.general_price_escalation_rate
+        return ResolvedRate(
+            rate=defaults.carrier_rates[carrier],
+            origin=RateOrigin.COUNTRY_DEFAULTS,
+            source_ids=list(defaults.source_ids),
+        )
+    return ResolvedRate(
+        rate=parameters.general_price_escalation_rate, origin=RateOrigin.GENERAL_FALLBACK
+    )
 
 
 def investment_escalation_rate(
@@ -128,9 +159,40 @@ def investment_escalation_rate(
     Returns:
         A nominal annual rate as a fraction; negative for a falling technology cost.
     """
+    return resolve_investment_escalation_rate(asset_class, parameters, database).rate
+
+
+def resolve_investment_escalation_rate(
+    asset_class: ComponentType, parameters: EconomicParameters, database: CostDatabase
+) -> ResolvedRate:
+    """The capital-cost twin of :func:`resolve_carrier_escalation_rate`, origin included.
+
+    Same three-step chain as :func:`investment_escalation_rate`, which delegates here, with the
+    step that produced the rate recorded so the assumptions section can cite it. Today the chain
+    normally ends at the general investment rate, because the shipped per-asset-class tables are
+    empty on purpose (spec Q2) — and a table that publishes "general fallback" beside that rate is
+    exactly how a reader learns that no technology-specific trajectory was assumed.
+
+    Args:
+        asset_class: The `ComponentType` of the subject being escalated.
+        parameters: The run's economic parameters.
+        database: Loaded cost database, consulted for `escalation_defaults_<COUNTRY>.json`.
+
+    Returns:
+        The rate with the origin that produced it and, for a defaults hit, that file's source ids.
+    """
     if asset_class in parameters.investment_price_escalation_rates:
-        return parameters.investment_price_escalation_rates[asset_class]
+        return ResolvedRate(
+            rate=parameters.investment_price_escalation_rates[asset_class],
+            origin=RateOrigin.CONFIGURATION,
+        )
     defaults = database.get_escalation_defaults(parameters.country)
     if asset_class in defaults.asset_class_rates:
-        return defaults.asset_class_rates[asset_class]
-    return parameters.investment_price_escalation_rate
+        return ResolvedRate(
+            rate=defaults.asset_class_rates[asset_class],
+            origin=RateOrigin.COUNTRY_DEFAULTS,
+            source_ids=list(defaults.source_ids),
+        )
+    return ResolvedRate(
+        rate=parameters.investment_price_escalation_rate, origin=RateOrigin.GENERAL_FALLBACK
+    )

--- a/hisim/economics/carriers.py
+++ b/hisim/economics/carriers.py
@@ -19,6 +19,7 @@ and `LoadTypes` (the adapter and the meter components make that mapping where th
 from __future__ import annotations
 
 import enum
+from typing import Dict
 
 
 @enum.unique
@@ -78,3 +79,36 @@ class EnergyFlowRole(str, enum.Enum):
     HOUSEHOLD_ELECTRICITY = "HOUSEHOLD_ELECTRICITY"
     GRID_IMPORT = "GRID_IMPORT"
     GRID_EXPORT = "GRID_EXPORT"
+
+
+def validate_energy_attribution(attribution: Dict[str, Dict[str, float]], context: str) -> None:
+    """Refuses a per-subject energy record carrying a negative quantity.
+
+    Every value in the attribution map is a **magnitude**: direction is the role, which is exactly
+    why the battery has two of them. A negative number therefore has no meaning the balance can
+    draw — it would shrink the side it sits on and silently move the residual node by twice its
+    size, which reads as a smaller loss rather than as a defect. The check is applied at each of
+    the three places a map can enter the system (the extraction that builds one, the annualization
+    that rescales one, the deserializer that reads one back), because each is reachable without
+    the other two.
+
+    Args:
+        attribution: Subject -> `EnergyFlowRole` value -> kWh.
+        context: What is being validated, for the message — the field or the function name.
+
+    Raises:
+        ValueError: If any quantity is negative, naming every one of them.
+    """
+    negative = [
+        f"{subject}.{role}={value!r}"
+        for subject, by_role in attribution.items()
+        for role, value in by_role.items()
+        if value < 0
+    ]
+    if negative:
+        raise ValueError(
+            f"{context} carries negative energy: {', '.join(sorted(negative))}. Attribution "
+            "values are magnitudes and the direction is the role (a battery charges under one "
+            "role and discharges under another), so a negative quantity would be drawn on the "
+            "wrong side of the household balance."
+        )

--- a/hisim/economics/carriers.py
+++ b/hisim/economics/carriers.py
@@ -50,3 +50,31 @@ class EnergyCarrier(str, enum.Enum):
     DISTRICT_HEATING = "DISTRICT_HEATING"
     HYDROGEN = "HYDROGEN"
     DIESEL = "DIESEL"
+
+
+@enum.unique
+class EnergyFlowRole(str, enum.Enum):
+    """What a measured device flow *is* in the household's energy balance.
+
+    The vocabulary of the per-subject energy record the extraction fills and the household energy
+    balance draws: not what a device is priced as, but which side of the electricity balance its
+    kilowatt hours sit on. It lives beside `EnergyCarrier` because it is the same kind of thing —
+    a small, serialization-stable vocabulary that both the extraction side and the presentation
+    side have to agree on — and because both sides can import this leaf module without dragging
+    anything along.
+
+    Roles carry **positive magnitudes**; direction is the role, not the sign, which is why the
+    battery has two of them. `GRID_IMPORT`/`GRID_EXPORT` are the meter's own two flows and are
+    the only roles that also correspond to a priced carrier boundary; the rest are internal
+    device flows that no bill is ever computed from. A flow that carries no role is simply not
+    recorded — this enum is deliberately not a total classification of everything a simulation
+    moves.
+    """
+
+    PV_GENERATION = "PV_GENERATION"
+    BATTERY_CHARGE = "BATTERY_CHARGE"
+    BATTERY_DISCHARGE = "BATTERY_DISCHARGE"
+    HEAT_PUMP_ELECTRICITY = "HEAT_PUMP_ELECTRICITY"
+    HOUSEHOLD_ELECTRICITY = "HOUSEHOLD_ELECTRICITY"
+    GRID_IMPORT = "GRID_IMPORT"
+    GRID_EXPORT = "GRID_EXPORT"

--- a/hisim/economics/evaluator.py
+++ b/hisim/economics/evaluator.py
@@ -95,7 +95,7 @@ from hisim.economics.results import (
     TariffAssumption,
 )
 from hisim.economics.subsidies import SubsidyCatalog, SubsidyContext, SubsidyDecision
-from hisim.economics.tariffs import FeedInKind, TariffContract
+from hisim.economics.tariffs import TariffContract
 from hisim.economics.timeline import CashFlowTimeline, CostCategory
 from hisim.economics.uncertainty import UncertainValue
 from hisim.loadtypes import ComponentType
@@ -450,9 +450,10 @@ def _levy_summary(outcome: Optional[ModernizationLevyOutcome]) -> Optional[Moder
         annual_amount_in_euro=outcome.total_in_euro,
         general_leg_in_euro=outcome.general_levy_in_euro,
         heating_leg_in_euro=outcome.heating_levy_in_euro,
-        cap_binding=outcome.cap_binding,
         cap_in_euro_per_m2_per_month=outcome.cap_in_euro_per_m2_per_month,
-        # Which mechanism set the levy in each of the three worlds.
+        # Which mechanism set the levy in each of the three worlds. Copied through as one shape:
+        # both sides key by `Slot`, so this is a copy rather than a translation, and "did a
+        # ceiling decide the headline figure" is derived from it on the summary.
         binding_mechanism_by_slot=dict(outcome.binding_mechanism_by_slot),
     )
 
@@ -772,14 +773,19 @@ class EconomicEvaluator:
                 modernization_cost = modernization_cost + addend
                 levy_cost_by_subject[subject] = levy_cost_by_subject[subject] + addend
             accumulate_embodied_co2(co2_result, subject, schedule.embodied_co2_addends)
-            if schedule.embodied_co2_addends:
+            size = costing.facts.size * costing.facts.count
+            if schedule.embodied_co2_addends and size:
                 # The factor and the size behind the mass just accumulated, so the CO2 section
                 # states `factor x size = kg` per installation rather than a bare total.
                 # `costing.embodied_co2_kg` is the mass of one installation with size and count
-                # already applied, so the factor is the per-unit figure it was built from.
-                size = costing.facts.size * costing.facts.count
+                # already applied, so the factor is the per-unit figure it was built from — always
+                # that quotient, including for an entry that states an absolute mass with no
+                # `per_unit`. A size of zero is the one case with no such quotient, and a mass
+                # that is not a multiple of a size cannot be published as one, so no basis record
+                # is written; the section then prints the mass without the multiplication rather
+                # than a factor of zero that does not reproduce it.
                 co2_result.embodied_basis_by_subject[subject] = EmbodiedCo2Basis(
-                    factor_in_kg_per_unit=(costing.embodied_co2_kg / size) if size else 0.0,
+                    factor_in_kg_per_unit=costing.embodied_co2_kg / size,
                     size=size,
                     size_unit=costing.facts.size_unit.value,
                     per_installation_in_kg=costing.embodied_co2_kg,
@@ -1006,7 +1012,7 @@ class EconomicEvaluator:
             # The per-subject half of the same physical context, annualized with the identical
             # divisor so the device column of the household energy balance adds up to the carrier
             # totals above it rather than to a slightly different year.
-            energy_attribution_by_subject_in_kwh=annual_energy_attribution(
+            annual_energy_attribution_by_subject_in_kwh=annual_energy_attribution(
                 inputs.energy_attribution_by_subject_in_kwh, inputs.simulated_period_fraction
             ),
             reference_areas=ReferenceAreas(
@@ -1073,21 +1079,10 @@ class EconomicEvaluator:
             rates[f"investment:{asset_class.name}"] = resolve_investment_escalation_rate(
                 asset_class, params, self.database
             )
-        tariffs: Dict[str, TariffAssumption] = {}
-        for contract in build.tariffs_applied:
-            feed_in = contract.feed_in
-            tariffs[contract.carrier.value] = TariffAssumption(
-                carrier=contract.carrier.value,
-                contract_id=contract.id,
-                working_price_in_euro_per_kwh=contract.supply.working_price_in_euro_per_kwh,
-                standing_charge_in_euro_per_year=contract.standing_charge_in_euro_per_year,
-                feed_in_kind=feed_in.kind.value,
-                feed_in_rate_in_euro_per_kwh=(
-                    feed_in.rate_in_euro_per_kwh if feed_in.kind != FeedInKind.NONE else None
-                ),
-                is_default_contract=contract.is_default_contract,
-                source_ids=list(contract.source_ids),
-            )
+        tariffs: Dict[str, TariffAssumption] = {
+            contract.carrier.value: TariffAssumption.from_contract(contract)
+            for contract in build.tariffs_applied
+        }
         return EconomicAssumptions(
             escalation_rates=rates,
             tariffs=tariffs,

--- a/hisim/economics/evaluator.py
+++ b/hisim/economics/evaluator.py
@@ -31,8 +31,17 @@ from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 from hisim import log
-from hisim.economics.actors import AllocationContext, ModernizationLevySubjectBasis, get_ruleset
-from hisim.economics.calculators.aggregation import aggregate_timeline, annual_energy_quantities
+from hisim.economics.actors import (
+    AllocationContext,
+    ModernizationLevyOutcome,
+    ModernizationLevySubjectBasis,
+    get_ruleset,
+)
+from hisim.economics.calculators.aggregation import (
+    aggregate_timeline,
+    annual_energy_attribution,
+    annual_energy_quantities,
+)
 from hisim.economics.calculators.context_resolution import resolve_device, resolve_replaced_asset
 from hisim.economics.calculators.co2 import (
     accumulate_embodied_co2,
@@ -47,8 +56,8 @@ from hisim.economics.calculators.financing_application import (
     resolve_loan_plan,
 )
 from hisim.economics.calculators.escalation import (
-    carrier_escalation_rate as resolve_carrier_escalation_rate,
-    investment_escalation_rate as resolve_investment_escalation_rate,
+    resolve_carrier_escalation_rate,
+    resolve_investment_escalation_rate,
 )
 from hisim.economics.calculators.investment import build_investment_schedule
 from hisim.economics.calculators.maintenance import build_maintenance_entries
@@ -74,13 +83,19 @@ from hisim.economics.perspectives import (
 )
 from hisim.economics.provenance import ProvenanceLedger, ResolvedSource
 from hisim.economics.results import (
+    EconomicAssumptions,
+    EmbodiedCo2Basis,
     EvaluationMatrix,
     LifecycleCo2Result,
     LifecycleCostResult,
+    ModernizationLevySummary,
+    RateOrigin,
     ReferenceAreas,
+    ResolvedRate,
+    TariffAssumption,
 )
 from hisim.economics.subsidies import SubsidyCatalog, SubsidyContext, SubsidyDecision
-from hisim.economics.tariffs import TariffContract
+from hisim.economics.tariffs import FeedInKind, TariffContract
 from hisim.economics.timeline import CashFlowTimeline, CostCategory
 from hisim.economics.uncertainty import UncertainValue
 from hisim.loadtypes import ComponentType
@@ -205,6 +220,14 @@ class EvaluationInputs:
     # Subjects the extraction recognized but could not describe (issue #2); they block the D7
     # resolution check exactly like a subject the cost database cannot price.
     unresolved_subjects: List[UnresolvedSubject] = field(default_factory=list)
+    #: Subject -> energy-balance role (`EnergyFlowRole.value`) -> energy of the *simulated
+    #: period* in kWh, as positive magnitudes (the role says which way it flows). Additive and
+    #: optional: the extraction fills it from the component output columns the adapter's
+    #: `DeviceEnergySpecs` table names (`bridge._device_energy_flows`), and nothing prices it —
+    #: the engine only annualizes it onto the result, where the household energy balance reads it
+    #: and skips itself when it carries no device flows. A file written before the field existed
+    #: loads with an empty map.
+    energy_attribution_by_subject_in_kwh: Dict[str, Dict[str, float]] = field(default_factory=dict)
     existing_assets: Optional[ExistingAssetRegister] = None
     subsidy_context: SubsidyContext = field(default_factory=SubsidyContext)
     tariff_contracts: Dict[EnergyCarrier, TariffContract] = field(default_factory=dict)
@@ -395,6 +418,43 @@ class TimelineBuildResult:
     basis: ModernizationLevyBasis
     #: Per-carrier flexibility value before the §8.5 clamp, for the plausibility panel (#25b).
     raw_flexibility_value_by_carrier: Dict[str, float] = field(default_factory=dict)
+    #: The Sowieso share every booked anyway credit was computed at (subject -> share), for the
+    #: result the report reads it from.
+    anyway_share_by_subject: Dict[str, float] = field(default_factory=dict)
+    #: The like-for-like cost each of those credits was computed *on* (subject -> euro).
+    anyway_basis_by_subject: Dict[str, float] = field(default_factory=dict)
+    #: The tariff contracts the energy calculator actually billed under, for the assumptions
+    #: record the report's assumptions section publishes.
+    tariffs_applied: List[TariffContract] = field(default_factory=list)
+
+
+def _levy_summary(outcome: Optional[ModernizationLevyOutcome]) -> Optional[ModernizationLevySummary]:
+    """The result-side record of a ruleset's levy outcome, or None when there is no levy.
+
+    The ruleset's outcome is an engine object carrying the uncapped legs and the resolved caps;
+    what the result has to carry is the smaller, serializable statement a reader needs beside the
+    levy amount — the two legs, whether a ceiling decided the figure and which mechanism decided
+    it in each world. Converting here rather than at the call site keeps `evaluate` a sequence of
+    named steps, and gives the "no levy at all" case one spelling: an owner-occupier ruleset that
+    knows no levy and a levied ruleset whose levy came out at zero both yield None.
+
+    Args:
+        outcome: What `AllocationRuleset.modernization_levy_outcome` returned.
+
+    Returns:
+        The record for `LifecycleCostResult.modernization_levy`, or None.
+    """
+    if outcome is None or outcome.total_in_euro.maximum <= 0:
+        return None
+    return ModernizationLevySummary(
+        annual_amount_in_euro=outcome.total_in_euro,
+        general_leg_in_euro=outcome.general_levy_in_euro,
+        heating_leg_in_euro=outcome.heating_levy_in_euro,
+        cap_binding=outcome.cap_binding,
+        cap_in_euro_per_m2_per_month=outcome.cap_in_euro_per_m2_per_month,
+        # Which mechanism set the levy in each of the three worlds.
+        binding_mechanism_by_slot=dict(outcome.binding_mechanism_by_slot),
+    )
 
 
 class EconomicEvaluator:
@@ -460,7 +520,7 @@ class EconomicEvaluator:
         database. The returned nominal annual rate is what the energy calculator escalates a
         carrier's year-1 bill with over the horizon (§3.6 rule 5).
         """
-        return resolve_carrier_escalation_rate(carrier, self.parameters, self.database)
+        return resolve_carrier_escalation_rate(carrier, self.parameters, self.database).rate
 
     def investment_escalation_rate(self, asset_class: ComponentType) -> float:
         """Fallback chain for per-asset-class investment escalation (learning curves, §3.2).
@@ -470,7 +530,7 @@ class EconomicEvaluator:
         `build_timeline` resolves it once per subject and passes it to the investment calculator,
         which uses it for replacements and for the residual value (§3.6 rules 2-3).
         """
-        return resolve_investment_escalation_rate(asset_class, self.parameters, self.database)
+        return resolve_investment_escalation_rate(asset_class, self.parameters, self.database).rate
 
     def price_basis_year(self, inputs: EvaluationInputs) -> int:
         """Price basis year for database lookups (see `effective_price_basis_year`).
@@ -674,6 +734,8 @@ class EconomicEvaluator:
         sunk_cost = UncertainValue.exact(0.0)
         modernization_cost = UncertainValue.exact(0.0)
         anyway_credit_total = UncertainValue.exact(0.0)
+        anyway_share_by_subject: Dict[str, float] = {}
+        anyway_basis_by_subject: Dict[str, float] = {}
         # Per-measure levy basis for the §559/§559e split (§6.4, D27): asset class, modernization
         # cost and anyway credit per subject; the subsidy leg is read off the finished timeline.
         levy_asset_classes: Dict[str, str] = {}
@@ -710,6 +772,19 @@ class EconomicEvaluator:
                 modernization_cost = modernization_cost + addend
                 levy_cost_by_subject[subject] = levy_cost_by_subject[subject] + addend
             accumulate_embodied_co2(co2_result, subject, schedule.embodied_co2_addends)
+            if schedule.embodied_co2_addends:
+                # The factor and the size behind the mass just accumulated, so the CO2 section
+                # states `factor x size = kg` per installation rather than a bare total.
+                # `costing.embodied_co2_kg` is the mass of one installation with size and count
+                # already applied, so the factor is the per-unit figure it was built from.
+                size = costing.facts.size * costing.facts.count
+                co2_result.embodied_basis_by_subject[subject] = EmbodiedCo2Basis(
+                    factor_in_kg_per_unit=(costing.embodied_co2_kg / size) if size else 0.0,
+                    size=size,
+                    size_unit=costing.facts.size_unit.value,
+                    per_installation_in_kg=costing.embodied_co2_kg,
+                    installations=len(schedule.embodied_co2_addends),
+                )
             replacement_flows_for_reserve.extend(schedule.reserve_flows)
 
             # --- replaced asset: sunk cost and anyway-cost credit (§4.1)
@@ -720,10 +795,15 @@ class EconomicEvaluator:
                     database=self.database,
                     parameters=params,
                     price_basis_year=price_basis_year,
+                    ledger=ledger,
                 )
                 sunk_cost = sunk_cost + replaced_outcome.sunk_cost
                 if replaced_outcome.credit_entry is not None:
                     timeline.add(replaced_outcome.credit_entry)
+                    anyway_share_by_subject[subject] = replaced_outcome.anyway_share
+                    # The like-for-like cost the share was applied to, so the credit is a visible
+                    # multiplication rather than a figure with a percentage beside it.
+                    anyway_basis_by_subject[subject] = replaced_outcome.credit_basis_in_euro
                     anyway_credit_total = anyway_credit_total + replaced_outcome.credit_amount
                     levy_credit_by_subject[subject] = (
                         levy_credit_by_subject[subject] + replaced_outcome.credit_amount
@@ -813,6 +893,9 @@ class EconomicEvaluator:
                 ),
             ),
             raw_flexibility_value_by_carrier=energy_result.raw_flexibility_value_by_carrier,
+            anyway_share_by_subject=anyway_share_by_subject,
+            anyway_basis_by_subject=anyway_basis_by_subject,
+            tariffs_applied=list(energy_result.tariffs_applied),
         )
 
     # ------------------------------------------------------------------ evaluation (§3.7)
@@ -864,6 +947,7 @@ class EconomicEvaluator:
         co2_result = build.co2_result
 
         # Actor allocation (§6).
+        levy_summary: Optional[ModernizationLevySummary] = None
         if perspective.actor_scope != ActorScope.SYSTEM:
             rented = perspective.actor_scope in (ActorScope.LANDLORD, ActorScope.TENANT)
             ruleset = get_ruleset(rented, params.country)
@@ -879,6 +963,10 @@ class EconomicEvaluator:
                 levy_subjects=build.basis.by_subject,
             )
             timeline = ruleset.allocate(timeline, allocation_context)
+            # The levy's ceiling verdict, asked of the ruleset that just applied it. The amount is
+            # on the timeline; whether a cap decided it is not, and the landlord statement has to
+            # say so.
+            levy_summary = _levy_summary(ruleset.modernization_levy_outcome(allocation_context))
 
         aggregation = aggregate_timeline(
             timeline=timeline,
@@ -915,6 +1003,12 @@ class EconomicEvaluator:
             annual_energy_quantities_by_carrier=annual_energy_quantities(
                 inputs.billing, inputs.simulated_period_fraction
             ),
+            # The per-subject half of the same physical context, annualized with the identical
+            # divisor so the device column of the household energy balance adds up to the carrier
+            # totals above it rather than to a slightly different year.
+            energy_attribution_by_subject_in_kwh=annual_energy_attribution(
+                inputs.energy_attribution_by_subject_in_kwh, inputs.simulated_period_fraction
+            ),
             reference_areas=ReferenceAreas(
                 heated_floor_area_in_m2=inputs.heated_floor_area_in_m2,
                 living_area_in_m2=inputs.living_area_in_m2,
@@ -924,6 +1018,80 @@ class EconomicEvaluator:
             # Diagnostics rather than result: the pre-clamp §8.5 flexibility value, which the
             # plausibility panel warns about when it is negative (issue #25b).
             raw_flexibility_value_by_carrier=build.raw_flexibility_value_by_carrier,
+            # The Sowieso share behind each anyway credit, so the report can state it beside the
+            # credit rather than leaving a reader to guess at the basis.
+            anyway_share_by_subject=build.anyway_share_by_subject,
+            anyway_basis_by_subject=build.anyway_basis_by_subject,
+            modernization_levy=levy_summary,
+            # The assumption set the report's assumptions section publishes — escalation rates as
+            # the fallback chains resolved them, the tariff terms actually billed, and the heat
+            # demand every per-kWh heat figure divides by.
+            assumptions=self._resolve_assumptions(inputs, build),
+        )
+
+    def _resolve_assumptions(
+        self, inputs: EvaluationInputs, build: TimelineBuildResult
+    ) -> EconomicAssumptions:
+        """The assumption set behind the run, resolved once per evaluation.
+
+        The report has to publish every economic assumption with its value *and* its source, and
+        three of those groups are only knowable inside the engine: an escalation rate is the
+        outcome of a three-step fallback chain against the country defaults file, the tariff terms
+        are whichever contract the energy calculator ended up billing under (an explicit one or
+        the flat contract generated from the price entries), and the heat demand lives in
+        `EvaluationInputs`, which presentation may not read. Resolving them here and carrying the
+        answer on the result is the same W4.2 move the reference areas made.
+
+        Only rates that actually applied to this run are recorded: one per billed carrier, one per
+        asset class among the cost subjects, plus the three general rates. A table of every rate
+        the parameter object *could* express would be longer and less true.
+
+        Args:
+            inputs: The variant's extract — billed carriers, cost subjects, heat demand.
+            build: The finished timeline build, read for the contracts the energy calculator used.
+
+        Returns:
+            The record stored on `LifecycleCostResult.assumptions`.
+        """
+        params = self.parameters
+        rates: Dict[str, ResolvedRate] = {
+            "general": ResolvedRate(
+                rate=params.general_price_escalation_rate, origin=RateOrigin.CONFIGURATION
+            ),
+            "investment": ResolvedRate(
+                rate=params.investment_price_escalation_rate, origin=RateOrigin.CONFIGURATION
+            ),
+            "feed-in": ResolvedRate(rate=params.feed_in_escalation_rate, origin=RateOrigin.CONFIGURATION),
+        }
+        for determinants in inputs.billing:
+            carrier = determinants.carrier
+            rates[f"energy:{carrier.value}"] = resolve_carrier_escalation_rate(
+                carrier, params, self.database
+            )
+        for subject_facts in inputs.cost_facts:
+            asset_class = subject_facts.facts.asset_class
+            rates[f"investment:{asset_class.name}"] = resolve_investment_escalation_rate(
+                asset_class, params, self.database
+            )
+        tariffs: Dict[str, TariffAssumption] = {}
+        for contract in build.tariffs_applied:
+            feed_in = contract.feed_in
+            tariffs[contract.carrier.value] = TariffAssumption(
+                carrier=contract.carrier.value,
+                contract_id=contract.id,
+                working_price_in_euro_per_kwh=contract.supply.working_price_in_euro_per_kwh,
+                standing_charge_in_euro_per_year=contract.standing_charge_in_euro_per_year,
+                feed_in_kind=feed_in.kind.value,
+                feed_in_rate_in_euro_per_kwh=(
+                    feed_in.rate_in_euro_per_kwh if feed_in.kind != FeedInKind.NONE else None
+                ),
+                is_default_contract=contract.is_default_contract,
+                source_ids=list(contract.source_ids),
+            )
+        return EconomicAssumptions(
+            escalation_rates=rates,
+            tariffs=tariffs,
+            annual_heat_demand_in_kwh=inputs.annual_heat_demand_in_kwh,
         )
 
     def _source_resolver(self) -> Dict[str, ResolvedSource]:

--- a/hisim/economics/facts.py
+++ b/hisim/economics/facts.py
@@ -460,6 +460,11 @@ class ExistingAsset:
     declaration of which measure supersedes this asset: without it a same-class register entry means
     "kept", and only with it does a like-for-like replacement (old windows → new windows) get
     recognized as a replacement with its avoided future cost credited (§3.2b).
+
+    `anyway_share` is how honest that credit is. See its own comment below: crediting 100 % of an
+    insulation measure against a facade that was never insulated was methodologically wrong, and
+    the share is the field that says how much of the new measure the counterfactual would really
+    have bought.
     """
 
     asset_class: ComponentType
@@ -474,16 +479,35 @@ class ExistingAsset:
     # a component with one of these classes is charged full investment + this asset's removal
     # cost, and triggers the sunk-cost / anyway-cost logic of §4.1):
     replaced_by_asset_classes: List[ComponentType] = field(default_factory=list)
+    #: Sowieso-Kosten share: the fraction of the *new* measure's cost that the counterfactual —
+    #: the world in which the renovation does not happen — would truly have spent on this asset.
+    #: `1.0` is a genuine like-for-like replacement: dead windows are replaced by windows, so the
+    #: whole price of the new windows was going to be paid anyway. A **first-time improvement** is
+    #: not like-for-like and must be well below 1: a facade that was never insulated would have
+    #: been *repaired*, not insulated, so only the repair share — scaffolding, render, paint — is a
+    #: cost the building would have caused regardless, and crediting the full insulation price
+    #: against it credits money nobody would ever have spent. The default keeps the historical
+    #: behaviour, so every register written before this field existed is unchanged.
+    anyway_share: float = 1.0
 
     def __post_init__(self) -> None:
-        """Validation: normalizes the replacement-cost override and rejects a non-positive size.
+        """Validation: normalizes the replacement-cost override and rejects impossible inputs.
 
         Raises:
-            ValueError: If the size is not finite and greater than zero.
+            ValueError: If the size is not finite and greater than zero, or if `anyway_share` is
+                outside `(0, 1]` — a share of zero is spelled by not declaring the asset as
+                replaced at all, and a share above one would credit the renovation with more than
+                the measure costs.
         """
         self.replacement_cost_override_in_euro = _coerce_uncertain(self.replacement_cost_override_in_euro)
         if self.size <= 0 or not math.isfinite(self.size):
             raise ValueError("ExistingAsset.size must be finite and > 0.")
+        if not math.isfinite(self.anyway_share) or not 0.0 < self.anyway_share <= 1.0:
+            raise ValueError(
+                f"ExistingAsset.anyway_share must be in (0, 1], got {self.anyway_share!r} for "
+                f"{self.asset_class.value}: it is the share of the new measure's cost the "
+                "counterfactual would truly have spent (§4.1)."
+            )
 
     def age_in_years(self, reference_year: int) -> int:
         """Age at the reference (simulation) year, floored at 0.

--- a/hisim/economics/input_audit.py
+++ b/hisim/economics/input_audit.py
@@ -98,6 +98,16 @@ class ResolvedInputRow:
     subsidy_scheme_ids: List[str] = field(default_factory=list)
     #: scheme id -> the slots whose cap bound, only for awards where at least one did.
     caps_binding_by_scheme: Dict[str, List[str]] = field(default_factory=dict)
+    #: The Sowieso share the subject's anyway credit was computed at, or None when the subject
+    #: earned no such credit. A credit is `share x like-for-like cost`, so this is the factor
+    #: that turns the counterfactual's price into what is actually credited; printing the credit
+    #: without it is what let a facade that was never insulated be credited with a full
+    #: insulation measure.
+    anyway_share: Optional[float] = None
+    #: The like-for-like cost that share was applied to, in euro. The share alone states a
+    #: factor without its base, so the audited credit could not be reproduced from the row; with
+    #: both, `share x basis` is the credit the timeline booked.
+    anyway_basis_in_euro: Optional[float] = None
     #: Review flags, in the order they are raised. Rendered by the HTML report only.
     flags: List[str] = field(default_factory=list)
 
@@ -124,6 +134,8 @@ class ResolvedInputRow:
             "subsidies_nominal_in_euro": UncertainValue.optional_to_json(self.subsidies_nominal_in_euro),
             "subsidy_scheme_ids": self.subsidy_scheme_ids,
             "caps_binding_by_scheme": self.caps_binding_by_scheme,
+            "anyway_share": self.anyway_share,
+            "anyway_basis_in_euro": self.anyway_basis_in_euro,
             "flags": self.flags,
         }
 
@@ -160,6 +172,8 @@ class ResolvedInputRow:
             caps_binding_by_scheme={
                 scheme: list(slots) for scheme, slots in raw.get("caps_binding_by_scheme", {}).items()
             },
+            anyway_share=raw.get("anyway_share"),
+            anyway_basis_in_euro=raw.get("anyway_basis_in_euro"),
             flags=list(raw.get("flags", [])),
         )
 

--- a/hisim/economics/results.py
+++ b/hisim/economics/results.py
@@ -22,9 +22,10 @@ saying so in their names (W3.4).
 
 from __future__ import annotations
 
+import enum
 import re
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional
 
 from hisim.economics.parameters import EconomicParameters
 from hisim.economics.provenance import (
@@ -34,6 +35,7 @@ from hisim.economics.provenance import (
     ResolvedSource,
 )
 from hisim.economics.subsidies import SubsidyDecision
+from hisim.economics.tariffs import FeedInKind, TariffContract
 from hisim.economics.timeline import (
     Actor,
     CashFlowEntry,
@@ -42,7 +44,7 @@ from hisim.economics.timeline import (
     SubjectKind,
     discount_factor,
 )
-from hisim.economics.uncertainty import UncertainValue
+from hisim.economics.uncertainty import Slot, UncertainValue
 from hisim.loadtypes import ComponentType
 from hisim.postprocessing.kpi_computation.kpi_structure import KpiTagEnumClass
 
@@ -117,18 +119,45 @@ class EmbodiedCo2Basis:
     state `factor x size = kg per installation` and multiply that by the number of installations
     booked within the horizon.
 
-    `factor_in_kg_per_unit` is the database entry's embodied-CO2 figure per size unit, or the
-    absolute mass per installation when the entry states one without a `per_unit` (in which case
-    `size` is reported as 1 of the entry's own unit). `installations` counts the year-0
-    installation plus every replacement within the horizon, i.e. exactly the events the mass was
-    accumulated for.
+    `size` is the installed size the mass was computed for — `facts.size x facts.count`, so a
+    fleet of three identical devices is one record of three units rather than three records — and
+    `factor_in_kg_per_unit` is always the quotient `per_installation_in_kg / size`. There is no
+    second branch: an entry that states an absolute mass without a `per_unit` is divided by that
+    same size like any other, so the factor is a derived per-unit figure rather than the data
+    file's own. `installations` counts the year-0 installation plus every replacement within the
+    horizon, i.e. exactly the events the mass was accumulated for.
+
+    The identity is enforced rather than documented (see `__post_init__`): a record whose three
+    numbers do not multiply out is worse than no record, because the CO2 section prints it *as*
+    the multiplication and a reader would check the arithmetic and find the engine wrong.
     """
+
+    #: Tolerance of the `factor x size = per installation` check, in kg. Absolute rather than
+    #: relative because the product is a float division multiplied straight back out, so the only
+    #: error it can carry is the rounding of one division — orders of magnitude below a gram.
+    IDENTITY_TOLERANCE_IN_KG: ClassVar[float] = 1e-6
 
     factor_in_kg_per_unit: float
     size: float
     size_unit: str
     per_installation_in_kg: float
     installations: int = 1
+
+    def __post_init__(self) -> None:
+        """Refuses a record whose factor, size and mass do not multiply out.
+
+        Raises:
+            ValueError: If `abs(factor_in_kg_per_unit * size - per_installation_in_kg)` exceeds
+                `IDENTITY_TOLERANCE_IN_KG`.
+        """
+        product = self.factor_in_kg_per_unit * self.size
+        if abs(product - self.per_installation_in_kg) > self.IDENTITY_TOLERANCE_IN_KG:
+            raise ValueError(
+                f"EmbodiedCo2Basis states {self.factor_in_kg_per_unit:g} kg per {self.size_unit} "
+                f"x {self.size:g} {self.size_unit} = {product:g} kg, but carries "
+                f"{self.per_installation_in_kg:g} kg per installation. The record is printed as "
+                "that multiplication, so the three numbers have to be one statement."
+            )
 
     def to_json(self) -> dict:
         """Serialization for lifecycle_costs.json."""
@@ -224,6 +253,83 @@ class AnnualEnergyQuantities:
         return {"bought_in_kwh": self.bought_in_kwh, "sold_in_kwh": self.sold_in_kwh}
 
 
+def _slot_from_json(name: str, context: str) -> Slot:
+    """Parses one `Slot` value out of a stored map key.
+
+    Args:
+        name: The key as the file spells it (`low` / `best_estimate` / `high`).
+        context: Dotted path of the field being parsed, so the error names the map.
+
+    Returns:
+        The slot the key names.
+
+    Raises:
+        ValueError: If the key is not a slot this package knows.
+    """
+    try:
+        return Slot(name)
+    except ValueError:
+        raise ValueError(
+            f"{context} is keyed by evaluation slot, and {name!r} is not one of "
+            f"{', '.join(slot.value for slot in Slot)}. A value filed under an unknown slot is a "
+            "value nothing will ever read."
+        ) from None
+
+
+class LevyBindingMechanism:
+    """The vocabulary of the per-world levy verdicts.
+
+    "The levy is 1,847 EUR a year" is two different statements depending on what produced it: at a
+    ceiling the figure is fixed by law and the same renovation costing more would yield the same
+    rent, below it the figure is a percentage and every extra euro spent raises the rent. The
+    ruleset already knew which of the two applied; the constants here are what let it *say* so, in
+    one spelling, for each of the three worlds separately.
+
+    It lives here rather than beside the ruleset that writes the verdicts because both sides need
+    it: `actors.DE2024Ruleset` composes the sentences and `ModernizationLevySummary` reads one
+    back to answer "did a ceiling decide the headline figure". A vocabulary owned by the writer
+    alone would leave the reader matching literals.
+
+    Two caps can cut the same world — the §559e ceiling on the heating leg and the §559 Abs. 3a
+    ceiling on the two legs together — so the verdict is a *composition*: each cap that removed
+    euros is named, joined by `BOTH_CAPS_JOINER` when both did. That keeps `startswith` on either
+    cap constant a true test of "this cap bound", whichever other cap also bound.
+
+    `SLOT_NAMES` maps the band's own field names onto the `Slot` vocabulary the rest of the
+    package uses, so the verdict map is keyed like every other per-slot map.
+    """
+
+    GENERAL_CAP = "§559 general cap"
+    HEATING_CAP = "§559e heating cap"
+    RATE_BELOW_CAP = "of eligible cost, below cap"
+    #: What joins the two cap clauses in a world where both ceilings removed euros.
+    BOTH_CAPS_JOINER = " and "
+    #: Euro per year below which a cap counts as not having removed anything.
+    TOLERANCE_IN_EURO = 1e-6
+    SLOT_NAMES = {
+        "minimum": Slot.LOW,
+        "best_estimate": Slot.BEST_ESTIMATE,
+        "maximum": Slot.HIGH,
+    }
+
+    @staticmethod
+    def names_a_cap(verdict: str) -> bool:
+        """Whether this verdict says a statutory ceiling decided the levy.
+
+        The one place a verdict sentence is classified. The alternative — every reader testing the
+        prefixes itself — is how the three spellings drift apart.
+
+        Args:
+            verdict: One value of `ModernizationLevySummary.binding_mechanism_by_slot`.
+
+        Returns:
+            True for a verdict naming either cap (or both), False for the rate verdict.
+        """
+        return verdict.startswith(
+            (LevyBindingMechanism.HEATING_CAP, LevyBindingMechanism.GENERAL_CAP)
+        )
+
+
 @dataclass(frozen=True)
 class ModernizationLevySummary:
     """The §559/§559e rent increase as the report has to state it.
@@ -245,17 +351,31 @@ class ModernizationLevySummary:
     annual_amount_in_euro: UncertainValue
     general_leg_in_euro: UncertainValue
     heating_leg_in_euro: UncertainValue
-    #: Whether a statutory cap actually bit in the AVERAGE slot.
-    cap_binding: bool = False
     #: The general §559 Abs. 3a ceiling in EUR per m² and month, when one was evaluated.
     cap_in_euro_per_m2_per_month: Optional[float] = None
-    #: Which mechanism actually set the levy **in each world**, keyed by slot name (`low` /
-    #: `average` / `high`). The caps are applied per slot, so the ceiling can decide the expensive
-    #: world while the cheap one is still set by the percentage of the modernization cost — two
-    #: economically different answers that a single average-slot flag hides. Empty for a result
-    #: serialized before the field existed, in which case the report falls back to the
-    #: average-slot `cap_binding` statement.
-    binding_mechanism_by_slot: Dict[str, str] = field(default_factory=dict)
+    #: Which mechanism actually set the levy **in each world**, keyed by `Slot`. The caps are
+    #: applied per slot, so the ceiling can decide the expensive world while the cheap one is
+    #: still set by the percentage of the modernization cost — two economically different answers
+    #: that a single best-estimate flag would hide. Empty for a result serialized before the field
+    #: existed and for a run with no living area, in which case no cap could be evaluated at all
+    #: and the report states the levy without a verdict.
+    binding_mechanism_by_slot: Dict[Slot, str] = field(default_factory=dict)
+
+    @property
+    def cap_binding_in_best_estimate(self) -> bool:
+        """Whether a statutory ceiling decided the headline figure (the BEST_ESTIMATE slot).
+
+        Derived rather than stored: the per-slot verdicts already say which mechanism set each
+        world's levy, and a second field repeating one of them for the headline world is a copy
+        that can disagree with its original. Readers that want the one-line "did a ceiling decide
+        this" answer read this property, so there is one expression of it in the package.
+
+        Returns:
+            True when the best-estimate verdict names a cap; False when it names the statutory
+            rate, and False when there is no verdict at all (no living area, no cap evaluated).
+        """
+        verdict = self.binding_mechanism_by_slot.get(Slot.BEST_ESTIMATE)
+        return verdict is not None and LevyBindingMechanism.names_a_cap(verdict)
 
     def to_json(self) -> dict:
         """Serialization for lifecycle_costs.json."""
@@ -263,32 +383,44 @@ class ModernizationLevySummary:
             "annual_amount_in_euro": self.annual_amount_in_euro.to_json(),
             "general_leg_in_euro": self.general_leg_in_euro.to_json(),
             "heating_leg_in_euro": self.heating_leg_in_euro.to_json(),
-            "cap_binding": self.cap_binding,
             "cap_in_euro_per_m2_per_month": self.cap_in_euro_per_m2_per_month,
-            "binding_mechanism_by_slot": dict(self.binding_mechanism_by_slot),
+            "binding_mechanism_by_slot": {
+                slot.value: verdict for slot, verdict in self.binding_mechanism_by_slot.items()
+            },
         }
 
     @staticmethod
     def from_json(raw: Optional[dict]) -> Optional["ModernizationLevySummary"]:
-        """Inverse of `to_json`; `None` stays `None` (a run without a levy)."""
+        """Inverse of `to_json`; `None` stays `None` (a run without a levy).
+
+        Raises:
+            ValueError: If a verdict is filed under a slot name this package does not know. The
+                map is read by slot, so an unknown key is a verdict nobody would ever see — the
+                silent kind of data loss the round trip exists to prevent.
+        """
         if not raw:
             return None
         return ModernizationLevySummary(
             annual_amount_in_euro=UncertainValue.from_json(raw["annual_amount_in_euro"]),
             general_leg_in_euro=UncertainValue.from_json(raw["general_leg_in_euro"]),
             heating_leg_in_euro=UncertainValue.from_json(raw["heating_leg_in_euro"]),
-            cap_binding=bool(raw.get("cap_binding", False)),
             cap_in_euro_per_m2_per_month=raw.get("cap_in_euro_per_m2_per_month"),
-            binding_mechanism_by_slot=dict(raw.get("binding_mechanism_by_slot", {})),
+            binding_mechanism_by_slot={
+                _slot_from_json(name, "ModernizationLevySummary.binding_mechanism_by_slot"): verdict
+                for name, verdict in raw.get("binding_mechanism_by_slot", {}).items()
+            },
         )
 
 
-class RateOrigin:
+class RateOrigin(str, enum.Enum):
     """The three steps of the §3.2 escalation fallback chain, as the values `ResolvedRate` carries.
 
-    Named constants rather than free strings because both the evaluator that records the origin
-    and the report that renders it have to agree on the spelling, and a third spelling would show
-    up as an uncited assumption rather than as an error.
+    An enum rather than free strings because both the evaluator that records the origin and the
+    report that renders it have to agree on the spelling, and a fourth spelling would show up as
+    an uncited assumption rather than as an error. It is `str`-valued, so the serialized form is
+    the same word it always was and a stored `lifecycle_costs.json` round-trips unchanged; what
+    changed is that a file carrying a word outside this set is now refused at load time instead of
+    reaching a renderer that silently treats it as "configuration".
     """
 
     CONFIGURATION = "configuration"
@@ -306,25 +438,40 @@ class ResolvedRate:
     table has to cite a source for every value it publishes, so the winning step travels with the
     number instead of being re-derived by a renderer that has no database.
 
-    `origin` is one of the `RateOrigin` constants; `source_ids` are the §3.10 registry ids of the
-    defaults file when that is what won, and empty for a configured or fallback rate, which the
-    report renders as "configuration".
+    `origin` is a `RateOrigin`; `source_ids` are the §3.10 registry ids of the defaults file when
+    that is what won, and empty for a configured or fallback rate, which the report renders as
+    "configuration".
     """
 
     rate: float
-    origin: str
+    origin: RateOrigin
     source_ids: List[str] = field(default_factory=list)
 
     def to_json(self) -> dict:
         """Serialization for lifecycle_costs.json."""
-        return {"rate": self.rate, "origin": self.origin, "source_ids": list(self.source_ids)}
+        return {"rate": self.rate, "origin": self.origin.value, "source_ids": list(self.source_ids)}
 
     @staticmethod
     def from_json(raw: dict) -> "ResolvedRate":
-        """Inverse of `to_json`."""
+        """Inverse of `to_json`.
+
+        Raises:
+            ValueError: If `origin` is not a step of the §3.2 chain. An unknown step would be
+                rendered as a configured rate — the most reviewed of the three — which is the one
+                misreading that overstates how well sourced the number is.
+        """
+        origin = raw.get("origin", RateOrigin.CONFIGURATION.value)
+        try:
+            resolved_origin = RateOrigin(origin)
+        except ValueError:
+            raise ValueError(
+                f"ResolvedRate.origin {origin!r} is not a step of the escalation fallback chain "
+                f"({', '.join(step.value for step in RateOrigin)}); the assumptions table cites "
+                "the step, so an unknown one would be published as a source it is not."
+            ) from None
         return ResolvedRate(
             rate=float(raw["rate"]),
-            origin=str(raw.get("origin", RateOrigin.CONFIGURATION)),
+            origin=resolved_origin,
             source_ids=list(raw.get("source_ids", [])),
         )
 
@@ -343,16 +490,69 @@ class TariffAssumption:
     contract of `calculators/energy.py` it is that contract's synthetic id and
     `is_default_contract` is True, which the report states as "database price entry" rather than
     pretending a contract file was read.
+
+    `feed_in_kind` is the contract's own `FeedInKind`, and the rate beside it is present exactly
+    when that kind is not `NONE` — the assumptions table renders the two as one row ("feed-in rate
+    (FIXED_TARIFF)"), so a kind with no rate would publish a heading over an empty cell and a rate
+    with kind `NONE` would publish a price nothing was ever paid at. `__post_init__` refuses both.
     """
 
     carrier: str
     contract_id: str
     working_price_in_euro_per_kwh: UncertainValue
     standing_charge_in_euro_per_year: UncertainValue
-    feed_in_kind: str = "NONE"
+    feed_in_kind: FeedInKind = FeedInKind.NONE
     feed_in_rate_in_euro_per_kwh: Optional[UncertainValue] = None
     is_default_contract: bool = False
     source_ids: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Refuses a feed-in kind and a feed-in rate that do not agree.
+
+        Raises:
+            ValueError: If a remunerated kind carries no rate, or a rate is carried under
+                `FeedInKind.NONE`.
+        """
+        has_rate = self.feed_in_rate_in_euro_per_kwh is not None
+        remunerated = self.feed_in_kind != FeedInKind.NONE
+        if has_rate != remunerated:
+            raise ValueError(
+                f"TariffAssumption for {self.carrier!r} states feed_in_kind "
+                f"{self.feed_in_kind.value} with "
+                f"{'a' if has_rate else 'no'} feed-in rate. The rate is present exactly when the "
+                "kind is not NONE: the assumptions table prints the two as one row, so either "
+                "half alone is a row that cannot be read."
+            )
+
+    @staticmethod
+    def from_contract(contract: TariffContract) -> "TariffAssumption":
+        """The assumption record for one billed contract — the only place it is built.
+
+        The engine bills under a `TariffContract` and the report publishes a `TariffAssumption`;
+        this is the single copy between the two. Written here rather than in the evaluator so that
+        the record and the rule that fills it live together: the feed-in half in particular is a
+        pair of fields that has to be filled consistently, and a hand copy at the call site is
+        where the pair comes apart.
+
+        Args:
+            contract: The contract `calculators/energy.py` actually billed the carrier under —
+                an authored one or the flat contract generated from the price entries.
+
+        Returns:
+            The record for `EconomicAssumptions.tariffs`, keyed by the carrier's value.
+        """
+        feed_in = contract.feed_in
+        remunerated = feed_in.kind != FeedInKind.NONE
+        return TariffAssumption(
+            carrier=contract.carrier.value,
+            contract_id=contract.id,
+            working_price_in_euro_per_kwh=contract.supply.working_price_in_euro_per_kwh,
+            standing_charge_in_euro_per_year=contract.standing_charge_in_euro_per_year,
+            feed_in_kind=feed_in.kind,
+            feed_in_rate_in_euro_per_kwh=feed_in.rate_in_euro_per_kwh if remunerated else None,
+            is_default_contract=contract.is_default_contract,
+            source_ids=list(contract.source_ids),
+        )
 
     def to_json(self) -> dict:
         """Serialization for lifecycle_costs.json."""
@@ -361,7 +561,7 @@ class TariffAssumption:
             "contract_id": self.contract_id,
             "working_price_in_euro_per_kwh": self.working_price_in_euro_per_kwh.to_json(),
             "standing_charge_in_euro_per_year": self.standing_charge_in_euro_per_year.to_json(),
-            "feed_in_kind": self.feed_in_kind,
+            "feed_in_kind": self.feed_in_kind.value,
             "feed_in_rate_in_euro_per_kwh": (
                 self.feed_in_rate_in_euro_per_kwh.to_json()
                 if self.feed_in_rate_in_euro_per_kwh is not None
@@ -373,14 +573,28 @@ class TariffAssumption:
 
     @staticmethod
     def from_json(raw: dict) -> "TariffAssumption":
-        """Inverse of `to_json`."""
+        """Inverse of `to_json`.
+
+        Raises:
+            ValueError: If `feed_in_kind` is not a `FeedInKind`, or if the kind and the rate
+                disagree (`__post_init__`).
+        """
         feed_in = raw.get("feed_in_rate_in_euro_per_kwh")
+        kind = raw.get("feed_in_kind", FeedInKind.NONE.value)
+        try:
+            feed_in_kind = FeedInKind(kind)
+        except ValueError:
+            raise ValueError(
+                f"TariffAssumption.feed_in_kind {kind!r} is not a feed-in remuneration structure "
+                f"({', '.join(item.value for item in FeedInKind)}); the kind selects how the "
+                "export revenue was computed, so an unknown one cannot be republished as a fact."
+            ) from None
         return TariffAssumption(
             carrier=raw["carrier"],
             contract_id=raw.get("contract_id", ""),
             working_price_in_euro_per_kwh=UncertainValue.from_json(raw["working_price_in_euro_per_kwh"]),
             standing_charge_in_euro_per_year=UncertainValue.from_json(raw["standing_charge_in_euro_per_year"]),
-            feed_in_kind=raw.get("feed_in_kind", "NONE"),
+            feed_in_kind=feed_in_kind,
             feed_in_rate_in_euro_per_kwh=UncertainValue.from_json(feed_in) if feed_in is not None else None,
             is_default_contract=bool(raw.get("is_default_contract", False)),
             source_ids=list(raw.get("source_ids", [])),
@@ -523,14 +737,17 @@ class LifecycleCostResult:
     #: year" and the fallback price basis of the degenerate-band note. Carried here (W4.6) so
     #: presentation needs no `EvaluationInputs`.
     simulation_year: Optional[int] = None
-    #: Per-subject annual energy attribution: subject -> energy-balance role
-    #: (`EnergyFlowRole.value`) -> annualized kWh as a positive magnitude. Additive and optional:
-    #: it is filled from the component output columns `adapter.DeviceEnergySpecs` names and stays
-    #: empty everywhere else, including for results serialized before it existed. Only the
-    #: household energy balance reads it, and that chart skips itself rather than drawing a
-    #: partial picture when the map carries fewer than two device flows — no KPI, export or
-    #: invariant depends on it.
-    energy_attribution_by_subject_in_kwh: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    #: Per-subject **annualized** energy attribution: subject -> energy-balance role
+    #: (`EnergyFlowRole.value`) -> kWh per year as a positive magnitude. The name says
+    #: `annual_` because the field of the same shape on `EvaluationInputs` holds the *simulated
+    #: period*, and the two were spelled identically while differing by the §3.6 annualization
+    #: divisor — a short run's chart would then have been compared against a year's meter table.
+    #: Additive and optional: it is filled from the component output columns
+    #: `adapter.DeviceEnergySpecs` names and stays empty everywhere else, including for results
+    #: serialized before it existed. Only the household energy balance reads it, and that chart
+    #: skips itself rather than drawing a partial picture when the map carries fewer than two
+    #: device flows — no KPI, export or invariant depends on it.
+    annual_energy_attribution_by_subject_in_kwh: Dict[str, Dict[str, float]] = field(default_factory=dict)
     #: Per-carrier §8.5 flexibility value of the year-1 bill *before* the clamp the projection
     #: applies (key = `EnergyCarrier.value`). Diagnostics, not a published figure: a negative
     #: entry means the load was timed worse than a flat profile and is what the plausibility
@@ -731,9 +948,9 @@ class LifecycleCostResult:
             "simulated_period_fraction": self.simulated_period_fraction,
             # Additive with the visualization extension: the per-subject energy attribution the
             # household energy balance needs. Written even when empty so the schema is stable.
-            "energy_attribution_by_subject_in_kwh": {
+            "annual_energy_attribution_by_subject_in_kwh": {
                 subject: dict(by_role)
-                for subject, by_role in self.energy_attribution_by_subject_in_kwh.items()
+                for subject, by_role in self.annual_energy_attribution_by_subject_in_kwh.items()
             },
             # Additive with the Sowieso share behind every anyway credit on the timeline, and the
             # like-for-like cost that share was applied to.

--- a/hisim/economics/results.py
+++ b/hisim/economics/results.py
@@ -107,6 +107,51 @@ class ComponentCostBreakdown:
         }
 
 
+@dataclass(frozen=True)
+class EmbodiedCo2Basis:
+    """The multiplication behind one subject's embodied CO2: factor x size, once per installation.
+
+    The embodied mass of a device is a data factor times the size that was installed, charged
+    again at every replacement, and a report that prints only the product asks the reader to
+    trust it. This record carries the three numbers the product is made of so the CO2 section can
+    state `factor x size = kg per installation` and multiply that by the number of installations
+    booked within the horizon.
+
+    `factor_in_kg_per_unit` is the database entry's embodied-CO2 figure per size unit, or the
+    absolute mass per installation when the entry states one without a `per_unit` (in which case
+    `size` is reported as 1 of the entry's own unit). `installations` counts the year-0
+    installation plus every replacement within the horizon, i.e. exactly the events the mass was
+    accumulated for.
+    """
+
+    factor_in_kg_per_unit: float
+    size: float
+    size_unit: str
+    per_installation_in_kg: float
+    installations: int = 1
+
+    def to_json(self) -> dict:
+        """Serialization for lifecycle_costs.json."""
+        return {
+            "factor_in_kg_per_unit": self.factor_in_kg_per_unit,
+            "size": self.size,
+            "size_unit": self.size_unit,
+            "per_installation_in_kg": self.per_installation_in_kg,
+            "installations": self.installations,
+        }
+
+    @staticmethod
+    def from_json(raw: dict) -> "EmbodiedCo2Basis":
+        """Inverse of `to_json`."""
+        return EmbodiedCo2Basis(
+            factor_in_kg_per_unit=float(raw["factor_in_kg_per_unit"]),
+            size=float(raw["size"]),
+            size_unit=str(raw.get("size_unit", "")),
+            per_installation_in_kg=float(raw["per_installation_in_kg"]),
+            installations=int(raw.get("installations", 1)),
+        )
+
+
 @dataclass
 class LifecycleCo2Result:
     """Parallel, undiscounted CO2 accounting (§3.8).
@@ -132,6 +177,13 @@ class LifecycleCo2Result:
     operational_co2_by_carrier_in_kg: Dict[str, float] = field(default_factory=dict)
     total_co2_in_kg: float = 0.0
     embodied_by_subject_in_kg: Dict[str, float] = field(default_factory=dict)
+    #: The conversion factors behind the two mass maps above, so the report can state every mass
+    #: as one visible multiplication instead of asserting it. Keyed like the maps they explain —
+    #: carrier value for the operational factors, timeline subject for the embodied ones. Empty
+    #: for a result serialized before the fields existed, in which case the factors table is
+    #: skipped rather than reconstructed by division.
+    emission_factor_by_carrier_in_kg_per_kwh: Dict[str, float] = field(default_factory=dict)
+    embodied_basis_by_subject: Dict[str, "EmbodiedCo2Basis"] = field(default_factory=dict)
 
     def to_json(self) -> dict:
         """Serialization.
@@ -146,6 +198,10 @@ class LifecycleCo2Result:
             "operational_co2_by_carrier_in_kg": self.operational_co2_by_carrier_in_kg,
             "total_co2_in_kg": self.total_co2_in_kg,
             "embodied_by_subject_in_kg": self.embodied_by_subject_in_kg,
+            "emission_factor_by_carrier_in_kg_per_kwh": dict(self.emission_factor_by_carrier_in_kg_per_kwh),
+            "embodied_basis_by_subject": {
+                subject: basis.to_json() for subject, basis in self.embodied_basis_by_subject.items()
+            },
         }
 
 
@@ -166,6 +222,216 @@ class AnnualEnergyQuantities:
     def to_json(self) -> dict:
         """Serialization for lifecycle_costs.json."""
         return {"bought_in_kwh": self.bought_in_kwh, "sold_in_kwh": self.sold_in_kwh}
+
+
+@dataclass(frozen=True)
+class ModernizationLevySummary:
+    """The §559/§559e rent increase as the report has to state it.
+
+    The levy's euro amount is on the timeline as a transfer pair, but two facts a landlord reading
+    the statement needs are not derivable from a cash flow: whether a statutory ceiling decided the
+    figure, and which ceiling. Below the cap the levy scales with what was spent on the
+    modernization; at the cap it does not, and the same renovation costing 20 % more would produce
+    the identical rent increase — economically a completely different situation, invisible in the
+    number itself.
+
+    Carried on the result rather than recomputed in a view for the same reason the areas are: a
+    stored `lifecycle_costs.json` has to be enough to render the report, and a second
+    implementation of §559 Abs. 3a inside the presentation layer is precisely the duplication the
+    seam-4 rule forbids. It is `None` for every perspective that has no levy — an owner-occupier
+    run, a country whose ruleset knows none.
+    """
+
+    annual_amount_in_euro: UncertainValue
+    general_leg_in_euro: UncertainValue
+    heating_leg_in_euro: UncertainValue
+    #: Whether a statutory cap actually bit in the AVERAGE slot.
+    cap_binding: bool = False
+    #: The general §559 Abs. 3a ceiling in EUR per m² and month, when one was evaluated.
+    cap_in_euro_per_m2_per_month: Optional[float] = None
+    #: Which mechanism actually set the levy **in each world**, keyed by slot name (`low` /
+    #: `average` / `high`). The caps are applied per slot, so the ceiling can decide the expensive
+    #: world while the cheap one is still set by the percentage of the modernization cost — two
+    #: economically different answers that a single average-slot flag hides. Empty for a result
+    #: serialized before the field existed, in which case the report falls back to the
+    #: average-slot `cap_binding` statement.
+    binding_mechanism_by_slot: Dict[str, str] = field(default_factory=dict)
+
+    def to_json(self) -> dict:
+        """Serialization for lifecycle_costs.json."""
+        return {
+            "annual_amount_in_euro": self.annual_amount_in_euro.to_json(),
+            "general_leg_in_euro": self.general_leg_in_euro.to_json(),
+            "heating_leg_in_euro": self.heating_leg_in_euro.to_json(),
+            "cap_binding": self.cap_binding,
+            "cap_in_euro_per_m2_per_month": self.cap_in_euro_per_m2_per_month,
+            "binding_mechanism_by_slot": dict(self.binding_mechanism_by_slot),
+        }
+
+    @staticmethod
+    def from_json(raw: Optional[dict]) -> Optional["ModernizationLevySummary"]:
+        """Inverse of `to_json`; `None` stays `None` (a run without a levy)."""
+        if not raw:
+            return None
+        return ModernizationLevySummary(
+            annual_amount_in_euro=UncertainValue.from_json(raw["annual_amount_in_euro"]),
+            general_leg_in_euro=UncertainValue.from_json(raw["general_leg_in_euro"]),
+            heating_leg_in_euro=UncertainValue.from_json(raw["heating_leg_in_euro"]),
+            cap_binding=bool(raw.get("cap_binding", False)),
+            cap_in_euro_per_m2_per_month=raw.get("cap_in_euro_per_m2_per_month"),
+            binding_mechanism_by_slot=dict(raw.get("binding_mechanism_by_slot", {})),
+        )
+
+
+class RateOrigin:
+    """The three steps of the §3.2 escalation fallback chain, as the values `ResolvedRate` carries.
+
+    Named constants rather than free strings because both the evaluator that records the origin
+    and the report that renders it have to agree on the spelling, and a third spelling would show
+    up as an uncited assumption rather than as an error.
+    """
+
+    CONFIGURATION = "configuration"
+    COUNTRY_DEFAULTS = "country defaults"
+    GENERAL_FALLBACK = "general fallback"
+
+
+@dataclass(frozen=True)
+class ResolvedRate:
+    """One escalation rate as the run actually resolved it, with the step of the chain that won.
+
+    An escalation rate reaches the engine through a three-step fallback — an explicit
+    `EconomicParameters` entry, the country's `escalation_defaults_<COUNTRY>.json` table, then the
+    general rate (§3.2) — and the rate alone does not say which step produced it. The assumptions
+    table has to cite a source for every value it publishes, so the winning step travels with the
+    number instead of being re-derived by a renderer that has no database.
+
+    `origin` is one of the `RateOrigin` constants; `source_ids` are the §3.10 registry ids of the
+    defaults file when that is what won, and empty for a configured or fallback rate, which the
+    report renders as "configuration".
+    """
+
+    rate: float
+    origin: str
+    source_ids: List[str] = field(default_factory=list)
+
+    def to_json(self) -> dict:
+        """Serialization for lifecycle_costs.json."""
+        return {"rate": self.rate, "origin": self.origin, "source_ids": list(self.source_ids)}
+
+    @staticmethod
+    def from_json(raw: dict) -> "ResolvedRate":
+        """Inverse of `to_json`."""
+        return ResolvedRate(
+            rate=float(raw["rate"]),
+            origin=str(raw.get("origin", RateOrigin.CONFIGURATION)),
+            source_ids=list(raw.get("source_ids", [])),
+        )
+
+
+@dataclass(frozen=True)
+class TariffAssumption:
+    """The commercial terms one carrier was billed under, as the assumptions table states them.
+
+    The three prices a reader needs to reproduce an energy bill by hand — the per-kilowatt-hour
+    working price, the fixed annual standing charge and the rate paid per exported kilowatt hour —
+    plus the contract they came from. Carried on the result for the same reason the reference
+    areas are (W4.2): a stored `lifecycle_costs.json` has to be enough to render the report, and
+    the tariff contracts live in `EvaluationInputs`, which presentation may not read.
+
+    `contract_id` is the tariff contract's id; for a carrier billed under the generated flat
+    contract of `calculators/energy.py` it is that contract's synthetic id and
+    `is_default_contract` is True, which the report states as "database price entry" rather than
+    pretending a contract file was read.
+    """
+
+    carrier: str
+    contract_id: str
+    working_price_in_euro_per_kwh: UncertainValue
+    standing_charge_in_euro_per_year: UncertainValue
+    feed_in_kind: str = "NONE"
+    feed_in_rate_in_euro_per_kwh: Optional[UncertainValue] = None
+    is_default_contract: bool = False
+    source_ids: List[str] = field(default_factory=list)
+
+    def to_json(self) -> dict:
+        """Serialization for lifecycle_costs.json."""
+        return {
+            "carrier": self.carrier,
+            "contract_id": self.contract_id,
+            "working_price_in_euro_per_kwh": self.working_price_in_euro_per_kwh.to_json(),
+            "standing_charge_in_euro_per_year": self.standing_charge_in_euro_per_year.to_json(),
+            "feed_in_kind": self.feed_in_kind,
+            "feed_in_rate_in_euro_per_kwh": (
+                self.feed_in_rate_in_euro_per_kwh.to_json()
+                if self.feed_in_rate_in_euro_per_kwh is not None
+                else None
+            ),
+            "is_default_contract": self.is_default_contract,
+            "source_ids": list(self.source_ids),
+        }
+
+    @staticmethod
+    def from_json(raw: dict) -> "TariffAssumption":
+        """Inverse of `to_json`."""
+        feed_in = raw.get("feed_in_rate_in_euro_per_kwh")
+        return TariffAssumption(
+            carrier=raw["carrier"],
+            contract_id=raw.get("contract_id", ""),
+            working_price_in_euro_per_kwh=UncertainValue.from_json(raw["working_price_in_euro_per_kwh"]),
+            standing_charge_in_euro_per_year=UncertainValue.from_json(raw["standing_charge_in_euro_per_year"]),
+            feed_in_kind=raw.get("feed_in_kind", "NONE"),
+            feed_in_rate_in_euro_per_kwh=UncertainValue.from_json(feed_in) if feed_in is not None else None,
+            is_default_contract=bool(raw.get("is_default_contract", False)),
+            source_ids=list(raw.get("source_ids", [])),
+        )
+
+
+@dataclass(frozen=True)
+class EconomicAssumptions:
+    """Every economic assumption the evaluation ran on that is not already on the parameters.
+
+    The data half of the report's assumptions section: the escalation rates *as resolved* through
+    their fallback chains, the tariff terms per carrier, and the annual heat demand the heat-cost
+    figure divides by. What `EconomicParameters` already states — interest rate, horizon, price
+    basis year, CO2 damage cost — is not copied here; the section reads both, and duplicating a
+    parameter would let the two drift.
+
+    It exists because those three groups are resolved *inside* the engine against the cost
+    database and `EvaluationInputs`, neither of which presentation may reach (seam 4). Without
+    this record the only honest assumptions table would be the empty one.
+
+    Keys: escalation rates are keyed by a stable label — `general`, `investment`, `feed-in`,
+    `energy:<carrier value>`, `investment:<asset class name>` — and the tariffs by carrier value,
+    the same string the timeline uses as the subject of that carrier's energy entries.
+    """
+
+    escalation_rates: Dict[str, ResolvedRate] = field(default_factory=dict)
+    tariffs: Dict[str, TariffAssumption] = field(default_factory=dict)
+    annual_heat_demand_in_kwh: Optional[float] = None
+
+    def to_json(self) -> dict:
+        """Serialization for lifecycle_costs.json."""
+        return {
+            "escalation_rates": {label: rate.to_json() for label, rate in self.escalation_rates.items()},
+            "tariffs": {carrier: tariff.to_json() for carrier, tariff in self.tariffs.items()},
+            "annual_heat_demand_in_kwh": self.annual_heat_demand_in_kwh,
+        }
+
+    @staticmethod
+    def from_json(raw: Optional[dict]) -> Optional["EconomicAssumptions"]:
+        """Inverse of `to_json`; `None` stays `None` (a result written before the field existed)."""
+        if not raw:
+            return None
+        return EconomicAssumptions(
+            escalation_rates={
+                label: ResolvedRate.from_json(value) for label, value in raw.get("escalation_rates", {}).items()
+            },
+            tariffs={
+                carrier: TariffAssumption.from_json(value) for carrier, value in raw.get("tariffs", {}).items()
+            },
+            annual_heat_demand_in_kwh=raw.get("annual_heat_demand_in_kwh"),
+        )
 
 
 @dataclass(frozen=True)
@@ -257,11 +523,39 @@ class LifecycleCostResult:
     #: year" and the fallback price basis of the degenerate-band note. Carried here (W4.6) so
     #: presentation needs no `EvaluationInputs`.
     simulation_year: Optional[int] = None
+    #: Per-subject annual energy attribution: subject -> energy-balance role
+    #: (`EnergyFlowRole.value`) -> annualized kWh as a positive magnitude. Additive and optional:
+    #: it is filled from the component output columns `adapter.DeviceEnergySpecs` names and stays
+    #: empty everywhere else, including for results serialized before it existed. Only the
+    #: household energy balance reads it, and that chart skips itself rather than drawing a
+    #: partial picture when the map carries fewer than two device flows — no KPI, export or
+    #: invariant depends on it.
+    energy_attribution_by_subject_in_kwh: Dict[str, Dict[str, float]] = field(default_factory=dict)
     #: Per-carrier §8.5 flexibility value of the year-1 bill *before* the clamp the projection
     #: applies (key = `EnergyCarrier.value`). Diagnostics, not a published figure: a negative
     #: entry means the load was timed worse than a flat profile and is what the plausibility
     #: panel's flexibility check reads (issue #25b).
     raw_flexibility_value_by_carrier: Dict[str, float] = field(default_factory=dict)
+    #: The Sowieso share each anyway credit was computed at (subject -> share). A credit is
+    #: `share x like-for-like cost`, and a reader looking at a credit against an insulation
+    #: measure has to be told which share produced it — so the report's timeline detail table and
+    #: the captions that name the credit read this. Empty for a run without replaced assets and
+    #: for results serialized before the field existed, in which case the renderers say nothing
+    #: rather than claiming a share they do not know.
+    anyway_share_by_subject: Dict[str, float] = field(default_factory=dict)
+    #: The like-for-like cost each anyway credit was computed *on*, per subject, in nominal euro
+    #: of the credit year. With `anyway_share_by_subject` this makes the credit a visible
+    #: multiplication — `share x basis = credit` — instead of a figure the reader has to trust.
+    #: Empty for a run without replaced assets and for results serialized before the field
+    #: existed, in which case the caption states the share alone as it did before.
+    anyway_basis_by_subject: Dict[str, float] = field(default_factory=dict)
+    #: The §559/§559e rent increase and whether a statutory cap decided it. Present only for
+    #: perspectives the rented-case ruleset allocated; None everywhere else.
+    modernization_levy: Optional[ModernizationLevySummary] = None
+    #: The escalation rates, tariffs and heat demand this evaluation resolved. None for a result
+    #: serialized before the field existed; the assumptions section then renders the parameter
+    #: half only and says which half is missing rather than inventing it.
+    assumptions: Optional[EconomicAssumptions] = None
 
     def scoped_timeline(self) -> CashFlowTimeline:
         """The flows this perspective actually reports on (filtered by `scope_payer`).
@@ -435,6 +729,20 @@ class LifecycleCostResult:
             },
             "reference_areas": self.reference_areas.to_json(),
             "simulated_period_fraction": self.simulated_period_fraction,
+            # Additive with the visualization extension: the per-subject energy attribution the
+            # household energy balance needs. Written even when empty so the schema is stable.
+            "energy_attribution_by_subject_in_kwh": {
+                subject: dict(by_role)
+                for subject, by_role in self.energy_attribution_by_subject_in_kwh.items()
+            },
+            # Additive with the Sowieso share behind every anyway credit on the timeline, and the
+            # like-for-like cost that share was applied to.
+            "anyway_share_by_subject": dict(self.anyway_share_by_subject),
+            "anyway_basis_by_subject": dict(self.anyway_basis_by_subject),
+            # Additive: the levy the landlord statement reports on.
+            "modernization_levy": self.modernization_levy.to_json() if self.modernization_levy else None,
+            # Additive: the resolved assumptions the assumptions section publishes.
+            "assumptions": self.assumptions.to_json() if self.assumptions else None,
             # Additive since W4.6 — the scope and the simulation year presentation needs so it
             # can render from a stored result alone (W4.5).
             "scope_payer": self.scope_payer.value,

--- a/hisim/economics/scenarios.py
+++ b/hisim/economics/scenarios.py
@@ -314,6 +314,12 @@ def apply_parameter_overrides(base: EconomicParameters, overrides: Dict[str, Any
     a dict-typed field, a whole dict merged key by key into a dict-typed field, and a plain
     attribute assignment.
 
+    The result is re-validated by re-running `EconomicParameters.__post_init__`, because a
+    `setattr` bypasses the constructor: without it a scenario axis could set `interest_rate` to
+    -1.5 or `observation_period_in_years` to 0 and the cube would evaluate a cell whose discounting
+    and annuity formulas are meaningless, silently, rather than the axis being refused where it is
+    declared.
+
     Args:
         base: The run's parameters; left untouched.
         overrides: Dotted path or field name -> value, from one `Scenario`.
@@ -323,6 +329,7 @@ def apply_parameter_overrides(base: EconomicParameters, overrides: Dict[str, Any
 
     Raises:
         ScenarioDataError: If a dotted path targets a field that is not a dict.
+        ValueError: If the overridden parameters fail their own validation.
     """
     params = copy.deepcopy(base)
     for fieldname, value in overrides.items():
@@ -338,6 +345,7 @@ def apply_parameter_overrides(base: EconomicParameters, overrides: Dict[str, Any
                 container[_coerce_dict_key(fieldname, key)] = sub_value
         else:
             setattr(params, fieldname, value)
+    params.__post_init__()
     return params
 
 

--- a/hisim/economics/serialization.py
+++ b/hisim/economics/serialization.py
@@ -39,7 +39,7 @@ import json
 import os
 from typing import Any, Dict, Optional
 
-from hisim.economics.carriers import EnergyCarrier
+from hisim.economics.carriers import EnergyCarrier, validate_energy_attribution
 from hisim.economics.evaluator import EvaluationInputs, SubjectCostFacts, UnresolvedSubject
 from hisim.economics.exports import ExportFileNames
 from hisim.economics.facts import (
@@ -332,6 +332,34 @@ def subsidy_context_from_json(raw: dict) -> SubsidyContext:
     )
 
 
+def _attribution_from_json(raw: dict, key: str, context: str) -> Dict[str, Dict[str, float]]:
+    """Reads one per-subject energy-attribution map back, refusing a negative quantity.
+
+    Both sides of the round trip carry a map of this shape — the extract's simulated-period one
+    and the result's annualized one — and both are read back here so a hand-edited or
+    foreign-written file cannot put a negative magnitude into the household balance. Absent is not
+    an error: it is what every file written before the field existed looks like, and the chart
+    skips itself on the empty map.
+
+    Args:
+        raw: The decoded JSON object holding the map.
+        key: Its key in that object.
+        context: The dotted field path, for the error message.
+
+    Returns:
+        Subject -> role -> kWh, empty when the key is absent.
+
+    Raises:
+        ValueError: If any quantity is negative.
+    """
+    attribution = {
+        subject: {role: float(value) for role, value in by_role.items()}
+        for subject, by_role in raw.get(key, {}).items()
+    }
+    validate_energy_attribution(attribution, context)
+    return attribution
+
+
 def inputs_to_json(inputs: EvaluationInputs) -> dict:
     """Serializes EvaluationInputs to the economic_inputs.json structure.
 
@@ -447,10 +475,11 @@ def inputs_from_json(raw: dict, tariffs_base_path: Optional[str] = None) -> Eval
             for item in raw.get("cost_facts", [])
         ],
         billing=[billing_from_json(item) for item in raw.get("billing", [])],
-        energy_attribution_by_subject_in_kwh={
-            subject: {role: float(value) for role, value in by_role.items()}
-            for subject, by_role in raw.get("energy_attribution_by_subject_in_kwh", {}).items()
-        },
+        energy_attribution_by_subject_in_kwh=_attribution_from_json(
+            raw,
+            "energy_attribution_by_subject_in_kwh",
+            "EvaluationInputs.energy_attribution_by_subject_in_kwh",
+        ),
         unresolved_subjects=[
             UnresolvedSubject(subject=item["subject"], reason=item["reason"])
             for item in raw.get("unresolved_subjects", [])
@@ -716,10 +745,11 @@ def result_from_json(
         simulation_year=raw.get("simulation_year"),
         # Additive with the visualization extension; absent in files written before it, which is
         # exactly the case the household energy balance skips itself on.
-        energy_attribution_by_subject_in_kwh={
-            subject: {role: float(value) for role, value in by_role.items()}
-            for subject, by_role in raw.get("energy_attribution_by_subject_in_kwh", {}).items()
-        },
+        annual_energy_attribution_by_subject_in_kwh=_attribution_from_json(
+            raw,
+            "annual_energy_attribution_by_subject_in_kwh",
+            "LifecycleCostResult.annual_energy_attribution_by_subject_in_kwh",
+        ),
         raw_flexibility_value_by_carrier=dict(raw.get("raw_flexibility_value_by_carrier", {})),
         # Additive; absent in a result written before the Sowieso share existed, where every
         # credit was implicitly a full one.

--- a/hisim/economics/serialization.py
+++ b/hisim/economics/serialization.py
@@ -53,9 +53,12 @@ from hisim.economics.provenance import ProvenanceLedger
 from hisim.economics.results import (
     AnnualEnergyQuantities,
     ComponentCostBreakdown,
+    EconomicAssumptions,
+    EmbodiedCo2Basis,
     EvaluationMatrix,
     LifecycleCo2Result,
     LifecycleCostResult,
+    ModernizationLevySummary,
     ReferenceAreas,
 )
 from hisim.economics.subsidies import (
@@ -197,7 +200,8 @@ def asset_to_json(asset: ExistingAsset) -> dict:
     An `ExistingAsset` is a piece of the building as it was *before* the measure, and the fields
     below are exactly what the brownfield arithmetic of §4.1 needs: installation year (drives
     remaining life, first replacement and the anyway-cost credit), functionality, carrier, an
-    optional like-for-like replacement price, and `replaced_by_asset_classes` — the declaration that
+    optional like-for-like replacement price, `anyway_share` (the Sowieso share the credit is
+    computed at) and `replaced_by_asset_classes` — the declaration that
     turns "kept" into "replaced by this measure". Used both for register entries and for the
     subsidy context's `existing_heating`, which the BEG speed bonus conditions on.
     """
@@ -210,6 +214,7 @@ def asset_to_json(asset: ExistingAsset) -> dict:
         "is_functional": asset.is_functional,
         "energy_carrier": asset.energy_carrier.value if asset.energy_carrier else None,
         "replaced_by_asset_classes": [asset_class.name for asset_class in asset.replaced_by_asset_classes],
+        "anyway_share": asset.anyway_share,
     }
 
 
@@ -230,6 +235,9 @@ def asset_from_json(item: dict) -> ExistingAsset:
         is_functional=item.get("is_functional", True),
         energy_carrier=EnergyCarrier(item["energy_carrier"]) if item.get("energy_carrier") else None,
         replaced_by_asset_classes=[ComponentType[name] for name in item.get("replaced_by_asset_classes", [])],
+        # Absent in a register written before the Sowieso share existed, which means the
+        # implicit full like-for-like credit the field now makes explicit.
+        anyway_share=item.get("anyway_share", 1.0),
     )
 
 
@@ -345,6 +353,13 @@ def inputs_to_json(inputs: EvaluationInputs) -> dict:
             for subject_facts in inputs.cost_facts
         ],
         "billing": [billing_to_json(determinants) for determinants in inputs.billing],
+        # Per-subject energy-balance flows (simulated-period kWh per role). Additive: nothing
+        # prices it, but it has to survive the round trip or a re-priced archive would silently
+        # lose the household energy balance it was extracted for.
+        "energy_attribution_by_subject_in_kwh": {
+            subject: dict(by_role)
+            for subject, by_role in inputs.energy_attribution_by_subject_in_kwh.items()
+        },
         # Extraction failures travel with the extract (issue #2): re-pricing an archived run must
         # hit the same D7 wall as the original one, not quietly price a smaller system.
         "unresolved_subjects": [
@@ -432,6 +447,10 @@ def inputs_from_json(raw: dict, tariffs_base_path: Optional[str] = None) -> Eval
             for item in raw.get("cost_facts", [])
         ],
         billing=[billing_from_json(item) for item in raw.get("billing", [])],
+        energy_attribution_by_subject_in_kwh={
+            subject: {role: float(value) for role, value in by_role.items()}
+            for subject, by_role in raw.get("energy_attribution_by_subject_in_kwh", {}).items()
+        },
         unresolved_subjects=[
             UnresolvedSubject(subject=item["subject"], reason=item["reason"])
             for item in raw.get("unresolved_subjects", [])
@@ -669,6 +688,15 @@ def result_from_json(
             operational_co2_by_carrier_in_kg=dict(co2.get("operational_co2_by_carrier_in_kg", {})),
             total_co2_in_kg=co2.get("total_co2_in_kg", 0.0),
             embodied_by_subject_in_kg=dict(co2.get("embodied_by_subject_in_kg", {})),
+            # Additive; absent in files written before the factors table existed, where the
+            # CO2 section states the masses without their multiplication.
+            emission_factor_by_carrier_in_kg_per_kwh=dict(
+                co2.get("emission_factor_by_carrier_in_kg_per_kwh", {})
+            ),
+            embodied_basis_by_subject={
+                subject: EmbodiedCo2Basis.from_json(value)
+                for subject, value in co2.get("embodied_basis_by_subject", {}).items()
+            },
         ),
         subsidy_decisions=[_decision_from_json(item) for item in raw.get("subsidy_decisions", [])],
         sunk_cost_written_off_in_euro=UncertainValue.from_json(raw["sunk_cost_written_off_in_euro"]),
@@ -686,7 +714,26 @@ def result_from_json(
         ),
         simulated_period_fraction=raw.get("simulated_period_fraction", 1.0),
         simulation_year=raw.get("simulation_year"),
+        # Additive with the visualization extension; absent in files written before it, which is
+        # exactly the case the household energy balance skips itself on.
+        energy_attribution_by_subject_in_kwh={
+            subject: {role: float(value) for role, value in by_role.items()}
+            for subject, by_role in raw.get("energy_attribution_by_subject_in_kwh", {}).items()
+        },
         raw_flexibility_value_by_carrier=dict(raw.get("raw_flexibility_value_by_carrier", {})),
+        # Additive; absent in a result written before the Sowieso share existed, where every
+        # credit was implicitly a full one.
+        anyway_share_by_subject={
+            subject: float(share) for subject, share in raw.get("anyway_share_by_subject", {}).items()
+        },
+        # Additive; without it the anyway caption states the share alone.
+        anyway_basis_by_subject={
+            subject: float(basis) for subject, basis in raw.get("anyway_basis_by_subject", {}).items()
+        },
+        # Additive; None for every perspective without a levy, which is most of them.
+        modernization_levy=ModernizationLevySummary.from_json(raw.get("modernization_levy")),
+        # Additive; None for a file written before the assumptions section existed.
+        assumptions=EconomicAssumptions.from_json(raw.get("assumptions")),
     )
 
 

--- a/hisim/economics/views.py
+++ b/hisim/economics/views.py
@@ -207,18 +207,28 @@ def nominal_annual_matrix_by_category(
 
 @dataclass(frozen=True)
 class LoanAmortization:
-    """Interest and principal per year 0..T (index = year), nominal euros (§4.4).
+    """Interest, principal and outstanding balance per year 0..T (index = year), nominal (§4.4).
 
     The two components of a financed perspective's debt service, split so the report can stack
     them and a reviewer can see the shape an annuity loan has (falling interest, rising
-    principal) or fails to have. Both lists always span the full horizon, zero-padded, so they
+    principal) or fails to have. All lists always span the full horizon, zero-padded, so they
     index by year directly and can be zipped with each other and with any other year series in
-    this module. The disbursement itself is *not* here — it is a year-0 flow of the
-    `LOAN_DISBURSEMENT` category and shows up in the investment waterfall instead.
+    this module. The disbursement itself is *not* one of the bar series — it is a year-0 flow of
+    the `LOAN_DISBURSEMENT` category and shows up in the investment waterfall instead — but it
+    is carried here as `disbursement_in_euro` because the balance line starts from it.
+
+    `outstanding_balance_in_euro` is the disbursement minus the cumulative principal repayments
+    up to and including that year, so it reconciles with the plotted bars by construction rather
+    than by a second schedule computation. Year 0 therefore carries the full disbursement, and a
+    fully amortizing plan ends at zero within float tolerance.
     """
 
     interest_in_euro: List[float]
     principal_in_euro: List[float]
+    #: Disbursement at year 0 as a positive amount (the timeline books it negative).
+    disbursement_in_euro: float = 0.0
+    #: Debt still outstanding at the end of each year 0..T; index = year.
+    outstanding_balance_in_euro: List[float] = field(default_factory=list)
 
     def has_flows(self) -> bool:
         """True when the perspective is financed at all."""
@@ -236,11 +246,16 @@ def loan_amortization_series(
     decide whether the perspective is financed at all and skip the chart when it is not, which
     is the common case (cash purchase).
 
+    The outstanding-balance series is built here from the same entries (disbursement minus the
+    running principal repayments), which is what keeps a balance line and the bars drawn beside it
+    from disagreeing.
+
     Replaces `reporting.py:517-526` (the amortization chart's accumulation loop).
     """
     horizon = result.parameters.observation_period_in_years
     interest_per_year = [0.0] * (horizon + 1)
     principal_per_year = [0.0] * (horizon + 1)
+    disbursement = 0.0
     for entry in result.scoped_timeline().entries:
         if not 0 <= entry.year <= horizon:
             continue
@@ -248,7 +263,19 @@ def loan_amortization_series(
             interest_per_year[entry.year] += entry.amount_in_euro.slot(slot)
         elif entry.category == CostCategory.LOAN_PRINCIPAL:
             principal_per_year[entry.year] += entry.amount_in_euro.slot(slot)
-    return LoanAmortization(interest_in_euro=interest_per_year, principal_in_euro=principal_per_year)
+        elif entry.category == CostCategory.LOAN_DISBURSEMENT:
+            disbursement += -entry.amount_in_euro.slot(slot)
+    balance: List[float] = []
+    outstanding = disbursement
+    for year in range(horizon + 1):
+        outstanding -= principal_per_year[year]
+        balance.append(outstanding)
+    return LoanAmortization(
+        interest_in_euro=interest_per_year,
+        principal_in_euro=principal_per_year,
+        disbursement_in_euro=disbursement,
+        outstanding_balance_in_euro=balance,
+    )
 
 
 def cumulative_operational_co2_in_kg(result: LifecycleCostResult) -> List[float]:

--- a/hisim/economics/views.py
+++ b/hisim/economics/views.py
@@ -219,8 +219,11 @@ class LoanAmortization:
 
     `outstanding_balance_in_euro` is the disbursement minus the cumulative principal repayments
     up to and including that year, so it reconciles with the plotted bars by construction rather
-    than by a second schedule computation. Year 0 therefore carries the full disbursement, and a
-    fully amortizing plan ends at zero within float tolerance.
+    than by a second schedule computation. Year 0 therefore carries the disbursement *less any
+    principal booked at year 0* — normally the full disbursement, since an annuity plan repays
+    nothing in the year it is taken out, but a plan that books a year-0 repayment starts below it
+    rather than above the sum of its own repayments. A fully amortizing plan ends at zero within
+    float tolerance.
     """
 
     interest_in_euro: List[float]

--- a/tests/test_economics_bridge.py
+++ b/tests/test_economics_bridge.py
@@ -551,20 +551,24 @@ class TestSharedHelpers:
         """One lookup behind both the sum and the raw series, so they cannot locate differently."""
 
         class _Output:
-            """The two attributes the positional lookup matches on."""
+            """The three attributes the positional lookup and the unit conversion read."""
 
-            def __init__(self, component_name: str, field_name: str) -> None:
-                """Names one declared output."""
+            def __init__(self, component_name: str, field_name: str, unit) -> None:
+                """Names one declared output and the unit it is declared in."""
                 self.component_name = component_name
                 self.field_name = field_name
+                self.unit = unit
 
-        outputs = [_Output("Meter", "A"), _Output("Meter", "B")]
+        outputs = [
+            _Output("Meter", "A", loadtypes.Units.WATT_HOUR),
+            _Output("Meter", "B", loadtypes.Units.WATT),
+        ]
         frame = pd.DataFrame({0: [1000.0, 2000.0], 1: [7.0, 8.0]})
 
         # pylint: disable=protected-access
-        assert bridge._sum_output_column("Meter", "A", outputs, frame) == pytest.approx(3.0)
+        assert bridge._sum_output_column("Meter", "A", outputs, frame, 900) == pytest.approx(3.0)
         series = bridge._power_series("Meter", "B", outputs, frame)
         assert series is not None
         assert series.tolist() == [7.0, 8.0]
-        assert bridge._sum_output_column("Meter", "C", outputs, frame) is None
+        assert bridge._sum_output_column("Meter", "C", outputs, frame, 900) is None
         assert bridge._power_series("Meter", "C", outputs, frame) is None

--- a/tests/test_economics_data_serialization.py
+++ b/tests/test_economics_data_serialization.py
@@ -17,7 +17,7 @@ from hisim.economics.facts import BillingDeterminants, ComponentCostFacts, Exist
 from hisim.economics.parameters import EconomicParameters
 from hisim.economics.perspectives import InstallationContext, Perspective, SubsidyMode
 from hisim.economics.results import compare
-from hisim.economics.uncertainty import UncertainValue
+from hisim.economics.uncertainty import Slot, UncertainValue
 from hisim.loadtypes import ComponentType, Units
 
 pytestmark = pytest.mark.base
@@ -572,7 +572,8 @@ class TestSerializationRoundtrip:
             id="gross", installation_context=InstallationContext.GREENFIELD, subsidy_mode=SubsidyMode.none()
         )
         result = EconomicEvaluator(CostDatabase(), parameters).evaluate(reloaded, perspective)
-        assert result.energy_attribution_by_subject_in_kwh["Battery"]["BATTERY_CHARGE"] == pytest.approx(800.0)
+        annual = result.annual_energy_attribution_by_subject_in_kwh
+        assert annual["Battery"]["BATTERY_CHARGE"] == pytest.approx(800.0)
 
     def test_an_extract_without_the_attribution_key_still_reads(self):
         """Every additive field defaults to empty, so an archive written before it still loads."""
@@ -604,16 +605,15 @@ class TestSerializationRoundtrip:
             id="gross", installation_context=InstallationContext.GREENFIELD, subsidy_mode=SubsidyMode.none()
         )
         result = EconomicEvaluator(CostDatabase(), parameters).evaluate(self._inputs(), perspective)
-        result.energy_attribution_by_subject_in_kwh = {"PVSystem": {"PV_GENERATION": 4200.0}}
+        result.annual_energy_attribution_by_subject_in_kwh = {"PVSystem": {"PV_GENERATION": 4200.0}}
         result.anyway_share_by_subject = {"HeatPump": 0.3}
         result.anyway_basis_by_subject = {"HeatPump": 9000.0}
         result.modernization_levy = ModernizationLevySummary(
             annual_amount_in_euro=UncertainValue.exact(1800.0),
             general_leg_in_euro=UncertainValue.exact(1200.0),
             heating_leg_in_euro=UncertainValue.exact(600.0),
-            cap_binding=True,
             cap_in_euro_per_m2_per_month=3.0,
-            binding_mechanism_by_slot={"best_estimate": "§559 general cap 3.00 EUR/m2*mo"},
+            binding_mechanism_by_slot={Slot.BEST_ESTIMATE: "§559 general cap 3.00 EUR/m2*mo"},
         )
         result.assumptions = EconomicAssumptions(
             escalation_rates={"general": ResolvedRate(rate=0.02, origin=RateOrigin.COUNTRY_DEFAULTS)},
@@ -634,12 +634,16 @@ class TestSerializationRoundtrip:
         restored = read_results(str(tmp_path))
         assert restored is not None
         reloaded = restored.results["gross"]
-        assert reloaded.energy_attribution_by_subject_in_kwh == {"PVSystem": {"PV_GENERATION": 4200.0}}
+        assert reloaded.annual_energy_attribution_by_subject_in_kwh == {
+            "PVSystem": {"PV_GENERATION": 4200.0}
+        }
         assert reloaded.anyway_share_by_subject == {"HeatPump": 0.3}
         assert reloaded.anyway_basis_by_subject == {"HeatPump": 9000.0}
         assert reloaded.modernization_levy is not None
-        assert reloaded.modernization_levy.cap_binding
-        assert reloaded.modernization_levy.binding_mechanism_by_slot["best_estimate"].startswith("§559")
+        assert reloaded.modernization_levy.cap_binding_in_best_estimate
+        assert reloaded.modernization_levy.binding_mechanism_by_slot[Slot.BEST_ESTIMATE].startswith(
+            "§559"
+        )
         assert reloaded.assumptions is not None
         assert reloaded.assumptions.escalation_rates["general"].origin == RateOrigin.COUNTRY_DEFAULTS
         assert reloaded.assumptions.annual_heat_demand_in_kwh == pytest.approx(15000.0)
@@ -664,7 +668,7 @@ class TestSerializationRoundtrip:
         with open(path, encoding="utf-8") as file:
             raw = json.load(file)
         for key in (
-            "energy_attribution_by_subject_in_kwh",
+            "annual_energy_attribution_by_subject_in_kwh",
             "anyway_share_by_subject",
             "anyway_basis_by_subject",
             "modernization_levy",
@@ -678,7 +682,7 @@ class TestSerializationRoundtrip:
         reloaded = read_results(str(tmp_path))
         assert reloaded is not None
         older = reloaded.results["gross"]
-        assert older.energy_attribution_by_subject_in_kwh == {}
+        assert older.annual_energy_attribution_by_subject_in_kwh == {}
         assert older.anyway_share_by_subject == {} and older.anyway_basis_by_subject == {}
         assert older.modernization_levy is None and older.assumptions is None
         assert older.lifecycle_co2_result.emission_factor_by_carrier_in_kg_per_kwh == {}
@@ -781,3 +785,189 @@ class TestVariantComparison:
         comparison = compare(reference, variant)
         assert "Heater" in comparison.npv_delta_by_subject
         assert EnergyCarrier.ELECTRICITY.value in comparison.npv_delta_by_subject
+
+
+class TestTheResultRecordsRefuseWhatTheyCannotVouchFor:
+    """Construction-time and read-time invariants of the disclosure records (review, decision 1).
+
+    Every record here is published as a *statement*: "this rate came from the country defaults",
+    "this carrier was paid 8.2 ct per exported kWh under a fixed tariff", "this mass is 120 kg per
+    kW times 10 kW". A record whose fields do not add up to its statement is worse than a missing
+    one, because the report prints the statement either way and the reader checks the arithmetic.
+    These tests pin the refusals — at construction, so a defect fails where it is made, and in
+    `from_json`, so a stored file cannot smuggle one in past the constructor.
+    """
+
+    def test_a_rate_origin_outside_the_chain_is_refused(self):
+        """An unknown origin used to read as "configuration", the best-sourced of the three."""
+        from hisim.economics.results import RateOrigin, ResolvedRate
+
+        assert ResolvedRate.from_json({"rate": 0.02, "origin": "country defaults"}).origin is (
+            RateOrigin.COUNTRY_DEFAULTS
+        )
+        with pytest.raises(ValueError, match="not a step of the escalation fallback chain"):
+            ResolvedRate.from_json({"rate": 0.02, "origin": "vibes"})
+
+    def test_a_resolved_rate_round_trips_through_its_enum(self):
+        """The JSON stays the same word it always was, so stored results keep loading."""
+        from hisim.economics.results import RateOrigin, ResolvedRate
+
+        rate = ResolvedRate(rate=0.03, origin=RateOrigin.GENERAL_FALLBACK, source_ids=["x"])
+        assert rate.to_json()["origin"] == "general fallback"
+        assert ResolvedRate.from_json(rate.to_json()) == rate
+
+    @staticmethod
+    def _contract(kind, rate=0.082):
+        """A flat electricity contract with the given feed-in terms."""
+        from hisim.economics.tariffs import FeedIn, SupplyKind, TariffContract, TariffSupply
+
+        return TariffContract(
+            id="TEST_FLAT",
+            carrier=EnergyCarrier.ELECTRICITY,
+            country="DE",
+            region=None,
+            valid_from_year=2024,
+            supply=TariffSupply(
+                kind=SupplyKind.FLAT, working_price_in_euro_per_kwh=UncertainValue.exact(0.32)
+            ),
+            standing_charge_in_euro_per_year=UncertainValue.exact(120.0),
+            feed_in=FeedIn(kind=kind, rate_in_euro_per_kwh=UncertainValue.exact(rate)),
+            source_ids=("src:1",),
+        )
+
+    def test_the_tariff_record_is_built_from_the_contract_and_round_trips(self):
+        """One builder, so the kind and the rate cannot be filled inconsistently by hand."""
+        from hisim.economics.results import TariffAssumption
+        from hisim.economics.tariffs import FeedInKind
+
+        assumption = TariffAssumption.from_contract(self._contract(FeedInKind.FIXED_TARIFF))
+        assert assumption.feed_in_kind is FeedInKind.FIXED_TARIFF
+        assert assumption.feed_in_rate_in_euro_per_kwh is not None
+        assert assumption.feed_in_rate_in_euro_per_kwh.best_estimate == pytest.approx(0.082)
+        assert assumption.to_json()["feed_in_kind"] == "FIXED_TARIFF"
+        assert TariffAssumption.from_json(assumption.to_json()) == assumption
+
+    def test_a_contract_without_feed_in_carries_no_rate(self):
+        """`NONE` with a rate would publish a price nothing was ever paid at."""
+        from hisim.economics.results import TariffAssumption
+        from hisim.economics.tariffs import FeedInKind
+
+        assumption = TariffAssumption.from_contract(self._contract(FeedInKind.NONE))
+        assert assumption.feed_in_rate_in_euro_per_kwh is None
+        assert TariffAssumption.from_json(assumption.to_json()) == assumption
+
+    @pytest.mark.parametrize(
+        "kind_value,rate",
+        [("FIXED_TARIFF", None), ("NONE", {"min": 0.08, "best_estimate": 0.08, "max": 0.08})],
+    )
+    def test_a_feed_in_kind_and_rate_that_disagree_are_refused(self, kind_value, rate):
+        """The assumptions table prints the two as one row; either half alone cannot be read."""
+        from hisim.economics.results import TariffAssumption
+
+        raw = {
+            "carrier": "ELECTRICITY",
+            "contract_id": "TEST_FLAT",
+            "working_price_in_euro_per_kwh": 0.32,
+            "standing_charge_in_euro_per_year": 120.0,
+            "feed_in_kind": kind_value,
+            "feed_in_rate_in_euro_per_kwh": rate,
+        }
+        with pytest.raises(ValueError, match="feed_in_kind"):
+            TariffAssumption.from_json(raw)
+
+    def test_an_unknown_feed_in_kind_is_refused(self):
+        """The kind selects how the export revenue was computed; an unknown one is not a fact."""
+        from hisim.economics.results import TariffAssumption
+
+        with pytest.raises(ValueError, match="not a feed-in remuneration structure"):
+            TariffAssumption.from_json(
+                {
+                    "carrier": "ELECTRICITY",
+                    "contract_id": "TEST_FLAT",
+                    "working_price_in_euro_per_kwh": 0.32,
+                    "standing_charge_in_euro_per_year": 120.0,
+                    "feed_in_kind": "BARTER",
+                }
+            )
+
+    def test_the_levy_verdicts_are_keyed_by_slot_on_both_sides(self):
+        """Slot keys travel as their values, and an unknown key is a verdict nobody would read."""
+        from hisim.economics.results import LevyBindingMechanism, ModernizationLevySummary
+
+        summary = ModernizationLevySummary(
+            annual_amount_in_euro=UncertainValue.exact(1800.0),
+            general_leg_in_euro=UncertainValue.exact(1200.0),
+            heating_leg_in_euro=UncertainValue.exact(600.0),
+            cap_in_euro_per_m2_per_month=3.0,
+            binding_mechanism_by_slot={
+                Slot.BEST_ESTIMATE: f"{LevyBindingMechanism.GENERAL_CAP} 3.00 EUR/m2*mo"
+            },
+        )
+        assert summary.cap_binding_in_best_estimate
+        assert summary.to_json()["binding_mechanism_by_slot"] == {
+            "best_estimate": "§559 general cap 3.00 EUR/m2*mo"
+        }
+        assert ModernizationLevySummary.from_json(summary.to_json()) == summary
+        with pytest.raises(ValueError, match="keyed by evaluation slot"):
+            ModernizationLevySummary.from_json(
+                {**summary.to_json(), "binding_mechanism_by_slot": {"average": "whatever"}}
+            )
+
+    def test_the_headline_cap_answer_is_derived_from_the_verdicts(self):
+        """No stored flag to disagree with the verdict it summarizes."""
+        from hisim.economics.results import LevyBindingMechanism, ModernizationLevySummary
+
+        def summary(verdict):
+            return ModernizationLevySummary(
+                annual_amount_in_euro=UncertainValue.exact(100.0),
+                general_leg_in_euro=UncertainValue.exact(100.0),
+                heating_leg_in_euro=UncertainValue.exact(0.0),
+                binding_mechanism_by_slot={Slot.BEST_ESTIMATE: verdict},
+            )
+
+        assert summary(f"{LevyBindingMechanism.HEATING_CAP} 0.50 EUR/m2*mo").cap_binding_in_best_estimate
+        assert not summary(f"8% {LevyBindingMechanism.RATE_BELOW_CAP}").cap_binding_in_best_estimate
+        # No verdict at all (no living area, no cap evaluated) is not "a cap decided it".
+        assert not ModernizationLevySummary(
+            annual_amount_in_euro=UncertainValue.exact(100.0),
+            general_leg_in_euro=UncertainValue.exact(100.0),
+            heating_leg_in_euro=UncertainValue.exact(0.0),
+        ).cap_binding_in_best_estimate
+
+    def test_an_embodied_co2_basis_that_does_not_multiply_out_is_refused(self):
+        """The record is printed *as* the multiplication, so the three numbers are one statement."""
+        from hisim.economics.results import EmbodiedCo2Basis
+
+        basis = EmbodiedCo2Basis(
+            factor_in_kg_per_unit=120.0, size=10.0, size_unit="kW", per_installation_in_kg=1200.0
+        )
+        assert EmbodiedCo2Basis.from_json(basis.to_json()) == basis
+        with pytest.raises(ValueError, match="per installation"):
+            EmbodiedCo2Basis(
+                factor_in_kg_per_unit=120.0, size=10.0, size_unit="kW", per_installation_in_kg=999.0
+            )
+        with pytest.raises(ValueError, match="per installation"):
+            EmbodiedCo2Basis.from_json({**basis.to_json(), "per_installation_in_kg": 999.0})
+
+    def test_a_negative_energy_attribution_is_refused_on_both_sides_of_the_round_trip(self):
+        """Direction is the role, so a negative kWh would be drawn on the wrong side of the bus."""
+        from hisim.economics.calculators.aggregation import annual_energy_attribution
+        from hisim.economics.serialization import _attribution_from_json, inputs_from_json
+
+        with pytest.raises(ValueError, match="carries negative energy"):
+            inputs_from_json(
+                {
+                    "simulation_year": 2024,
+                    "simulated_period_fraction": 1.0,
+                    "energy_attribution_by_subject_in_kwh": {"PVSystem": {"PV_GENERATION": -5.0}},
+                }
+            )
+        with pytest.raises(ValueError, match="carries negative energy"):
+            annual_energy_attribution({"PVSystem": {"PV_GENERATION": -5.0}}, 1.0)
+        # The result side reads its (annualized) map through the same guarded helper.
+        with pytest.raises(ValueError, match="carries negative energy"):
+            _attribution_from_json(
+                {"annual_energy_attribution_by_subject_in_kwh": {"PVSystem": {"PV_GENERATION": -5.0}}},
+                "annual_energy_attribution_by_subject_in_kwh",
+                "LifecycleCostResult.annual_energy_attribution_by_subject_in_kwh",
+            )

--- a/tests/test_economics_data_serialization.py
+++ b/tests/test_economics_data_serialization.py
@@ -549,6 +549,141 @@ class TestSerializationRoundtrip:
         )
         assert context.building.existing_heating is None
 
+    def test_roundtrip_preserves_the_per_subject_energy_attribution(self, tmp_path):
+        """The energy-balance flows survive `economic_inputs.json` and reach the result again.
+
+        Nothing prices this map, so a writer that dropped it would leave every published figure
+        untouched and only the household energy balance would quietly disappear from a report
+        rendered off an archived run — the exact failure mode an additive field invites. The
+        fraction is 0.5, so the reloaded values are also visibly annualized rather than copied.
+        """
+        from hisim.economics.serialization import read_inputs, write_inputs
+
+        inputs = self._inputs()
+        inputs.energy_attribution_by_subject_in_kwh = {
+            "ElectricityMeter": {"GRID_IMPORT": 2500.0, "GRID_EXPORT": 100.0},
+            "Battery": {"BATTERY_CHARGE": 400.0, "BATTERY_DISCHARGE": 340.0},
+        }
+        write_inputs(inputs, str(tmp_path))
+        reloaded = read_inputs(str(tmp_path))
+        assert reloaded.energy_attribution_by_subject_in_kwh == inputs.energy_attribution_by_subject_in_kwh
+        parameters = EconomicParameters(price_basis_year=2024)
+        perspective = Perspective(
+            id="gross", installation_context=InstallationContext.GREENFIELD, subsidy_mode=SubsidyMode.none()
+        )
+        result = EconomicEvaluator(CostDatabase(), parameters).evaluate(reloaded, perspective)
+        assert result.energy_attribution_by_subject_in_kwh["Battery"]["BATTERY_CHARGE"] == pytest.approx(800.0)
+
+    def test_an_extract_without_the_attribution_key_still_reads(self):
+        """Every additive field defaults to empty, so an archive written before it still loads."""
+        from hisim.economics.serialization import inputs_from_json
+
+        restored = inputs_from_json({"simulation_year": 2024, "simulated_period_fraction": 1.0})
+        assert restored.energy_attribution_by_subject_in_kwh == {}
+
+    def test_result_roundtrip_preserves_the_additive_result_fields(self, tmp_path):
+        """The result fields the report reads survive `lifecycle_costs.json` unchanged.
+
+        One assertion per group added on the result side — the energy attribution, the anyway
+        share with its basis, the levy verdict and the resolved assumptions — because each of them
+        is read by exactly one section of the report and a lost one is invisible everywhere else.
+        """
+        from hisim.economics.exports import write_lifecycle_costs_json
+        from hisim.economics.results import (
+            EconomicAssumptions,
+            EmbodiedCo2Basis,
+            EvaluationMatrix,
+            ModernizationLevySummary,
+            RateOrigin,
+            ResolvedRate,
+        )
+        from hisim.economics.serialization import read_results
+
+        parameters = EconomicParameters(price_basis_year=2024)
+        perspective = Perspective(
+            id="gross", installation_context=InstallationContext.GREENFIELD, subsidy_mode=SubsidyMode.none()
+        )
+        result = EconomicEvaluator(CostDatabase(), parameters).evaluate(self._inputs(), perspective)
+        result.energy_attribution_by_subject_in_kwh = {"PVSystem": {"PV_GENERATION": 4200.0}}
+        result.anyway_share_by_subject = {"HeatPump": 0.3}
+        result.anyway_basis_by_subject = {"HeatPump": 9000.0}
+        result.modernization_levy = ModernizationLevySummary(
+            annual_amount_in_euro=UncertainValue.exact(1800.0),
+            general_leg_in_euro=UncertainValue.exact(1200.0),
+            heating_leg_in_euro=UncertainValue.exact(600.0),
+            cap_binding=True,
+            cap_in_euro_per_m2_per_month=3.0,
+            binding_mechanism_by_slot={"best_estimate": "§559 general cap 3.00 EUR/m2*mo"},
+        )
+        result.assumptions = EconomicAssumptions(
+            escalation_rates={"general": ResolvedRate(rate=0.02, origin=RateOrigin.COUNTRY_DEFAULTS)},
+            annual_heat_demand_in_kwh=15000.0,
+        )
+        result.lifecycle_co2_result.emission_factor_by_carrier_in_kg_per_kwh = {"ELECTRICITY": 0.38}
+        result.lifecycle_co2_result.embodied_basis_by_subject = {
+            "HeatPump": EmbodiedCo2Basis(
+                factor_in_kg_per_unit=120.0,
+                size=10.0,
+                size_unit="kW",
+                per_installation_in_kg=1200.0,
+                installations=2,
+            )
+        }
+
+        write_lifecycle_costs_json(EvaluationMatrix(results={"gross": result}), str(tmp_path))
+        restored = read_results(str(tmp_path))
+        assert restored is not None
+        reloaded = restored.results["gross"]
+        assert reloaded.energy_attribution_by_subject_in_kwh == {"PVSystem": {"PV_GENERATION": 4200.0}}
+        assert reloaded.anyway_share_by_subject == {"HeatPump": 0.3}
+        assert reloaded.anyway_basis_by_subject == {"HeatPump": 9000.0}
+        assert reloaded.modernization_levy is not None
+        assert reloaded.modernization_levy.cap_binding
+        assert reloaded.modernization_levy.binding_mechanism_by_slot["best_estimate"].startswith("§559")
+        assert reloaded.assumptions is not None
+        assert reloaded.assumptions.escalation_rates["general"].origin == RateOrigin.COUNTRY_DEFAULTS
+        assert reloaded.assumptions.annual_heat_demand_in_kwh == pytest.approx(15000.0)
+        assert reloaded.lifecycle_co2_result.emission_factor_by_carrier_in_kg_per_kwh == {"ELECTRICITY": 0.38}
+        assert reloaded.lifecycle_co2_result.embodied_basis_by_subject["HeatPump"].installations == 2
+
+    def test_a_result_written_before_the_additive_fields_still_reads(self, tmp_path):
+        """A stored result missing every new key loads with empty/None, never with an invention."""
+        import json
+
+        from hisim.economics.exports import write_lifecycle_costs_json
+        from hisim.economics.results import EvaluationMatrix
+        from hisim.economics.serialization import read_results
+
+        parameters = EconomicParameters(price_basis_year=2024)
+        perspective = Perspective(
+            id="gross", installation_context=InstallationContext.GREENFIELD, subsidy_mode=SubsidyMode.none()
+        )
+        result = EconomicEvaluator(CostDatabase(), parameters).evaluate(self._inputs(), perspective)
+        write_lifecycle_costs_json(EvaluationMatrix(results={"gross": result}), str(tmp_path))
+        path = os.path.join(str(tmp_path), "lifecycle_costs.json")
+        with open(path, encoding="utf-8") as file:
+            raw = json.load(file)
+        for key in (
+            "energy_attribution_by_subject_in_kwh",
+            "anyway_share_by_subject",
+            "anyway_basis_by_subject",
+            "modernization_levy",
+            "assumptions",
+        ):
+            raw["gross"].pop(key, None)
+        raw["gross"]["lifecycle_co2"].pop("emission_factor_by_carrier_in_kg_per_kwh", None)
+        raw["gross"]["lifecycle_co2"].pop("embodied_basis_by_subject", None)
+        with open(path, "w", encoding="utf-8") as file:
+            json.dump(raw, file)
+        reloaded = read_results(str(tmp_path))
+        assert reloaded is not None
+        older = reloaded.results["gross"]
+        assert older.energy_attribution_by_subject_in_kwh == {}
+        assert older.anyway_share_by_subject == {} and older.anyway_basis_by_subject == {}
+        assert older.modernization_levy is None and older.assumptions is None
+        assert older.lifecycle_co2_result.emission_factor_by_carrier_in_kg_per_kwh == {}
+        assert older.lifecycle_co2_result.embodied_basis_by_subject == {}
+
 
 class TestVariantComparison:
     """§3.7 differential analysis."""

--- a/tests/test_economics_engine.py
+++ b/tests/test_economics_engine.py
@@ -394,6 +394,79 @@ class TestBrownfieldAndStatusQuo:
         like_for_like = database.get_device_entry(ComponentType.GAS_HEATER, 2024, "DE").investment_for_size(15.0)
         assert result.sunk_cost_written_off_in_euro.best_estimate == pytest.approx(like_for_like.best_estimate / 18.0)
 
+    def test_the_anyway_share_scales_the_credit(self, database):
+        """`credit = share x like-for-like cost`, and the default 1.0 is the old behaviour.
+
+        The methodology fix. Before it, replacing an existing asset credited **100 %** of the
+        like-for-like replacement against the measure, whatever the measure was — which credited a
+        first-time facade insulation with the full price of the insulation, against a facade that
+        would only ever have been repaired. The share is the fraction the counterfactual would
+        truly have spent, and this pins both that it is applied and that leaving it at its default
+        reproduces the previous figure exactly.
+        """
+        params = zero_rate_parameters(horizon=20)
+        evaluator = EconomicEvaluator(database, params)
+
+        def credit_at(share: float) -> float:
+            """The ANYWAY_COST_CREDIT NPV of the standard replacement case at the given share."""
+            register = self._register(age_years=17, replaced=True)
+            register.assets[0].anyway_share = share
+            inputs = EvaluationInputs(
+                simulation_year=2024,
+                simulated_period_fraction=1.0,
+                cost_facts=[SubjectCostFacts("HeatPump", make_facts(16000.0, 18.0))],
+                existing_assets=register,
+            )
+            perspective = Perspective(
+                id="brownfield",
+                installation_context=InstallationContext.BROWNFIELD,
+                subsidy_mode=SubsidyMode.none(),
+            )
+            result = evaluator.evaluate(inputs, perspective)
+            return result.npv_by_category[CostCategory.ANYWAY_COST_CREDIT].best_estimate
+
+        full = credit_at(1.0)
+        third = credit_at(0.3)
+        assert third == pytest.approx(full * 0.3)
+        assert full < 0  # a credit, cost-negative
+
+    def test_the_applied_anyway_share_reaches_the_result_and_the_ledger(self, database):
+        """The share is disclosed, not just applied: on the result and in the provenance trail."""
+        from hisim.economics.provenance import ProvenanceLedger
+
+        params = zero_rate_parameters(horizon=20)
+        evaluator = EconomicEvaluator(database, params)
+        register = self._register(age_years=17, replaced=True)
+        register.assets[0].anyway_share = 0.3
+        inputs = EvaluationInputs(
+            simulation_year=2024,
+            simulated_period_fraction=1.0,
+            cost_facts=[SubjectCostFacts("HeatPump", make_facts(16000.0, 18.0))],
+            existing_assets=register,
+        )
+        perspective = Perspective(
+            id="brownfield", installation_context=InstallationContext.BROWNFIELD, subsidy_mode=SubsidyMode.none()
+        )
+        ledger = ProvenanceLedger()
+        result = evaluator.evaluate(inputs, perspective, ledger)
+        assert result.anyway_share_by_subject == {"HeatPump": 0.3}
+        credit = -result.npv_by_category[CostCategory.ANYWAY_COST_CREDIT].best_estimate
+        assert result.anyway_basis_by_subject["HeatPump"] == pytest.approx(credit / 0.3)
+        details = [record.detail or "" for record in ledger.records]
+        assert any("anyway credit = 30% x like-for-like cost" in detail for detail in details), details
+
+    def test_an_anyway_share_outside_the_unit_interval_is_refused(self):
+        """A share of 0, a negative one or one above 1 is a data error, named at the asset."""
+        for share in (0.0, -0.2, 1.5, float("nan")):
+            with pytest.raises(ValueError, match="anyway_share"):
+                ExistingAsset(
+                    asset_class=ComponentType.GAS_HEATER,
+                    size=15.0,
+                    size_unit=Units.KILOWATT,
+                    installation_year=2010,
+                    anyway_share=share,
+                )
+
     def test_kept_asset_outliving_the_horizon_earns_no_residual(self, database):
         """A kept asset whose install was never charged gets no year-T residual (§3.6 rule 3).
 

--- a/tests/test_economics_engine.py
+++ b/tests/test_economics_engine.py
@@ -429,6 +429,20 @@ class TestBrownfieldAndStatusQuo:
         third = credit_at(0.3)
         assert third == pytest.approx(full * 0.3)
         assert full < 0  # a credit, cost-negative
+        # Linearity alone would survive a wrong basis — both figures would simply be wrong by the
+        # same factor — so the basis itself is computed here from the database entry the code
+        # documents it reads: the like-for-like replacement of the registered 15 kW gas boiler,
+        # escalated to the credit year at the investment rate. The register's boiler is 17 years
+        # into an 18-year service life, so the credit falls in year 1; `zero_rate_parameters`
+        # switches the escalation off and the shipped per-asset-class table is empty by design
+        # (spec Q2), which makes that escalation the identity and is asserted rather than assumed.
+        assert database.get_escalation_defaults("DE").asset_class_rates == {}
+        like_for_like = database.get_device_entry(
+            ComponentType.GAS_HEATER, 2024, "DE"
+        ).investment_for_size(15.0)
+        escalated = like_for_like.best_estimate * (1.0 + params.investment_price_escalation_rate) ** 1
+        assert -full == pytest.approx(escalated)
+        assert -third == pytest.approx(escalated * 0.3)
 
     def test_the_applied_anyway_share_reaches_the_result_and_the_ledger(self, database):
         """The share is disclosed, not just applied: on the result and in the provenance trail."""

--- a/tests/test_economics_engine_actors.py
+++ b/tests/test_economics_engine_actors.py
@@ -309,6 +309,68 @@ class TestHeatingModernizationLevy:
         assert outcome.general_levy_in_euro.best_estimate == pytest.approx(0.0)
         assert outcome.total_in_euro.best_estimate == pytest.approx(300.0)
 
+    def test_the_binding_mechanism_is_recorded_per_world(self):
+        """The caps apply per slot, so the verdict is per slot too.
+
+        A banded basis whose general cap binds in the expensive world and not in the cheap one is
+        the case a single best-estimate-slot flag cannot describe, and it is the case a landlord
+        most needs described: in one world spending more raises the rent, in the other it does
+        not. The basis here is 20,000 / 40,000 / 60,000, so §559's 8 % gives 1,600 / 3,200 / 4,800
+        EUR/a against a 3,600 EUR/a ceiling — below it, below it, above it.
+        """
+        from hisim.economics.actors import (
+            DE2024Ruleset,
+            LevyBindingMechanism,
+            ModernizationLevySubjectBasis,
+        )
+
+        ruleset = DE2024Ruleset.load()
+        banded = ModernizationLevySubjectBasis(
+            subject="wall.subject",
+            asset_class_name="WALL_INSULATION",
+            modernization_cost_in_euro=UncertainValue(
+                minimum=20000.0, best_estimate=40000.0, maximum=60000.0
+            ),
+        )
+        outcome = ruleset.compute_modernization_levy(self._context([banded]))
+        verdicts = outcome.binding_mechanism_by_slot
+        assert set(verdicts) == {"low", "best_estimate", "high"}
+        assert LevyBindingMechanism.RATE_BELOW_CAP in verdicts["low"]
+        assert verdicts["low"].startswith("8%")
+        assert LevyBindingMechanism.RATE_BELOW_CAP in verdicts["best_estimate"]
+        assert verdicts["high"].startswith(LevyBindingMechanism.GENERAL_CAP)
+        assert "3.00 EUR/m2*mo" in verdicts["high"]
+        # The cheap world is uncapped, so its levy is exactly the percentage of its own basis.
+        assert outcome.total_in_euro.minimum == pytest.approx(1600.0)
+        assert outcome.total_in_euro.maximum == pytest.approx(3600.0)
+        assert outcome.cap_in_euro_per_m2_per_month == pytest.approx(3.0)
+
+    def test_the_heating_cap_is_named_when_it_is_the_binding_one(self):
+        """A pure §559e package above its own ceiling names that ceiling, not the general one."""
+        from hisim.economics.actors import DE2024Ruleset, LevyBindingMechanism
+
+        ruleset = DE2024Ruleset.load()
+        # 40,000 x 10 % = 4,000 EUR/a, cut to the 600 EUR/a §559e ceiling; §559 leg is empty.
+        outcome = ruleset.compute_modernization_levy(
+            self._context([self._measure("HEAT_PUMP", 40000.0)])
+        )
+        assert outcome.cap_binding
+        assert outcome.binding_mechanism_by_slot["best_estimate"].startswith(
+            LevyBindingMechanism.HEATING_CAP
+        )
+        assert "0.50 EUR/m2*mo" in outcome.binding_mechanism_by_slot["best_estimate"]
+
+    def test_a_levy_without_a_living_area_records_no_verdict(self):
+        """No living area means no cap could be evaluated, so there is nothing to state."""
+        from hisim.economics.actors import DE2024Ruleset
+
+        ruleset = DE2024Ruleset.load()
+        context = self._context([self._measure("HEAT_PUMP", 40000.0)], living_area=None)
+        outcome = ruleset.compute_modernization_levy(context)
+        assert outcome.binding_mechanism_by_slot == {}
+        assert not outcome.cap_binding
+        assert outcome.cap_in_euro_per_m2_per_month is None
+
     def test_pure_heating_package_is_capped_at_fifty_cents_per_m2_and_month(self):
         """The §559e cap binds long before the general one: 0.50 x 12 x 100 = 600 EUR/a."""
         from hisim.economics.actors import DE2024Ruleset
@@ -518,6 +580,53 @@ class TestResultQuantities:
         assert result.reference_areas.living_area_in_m2 == pytest.approx(100.0)
         # Living area wins for per-area figures (the precedence the reports have always used).
         assert result.reference_areas.preferred() == pytest.approx(100.0)
+
+    def test_the_energy_attribution_is_annualized_with_the_carriers_divisor(self, database):
+        """A partial year scales the per-device kWh by exactly the same factor as the meters'.
+
+        The household energy balance compares its grid nodes against the metered carrier
+        quantities, so the two must be annualized by one divisor or the chart would not reconcile
+        with the table beside it. A quarter-year run is the sharpest case: the two sides differ by
+        a factor of four if either forgets, and the assertion below pins both at once.
+        """
+        params = zero_rate_parameters(horizon=10)
+        evaluator = EconomicEvaluator(database, params)
+        inputs = EvaluationInputs(
+            simulation_year=2024,
+            simulated_period_fraction=0.25,
+            cost_facts=[SubjectCostFacts("Device", make_facts(1000.0, 10.0))],
+            billing=[
+                BillingDeterminants(
+                    carrier=EnergyCarrier.ELECTRICITY, energy_bought_in_kwh=500.0
+                )
+            ],
+            energy_attribution_by_subject_in_kwh={
+                "ElectricityMeter": {"GRID_IMPORT": 500.0, "GRID_EXPORT": 120.0},
+                "PVSystem": {"PV_GENERATION": 900.0},
+            },
+        )
+        result = evaluator.evaluate(inputs, GREENFIELD_GROSS)
+        attribution = result.energy_attribution_by_subject_in_kwh
+        assert attribution["ElectricityMeter"]["GRID_IMPORT"] == pytest.approx(2000.0)
+        assert attribution["ElectricityMeter"]["GRID_EXPORT"] == pytest.approx(480.0)
+        assert attribution["PVSystem"]["PV_GENERATION"] == pytest.approx(3600.0)
+        # The metered carrier total and the meter's own role scale by the identical divisor.
+        assert result.annual_energy_quantities_by_carrier["ELECTRICITY"].bought_in_kwh == pytest.approx(
+            attribution["ElectricityMeter"]["GRID_IMPORT"]
+        )
+
+    def test_a_run_without_an_energy_attribution_reports_an_empty_map(self, database):
+        """The field is additive: an extract that carries none yields none, never a guess."""
+        params = zero_rate_parameters(horizon=10)
+        evaluator = EconomicEvaluator(database, params)
+        inputs = EvaluationInputs(
+            simulation_year=2024,
+            simulated_period_fraction=1.0,
+            cost_facts=[SubjectCostFacts("Device", make_facts(1000.0, 10.0))],
+        )
+        result = evaluator.evaluate(inputs, GREENFIELD_GROSS)
+        assert result.energy_attribution_by_subject_in_kwh == {}
+        assert result.to_json()["energy_attribution_by_subject_in_kwh"] == {}
 
     def test_quantities_are_serialized_additively(self, database):
         """lifecycle_costs.json gains the new fields without losing any existing one."""

--- a/tests/test_economics_engine_actors.py
+++ b/tests/test_economics_engine_actors.py
@@ -29,7 +29,7 @@ from hisim.economics.timeline import (
     CashFlowTimeline,
     CostCategory,
 )
-from hisim.economics.uncertainty import UncertainValue
+from hisim.economics.uncertainty import Slot, UncertainValue
 from hisim.loadtypes import ComponentType, Units
 
 pytestmark = pytest.mark.base
@@ -334,12 +334,12 @@ class TestHeatingModernizationLevy:
         )
         outcome = ruleset.compute_modernization_levy(self._context([banded]))
         verdicts = outcome.binding_mechanism_by_slot
-        assert set(verdicts) == {"low", "best_estimate", "high"}
-        assert LevyBindingMechanism.RATE_BELOW_CAP in verdicts["low"]
-        assert verdicts["low"].startswith("8%")
-        assert LevyBindingMechanism.RATE_BELOW_CAP in verdicts["best_estimate"]
-        assert verdicts["high"].startswith(LevyBindingMechanism.GENERAL_CAP)
-        assert "3.00 EUR/m2*mo" in verdicts["high"]
+        assert set(verdicts) == {Slot.LOW, Slot.BEST_ESTIMATE, Slot.HIGH}
+        assert LevyBindingMechanism.RATE_BELOW_CAP in verdicts[Slot.LOW]
+        assert verdicts[Slot.LOW].startswith("8%")
+        assert LevyBindingMechanism.RATE_BELOW_CAP in verdicts[Slot.BEST_ESTIMATE]
+        assert verdicts[Slot.HIGH].startswith(LevyBindingMechanism.GENERAL_CAP)
+        assert "3.00 EUR/m2*mo" in verdicts[Slot.HIGH]
         # The cheap world is uncapped, so its levy is exactly the percentage of its own basis.
         assert outcome.total_in_euro.minimum == pytest.approx(1600.0)
         assert outcome.total_in_euro.maximum == pytest.approx(3600.0)
@@ -354,11 +354,112 @@ class TestHeatingModernizationLevy:
         outcome = ruleset.compute_modernization_levy(
             self._context([self._measure("HEAT_PUMP", 40000.0)])
         )
-        assert outcome.cap_binding
-        assert outcome.binding_mechanism_by_slot["best_estimate"].startswith(
-            LevyBindingMechanism.HEATING_CAP
+        verdict = outcome.binding_mechanism_by_slot[Slot.BEST_ESTIMATE]
+        assert LevyBindingMechanism.names_a_cap(verdict)
+        assert verdict == f"{LevyBindingMechanism.HEATING_CAP} 0.50 EUR/m2*mo"
+
+    def test_the_heating_cap_is_named_even_when_the_general_leg_survives(self):
+        """The bug: a cut heating leg beside a surviving general leg named the *general* cap.
+
+        The old rule reported the §559e ceiling only when the general leg came out at zero, so the
+        commonest mixed package — a heat pump above its own ceiling plus insulation comfortably
+        below the general one — told the landlord that §559 Abs. 3a had decided the rent increase.
+        It had not: the §559e cap is 0.50 EUR/m²·month against §559's 3.00, so the reader was
+        pointed at the wrong paragraph and at a ceiling six times higher than the one that bound.
+
+        40,000 EUR of heat pump gives a 4,000 EUR/a §559e leg, cut to 600; 30,000 EUR of wall
+        insulation gives a 2,400 EUR/a §559 leg against the 3,000 EUR/a the general cap leaves.
+        """
+        from hisim.economics.actors import DE2024Ruleset, LevyBindingMechanism
+
+        ruleset = DE2024Ruleset.load()
+        outcome = ruleset.compute_modernization_levy(
+            self._context(
+                [
+                    self._measure("HEAT_PUMP", 40000.0),
+                    self._measure("WALL_INSULATION", 30000.0),
+                ]
+            )
         )
-        assert "0.50 EUR/m2*mo" in outcome.binding_mechanism_by_slot["best_estimate"]
+        assert outcome.heating_levy_in_euro.best_estimate == pytest.approx(600.0)
+        assert outcome.general_levy_in_euro.best_estimate == pytest.approx(2400.0)
+        assert outcome.binding_mechanism_by_slot[Slot.BEST_ESTIMATE] == (
+            f"{LevyBindingMechanism.HEATING_CAP} 0.50 EUR/m2*mo"
+        )
+
+    def test_both_caps_are_named_when_both_removed_euros(self):
+        """Two ceilings cut the same world, so the verdict names both rather than the last one.
+
+        40,000 EUR of heat pump is cut from 4,000 to 600 by §559e; 50,000 EUR of insulation is cut
+        from 4,000 to the 3,000 the general cap leaves beside it. Naming only §559 would hide the
+        ceiling that is actually binding the heating measure the landlord is deciding about.
+        """
+        from hisim.economics.actors import DE2024Ruleset, LevyBindingMechanism
+
+        ruleset = DE2024Ruleset.load()
+        outcome = ruleset.compute_modernization_levy(
+            self._context(
+                [
+                    self._measure("HEAT_PUMP", 40000.0),
+                    self._measure("WALL_INSULATION", 50000.0),
+                ]
+            )
+        )
+        assert outcome.total_in_euro.best_estimate == pytest.approx(3600.0)
+        assert outcome.binding_mechanism_by_slot[Slot.BEST_ESTIMATE] == (
+            f"{LevyBindingMechanism.HEATING_CAP} 0.50 EUR/m2*mo"
+            f"{LevyBindingMechanism.BOTH_CAPS_JOINER}"
+            f"{LevyBindingMechanism.GENERAL_CAP} 3.00 EUR/m2*mo"
+        )
+
+    def test_the_general_cap_alone_is_named_when_only_it_cut(self):
+        """A package with no §559e measure can only ever be decided by the general ceiling."""
+        from hisim.economics.actors import DE2024Ruleset, LevyBindingMechanism
+
+        ruleset = DE2024Ruleset.load()
+        outcome = ruleset.compute_modernization_levy(
+            self._context([self._measure("WALL_INSULATION", 50000.0)])
+        )
+        assert outcome.binding_mechanism_by_slot[Slot.BEST_ESTIMATE] == (
+            f"{LevyBindingMechanism.GENERAL_CAP} 3.00 EUR/m2*mo"
+        )
+
+    def test_neither_cap_is_named_when_neither_cut(self):
+        """Below both ceilings the levy is the statutory percentage, and spending more raises it."""
+        from hisim.economics.actors import DE2024Ruleset, LevyBindingMechanism
+
+        ruleset = DE2024Ruleset.load()
+        outcome = ruleset.compute_modernization_levy(
+            self._context([self._measure("WALL_INSULATION", 20000.0)])
+        )
+        verdict = outcome.binding_mechanism_by_slot[Slot.BEST_ESTIMATE]
+        assert not LevyBindingMechanism.names_a_cap(verdict)
+        assert verdict == f"8% {LevyBindingMechanism.RATE_BELOW_CAP}"
+
+    def test_a_heating_cap_above_the_general_one_is_not_the_binding_ceiling(self):
+        """A leg is classified by the ceiling that produced its value, not by the one that exists.
+
+        The shipped parameters put the §559e ceiling far below the general one, so this ordering
+        never occurs in practice; a future data file could invert it, and then the euros a heating
+        leg loses are lost to §559 Abs. 3a and naming §559e would be simply false.
+        """
+        import dataclasses
+
+        from hisim.economics.actors import DE2024Ruleset, LevyBindingMechanism
+
+        shipped = DE2024Ruleset.load()
+        ruleset = DE2024Ruleset(
+            levy=dataclasses.replace(shipped.levy, heating_cap_in_euro_per_m2_per_month=9.0)
+        )
+        # Heating cap 9.00 -> 10,800 EUR/a, above the 3,600 EUR/a general cap, so the general one
+        # is what cuts the 4,000 EUR/a heating leg down to 3,600.
+        outcome = ruleset.compute_modernization_levy(
+            self._context([self._measure("HEAT_PUMP", 40000.0)])
+        )
+        assert outcome.heating_levy_in_euro.best_estimate == pytest.approx(3600.0)
+        assert outcome.binding_mechanism_by_slot[Slot.BEST_ESTIMATE] == (
+            f"{LevyBindingMechanism.GENERAL_CAP} 3.00 EUR/m2*mo"
+        )
 
     def test_a_levy_without_a_living_area_records_no_verdict(self):
         """No living area means no cap could be evaluated, so there is nothing to state."""
@@ -368,7 +469,6 @@ class TestHeatingModernizationLevy:
         context = self._context([self._measure("HEAT_PUMP", 40000.0)], living_area=None)
         outcome = ruleset.compute_modernization_levy(context)
         assert outcome.binding_mechanism_by_slot == {}
-        assert not outcome.cap_binding
         assert outcome.cap_in_euro_per_m2_per_month is None
 
     def test_pure_heating_package_is_capped_at_fifty_cents_per_m2_and_month(self):
@@ -606,7 +706,7 @@ class TestResultQuantities:
             },
         )
         result = evaluator.evaluate(inputs, GREENFIELD_GROSS)
-        attribution = result.energy_attribution_by_subject_in_kwh
+        attribution = result.annual_energy_attribution_by_subject_in_kwh
         assert attribution["ElectricityMeter"]["GRID_IMPORT"] == pytest.approx(2000.0)
         assert attribution["ElectricityMeter"]["GRID_EXPORT"] == pytest.approx(480.0)
         assert attribution["PVSystem"]["PV_GENERATION"] == pytest.approx(3600.0)
@@ -625,8 +725,8 @@ class TestResultQuantities:
             cost_facts=[SubjectCostFacts("Device", make_facts(1000.0, 10.0))],
         )
         result = evaluator.evaluate(inputs, GREENFIELD_GROSS)
-        assert result.energy_attribution_by_subject_in_kwh == {}
-        assert result.to_json()["energy_attribution_by_subject_in_kwh"] == {}
+        assert result.annual_energy_attribution_by_subject_in_kwh == {}
+        assert result.to_json()["annual_energy_attribution_by_subject_in_kwh"] == {}
 
     def test_quantities_are_serialized_additively(self, database):
         """lifecycle_costs.json gains the new fields without losing any existing one."""

--- a/tests/test_economics_engine_financing.py
+++ b/tests/test_economics_engine_financing.py
@@ -318,6 +318,45 @@ class TestOperationalCo2Accumulation:
         assert by_carrier == pytest.approx((100.0 + 250.0) * horizon)
         assert by_carrier == pytest.approx(sum(co2_result.operational_co2_by_year_in_kg))
 
+    def test_two_factors_for_one_carrier_are_refused(self):
+        """The published factor has to reproduce the published mass (review, agreed small fix).
+
+        The mass accumulates over records while the factor was assigned last-wins, so two meters
+        of one carrier at different factors left the CO2 section stating `factor x kWh` with a
+        factor that multiplies out to something other than the mass beside it. Two records at the
+        same factor are the ordinary case and stay legal; two at different factors are a data
+        state no single published factor can describe, and the run says so.
+        """
+        from hisim.economics.calculators.co2 import accumulate_operational_emissions
+        from hisim.economics.calculators.energy import CarrierEmissions, EnergyFlowResult
+        from hisim.economics.database import CostDataError
+        from hisim.economics.results import LifecycleCo2Result
+
+        def accumulate(second_factor):
+            energy_result = EnergyFlowResult(
+                emissions=[
+                    CarrierEmissions(
+                        carrier_value=EnergyCarrier.ELECTRICITY.value,
+                        annual_emissions_in_kg=100.0,
+                        emission_factor_in_kg_per_kwh=0.38,
+                    ),
+                    CarrierEmissions(
+                        carrier_value=EnergyCarrier.ELECTRICITY.value,
+                        annual_emissions_in_kg=250.0,
+                        emission_factor_in_kg_per_kwh=second_factor,
+                    ),
+                ]
+            )
+            co2_result = LifecycleCo2Result(operational_co2_by_year_in_kg=[0.0] * 6)
+            accumulate_operational_emissions(energy_result, co2_result, 5)
+            return co2_result
+
+        assert accumulate(0.38).emission_factor_by_carrier_in_kg_per_kwh == {
+            EnergyCarrier.ELECTRICITY.value: pytest.approx(0.38)
+        }
+        with pytest.raises(CostDataError, match="two different"):
+            accumulate(0.15)
+
 
 class TestSignValidation:
     """§3.9 / W3.7: cost positive, money arriving negative — enforced on `add`."""

--- a/tests/test_economics_envelope.py
+++ b/tests/test_economics_envelope.py
@@ -299,6 +299,47 @@ class TestEnvelopeTimeline:
         assert credit.minimum == pytest.approx(-gross.maximum * (1.0 - 0.4))
         assert credit.maximum == pytest.approx(-gross.minimum * (1.0 - 0.7))
 
+    def test_the_coupled_branch_names_its_own_basis_in_the_provenance(self, database):
+        """The credit's detail says what was multiplied, and the branches multiply different things.
+
+        (Review, agreed small fix.)
+
+        Both branches used to record "x like-for-like cost of <class>", which is true only of the
+        second: on this branch the basis is the *non-energy share of the measure being built now*,
+        not the cost of replacing the old element like for like. A reader reconciling the euro
+        figure against a like-for-like price would not find it.
+        """
+        from hisim.economics.provenance import ProvenanceLedger
+
+        overlaid = database.with_overlays(
+            {"devices_DE.WALL_EXTERNAL_INSULATION.energy_related_cost_share": 0.55},
+            "coupled_cost_provenance_test",
+        )
+        evaluator = EconomicEvaluator(overlaid, zero_rate_parameters())
+        register = ExistingAssetRegister(
+            assets=[
+                ExistingAsset(
+                    asset_class=ComponentType.WALL_EXTERNAL_INSULATION,
+                    size=100.0,
+                    size_unit=Units.SQUARE_METER,
+                    installation_year=2026 - 38,
+                    replaced_by_asset_classes=[ComponentType.WALL_EXTERNAL_INSULATION],
+                    anyway_share=0.4,
+                )
+            ]
+        )
+        inputs = EvaluationInputs(
+            simulation_year=2026,
+            simulated_period_fraction=1.0,
+            cost_facts=[SubjectCostFacts("Envelope.WallInsulation", wall_facts(100.0))],
+            existing_assets=register,
+        )
+        ledger = ProvenanceLedger()
+        evaluator.evaluate(inputs, BROWNFIELD, ledger)
+        details = [record.detail or "" for record in ledger.records]
+        assert any("40% x non-energy share of the measure" in detail for detail in details), details
+        assert not any("like-for-like cost of" in detail for detail in details), details
+
 
 class TestEnvelopeSubsidies:
     """BEG EM envelope schemes (15 % + 5 % iSFP, U-value conditions)."""

--- a/tests/test_economics_extraction.py
+++ b/tests/test_economics_extraction.py
@@ -43,8 +43,12 @@ nothing" answer still costs nothing.
 
 # clean
 
+import ast
 import datetime
+import importlib
 import json
+import os
+import re
 from typing import Any
 
 import pandas as pd
@@ -73,15 +77,28 @@ class _Output:
     nothing more than those two strings. Using a stub instead of the real class keeps the tests
     independent of whatever else `ComponentOutput` grows.
 
-    `unit` is optional because only the meters' own `get_energy_flow_facts` hooks read it — they
-    filter on `WATT_HOUR` so a same-named power output in watts can never be summed as energy —
-    while the bridge's positional lookup does not care.
+    `unit` defaults to `WATT_HOUR`, the unit every billable meter column is declared in, because
+    both summing paths now convert by the declared unit rather than assuming one: the meters' own
+    `get_energy_flow_facts` hooks filter on it so a same-named power output in watts can never be
+    summed as energy, and `bridge._sum_output_column` and `bridge._device_energy_flows` read it
+    through the same conversion table. A power column has to say so explicitly.
+
+    `load_type` is None unless a test declares one. Only the check that refuses a component class
+    missing from the energy-balance table reads it, and a stub with no declared load type is
+    exactly the "moves nothing the balance cares about" case that check has to let through.
     """
 
-    def __init__(self, component_name: str, field_name: str, unit: Any = None) -> None:
+    def __init__(
+        self,
+        component_name: str,
+        field_name: str,
+        unit: Any = lt.Units.WATT_HOUR,
+        load_type: Any = None,
+    ) -> None:
         self.component_name = component_name
         self.field_name = field_name
         self.unit = unit
+        self.load_type = load_type
 
 
 class _Wrapper:
@@ -537,8 +554,31 @@ class TestMeterExtraction:
         """The bridge sums the Wh column and scales by 1e-3; unknown outputs give None."""
         all_outputs = [_Output("Meter", "Other"), _Output("Meter", "ElectricityFromGrid")]
         results = _results_frame([("a", [1000.0, 2000.0, 0.0]), ("b", [500.0, 250.0, 250.0])])
-        assert _sum_output_column("Meter", "ElectricityFromGrid", all_outputs, results) == pytest.approx(1.0)
-        assert _sum_output_column("Meter", "Missing", all_outputs, results) is None
+        assert _sum_output_column(
+            "Meter", "ElectricityFromGrid", all_outputs, results, 900
+        ) == pytest.approx(1.0)
+        assert _sum_output_column("Meter", "Missing", all_outputs, results, 900) is None
+
+    def test_the_billing_sum_converts_by_the_declared_unit_like_the_balance_does(self):
+        """One conversion table for both paths, so a bill and a chart cannot disagree (review).
+
+        The billing sum used to hardcode `* 1e-3`, which is right for the Wh every shipped meter
+        column is declared in and wrong for anything else. Here the same column is declared in kWh
+        and in W, and the result follows the declaration rather than the old assumption.
+        """
+        results = _results_frame([("a", [1.5, 2.5])])
+        in_kwh = [_Output("Meter", "Column", unit=lt.Units.KWH)]
+        assert _sum_output_column("Meter", "Column", in_kwh, results, 900) == pytest.approx(4.0)
+        in_watt = [_Output("Meter", "Column", unit=lt.Units.WATT)]
+        # 4 W-steps of 900 s = 4 x 0.25 Wh = 1 Wh = 1e-3 kWh.
+        assert _sum_output_column("Meter", "Column", in_watt, results, 900) == pytest.approx(1e-3)
+
+    def test_a_meter_column_in_an_unconvertible_unit_is_refused(self):
+        """A degree Celsius is not energy, and billing it would be a number out of nowhere."""
+        results = _results_frame([("a", [1.0, 2.0])])
+        outputs = [_Output("Meter", "Column", unit=lt.Units.CELSIUS)]
+        with pytest.raises(CostDataError, match="neither an energy nor a power unit"):
+            _sum_output_column("Meter", "Column", outputs, results, 900)
 
     def test_electricity_meter_yields_bought_sold_and_peaks(self):
         """Bought/sold energy in kWh and the 15-minute peaks land on the determinants."""
@@ -546,7 +586,7 @@ class TestMeterExtraction:
         all_outputs = [
             _Output("ElectricityMeter", "ElectricityFromGrid"),
             _Output("ElectricityMeter", "ElectricityToGrid"),
-            _Output("ElectricityMeter", "ElectricityFromGridInWatt"),
+            _Output("ElectricityMeter", "ElectricityFromGridInWatt", unit=lt.Units.WATT),
         ]
         bought = [1000.0] * 24  # Wh per 15-min step -> 24 kWh
         sold = [500.0] * 24  # -> 12 kWh
@@ -766,7 +806,7 @@ class TestEnergyFlowHookAdoption:
     _ALL_OUTPUTS = [
         _Output("ElectricityMeter", "ElectricityFromGrid"),
         _Output("ElectricityMeter", "ElectricityToGrid"),
-        _Output("ElectricityMeter", "ElectricityFromGridInWatt"),
+        _Output("ElectricityMeter", "ElectricityFromGridInWatt", unit=lt.Units.WATT),
     ]
 
     @classmethod
@@ -981,21 +1021,25 @@ class _PvConfigStub:
         self.device_co2_footprint_in_kg = device_co2_footprint_in_kg
 
 
-def _device(class_name: str):
-    """A component stub whose *class name* is the one the energy-balance table keys on.
+def _device(class_name: str, **constants: str):
+    """A component stub carrying the class name and the output constants the table refers to.
 
-    `adapter.DeviceEnergySpecs` is keyed by class name, exactly like the cost-facts table, so the
-    class name is the whole contract a device has with the collector — and building the stub with
-    `type()` states that instead of hiding it behind a hand-written class whose name happens to
-    match. `component_name` is the only attribute the collector reads off the instance.
+    `adapter.DeviceEnergySpecs` is keyed by class name, exactly like the cost-facts table, and its
+    rows name *constants* on that class rather than column names, so a stub needs both halves of
+    the contract — and building it with `type()` states that instead of hiding it behind a
+    hand-written class whose name happens to match. `component_name` is the only attribute the
+    collector reads off the instance.
 
     Args:
         class_name: The component class name the table is expected to know.
+        **constants: The output-name constants the row names, mapped to the column names the real
+            class declares. `TestTheEnergyBalanceTableMatchesTheRealClasses` is what pins these
+            against the real classes; here they only have to exist.
 
     Returns:
         An instance of a freshly made class of that name.
     """
-    return type(class_name, (), {"component_name": class_name})()
+    return type(class_name, (), {"component_name": class_name, **constants})()
 
 
 class TestDeviceEnergyFlows:
@@ -1015,18 +1059,20 @@ class TestDeviceEnergyFlows:
 
     SECONDS_PER_TIMESTEP = 900
 
-    def _flows(self, component, columns):
+    def _flows(self, component, columns, load_type=None):
         """Runs the collector over one component and the columns it declares.
 
         Args:
             component: The stub component; its class name selects the declared specs.
             columns: `(field_name, unit, values)` triples, in the frame's column order.
+            load_type: The load type every declared column carries. Only the completeness check
+                reads it, so it stays None unless a test is about a class outside the table.
 
         Returns:
             The role -> kWh map the collector produced.
         """
         outputs = [
-            _Output(component.component_name, field_name, unit=unit)
+            _Output(component.component_name, field_name, unit=unit, load_type=load_type)
             for field_name, unit, _ in columns
         ]
         frame = _results_frame([(field_name, values) for field_name, _, values in columns])
@@ -1037,7 +1083,7 @@ class TestDeviceEnergyFlows:
     def test_watt_hours_are_divided_by_a_thousand(self):
         """A Wh channel is energy already: 1,000 + 2,000 + 3,000 Wh = 6 kWh."""
         flows = self._flows(
-            _device("PVSystem"),
+            _device("PVSystem", ElectricityEnergyOutput="ElectricityEnergyOutput"),
             [("ElectricityEnergyOutput", lt.Units.WATT_HOUR, [1000.0, 2000.0, 3000.0])],
         )
         assert flows == {"PV_GENERATION": pytest.approx(6.0)}
@@ -1045,7 +1091,11 @@ class TestDeviceEnergyFlows:
     def test_kilowatt_hours_are_taken_as_they_are(self):
         """A kWh channel needs no conversion; a second division would be a factor of 1,000."""
         flows = self._flows(
-            _device("ElectricityMeter"),
+            _device(
+                "ElectricityMeter",
+                ElectricityFromGrid="ElectricityFromGrid",
+                ElectricityToGrid="ElectricityToGrid",
+            ),
             [
                 ("ElectricityFromGrid", lt.Units.KWH, [1.5, 2.5]),
                 ("ElectricityToGrid", lt.Units.KWH, [0.25, 0.75]),
@@ -1054,9 +1104,17 @@ class TestDeviceEnergyFlows:
         assert flows == {"GRID_IMPORT": pytest.approx(4.0), "GRID_EXPORT": pytest.approx(1.0)}
 
     def test_watts_are_integrated_over_the_timestep(self):
-        """A power channel is integrated: 2 x 4,000 W over 900 s each = 2 kWh, not 8 kWh."""
+        """A power channel is integrated: 2 x 4,000 W over 900 s each = 2 kWh, not 8 kWh.
+
+        The column name also differs from the constant that names it, which is the case the
+        constant lookup exists for: the class calls the constant `ElectricalInputPowerTotal` and
+        writes the column `ElectricalInputPowerTotalHeatpump`.
+        """
         flows = self._flows(
-            _device("MoreAdvancedHeatPumpHPLib"),
+            _device(
+                "MoreAdvancedHeatPumpHPLib",
+                ElectricalInputPowerTotal="ElectricalInputPowerTotalHeatpump",
+            ),
             [("ElectricalInputPowerTotalHeatpump", lt.Units.WATT, [4000.0, 4000.0])],
         )
         assert flows == {"HEAT_PUMP_ELECTRICITY": pytest.approx(2.0)}
@@ -1069,7 +1127,7 @@ class TestDeviceEnergyFlows:
         the round-trip loss the balance exists to show.
         """
         flows = self._flows(
-            _device("Battery"),
+            _device("Battery", AcBatteryPowerUsed="AcBatteryPowerUsed"),
             [("AcBatteryPowerUsed", lt.Units.WATT, [4000.0, -2000.0, 1000.0])],
         )
         assert flows == {
@@ -1077,17 +1135,74 @@ class TestDeviceEnergyFlows:
             "BATTERY_DISCHARGE": pytest.approx(0.5),
         }
 
-    def test_an_unconvertible_unit_is_left_out_rather_than_guessed(self):
-        """A column declared in something that is neither energy nor power contributes nothing."""
+    def test_an_unconvertible_unit_is_refused_rather_than_guessed_or_dropped(self):
+        """A column that is neither energy nor power stops the run instead of vanishing.
+
+        It used to be logged and skipped, which is the failure this whole section is about: the
+        chart then draws a house with no PV and nothing on it says a column was dropped.
+        """
+        with pytest.raises(CostDataError, match="neither an energy nor a power unit"):
+            self._flows(
+                _device("PVSystem", ElectricityEnergyOutput="ElectricityEnergyOutput"),
+                [("ElectricityEnergyOutput", lt.Units.CELSIUS, [1000.0, 2000.0])],
+            )
+
+    def test_a_listed_column_this_run_did_not_produce_is_refused(self):
+        """A row naming a column the run does not contain is a renamed output, not an absence."""
+        with pytest.raises(CostDataError, match="which this run did not produce"):
+            self._flows(
+                _device("PVSystem", ElectricityEnergyOutput="ElectricityEnergyOutput"),
+                [("SomethingElse", lt.Units.WATT_HOUR, [1000.0])],
+            )
+
+    def test_a_row_naming_a_constant_the_class_does_not_declare_is_refused(self):
+        """The constant is the contract; a class that lost it cannot say which column to read."""
+        with pytest.raises(CostDataError, match="declares no output-name constant"):
+            self._flows(_device("PVSystem"), [("ElectricityEnergyOutput", lt.Units.WATT_HOUR, [1.0])])
+
+    def test_an_explicitly_empty_row_contributes_nothing_and_complains_about_nothing(self):
+        """A controller's watts are an instruction, and the empty row is that decision written down.
+
+        The EMS publishes electricity in watts, so the completeness check would refuse it; its
+        empty row is what says a person looked and decided it is not a flow across a balance node.
+        """
         flows = self._flows(
-            _device("PVSystem"),
-            [("ElectricityEnergyOutput", lt.Units.CELSIUS, [1000.0, 2000.0])],
+            _device("L2GenericEnergyManagementSystem"),
+            [("TotalElectricityToOrFromGrid", lt.Units.WATT, [4000.0, 4000.0])],
         )
         assert not flows
 
-    def test_a_component_the_table_does_not_know_contributes_nothing(self):
+    def test_a_class_outside_the_table_that_publishes_electricity_is_refused(self):
+        """The table is the one statement of who is in the balance, so silence is not an answer.
+
+        A class nobody has classified might be a device whose kilowatt hours belong on the chart
+        or a controller whose watts are a signal; the collector cannot tell, and used to assume
+        the second.
+        """
+        with pytest.raises(CostDataError, match="no row in adapter.DeviceEnergySpecs"):
+            self._flows(
+                _device("SomeBrandNewInverter"),
+                [("ElectricityOutput", lt.Units.WATT, [4000.0])],
+                load_type=lt.LoadTypes.ELECTRICITY,
+            )
+
+    def test_a_class_outside_the_table_that_publishes_no_electricity_is_fine(self):
         """Most components move no electricity across a balance node; that is not a defect."""
+        assert not self._flows(
+            _device("SomeThermalThing"), [("ThermalPower", lt.Units.WATT, [4000.0])]
+        )
+
+    def test_a_component_the_table_does_not_know_contributes_nothing(self):
+        """A component that declares no outputs at all cannot be in the balance either way."""
         assert not self._flows(FakeHeatPump(), [])
+
+    def test_a_role_that_comes_out_negative_is_refused(self):
+        """Direction is the role, so a negative magnitude means the row named the wrong column."""
+        with pytest.raises(CostDataError, match="carries negative energy"):
+            self._flows(
+                _device("PVSystem", ElectricityEnergyOutput="ElectricityEnergyOutput"),
+                [("ElectricityEnergyOutput", lt.Units.WATT_HOUR, [-1000.0, -2000.0])],
+            )
 
     def test_the_collector_reaches_the_extract_for_every_component(self):
         """A meter contributes its two grid roles alongside its billing determinants.
@@ -1114,3 +1229,226 @@ class TestDeviceEnergyFlows:
         attribution = inputs.energy_attribution_by_subject_in_kwh["ElectricityMeter"]
         assert attribution["GRID_IMPORT"] == pytest.approx(96.0)
         assert attribution["GRID_EXPORT"] == pytest.approx(48.0)
+
+    def test_a_free_of_cost_device_still_contributes_its_flows(self):
+        """The balance is physics: a PV array nobody prices still generates the kilowatt hours.
+
+        The class above claims the energy question is asked independently of cost relevance, but
+        only ever ran a priced meter, so the branch that would have made the flows conditional on
+        pricing was never exercised. This runs a `FREE_OF_COST` device through the same walk.
+        """
+        pv_system = _device("PVSystem", ElectricityEnergyOutput="ElectricityEnergyOutput")
+        type(pv_system).cost_relevance = CostRelevance.FREE_OF_COST
+        outputs = [_Output("PVSystem", "ElectricityEnergyOutput", unit=lt.Units.WATT_HOUR)]
+        inputs = bridge.build_evaluation_inputs(
+            [_Wrapper(pv_system)],
+            outputs,
+            _results_frame([("generation", [1000.0] * 96)]),
+            _SimulationParameters(days=1),
+        )
+        assert inputs.cost_facts == [] and inputs.unresolved_subjects == []
+        assert inputs.energy_attribution_by_subject_in_kwh == {
+            "PVSystem": {"PV_GENERATION": pytest.approx(96.0)}
+        }
+
+    def test_a_missing_device_column_becomes_an_unresolved_subject(self):
+        """The extract records the failure and the D7 check refuses to price around it."""
+        pv_system = _device("PVSystem", ElectricityEnergyOutput="ElectricityEnergyOutput")
+        type(pv_system).cost_relevance = CostRelevance.FREE_OF_COST
+        inputs = bridge.build_evaluation_inputs(
+            [_Wrapper(pv_system)],
+            [_Output("PVSystem", "SomethingElse", unit=lt.Units.WATT_HOUR)],
+            _results_frame([("other", [1000.0])]),
+            _SimulationParameters(days=1),
+        )
+        assert [item.subject for item in inputs.unresolved_subjects] == ["PVSystem"]
+        assert "ElectricityEnergyOutput" in _fail_evaluation(inputs)
+
+    def test_an_unlisted_electricity_carrying_class_becomes_an_unresolved_subject(self):
+        """A device nobody classified stops the run rather than shrinking the chart in silence."""
+        inverter = _device("SomeBrandNewInverter")
+        type(inverter).cost_relevance = CostRelevance.FREE_OF_COST
+        inputs = bridge.build_evaluation_inputs(
+            [_Wrapper(inverter)],
+            [
+                _Output(
+                    "SomeBrandNewInverter",
+                    "ElectricityOutput",
+                    unit=lt.Units.WATT,
+                    load_type=lt.LoadTypes.ELECTRICITY,
+                )
+            ],
+            _results_frame([("power", [4000.0])]),
+            _SimulationParameters(days=1),
+        )
+        assert [item.subject for item in inputs.unresolved_subjects] == ["SomeBrandNewInverter"]
+        assert "DeviceEnergySpecs" in _fail_evaluation(inputs)
+
+
+#: Every class named by `adapter.DeviceEnergySpecs`, mapped to the module it lives in. Written out
+#: rather than derived, because the whole point of the binding test below is that a table keyed by
+#: class *name* — which is what keeps `hisim.economics` free of component imports — is checked
+#: against the classes those names refer to.
+_ENERGY_BALANCE_MODULES = {
+    "PVSystem": "generic_pv_system",
+    "Battery": "advanced_battery_bslib",
+    "MoreAdvancedHeatPumpHPLib": "more_advanced_heat_pump_hplib",
+    "GenericHeatPump": "generic_heat_pump",
+    "UtspLpgConnector": "loadprofilegenerator_utsp_connector",
+    "ElectricityMeter": "electricity_meter",
+    "L2GenericEnergyManagementSystem": "controller_l2_energy_management_system",
+    "ExtendedController": "advanced_fuel_cell_controller",
+    "FuelCellController": "controller_l1_fuel_cell",
+    "L1Controller": "controller_l1_generic_ev_charge",
+    "L1GenericElectrolyzerController": "controller_l1_electrolyzer",
+    "MpcController": "controller_mpc",
+    "PTXController": "controller_l2_ptx_energy_management_system",
+    "RsocBatteryController": "controller_l2_rsoc_battery_system",
+    "XTPController": "controller_l2_xtp_fuel_cell_ems",
+    "ExampleComponent": "example_component",
+    "ComponentName": "example_template",
+    "CarBattery": "advanced_ev_battery_bslib",
+    "Car": "generic_car",
+    "Windturbine": "generic_windturbine",
+    "ElectricHeating": "generic_electric_heating",
+    "AirConditioner": "air_conditioner",
+    "SimpleAirConditioner": "simple_air_conditioner",
+    "SmartDevice": "generic_smart_device",
+    "SolarThermalSystem": "solar_thermal_system",
+    "AdvancedElectrolyzer": "generic_electrolyzer_and_h2_storage",
+    "Electrolyzer": "generic_electrolyzer_h2",
+    "GenericElectrolyzer": "generic_electrolyzer",
+    "HydrogenStorage": "generic_electrolyzer_and_h2_storage",
+    "FuelCell": "generic_fuel_cell",
+    "Rsoc": "generic_rsoc",
+    "CHP": "advanced_fuel_cell",
+    "SimpleCHP": "generic_chp",
+}
+
+#: Unit values the energy collector can convert, i.e. the ones that make an electricity output
+#: count as a flow the balance would have to place.
+_CONVERTIBLE_UNITS = frozenset(bridge.EnergyUnitConversion.BY_UNIT)
+
+
+def _declared_electricity_outputs(module_name: str, class_name: str):
+    """Every `LoadTypes.ELECTRICITY` output one component class declares, read from its source.
+
+    Parsed rather than instantiated: building a real `MoreAdvancedHeatPumpHPLib` needs a weather
+    file, a config and a simulation, none of which say anything about the question here, which is
+    purely "does this class declare this output". The declaration is a literal `add_output(...)`
+    call in the class body's `__init__`, so the syntax tree is the faithful source.
+
+    Args:
+        module_name: The `hisim.components` submodule holding the class.
+        class_name: The class whose declarations to collect.
+
+    Returns:
+        `{constant_name: unit_value}` for every electricity output the class declares through a
+        `self.X` / `ClassName.X` constant, where `unit_value` is the `Units` member's value.
+    """
+    path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "hisim",
+        "components",
+        f"{module_name}.py",
+    )
+    with open(path, encoding="utf-8") as file:
+        source = file.read()
+    tree = ast.parse(source, filename=path)
+    declared = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call):
+                continue
+            function = call.func
+            if not isinstance(function, ast.Attribute) or function.attr != "add_output":
+                continue
+            text = " ".join((ast.get_source_segment(source, call) or "").split())
+            if "LoadTypes.ELECTRICITY" not in text:
+                continue
+            unit = re.search(r"Units\.([A-Z_]+)", text)
+            arguments = [argument for keyword, argument in
+                         [(kw.arg, kw.value) for kw in call.keywords] if keyword == "field_name"]
+            if not arguments:
+                arguments = call.args[1:2]
+            for argument in arguments:
+                if isinstance(argument, ast.Attribute):
+                    declared[argument.attr] = unit.group(1) if unit else ""
+    return declared
+
+
+class TestTheEnergyBalanceTableMatchesTheRealClasses:
+    """`adapter.DeviceEnergySpecs` against the components it names (review, decision 2).
+
+    The table is keyed by class name and names output *constants* by name, which is what keeps
+    `hisim.economics` free of component imports — and what makes it a set of strings nothing
+    checks. These tests are the check: every key is a real class, every constant a real constant
+    naming a real electricity output, and — the half that matters most — every component class in
+    the tree that publishes convertible electricity has a row, so "not in the table" can only ever
+    mean "nobody has looked at it yet", which is what the collector refuses runs over.
+    """
+
+    @pytest.mark.parametrize("class_name", sorted(adapter.DeviceEnergySpecs.BY_CLASS_NAME))
+    def test_every_key_names_a_real_component_class(self, class_name):
+        """A key that no longer matches a class is a row that can never fire again."""
+        module = importlib.import_module(f"hisim.components.{_ENERGY_BALANCE_MODULES[class_name]}")
+        assert hasattr(module, class_name)
+
+    @pytest.mark.parametrize(
+        "class_name",
+        sorted(name for name, specs in adapter.DeviceEnergySpecs.BY_CLASS_NAME.items() if specs),
+    )
+    def test_every_spec_names_a_declared_electricity_output(self, class_name):
+        """The constant exists on the class, holds a string, and names an electricity output.
+
+        This is the check the hardcoded column names could not have: `MoreAdvancedHeatPumpHPLib`
+        calls the constant `ElectricalInputPowerTotal` and writes the column
+        `ElectricalInputPowerTotalHeatpump`, and a table spelling the column would keep pointing at
+        a renamed constant and stop pointing at a renamed column.
+        """
+        module_name = _ENERGY_BALANCE_MODULES[class_name]
+        component_class = getattr(importlib.import_module(f"hisim.components.{module_name}"), class_name)
+        declared = _declared_electricity_outputs(module_name, class_name)
+        for spec in adapter.DeviceEnergySpecs.BY_CLASS_NAME[class_name]:
+            column = getattr(component_class, spec.output_constant, None)
+            assert isinstance(column, str), f"{class_name}.{spec.output_constant} is not a constant"
+            assert spec.output_constant in declared, (
+                f"{class_name}.{spec.output_constant} names no declared electricity output"
+            )
+            assert declared[spec.output_constant] in _CONVERTIBLE_UNITS or declared[
+                spec.output_constant
+            ] in {"WATT", "WATT_HOUR", "KWH"}
+
+    def test_every_electricity_carrying_class_in_the_tree_has_a_row(self):
+        """The table is total, so an absent class is an omission rather than a decision.
+
+        Scans `hisim/components` the way the collector's refusal does at runtime and asserts the
+        two agree: a class that would be refused mid-run is a class this test names now, with the
+        file it lives in, which is the difference between a maintainer adding a row and a user
+        seeing an aborted simulation.
+        """
+        directory = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "hisim", "components"
+        )
+        missing = []
+        for file_name in sorted(os.listdir(directory)):
+            if not file_name.endswith(".py"):
+                continue
+            module_name = file_name[:-3]
+            with open(os.path.join(directory, file_name), encoding="utf-8") as file:
+                tree = ast.parse(file.read(), filename=file_name)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ClassDef):
+                    continue
+                if node.name in adapter.DeviceEnergySpecs.BY_CLASS_NAME:
+                    continue
+                units = set(_declared_electricity_outputs(module_name, node.name).values())
+                if units & {"WATT", "WATT_HOUR", "KWH"}:
+                    missing.append(f"{node.name} ({file_name})")
+        assert not missing, (
+            "These component classes publish electricity the energy collector can convert and "
+            "have no row in adapter.DeviceEnergySpecs, so a run containing one of them aborts: "
+            + ", ".join(missing)
+        )

--- a/tests/test_economics_extraction.py
+++ b/tests/test_economics_extraction.py
@@ -51,7 +51,7 @@ import pandas as pd
 import pytest
 
 from hisim import loadtypes as lt
-from hisim.economics import adapter
+from hisim.economics import adapter, bridge
 from hisim.economics.bridge import (
     _peaks_from_power_series,
     _sum_output_column,
@@ -979,3 +979,138 @@ class _PvConfigStub:
         self.investment_costs_in_euro = investment_costs_in_euro
         self.lifetime_in_years = lifetime_in_years
         self.device_co2_footprint_in_kg = device_co2_footprint_in_kg
+
+
+def _device(class_name: str):
+    """A component stub whose *class name* is the one the energy-balance table keys on.
+
+    `adapter.DeviceEnergySpecs` is keyed by class name, exactly like the cost-facts table, so the
+    class name is the whole contract a device has with the collector — and building the stub with
+    `type()` states that instead of hiding it behind a hand-written class whose name happens to
+    match. `component_name` is the only attribute the collector reads off the instance.
+
+    Args:
+        class_name: The component class name the table is expected to know.
+
+    Returns:
+        An instance of a freshly made class of that name.
+    """
+    return type(class_name, (), {"component_name": class_name})()
+
+
+class TestDeviceEnergyFlows:
+    """The household energy balance's collector: role -> kWh, unit-aware and sign-aware.
+
+    Three things can go wrong here and each of them produces a chart that is silently wrong rather
+    than a run that fails: a power column summed as if it were energy (a factor of 3,600 over the
+    timestep), a kWh column divided by a thousand a second time, and a battery's signed channel
+    summed net so the round trip disappears. Every expected value below is hand-computed from the
+    stub series, and the timestep is 900 s so the watt conversion is a visible 0.25 h per step.
+
+    The collector is deliberately exercised directly rather than through
+    `build_evaluation_inputs`, because the question is the conversion table and the sign split —
+    everything the surrounding walk adds (cost relevance, meter contracts, the D7 check) belongs
+    to the cost path and would only obscure a unit bug.
+    """
+
+    SECONDS_PER_TIMESTEP = 900
+
+    def _flows(self, component, columns):
+        """Runs the collector over one component and the columns it declares.
+
+        Args:
+            component: The stub component; its class name selects the declared specs.
+            columns: `(field_name, unit, values)` triples, in the frame's column order.
+
+        Returns:
+            The role -> kWh map the collector produced.
+        """
+        outputs = [
+            _Output(component.component_name, field_name, unit=unit)
+            for field_name, unit, _ in columns
+        ]
+        frame = _results_frame([(field_name, values) for field_name, _, values in columns])
+        return bridge._device_energy_flows(  # pylint: disable=protected-access
+            component, outputs, frame, self.SECONDS_PER_TIMESTEP
+        )
+
+    def test_watt_hours_are_divided_by_a_thousand(self):
+        """A Wh channel is energy already: 1,000 + 2,000 + 3,000 Wh = 6 kWh."""
+        flows = self._flows(
+            _device("PVSystem"),
+            [("ElectricityEnergyOutput", lt.Units.WATT_HOUR, [1000.0, 2000.0, 3000.0])],
+        )
+        assert flows == {"PV_GENERATION": pytest.approx(6.0)}
+
+    def test_kilowatt_hours_are_taken_as_they_are(self):
+        """A kWh channel needs no conversion; a second division would be a factor of 1,000."""
+        flows = self._flows(
+            _device("ElectricityMeter"),
+            [
+                ("ElectricityFromGrid", lt.Units.KWH, [1.5, 2.5]),
+                ("ElectricityToGrid", lt.Units.KWH, [0.25, 0.75]),
+            ],
+        )
+        assert flows == {"GRID_IMPORT": pytest.approx(4.0), "GRID_EXPORT": pytest.approx(1.0)}
+
+    def test_watts_are_integrated_over_the_timestep(self):
+        """A power channel is integrated: 2 x 4,000 W over 900 s each = 2 kWh, not 8 kWh."""
+        flows = self._flows(
+            _device("MoreAdvancedHeatPumpHPLib"),
+            [("ElectricalInputPowerTotalHeatpump", lt.Units.WATT, [4000.0, 4000.0])],
+        )
+        assert flows == {"HEAT_PUMP_ELECTRICITY": pytest.approx(2.0)}
+
+    def test_a_signed_battery_series_becomes_two_positive_roles(self):
+        """Charging and discharging are two roles of one column, both positive magnitudes.
+
+        4,000 + 1,000 W of charging over 0.25 h each = 1.25 kWh in; 2,000 W of discharging over
+        0.25 h = 0.5 kWh out. Summing the column net would report 0.75 kWh of "something" and lose
+        the round-trip loss the balance exists to show.
+        """
+        flows = self._flows(
+            _device("Battery"),
+            [("AcBatteryPowerUsed", lt.Units.WATT, [4000.0, -2000.0, 1000.0])],
+        )
+        assert flows == {
+            "BATTERY_CHARGE": pytest.approx(1.25),
+            "BATTERY_DISCHARGE": pytest.approx(0.5),
+        }
+
+    def test_an_unconvertible_unit_is_left_out_rather_than_guessed(self):
+        """A column declared in something that is neither energy nor power contributes nothing."""
+        flows = self._flows(
+            _device("PVSystem"),
+            [("ElectricityEnergyOutput", lt.Units.CELSIUS, [1000.0, 2000.0])],
+        )
+        assert not flows
+
+    def test_a_component_the_table_does_not_know_contributes_nothing(self):
+        """Most components move no electricity across a balance node; that is not a defect."""
+        assert not self._flows(FakeHeatPump(), [])
+
+    def test_the_collector_reaches_the_extract_for_every_component(self):
+        """A meter contributes its two grid roles alongside its billing determinants.
+
+        The energy question is asked before and independently of the cost-relevance branch, so
+        this also pins that a component's flows are not conditional on it being priced.
+        """
+        meter = ElectricityMeter()
+        outputs = [
+            _Output("ElectricityMeter", "ElectricityFromGrid", unit=lt.Units.WATT_HOUR),
+            _Output("ElectricityMeter", "ElectricityToGrid", unit=lt.Units.WATT_HOUR),
+            _Output("ElectricityMeter", "ElectricityFromGridInWatt", unit=lt.Units.WATT),
+        ]
+        frame = _results_frame(
+            [
+                ("from_grid", [1000.0] * 96),
+                ("to_grid", [500.0] * 96),
+                ("power", [4000.0] * 96),
+            ]
+        )
+        inputs = bridge.build_evaluation_inputs(
+            [_Wrapper(meter)], outputs, frame, _SimulationParameters(days=1)
+        )
+        attribution = inputs.energy_attribution_by_subject_in_kwh["ElectricityMeter"]
+        assert attribution["GRID_IMPORT"] == pytest.approx(96.0)
+        assert attribution["GRID_EXPORT"] == pytest.approx(48.0)

--- a/tests/test_economics_reporting_outputs.py
+++ b/tests/test_economics_reporting_outputs.py
@@ -122,6 +122,34 @@ class TestInputAudit:
         assert f"sources used ({len(audit.sources)} registry entries" in html_text
         assert build_input_audit(inputs, database, EconomicParameters(country="DE", price_basis_year=2026)).rows
 
+    def test_the_anyway_columns_state_the_share_and_the_cost_it_applied_to(self, database, matrix, tmp_path):
+        """A share with no basis cannot be audited: 30 % of what? (review, agreed small fix).
+
+        The CSV published "Anyway share" alone, so a reader could see that a credit had been
+        reduced and had no second number to multiply it by. The basis is the escalated
+        like-for-like cost the share scaled, which is exactly what the row now carries beside it.
+        """
+        import copy
+
+        from hisim.economics.audit import build_input_audit, write_cost_audit
+
+        inputs = make_inputs()
+        # A copy, because the matrix fixture is module-scoped and every other test in this file
+        # reads the same results.
+        result = copy.copy(next(iter(matrix.results.values())))
+        result.anyway_share_by_subject = {"HeatPump": 0.3}
+        result.anyway_basis_by_subject = {"HeatPump": 9000.0}
+        audit = build_input_audit(
+            inputs, database, EconomicParameters(country="DE", price_basis_year=2026), result
+        )
+        with open(write_cost_audit(audit, str(tmp_path)), encoding="utf-8") as audit_file:
+            lines = audit_file.read().splitlines()
+        header = lines[0].split(";")
+        assert header.index("Anyway basis [EUR]") == header.index("Anyway share") + 1
+        cells = lines[1].split(";")
+        assert cells[header.index("Anyway share")] == "0.3"
+        assert cells[header.index("Anyway basis [EUR]")] == "9000.0"
+
     def test_override_survives_a_missing_database_entry(self, database, matrix):
         """Precedence is decided once: an override prices the row even with no entry (W4.6).
 

--- a/tests/test_economics_subsidies.py
+++ b/tests/test_economics_subsidies.py
@@ -758,6 +758,28 @@ class TestScenarioDataOverlays:
         assert database.get_device_entry(ComponentType.HEAT_PUMP, 2024, "DE").specific_investment.best_estimate == 1600.0
         assert overlaid.overlay_records and overlaid.overlay_records[0].detail == "cheap_hp"
 
+    def test_an_override_that_breaks_the_parameters_is_refused(self):
+        """A scenario axis cannot set a value the constructor would have rejected (§4.6).
+
+        `apply_parameter_overrides` assigns with `setattr`, which bypasses
+        `EconomicParameters.__post_init__` — so before the re-validation an axis could set
+        `interest_rate` to -1.5 or the observation period to 0 and the cube would happily evaluate
+        a cell whose discount factor divides by zero or flips sign. Both are meaningless rather
+        than merely extreme, which is why they are the two the parameter object validates at all,
+        and the refusal has to name them where the axis is declared.
+        """
+        from hisim.economics.scenarios import apply_parameter_overrides
+
+        base = EconomicParameters(price_basis_year=2024)
+        with pytest.raises(ValueError, match="interest_rate"):
+            apply_parameter_overrides(base, {"interest_rate": -1.5})
+        with pytest.raises(ValueError, match="observation_period_in_years"):
+            apply_parameter_overrides(base, {"observation_period_in_years": 0})
+        # The caller's parameters are untouched by the refused attempt, and a legal override still
+        # comes back applied.
+        assert base.interest_rate == EconomicParameters(price_basis_year=2024).interest_rate
+        assert apply_parameter_overrides(base, {"interest_rate": 0.05}).interest_rate == 0.05
+
     def test_legacy_flat_subsidy_share_is_not_overlayable(self):
         """W2.6: the §10.1 shim is subsidy data and left the device overlay surface."""
         from hisim.economics.database import CostDataError

--- a/tests/test_economics_views.py
+++ b/tests/test_economics_views.py
@@ -279,6 +279,29 @@ class TestTimeSeriesViews:
                 )
                 assert series[year] == pytest.approx(expected)
 
+    def test_the_outstanding_balance_starts_at_the_disbursement_and_ends_at_zero(self, result):
+        """The balance line is the disbursement minus the principal booked so far, year by year.
+
+        The docstring used to promise "year 0 carries the full disbursement" while the loop
+        subtracts year-0 principal first; the two agree here because an annuity plan repays
+        nothing in the year it is drawn, and the assertion below pins the *rule* — disbursement
+        minus cumulative principal — rather than the coincidence.
+        """
+        amortization = views.loan_amortization_series(result)
+        assert amortization.disbursement_in_euro > 0.0
+        assert amortization.principal_in_euro[0] == pytest.approx(0.0)
+        assert amortization.outstanding_balance_in_euro[0] == pytest.approx(
+            amortization.disbursement_in_euro
+        )
+        running = 0.0
+        for year, principal in enumerate(amortization.principal_in_euro):
+            running += principal
+            assert amortization.outstanding_balance_in_euro[year] == pytest.approx(
+                amortization.disbursement_in_euro - running
+            )
+        # The fixture's 12-year term fits inside the horizon, so the plan amortizes fully.
+        assert amortization.outstanding_balance_in_euro[-1] == pytest.approx(0.0, abs=1e-6)
+
     def test_cumulative_operational_co2_is_the_running_total(self, result):
         """Same numbers as the yearly series, accumulated."""
         yearly = result.lifecycle_co2_result.operational_co2_by_year_in_kg
@@ -336,6 +359,72 @@ class TestDetailTable:
         for detail_year in years:
             amounts = [row.nominal_in_euro.best_estimate for row in detail_year.rows]
             assert amounts == sorted(amounts)
+
+
+class TestTheLevySummaryOfARealLandlordRun:
+    """`LifecycleCostResult.modernization_levy` as an evaluation actually fills it (§6.4, D27).
+
+    Every other test of the levy builds an `AllocationContext` by hand and asks the ruleset
+    directly, which leaves the wiring untested: the evaluator has to derive the context from the
+    inputs, run the ruleset, convert the outcome into the summary record and hang it on the
+    result. A break anywhere along that chain shows up as `modernization_levy is None` and no
+    existing test would have noticed — the timeline still carries the transfer pair.
+
+    The fixture's building is 150 m² at 8.5 EUR/m²·month cold rent, so the general §559 Abs. 3a
+    ceiling is the upper tier (3.00 EUR/m²·month = 5,400 EUR/a) and the §559e one 900 EUR/a.
+    """
+
+    def test_the_summary_reaches_the_result_with_both_legs_and_a_verdict(self, allocated):
+        """The record exists, its legs add up to the amount, and every world has a verdict."""
+        from hisim.economics.results import LevyBindingMechanism
+
+        levy = allocated.modernization_levy
+        assert levy is not None
+        assert levy.annual_amount_in_euro.best_estimate == pytest.approx(
+            levy.general_leg_in_euro.best_estimate + levy.heating_leg_in_euro.best_estimate
+        )
+        assert levy.cap_in_euro_per_m2_per_month == pytest.approx(3.0)
+        assert set(levy.binding_mechanism_by_slot) == {Slot.LOW, Slot.BEST_ESTIMATE, Slot.HIGH}
+        for verdict in levy.binding_mechanism_by_slot.values():
+            assert LevyBindingMechanism.names_a_cap(verdict) or verdict.endswith(
+                LevyBindingMechanism.RATE_BELOW_CAP
+            )
+        assert levy.cap_binding_in_best_estimate == LevyBindingMechanism.names_a_cap(
+            levy.binding_mechanism_by_slot[Slot.BEST_ESTIMATE]
+        )
+
+    def test_the_summary_amount_is_the_amount_the_timeline_books(self, allocated):
+        """The record is a statement about the money, so it has to be the money (§6.4).
+
+        The levy is booked as one transfer pair per year; the summary states the annual figure.
+        A record that drifted from the entries would let the caption and the cash-flow table
+        disagree about the same rent increase.
+        """
+        levied_years = {
+            entry.year
+            for entry in allocated.timeline.entries
+            if entry.category == CostCategory.MODERNIZATION_LEVY and entry.payer == Actor.TENANT
+        }
+        assert levied_years
+        levy = allocated.modernization_levy
+        assert levy is not None
+        for year in sorted(levied_years):
+            booked = UncertainValue.sum(
+                entry.amount_in_euro
+                for entry in allocated.timeline.entries
+                if entry.category == CostCategory.MODERNIZATION_LEVY
+                and entry.payer == Actor.TENANT
+                and entry.year == year
+            )
+            assert booked.best_estimate == pytest.approx(levy.annual_amount_in_euro.best_estimate)
+
+    def test_both_legs_stay_inside_their_own_ceilings(self, allocated):
+        """900 EUR/a on the §559e leg, 5,400 EUR/a on the two together, in every world."""
+        levy = allocated.modernization_levy
+        assert levy is not None
+        for slot in Slot:
+            assert levy.heating_leg_in_euro.slot(slot) <= 900.0 + 1e-6
+            assert levy.annual_amount_in_euro.slot(slot) <= 5400.0 + 1e-6
 
 
 class TestPivotsAndAnnuities:


### PR DESCRIPTION
﻿Third slice of the 9/9 port: the engine-side data the new charts read, with no view functions, sections or plots. Per-subject annual energy per carrier now travels from the device energy specs in the adapter and bridge through the evaluation inputs and the annualisation into the result, serialised on both sides and defaulting to empty (V12's data). The loan amortisation carries its outstanding balance (V5's data). results gain the embodied-CO2 basis, the per-carrier emission factors, the modernisation levy summary, the resolved economic assumptions and the anyway-share maps, with their producers in the calculators, actors and evaluator; the audit trail records the anyway share. Scenario parameter overrides are re-validated so a scenario cannot set an interest rate or observation period the constructor would refuse. 26 new tests cover the collector's unit conversions, the annualisation below a full year, the levy binding mechanism, the anyway share and the serialisation round trips. Nothing in the goldens or the subsidy catalogs moves; the display-name plumbing this slice originally duplicated lives in slice 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
