### PR TITLE
Cost stack 9/9, slice 4 of 8: the view functions the first seven charts read

### DIFF
--- a/hisim/economics/numerics.py
+++ b/hisim/economics/numerics.py
@@ -1,0 +1,68 @@
+"""The package's one root finder, shared by the views and the scenario break-even (§4.6, V5).
+
+Two places in the cost package solve a scalar equation by bisection: `scenarios.find_break_even`
+looks for the parameter value at which two variants' KPI difference crosses zero, and
+`views._effective_annual_rate` looks for the discount rate at which a loan's own flow sequence has
+present value zero. They had one implementation each, with the same three decisions — the search
+window, what to do when the window does not bracket a sign change, and how many halvings to spend —
+made twice and worded differently. This module makes them once.
+
+Bisection rather than a faster root finder in both cases, and for the same reason: the functions
+are only piecewise smooth. A KPI difference has kinks wherever a subsidy cap binds, a replacement
+falls in or out of the horizon or a tariff tier changes; a loan's present value is smooth but is
+evaluated on a schedule that may be truncated. Bisection cannot be thrown by a kink as long as the
+interval brackets a sign change, and a bracket that does not is *reported* rather than solved
+around — a root reported outside the searched window would be a number nobody asked for.
+
+This module is a leaf: it imports nothing from `hisim.economics`, so both the engine-side scenario
+machinery and the view layer can use it without either reaching for the other.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Tuple
+
+
+def bisect_root(
+    function: Callable[[float], float],
+    window: Tuple[float, float],
+    max_iterations: int,
+    tolerance: Optional[float] = None,
+) -> Optional[float]:
+    """Bisects `function` inside `window`, or None when the window's ends share a sign.
+
+    The same-sign refusal is the point of the helper as much as the halving is: a window whose
+    ends have the same sign contains no crossing that bisection can find, and returning None says
+    "no root in the searched range" instead of returning whichever end the iteration drifted to.
+    Callers turn that None into their own statement — "no crossing in range" for a break-even, "no
+    non-negative effective rate" for a loan.
+
+    Args:
+        function: The function to root. It is evaluated once at each end and once per iteration,
+            and the value at an end is reused rather than recomputed, so an expensive function
+            (the break-even's is two full evaluations) costs one call per halving.
+        window: `(low, high)` bounds of the search, inclusive.
+        max_iterations: Hard cap on halvings. Reaching it returns the midpoint of the remaining
+            interval rather than raising: the interval still brackets the root, it is merely
+            wider than the caller hoped.
+        tolerance: Absolute interval width at which to stop early, or None to always spend
+            `max_iterations` halvings. A caller whose function is cheap passes None and buys
+            precision with iterations instead.
+
+    Returns:
+        The root, or None when `function(low)` and `function(high)` have the same sign.
+    """
+    low, high = window
+    value_low, value_high = function(low), function(high)
+    if value_low * value_high > 0:
+        return None
+    for _iteration in range(max_iterations):
+        middle = (low + high) / 2.0
+        value_middle = function(middle)
+        if tolerance is not None and abs(high - low) < tolerance:
+            return middle
+        if value_low * value_middle <= 0:
+            high, value_high = middle, value_middle
+        else:
+            low, value_low = middle, value_middle
+    return (low + high) / 2.0

--- a/hisim/economics/scenarios.py
+++ b/hisim/economics/scenarios.py
@@ -54,6 +54,7 @@ from hisim import log
 from hisim.economics.carriers import EnergyCarrier
 from hisim.economics.database import CostDatabase
 from hisim.economics.evaluator import EconomicEvaluator, EvaluationInputs
+from hisim.economics.numerics import bisect_root
 from hisim.economics.parameters import EconomicParameters
 from hisim.economics.perspectives import Perspective
 from hisim.economics.results import LifecycleCostResult
@@ -730,21 +731,16 @@ def find_break_even(
         Bisection rather than a faster root finder because the KPI is only piecewise smooth in most
         axes — subsidy caps, replacement years and tier tables all introduce kinks — and bisection
         is the method that cannot be thrown by them as long as the interval brackets a sign change.
+        The halving itself is `numerics.bisect_root`, shared with the loan view's effective-rate
+        solver; the None it returns for a window that brackets no crossing is this function's "no
+        crossing in range".
         """
-        low, high = search_range
-        delta_low, delta_high = delta_at(low, slot), delta_at(high, slot)
-        if delta_low * delta_high > 0:
-            return None  # no crossing in range
-        for _ in range(max_iterations):
-            mid = (low + high) / 2.0
-            delta_mid = delta_at(mid, slot)
-            if abs(high - low) < tolerance:
-                return mid
-            if delta_low * delta_mid <= 0:
-                high, delta_high = mid, delta_mid
-            else:
-                low, delta_low = mid, delta_mid
-        return (low + high) / 2.0
+        return bisect_root(
+            lambda value: delta_at(value, slot),
+            window=search_range,
+            max_iterations=max_iterations,
+            tolerance=tolerance,
+        )
 
     crossing = bisect("best_estimate")
     return {

--- a/hisim/economics/views.py
+++ b/hisim/economics/views.py
@@ -41,6 +41,7 @@ category→group mapping into `fold_categories` / `fold_category_matrix`.
 
 from __future__ import annotations
 
+import enum
 from collections.abc import Hashable
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, TypeVar
@@ -49,6 +50,7 @@ from hisim.economics.calculators.financing_application import FinancingConstants
 from hisim.economics.calculators.subsidy_application import nominal_support_from_entries
 from hisim.economics.carriers import EnergyCarrier
 from hisim.economics.catalog_entries import CostDataError
+from hisim.economics.numerics import bisect_root
 from hisim.economics.results import (
     LifecycleCostResult,
     ModernizationLevySummary,
@@ -90,19 +92,6 @@ class ViewCategories:
         CostCategory.SUBSIDY,
         CostCategory.LOAN_DISBURSEMENT,
     )
-
-
-class ViewThresholds:
-    """Numeric cut-offs the view models apply.
-
-    The one place where a view is allowed to drop data, and only ever to suppress float noise —
-    values that are arithmetically zero but land at 1e-13 after a chain of discounting and slot
-    arithmetic. Named rather than inlined so a reviewer can see the magnitude of what is being
-    hidden (half a cent) and confirm it cannot swallow a real flow.
-    """
-
-    #: Amounts below this (in every slot) are dropped from the detail table as float noise.
-    DETAIL_ROW_EPSILON = 0.005
 
 
 #: Whatever presentation groups categories by — an index, a label, anything hashable. Generic so
@@ -359,7 +348,7 @@ class TimelineDetailYear:
 
     Groups the rows of a single year so the renderer can print a bold subtotal line without
     re-adding anything. The totals cover exactly the rows in `rows` — including the noise cells
-    dropped by `ViewThresholds.DETAIL_ROW_EPSILON` being absent from both — so the table always
+    dropped by `ViewTolerances.DETAIL_ROW_EPSILON` being absent from both — so the table always
     adds up on screen.
     """
 
@@ -373,7 +362,7 @@ def timeline_detail_rows(result: LifecycleCostResult) -> List[TimelineDetailYear
     """The §3.6 timeline as a verification table: (year, subject, category) with subtotals.
 
     Same scoping as the chart it sits under; duplicate cells are aggregated, and cells that are
-    zero in every slot up to `ViewThresholds.DETAIL_ROW_EPSILON` are dropped as float noise. Rows within a year
+    zero in every slot up to `ViewTolerances.DETAIL_ROW_EPSILON` are dropped as float noise. Rows within a year
     are ordered by nominal BEST_ESTIMATE amount, so the biggest credit and the biggest cost of a year
     frame its block. The subtotals cover exactly the rows shown.
 
@@ -404,7 +393,7 @@ def timeline_detail_rows(result: LifecycleCostResult) -> List[TimelineDetailYear
         aggregated.items(), key=lambda item: (item[0][0], item[1].best_estimate)
     ):
         if all(
-            abs(value) < ViewThresholds.DETAIL_ROW_EPSILON
+            abs(value) < ViewTolerances.DETAIL_ROW_EPSILON
             for value in (amount.best_estimate, amount.minimum, amount.maximum)
         ):
             continue
@@ -981,23 +970,34 @@ def total_subsidies_received(result: LifecycleCostResult) -> Optional[UncertainV
 # ----- 9/9 views, V1-V7 -----
 
 class ViewTolerances:
-    """Tolerances the self-validating chart views reconcile against (visualization spec §5).
+    """The one namespace of numeric tolerances the views apply (visualization spec §5).
 
-    The views added for the V1-V15 chart set do not merely re-shape the result, they *check*
-    themselves: a Sankey whose transfer ribbons do not net to zero, a tornado whose bars do not
-    sum to the band or a sources-and-uses statement that does not balance is a lie about the
-    engine, so those views raise `CostDataError` instead of drawing. Every such comparison needs
-    a tolerance, and they are collected here so a reviewer can see in one place how much
-    disagreement counts as float noise (half a cent on a euro figure) rather than as a defect.
+    Two kinds of number live here, and there is exactly one place for both. Most of the views
+    added for the V1-V15 chart set do not merely re-shape the result, they *check* themselves: a
+    Sankey whose transfer ribbons do not net to zero, a tornado whose bars do not sum to the band
+    or a sources-and-uses statement that does not balance is a lie about the engine, so those
+    views raise `CostDataError` instead of drawing, and every such comparison needs a tolerance.
+    The other kind is `DETAIL_ROW_EPSILON`, the one point at which a view is allowed to *drop*
+    data — and only ever to suppress float noise, values that are arithmetically zero but land at
+    1e-13 after a chain of discounting and slot arithmetic.
+
+    Collecting both here is the point: a reviewer sees in one place how much disagreement counts
+    as float noise (half a cent on a euro figure) rather than as a defect, and how much may be
+    hidden from a table. There used to be a second namespace, `ViewThresholds`, holding the
+    dropping tolerance and claiming the same "one place" for itself; folding it in leaves one.
     """
 
-    #: Absolute euro tolerance for the reconciliation checks (half a cent, as in the detail table).
+    #: Absolute euro tolerance for the reconciliation checks (half a cent).
     RECONCILIATION_EPSILON = 0.005
+    #: Amounts below this (in every slot) are dropped from the detail table as float noise; the
+    #: same half a cent, named separately because dropping a row is not reconciling a total.
+    DETAIL_ROW_EPSILON = 0.005
     #: Balance below this counts as repaid; guards `LoanAmortization.loan_free_year` against
     #: float residue.
     BALANCE_EPSILON = 0.01
-    #: Relative tolerance for the kWh attribution check of the energy balance, where quantities
-    #: are large enough that an absolute euro epsilon means nothing.
+    #: Relative tolerance for the kWh attribution check of the energy balance (the V11 view of
+    #: the next slice is its reader), where quantities are large enough that an absolute euro
+    #: epsilon means nothing.
     QUANTITY_RELATIVE_EPSILON = 1e-6
 
 
@@ -1114,7 +1114,9 @@ class FlowCounterparties:
 
     #: Categories booked as *matched pairs* between two payers by the allocation rulesets. They
     #: are drawn payer-to-payer instead of as two external stubs, and the view validates that
-    #: they net to zero across payers (fail-fast, D25).
+    #: they net to zero across payers (fail-fast, D25). This is the narrow, Sankey sense of
+    #: "transfer" — both legs are on the timeline — and is deliberately *not*
+    #: `StatementPartitions.SOCIETY_TRANSFER_CATEGORIES`, which is the wider macroeconomic sense.
     TRANSFER_CATEGORIES = frozenset({CostCategory.MODERNIZATION_LEVY})
 
     #: Ribbons smaller than this share of the gross flow volume are folded per node pair.
@@ -1170,8 +1172,10 @@ class ActorFlowMatrix:
     the grand total as a band so the title can state the uncertainty the ribbons themselves
     cannot.
 
-    Reconciliation: `net_by_actor()` of an actor equals the nominal sum of that actor's scoped
-    timeline, and the transfer ribbons net to zero across payers (validated in the view).
+    Reconciliation: `net_by_actor()` of an actor equals the nominal sum of the entries booked on
+    that payer inside the horizon — its scoped timeline, for an actor-scoped perspective — and
+    the transfer ribbons net to zero across payers. Both are validated in `actor_flow_matrix`
+    before the matrix is returned, so an instance that exists reconciles.
     """
 
     flows: List[ActorFlow]
@@ -1228,9 +1232,9 @@ class ActorFlowMatrix:
     def net_by_actor(self) -> Dict[str, float]:
         """Outflows minus inflows per actor — the actor's nominal lifetime cost.
 
-        The reconciliation handle: this must equal the nominal sum of the actor's scoped
-        timeline, which is what makes the picture an accounting statement rather than an
-        illustration.
+        The reconciliation handle: this equals the nominal sum of the entries the timeline books
+        on that payer, which is what makes the picture an accounting statement rather than an
+        illustration. `actor_flow_matrix` checks it here rather than leaving it to a caption.
         """
         nets: Dict[str, float] = {actor: 0.0 for actor in self.actors}
         for flow in self.flows:
@@ -1288,7 +1292,13 @@ def story_perspectives(results: Iterable[LifecycleCostResult]) -> StoryPerspecti
 
     A run with no support at all would leave the owner story empty by that rule, which would be
     wrong rather than honest — a cash purchase without subsidies is still an owner's story — so
-    the remaining perspectives are used in that case.
+    the leftovers are promoted in that one case, and the case is tested for rather than inferred
+    from the owner list being empty. The difference matters for a bundle that pairs a gross
+    system perspective with a rented-out pair: support *is* on the page, the owner rule correctly
+    finds no owner perspective among the leftovers, and the chapter has to stay empty instead of
+    being filled with the perspective-free gross view, whose whole purpose is the common chapter.
+    When the fallback does fire it still prefers the owner-like leftovers — the ones scoped to an
+    owner-occupier or to the system as a whole — over anything scoped to some other party.
 
     Args:
         results: The evaluated perspectives, in bundle order (the order they are rendered in).
@@ -1296,10 +1306,11 @@ def story_perspectives(results: Iterable[LifecycleCostResult]) -> StoryPerspecti
     Returns:
         The three lists, each in the input's order.
     """
+    evaluated = list(results)
     society: List[LifecycleCostResult] = []
     rented: List[LifecycleCostResult] = []
     rest: List[LifecycleCostResult] = []
-    for result in results:
+    for result in evaluated:
         if has_macroeconomic_accounting(result):
             society.append(result)
         elif result.scope_payer in (Actor.LANDLORD, Actor.TENANT):
@@ -1311,7 +1322,28 @@ def story_perspectives(results: Iterable[LifecycleCostResult]) -> StoryPerspecti
         if result.scope_payer == Actor.OWNER_OCCUPIER
         or any(entry.category == CostCategory.SUBSIDY for entry in result.scoped_timeline().entries)
     )
-    return StoryPerspectives(owner=owner or tuple(rest), rented=tuple(rented), society=tuple(society))
+    if not owner and not _run_books_support(evaluated):
+        owner = tuple(
+            result for result in rest
+            if result.scope_payer in (Actor.OWNER_OCCUPIER, Actor.SYSTEM)
+        ) or tuple(rest)
+    return StoryPerspectives(owner=owner, rented=tuple(rented), society=tuple(society))
+
+
+def _run_books_support(results: Sequence[LifecycleCostResult]) -> bool:
+    """Whether any perspective of the run books a subsidy anywhere on its full timeline.
+
+    The guard on the owner chapter's fallback. It reads the **full** timeline of every
+    perspective rather than the scoped one, because the question is about the run — "was this
+    renovation supported at all" — and not about what one perspective reports on: a landlord
+    perspective's grant is support on the page even when the leftover gross perspective knows
+    nothing of it.
+    """
+    return any(
+        entry.category == CostCategory.SUBSIDY
+        for result in results
+        for entry in result.timeline.entries
+    )
 
 
 # ------------------------------------------- party statements (Q21 landlord, Q26 F4 the rest)
@@ -1427,8 +1459,12 @@ class StatementPartitions:
 
     #: Categories that move money between parties without consuming resources (§4.5). Society's
     #: second side; the macroeconomic accounting removes every one of them at source, which is
-    #: why they reach the statement summing to zero.
-    TRANSFER_CATEGORIES = (
+    #: why they reach the statement summing to zero. The wider, macroeconomic sense of
+    #: "transfer": `FlowCounterparties.TRANSFER_CATEGORIES` is the Sankey's narrow one, the
+    #: single category whose *both* legs are booked on the timeline and can be drawn payer to
+    #: payer — a subsidy or a feed-in tariff is a transfer to society without the state's leg
+    #: ever appearing as an entry.
+    SOCIETY_TRANSFER_CATEGORIES = (
         CostCategory.SUBSIDY,
         CostCategory.MODERNIZATION_LEVY,
         CostCategory.FEED_IN_REVENUE,
@@ -1477,7 +1513,7 @@ class StatementPartitions:
         party_label="society",
         primary_label="real resource costs",
         secondary_label="transfers",
-        secondary_categories=TRANSFER_CATEGORIES,
+        secondary_categories=SOCIETY_TRANSFER_CATEGORIES,
         secondary_is_transfer=True,
         labels={
             CostCategory.INVESTMENT: "hardware and installation",
@@ -1519,6 +1555,27 @@ class StatementLine:
 
 
 @dataclass(frozen=True)
+class IncomeRibbon:
+    """One ribbon of the landlord income Sankey: money arriving at or leaving the landlord node.
+
+    The named form of what used to be a five-tuple. Direction is already resolved — `source` pays
+    `target` — and `amount_in_euro` is the positive magnitude, because a Sankey ribbon has no
+    sign. It is deliberately *not* an `ActorFlow`: an actor-flow ribbon runs between a payer and
+    an external counterparty and carries the transfer flag, while these ribbons run between the
+    landlord and one of his own statement rows and carry the cash / accounting-credit split the
+    renderer styles them by.
+    """
+
+    source: str
+    target: str
+    amount_in_euro: float
+    is_accounting_credit: bool
+    #: The category the ribbon's money belongs to, which the renderer turns into a display-group
+    #: hue; None on the net-position ribbon, which is a result rather than a category.
+    category: Optional[CostCategory] = None
+
+
+@dataclass(frozen=True)
 class PerspectiveStatement:
     """One party's NPV as a two-sided statement (Q21 for the landlord, Q26 F4 for the rest).
 
@@ -1554,8 +1611,8 @@ class PerspectiveStatement:
     #: Which partition produced the two sides; supplies the side labels and the transfer flag.
     partition: StatementPartition = StatementPartitions.LANDLORD
 
-    def income_flows(self) -> Tuple[Tuple[Tuple[str, str, float, bool, Optional[CostCategory]], ...], bool]:
-        """The income-statement Sankey: `(source, target, amount, is_accounting_credit)` + a flag.
+    def income_flows(self) -> Tuple[Tuple[IncomeRibbon, ...], bool]:
+        """The landlord income Sankey as `IncomeRibbon`s, plus the net-position direction flag.
 
         The earnings-Sankey convention (Q25): everything that arrives flows into the landlord node
         from the left, everything that is spent leaves to the right, and **the ribbon left over is
@@ -1569,27 +1626,54 @@ class PerspectiveStatement:
         it is a net cost (positive NPV) the picture is a loss: the missing money has to come from
         somewhere, so the net position enters from the *left* as a source and the flag says so.
 
+        **Landlord only.** The node labels are the landlord's own (`LANDLORD_NODE`), so the
+        picture claims a party the statement may not be about. A statement is callable under any
+        of the four partitions, and drawing a tenant's or society's rows around a node labelled
+        "landlord" would be a mislabelled picture rather than a missing feature — so this refuses
+        instead. The tenant and society chapters state their sides as tables.
+
         Returns:
-            The ribbons as `(source, target, amount, is_accounting_credit, category)` — the
-            category so the renderer can hue a ribbon like the same money everywhere else, and
-            `None` on the net-position ribbon, which is a result rather than a category — and
-            `True` when the net-position ribbon is an inflow (a net cost) rather than the usual
-            leftover outflow. Ribbon amounts are magnitudes; a Sankey ribbon has no sign.
+            The ribbons, and `True` when the net-position ribbon is an inflow (a net cost) rather
+            than the usual leftover outflow. Ribbon amounts are magnitudes; a Sankey ribbon has
+            no sign.
+
+        Raises:
+            CostDataError: If the statement was built under a partition other than the landlord's.
         """
+        if self.partition.id != StatementPartitions.LANDLORD.id:
+            raise CostDataError(
+                f"The income Sankey is the landlord's picture, but this statement was built under "
+                f"the {self.partition.id!r} partition: its ribbons would run into a node labelled "
+                f"{LandlordStatementCategories.LANDLORD_NODE!r} while stating "
+                f"{self.partition.party_label}'s rows. Render that party's statement as a table."
+            )
         node = LandlordStatementCategories.LANDLORD_NODE
         net_node = LandlordStatementCategories.NET_POSITION_NODE
-        flows: List[Tuple[str, str, float, bool, Optional[CostCategory]]] = []
+        flows: List[IncomeRibbon] = []
         for line in list(self.cash_lines) + list(self.accounting_lines):
             if line.npv_in_euro < 0:
-                flows.append((line.label, node, -line.npv_in_euro, line.is_accounting_credit, line.category))
+                flows.append(IncomeRibbon(
+                    source=line.label, target=node, amount_in_euro=-line.npv_in_euro,
+                    is_accounting_credit=line.is_accounting_credit, category=line.category,
+                ))
             elif line.npv_in_euro > 0:
-                flows.append((node, line.label, line.npv_in_euro, line.is_accounting_credit, line.category))
+                flows.append(IncomeRibbon(
+                    source=node, target=line.label, amount_in_euro=line.npv_in_euro,
+                    is_accounting_credit=line.is_accounting_credit, category=line.category,
+                ))
         net_is_inflow = self.net_position_in_euro > 0
         if abs(self.net_position_in_euro) > ViewTolerances.RECONCILIATION_EPSILON:
-            if net_is_inflow:
-                flows.append((net_node, node, self.net_position_in_euro, False, None))
-            else:
-                flows.append((node, net_node, -self.net_position_in_euro, False, None))
+            flows.append(
+                IncomeRibbon(
+                    source=net_node, target=node, amount_in_euro=self.net_position_in_euro,
+                    is_accounting_credit=False,
+                )
+                if net_is_inflow
+                else IncomeRibbon(
+                    source=node, target=net_node, amount_in_euro=-self.net_position_in_euro,
+                    is_accounting_credit=False,
+                )
+            )
         return tuple(flows), net_is_inflow
 
 
@@ -1631,6 +1715,13 @@ def perspective_statement(
     reconciliation identity is unaffected — which is exactly the claim the society chapter makes
     and this is where it is checked rather than asserted.
 
+    That mixed reading is also why a transfer partition has a precondition: the primary side is
+    the perspective's *scoped* pivot while the transfer side is the *full* timeline, and the two
+    are reconciled against the scoped total. The sum only closes when the two readings coincide,
+    i.e. when the perspective is scoped to `Actor.SYSTEM` — which every macroeconomic perspective
+    is. Applied to an actor-scoped result the statement would raise a reconciliation error that
+    blamed a lost category for what is really a misuse, so the misuse is named up front instead.
+
     Args:
         result: The perspective to state; its `npv_by_category` and, for a transfer partition,
             its full `timeline`.
@@ -1640,10 +1731,19 @@ def perspective_statement(
         The two-sided statement with both subtotals and the net position.
 
     Raises:
-        CostDataError: If the two sides do not sum to the perspective's total NPV. That can only
-            happen if a category was dropped between the pivot and this split, which would make
-            the statement a picture of a business case that is not the one being reported.
+        CostDataError: If a transfer partition is asked for on a perspective that is not
+            SYSTEM-scoped, or if the two sides do not sum to the perspective's total NPV. The
+            latter can only happen if a category was dropped between the pivot and this split,
+            which would make the statement a picture of a business case that is not the one
+            being reported.
     """
+    if partition.secondary_is_transfer and result.scope_payer != Actor.SYSTEM:
+        raise CostDataError(
+            f"The {partition.id!r} statement reads the transfer side off the full timeline and the "
+            f"resource side off the scoped one, so it is defined only for a SYSTEM-scoped "
+            f"perspective; {result.perspective_id!r} is scoped to {result.scope_payer.value!r}. "
+            "State that party with its own partition instead."
+        )
     primary: List[StatementLine] = []
     secondary: List[StatementLine] = []
     for category, band in result.npv_by_category.items():
@@ -1744,21 +1844,28 @@ def actor_flow_matrix(result: LifecycleCostResult) -> ActorFlowMatrix:
     Three rules decide a ribbon. The counterparty comes from `FlowCounterparties`, declared per
     category and raising for anything unmapped. The direction comes from the entry's sign, so
     costs leave the payer and credits arrive. And a category declared in `TRANSFER_CATEGORIES` —
-    the §559e modernization levy today — is drawn payer to payer instead of as two external
-    stubs; the view checks that those legs net to zero across all payers and raises if they do
-    not, since a transfer that creates money is a defect in the allocation ruleset, not something
-    to render.
+    the §559e modernization levy today — is drawn as one payer-to-receiver ribbon instead of as
+    two external stubs; the view checks that those legs net to zero across all payers and raises
+    if they do not, since a transfer that creates money is a defect in the allocation ruleset,
+    not something to render, and it refuses a transfer running between more than two parties
+    rather than inventing a split (see `_transfer_ribbons`).
 
-    Reconciliation: per-actor net (outflows − inflows) equals the nominal sum of that actor's
-    scoped timeline; the transfer ribbons net to zero.
+    Reconciliation, both halves validated here: the transfer ribbons net to zero across payers,
+    and each actor's net (outflows − inflows) equals the nominal sum of the entries the timeline
+    books on that payer — which for an actor-scoped perspective is that actor's scoped timeline.
+    The second check is what makes the picture an accounting statement rather than an
+    illustration, and it catches what the first cannot: a ribbon drawn to the wrong end, a
+    counterparty label that collides with a payer node, a fold that lost euros.
 
     Raises:
-        CostDataError: On a category with no declared counterparty, or on declared transfers that
-            do not net to zero across payers.
+        CostDataError: On a category with no declared counterparty, on declared transfers that do
+            not net to zero across payers, or on an actor whose ribbons do not net to what the
+            timeline books on it.
     """
     horizon = result.parameters.observation_period_in_years
     ribbons: Dict[Tuple[str, str, Optional[CostCategory]], float] = {}
     transfer_net: Dict[str, float] = {}
+    nominal_by_actor: Dict[str, float] = {}
     actors: List[str] = []
     for entry in result.timeline.entries:
         if not 0 <= entry.year <= horizon:
@@ -1767,6 +1874,7 @@ def actor_flow_matrix(result: LifecycleCostResult) -> ActorFlowMatrix:
         if actor not in actors:
             actors.append(actor)
         amount = entry.amount_in_euro.best_estimate
+        nominal_by_actor[actor] = nominal_by_actor.get(actor, 0.0) + amount
         if entry.category in FlowCounterparties.TRANSFER_CATEGORIES:
             transfer_net[actor] = transfer_net.get(actor, 0.0) + amount
             continue
@@ -1785,7 +1893,7 @@ def actor_flow_matrix(result: LifecycleCostResult) -> ActorFlowMatrix:
     matrix_flows.extend(transfer_flows)
     sources = [flow.source for flow in matrix_flows if flow.source not in actors]
     sinks = [flow.target for flow in matrix_flows if flow.target not in actors]
-    return ActorFlowMatrix(
+    matrix = ActorFlowMatrix(
         flows=matrix_flows,
         actors=actors,
         sources=list(dict.fromkeys(sources)),
@@ -1796,20 +1904,70 @@ def actor_flow_matrix(result: LifecycleCostResult) -> ActorFlowMatrix:
         folded_ribbon_count=folded_count,
         folded_amount_in_euro=folded_amount,
     )
+    _validate_actor_nets(matrix, nominal_by_actor)
+    return matrix
+
+
+def _validate_actor_nets(matrix: ActorFlowMatrix, nominal_by_actor: Mapping[str, float]) -> None:
+    """Checks every actor's ribbon net against the nominal sum the timeline books on that payer.
+
+    The per-actor half of the V1 reconciliation, mirroring `_transfer_ribbons`' zero-sum check:
+    the ribbons are a re-shaping of the timeline, so re-summing them per node has to give the
+    timeline's own per-payer total back. A difference is never a rounding story — the ribbons are
+    the same nominal amounts — it means money changed ends on the way into the picture.
+
+    Args:
+        matrix: The assembled matrix, ribbons and node columns.
+        nominal_by_actor: Payer node -> nominal sum of that payer's entries inside the horizon.
+
+    Raises:
+        CostDataError: If any actor's net differs by more than
+            `ViewTolerances.RECONCILIATION_EPSILON`.
+    """
+    nets = matrix.net_by_actor()
+    mismatches = [
+        f"{actor}: ribbons net to {nets.get(actor, 0.0):,.2f} EUR, the timeline books "
+        f"{expected:,.2f} EUR"
+        for actor, expected in nominal_by_actor.items()
+        if abs(nets.get(actor, 0.0) - expected) > ViewTolerances.RECONCILIATION_EPSILON
+    ]
+    if mismatches:
+        raise CostDataError(
+            "The actor-flow ribbons do not reconcile with the timeline's per-payer nominal sums, "
+            "so the Sankey would misattribute money: " + "; ".join(mismatches) + ". Every ribbon "
+            "is one end of a timeline entry, so a difference means a ribbon was drawn to the "
+            "wrong node — check `FlowCounterparties` for a counterparty label that collides with "
+            "a payer's."
+        )
 
 
 def _transfer_ribbons(transfer_net: Dict[str, float]) -> List[ActorFlow]:
-    """Payer-to-payer ribbons for the declared transfer categories, validated to net to zero.
+    """The single payer-to-payer ribbon of the declared transfers, validated to net to zero.
 
-    Splits the payers into the ones a transfer category leaves (positive net, the paying leg) and
-    the ones it reaches (negative net, the receiving leg) and connects them, distributing
-    proportionally when there is more than one of either — today there is exactly one of each
-    (tenant pays, landlord receives), and the general form exists so a second transfer pair does
-    not need new code.
+    `FlowCounterparties.TRANSFER_CATEGORIES` declares one category today, the §559e modernization
+    levy, and it is booked as one matched pair: the tenant pays, the landlord receives. So the
+    ribbon is that pair — one payer, one receiver, the whole net — and a run with a second payer
+    or a second receiver is *refused* rather than drawn.
+
+    The refusal replaces a proportional payer × receiver split that used to run here. With one
+    payer and one receiver the split is the identity, so it was never exercised; with two of
+    either it would have invented an allocation the engine never made — a tenant's levy spread
+    over two landlords in proportion to what they received is an assumption, not a reading of the
+    timeline. Restoring a split is the right upgrade when a second transfer category arrives, and
+    it will then need the pair *the entries themselves* carry (per category and per subject)
+    rather than a proportion derived from the nets.
+
+    Args:
+        transfer_net: Payer node -> nominal net of that payer's transfer entries; positive is a
+            payer of the transfer, negative a receiver.
+
+    Returns:
+        The one ribbon, or an empty list when the run books no transfer at all.
 
     Raises:
         CostDataError: If the declared transfers do not net to zero across payers, i.e. if the
-            allocation created or destroyed money.
+            allocation created or destroyed money; or if more than one payer or more than one
+            receiver appears.
     """
     total = sum(transfer_net.values())
     if abs(total) > ViewTolerances.RECONCILIATION_EPSILON:
@@ -1818,25 +1976,35 @@ def _transfer_ribbons(transfer_net: Dict[str, float]) -> List[ActorFlow]:
             f"(residual {total:,.2f} EUR): {transfer_net}. A transfer pair that does not cancel "
             "means the allocation ruleset created or destroyed money (§6.5)."
         )
-    payers = {actor: value for actor, value in transfer_net.items() if value > 0}
-    receivers = {actor: -value for actor, value in transfer_net.items() if value < 0}
-    receiver_total = sum(receivers.values())
-    flows: List[ActorFlow] = []
-    for payer, paid in payers.items():
-        for receiver, received in receivers.items():
-            share = received / receiver_total if receiver_total else 0.0
-            amount = paid * share
-            if amount > ViewTolerances.RECONCILIATION_EPSILON:
-                flows.append(
-                    ActorFlow(
-                        source=payer,
-                        target=receiver,
-                        amount_in_euro=amount,
-                        category=CostCategory.MODERNIZATION_LEVY,
-                        is_transfer=True,
-                    )
-                )
-    return flows
+    payers = {
+        actor: value for actor, value in transfer_net.items()
+        if value > ViewTolerances.RECONCILIATION_EPSILON
+    }
+    receivers = {
+        actor: -value for actor, value in transfer_net.items()
+        if value < -ViewTolerances.RECONCILIATION_EPSILON
+    }
+    if len(payers) > 1 or len(receivers) > 1:
+        raise CostDataError(
+            f"The declared inter-actor transfers run between more than two parties — payers "
+            f"{sorted(payers)}, receivers {sorted(receivers)} — and the actor Sankey draws one "
+            "payer-to-receiver ribbon. Splitting the transfer across the parties would invent an "
+            "allocation the timeline does not carry; give the ribbon builder the per-entry pairs "
+            "before booking a second transfer category."
+        )
+    if not payers or not receivers:
+        return []
+    payer, paid = next(iter(payers.items()))
+    receiver = next(iter(receivers))
+    return [
+        ActorFlow(
+            source=payer,
+            target=receiver,
+            amount_in_euro=paid,
+            category=CostCategory.MODERNIZATION_LEVY,
+            is_transfer=True,
+        )
+    ]
 
 
 def _fold_small_flows(flows: List[ActorFlow]) -> Tuple[List[ActorFlow], int, float]:
@@ -1938,9 +2106,15 @@ class AttributionRow:
     """One subject's contribution to the width of the total NPV band (V3).
 
     `low_delta_in_euro` and `high_delta_in_euro` are the subject's own NPV in the LOW resp. HIGH
-    world minus its NPV in the BEST_ESTIMATE world — signed, and *not* absolute widths. For a
-    mirrored revenue subject (feed-in, support) the LOW delta can be positive, which puts the
-    whole bar on one side of the axis; that is correct and is what the caption explains.
+    world minus its NPV in the BEST_ESTIMATE world — signed, and *not* absolute widths.
+
+    The sign of a revenue subject's LOW delta follows the band's orientation, and the orientation
+    is already fixed by the time a flow reaches the timeline: a revenue-type amount enters through
+    `UncertainValue.as_revenue`, which mirrors the band so that `minimum` always means "this
+    entry in the LOW world" — for a revenue, the world where the *most* money arrives. A feed-in
+    or support subject therefore has a negative LOW delta and a positive HIGH delta exactly like a
+    cost subject, and its bar straddles the axis the same way. A positive LOW delta would mean an
+    unmirrored band reached the timeline, which the entry's own min <= best <= max check forbids.
     """
 
     subject: str
@@ -2053,18 +2227,27 @@ def comparison_bridge(
     BEST_ESTIMATE slot, validated here.
 
     Raises:
-        CostDataError: If the steps do not sum to the published NPV delta.
+        CostDataError: If the steps do not sum to the published NPV delta, or if the caller's
+            group keys cannot be ordered — see below.
     """
     variant_groups = fold_categories(variant.npv_by_category, mapping)
     reference_groups = fold_categories(reference.npv_by_category, mapping)
     present: Set[Any] = set(variant_groups) | set(reference_groups)
     try:
-        # Display-group indices sort into the fixed order every chart stacks them in; a mapping
-        # whose keys are not orderable keeps first-appearance order instead, which is still fixed.
+        # Display-group indices sort into the fixed order every chart stacks them in.
         keys: List[Any] = sorted(present)
-    except TypeError:
-        keys = [key for key in list(variant_groups) + list(reference_groups) if key in present]
-        keys = list(dict.fromkeys(keys))
+    except TypeError as error:
+        # A mapping whose keys cannot be compared has no bar order, and the bar order is the
+        # bridge's whole readability claim (IBCS): two reports drawn from mappings that happened
+        # to iterate differently would put the same group in different places, which is exactly
+        # the silent divergence this view exists to prevent. Falling back to first-appearance
+        # order used to hide that; naming the keys hands the caller the fix.
+        raise CostDataError(
+            "The comparison bridge's group keys cannot be ordered, so its bars have no fixed "
+            f"order: {sorted((type(key).__name__, repr(key)) for key in present)}. Give the "
+            "category mapping keys of one orderable type (the display-group index every caller "
+            "in this package passes)."
+        ) from error
     zero = UncertainValue.exact(0.0)
     steps = [
         BridgeStep(
@@ -2098,6 +2281,12 @@ class TotalCostOfCredit:
     sequence (disbursement and grant in, debt service out), i.e. the Effektivzins a reader can
     compare with a bank's offer.
 
+    The rate is `None` whenever the flows on the timeline do not define one, and
+    `effective_annual_rate_note` then says why in a phrase the panel can print beside the "n/a" —
+    "no rate" and "no rate *because the schedule reaches past the horizon*" are very different
+    statements about a loan, and the second one is not a defect the reader should have to guess
+    at. The note is empty exactly when a rate is given.
+
     `fees_in_euro` is structurally zero today: the engine books no loan fee category, and the
     field exists so that the disclosure is complete and a future fee flows straight in rather
     than being bolted onto the interest. `unrepaid_principal_in_euro` is the part of the
@@ -2111,6 +2300,8 @@ class TotalCostOfCredit:
     grants_in_euro: float
     unrepaid_principal_in_euro: float
     effective_annual_rate: Optional[float]
+    #: Why there is no rate, for the panel to print; empty when `effective_annual_rate` is set.
+    effective_annual_rate_note: str = ""
 
     @property
     def total_repaid_in_euro(self) -> float:
@@ -2136,19 +2327,21 @@ def total_cost_of_credit(result: LifecycleCostResult) -> TotalCostOfCredit:
     `net_cost_of_credit_in_euro` minus the unrepaid principal — validated here.
 
     Returns:
-        The disclosure. `effective_annual_rate` is None when there is no loan at all or when the
-        flow sequence has no sign change to solve for (a grant larger than the debt service).
+        The disclosure. `effective_annual_rate` is None when there is no loan at all, when the
+        schedule reaches past the observation horizon, or when the repayment grant exceeds the
+        whole debt service; `effective_annual_rate_note` names which of the last two it was.
 
     Raises:
         CostDataError: If the loan entries do not reconcile with the disclosure's parts.
     """
     amortization = loan_amortization_series(result)
     horizon = result.parameters.observation_period_in_years
+    scoped = result.scoped_timeline().entries
     interest_total = sum(amortization.interest_in_euro)
     principal_repaid = sum(amortization.principal_in_euro)
     grants = -sum(
         entry.amount_in_euro.best_estimate
-        for entry in result.scoped_timeline().entries
+        for entry in scoped
         if entry.category == CostCategory.SUBSIDY
         and entry.subject == FinancingConstants.FINANCING_SUBJECT
         and 0 <= entry.year <= horizon
@@ -2156,7 +2349,7 @@ def total_cost_of_credit(result: LifecycleCostResult) -> TotalCostOfCredit:
     disbursement = amortization.disbursement_in_euro
     nominal_loan_flows = sum(
         entry.amount_in_euro.best_estimate
-        for entry in result.scoped_timeline().entries
+        for entry in scoped
         if 0 <= entry.year <= horizon
         and (
             entry.category in (
@@ -2168,13 +2361,15 @@ def total_cost_of_credit(result: LifecycleCostResult) -> TotalCostOfCredit:
             )
         )
     )
+    rate, rate_note = _effective_annual_rate(amortization, grants)
     disclosure = TotalCostOfCredit(
         principal_in_euro=disbursement,
         interest_in_euro=interest_total,
         fees_in_euro=0.0,
         grants_in_euro=grants,
         unrepaid_principal_in_euro=disbursement - principal_repaid,
-        effective_annual_rate=_effective_annual_rate(amortization, grants),
+        effective_annual_rate=rate,
+        effective_annual_rate_note=rate_note,
     )
     expected = disclosure.net_cost_of_credit_in_euro - disclosure.unrepaid_principal_in_euro
     if abs(nominal_loan_flows - expected) > ViewTolerances.RECONCILIATION_EPSILON:
@@ -2188,21 +2383,38 @@ def total_cost_of_credit(result: LifecycleCostResult) -> TotalCostOfCredit:
 
 def _effective_annual_rate(
     amortization: LoanAmortization, grants_in_euro: float
-) -> Optional[float]:
+) -> Tuple[Optional[float], str]:
     """Internal rate of the loan's own flows: disbursement and grant in, debt service out.
 
-    The Effektivzins, found by bisection on the same `discount_factor` every other present value
-    in the package uses — one flow sequence instead of a grid. For a fee-free, grant-free annuity
-    with annual periods it returns the nominal rate exactly, which is the null test the spec asks
-    for; a repayment grant strictly lowers it because the borrower received money without owing
-    more.
+    The Effektivzins, found by bisection (`numerics.bisect_root`, shared with the scenario
+    break-even) on the same `discount_factor` every other present value in the package uses — one
+    flow sequence instead of a grid. For a fee-free, grant-free annuity with annual periods it
+    returns the nominal rate exactly, which is the null test the spec asks for; a repayment grant
+    strictly lowers it because the borrower received money without owing more.
+
+    **Two cases have no rate, and both used to produce a wrong one.** A schedule whose term
+    reaches past the observation horizon is only *partly* on the timeline: solving the truncated
+    sequence prices a loan the borrower never took — a ten-year 4 % annuity seen at a four-year
+    horizon looks like −23 %, because most of the repayment is missing. That is refused on the
+    same test `LoanAmortization.loan_free_year` uses, unrepaid principal above the reconciliation
+    epsilon. And the search window is non-negative, `[0, 5.0]`: a repayment grant larger than the
+    whole debt service means the borrower paid back less than was received, for which no
+    non-negative rate solves the sequence, and the old window's −0.99 end always produced a root
+    because the present value there is hugely negative. Both cases return a note instead.
+
+    Args:
+        amortization: The loan's booked interest, principal and disbursement.
+        grants_in_euro: The repayment grant, positive, received at year 0.
 
     Returns:
-        The rate as a fraction, or None when there is no loan or the sequence has no zero
-        crossing inside the searched window (a grant exceeding the whole debt service).
+        `(rate, note)`. The rate is a fraction and the note is empty; or the rate is None and the
+        note says why in a phrase a panel can print.
     """
     if not amortization.has_flows() or amortization.disbursement_in_euro <= 0:
-        return None
+        return None, ""
+    unrepaid = amortization.disbursement_in_euro - sum(amortization.principal_in_euro)
+    if unrepaid > ViewTolerances.RECONCILIATION_EPSILON:
+        return None, "the loan term reaches past the observation horizon"
     inflow = amortization.disbursement_in_euro + grants_in_euro
     service = [
         interest + principal
@@ -2214,32 +2426,36 @@ def _effective_annual_rate(
             amount * discount_factor(rate, year) for year, amount in enumerate(service) if amount
         )
 
-    low, high = -0.99, 5.0
-    if present_value(low) * present_value(high) > 0:
-        return None
-    for _iteration in range(200):
-        middle = (low + high) / 2.0
-        if present_value(low) * present_value(middle) <= 0:
-            high = middle
-        else:
-            low = middle
-    return (low + high) / 2.0
+    rate = bisect_root(present_value, window=(0.0, 5.0), max_iterations=200)
+    if rate is None:
+        return None, "the repayment grant exceeds the debt service"
+    return rate, ""
 
 
 # ============================================================================ V7 event strip
 
-class EventKinds:
+class EventKinds(str, enum.Enum):
     """The three things that can happen to a component on its lifetime strip (V7).
 
-    Named constants rather than an enum because they are compared and printed and nothing else;
-    keeping them together states the vocabulary of the strip in one place — a component is
-    bought, is replaced, or is worth something at the horizon, and nothing on the chart means
-    anything else.
+    The vocabulary of the strip in one place: a component is bought, is replaced, or is worth
+    something at the horizon, and nothing on the chart means anything else. It is an enum rather
+    than a bag of string constants because `LifecycleEvent.kind` is typed with it, which is what
+    makes "nothing else" a property the type checker holds rather than a sentence in a docstring;
+    the `str` mixin keeps the members printable and comparable with the plain strings the
+    renderers were written against, so `event.kind == "residual"` still means what it says.
     """
 
     INVESTMENT = "investment"
     REPLACEMENT = "replacement"
     RESIDUAL = "residual"
+
+    def __str__(self) -> str:
+        """The kind's own word, so a member printed into a label reads as the chart's vocabulary.
+
+        Without this, `f"{kind}"` would render "EventKinds.INVESTMENT" — the enum's default —
+        into a lane label, which is the one place the enum must not be visible.
+        """
+        return self.value
 
 
 @dataclass(frozen=True)
@@ -2253,7 +2469,7 @@ class LifecycleEvent:
 
     year: int
     amount_in_euro: float
-    kind: str
+    kind: EventKinds
 
 
 @dataclass(frozen=True)
@@ -2274,16 +2490,61 @@ class ServiceSpan:
 class EventStripRow:
     """One component's lifetime lane: its purchases, its replacements and its residual (V7).
 
-    The row makes the tightened residual rule visible: `residual` may only be set when the row
-    also has at least one investment or replacement event, because only an installation the
-    timeline actually charged may be written down. `component_event_strip` validates that and
-    raises, which turns a calculator-internal gate into a checked property of the output.
+    The row checks its own shape, because every property the renderer relies on to draw a lane is
+    a property of *this object* rather than of the loop that happened to build it:
+
+    * a `residual` requires at least one investment or replacement event — only an installation
+      the timeline actually charged may be written down (§4.1, review package A);
+    * the events are sorted by year, which is the order the lane is drawn in;
+    * the spans align to the events — one span per event, starting at its year, each running to
+      the start of the next and the last to the horizon — so a lane's bars tile its lane without
+      overlapping or leaving a hole between two events.
+
+    `component_event_strip` builds rows that satisfy all three; the checks are here so that a
+    second builder (a comparison strip, a webtool payload) cannot quietly produce a lane that
+    draws wrongly, and so that the gate is a checked property of the output rather than a
+    calculator-internal rule.
+
+    Raises:
+        CostDataError: If any of the three invariants is violated.
     """
 
     subject: str
     events: List[LifecycleEvent]
     spans: List[ServiceSpan]
     residual: Optional[LifecycleEvent] = None
+
+    def __post_init__(self) -> None:
+        """Enforces the three invariants stated in the class docstring."""
+        if self.residual is not None and not self.events:
+            raise CostDataError(
+                f"Subject {self.subject!r} carries a residual-value credit of "
+                f"{self.residual.amount_in_euro:,.2f} EUR without any investment or replacement "
+                "the timeline charged; only an installation charged inside the horizon may be "
+                "written down (§4.1, review package A)."
+            )
+        years = [event.year for event in self.events]
+        if years != sorted(years):
+            raise CostDataError(
+                f"The events of subject {self.subject!r} are not in year order ({years}); the "
+                "lane is drawn in this order and its spans are derived from it."
+            )
+        if len(self.spans) != len(self.events):
+            raise CostDataError(
+                f"Subject {self.subject!r} has {len(self.spans)} service span(s) for "
+                f"{len(self.events)} event(s); a span starts at every event and only there."
+            )
+        for index, (event, span) in enumerate(zip(self.events, self.spans)):
+            following = self.spans[index + 1].start_year if index + 1 < len(self.spans) else None
+            if span.start_year != event.year or span.end_year < span.start_year or (
+                following is not None and span.end_year != following
+            ):
+                raise CostDataError(
+                    f"The service spans of subject {self.subject!r} do not align to its events: "
+                    f"span {index} runs {span.start_year}..{span.end_year} for an event in year "
+                    f"{event.year}. Spans run from an event to the next one, and the last to the "
+                    "horizon."
+                )
 
     @property
     def year_zero_investment_in_euro(self) -> float:
@@ -2306,8 +2567,9 @@ def component_event_strip(result: LifecycleCostResult) -> List[EventStripRow]:
     sums equal the per-subject `npv_by_component` figures before discounting.
 
     Raises:
-        CostDataError: If a subject carries a residual-value credit without any investment or
-            replacement the timeline charged (the package-A residual gate, as an output property).
+        CostDataError: From `EventStripRow`, whose invariants every row built here has to
+            satisfy — most visibly the package-A residual gate: a subject carrying a
+            residual-value credit without any investment or replacement the timeline charged.
     """
     horizon = result.parameters.observation_period_in_years
     by_subject: Dict[str, List[CashFlowEntry]] = {}
@@ -2342,13 +2604,6 @@ def component_event_strip(result: LifecycleCostResult) -> List[EventStripRow]:
         if residual_amount:
             residual = LifecycleEvent(
                 year=horizon, amount_in_euro=residual_amount, kind=EventKinds.RESIDUAL
-            )
-        if residual is not None and not events:
-            raise CostDataError(
-                f"Subject {subject!r} carries a residual-value credit of "
-                f"{residual.amount_in_euro:,.2f} EUR without any investment or replacement the "
-                "timeline charged; only an installation charged inside the horizon may be "
-                "written down (§4.1, review package A)."
             )
         events.sort(key=lambda event: event.year)
         spans = [

--- a/hisim/economics/views.py
+++ b/hisim/economics/views.py
@@ -43,13 +43,26 @@ from __future__ import annotations
 
 from collections.abc import Hashable
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Mapping, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, TypeVar
 
+from hisim.economics.calculators.financing_application import FinancingConstants
 from hisim.economics.calculators.subsidy_application import nominal_support_from_entries
 from hisim.economics.carriers import EnergyCarrier
-from hisim.economics.results import LifecycleCostResult
+from hisim.economics.catalog_entries import CostDataError
+from hisim.economics.results import (
+    LifecycleCostResult,
+    ModernizationLevySummary,
+    discounted_payback_year,
+)
 from hisim.economics.subsidies import PayoutKind, SubsidyAward, SubsidySchemeLabels
-from hisim.economics.timeline import Actor, CategoryRules, CostCategory, discount_factor
+from hisim.economics.timeline import (
+    Actor,
+    CashFlowEntry,
+    CategoryRules,
+    CostCategory,
+    SubjectKind,
+    discount_factor,
+)
 from hisim.economics.uncertainty import Slot, UncertainValue
 
 
@@ -236,6 +249,25 @@ class LoanAmortization:
     def has_flows(self) -> bool:
         """True when the perspective is financed at all."""
         return any(self.interest_in_euro) or any(self.principal_in_euro)
+
+    def loan_free_year(self) -> Optional[int]:
+        """First year the outstanding balance reaches zero, or None while debt remains.
+
+        The "loan-free" milestone a lifecycle-milestone lane draws. It reads the balance series
+        rather than the plan's term so that a truncated schedule (a term reaching past the
+        observation horizon) honestly reports None instead of a maturity the timeline never books.
+        The tolerance is `ViewTolerances.BALANCE_EPSILON`, which is why this method is defined
+        here but documented with the chart views at the end of the module. An unfinanced
+        perspective has no milestone rather than one in year 1: its balance series is all zeros,
+        and reading a "loan-free" year off a loan that never existed would be a caption stating
+        something that did not happen.
+        """
+        if not self.has_flows():
+            return None
+        for year, balance in enumerate(self.outstanding_balance_in_euro):
+            if year > 0 and balance <= ViewTolerances.BALANCE_EPSILON:
+                return year
+        return None
 
 
 def loan_amortization_series(
@@ -944,3 +976,1388 @@ def total_subsidies_received(result: LifecycleCostResult) -> Optional[UncertainV
     if not entries:
         return None
     return nominal_support_from_entries(entries)
+
+
+# ----- 9/9 views, V1-V7 -----
+
+class ViewTolerances:
+    """Tolerances the self-validating chart views reconcile against (visualization spec §5).
+
+    The views added for the V1-V15 chart set do not merely re-shape the result, they *check*
+    themselves: a Sankey whose transfer ribbons do not net to zero, a tornado whose bars do not
+    sum to the band or a sources-and-uses statement that does not balance is a lie about the
+    engine, so those views raise `CostDataError` instead of drawing. Every such comparison needs
+    a tolerance, and they are collected here so a reviewer can see in one place how much
+    disagreement counts as float noise (half a cent on a euro figure) rather than as a defect.
+    """
+
+    #: Absolute euro tolerance for the reconciliation checks (half a cent, as in the detail table).
+    RECONCILIATION_EPSILON = 0.005
+    #: Balance below this counts as repaid; guards `LoanAmortization.loan_free_year` against
+    #: float residue.
+    BALANCE_EPSILON = 0.01
+    #: Relative tolerance for the kWh attribution check of the energy balance, where quantities
+    #: are large enough that an absolute euro epsilon means nothing.
+    QUANTITY_RELATIVE_EPSILON = 1e-6
+
+
+#: Whatever a fold is folding — a Sankey ribbon, a treemap tile. Generic so `_fold_small` hands
+#: back the caller's own item type rather than an untyped list.
+FoldItem = TypeVar("FoldItem")
+
+
+def _fold_small(
+    items: Sequence[FoldItem],
+    amount_of: Callable[[FoldItem], float],
+    share: float,
+    fold_key: Callable[[FoldItem], Any],
+    fold_factory: Callable[[Any, float], FoldItem],
+) -> Tuple[List[FoldItem], int, float]:
+    """Folds items below `share` of the total into one replacement item per fold key.
+
+    The one fold algorithm of the chart views, written once because the Sankey's ribbon fold and
+    the treemap's tile fold are the same operation on different item types: measure every item,
+    drop the ones carrying less than `share` of the whole, and put back a single replacement per
+    fold key carrying exactly what they carried together. Nothing is ever dropped — the fold is a
+    readability choice, never a silent cap — which is what lets the reconciliation invariants of
+    the folding views survive it.
+
+    Args:
+        items: The items to fold, in the order the caller wants them kept.
+        amount_of: The magnitude of one item; the fold threshold is `share` of their sum.
+        share: Fraction of the total below which an item is folded.
+        fold_key: Which replacement item an folded item belongs to — the (source, target) node
+            pair for ribbons, the display group for tiles — so a fold never merges across the
+            grouping the chart is built on.
+        fold_factory: Builds the replacement item from its fold key and its total amount.
+
+    Returns:
+        `(kept, folded_count, folded_total)` — the surviving items followed by one replacement
+        per fold key, how many items were folded, and the euros they carried.
+    """
+    total = sum(amount_of(item) for item in items)
+    threshold = total * share
+    kept: List[FoldItem] = []
+    folded_amounts: Dict[Any, float] = {}
+    folded_count = 0
+    for item in items:
+        amount = amount_of(item)
+        if amount < threshold:
+            key = fold_key(item)
+            folded_amounts[key] = folded_amounts.get(key, 0.0) + amount
+            folded_count += 1
+            continue
+        kept.append(item)
+    for key, amount in folded_amounts.items():
+        kept.append(fold_factory(key, amount))
+    return kept, folded_count, sum(folded_amounts.values())
+
+
+# ============================================================================ V1 actor flows
+
+class FlowCounterparties:
+    """Who is on the other side of a cash flow, per cost category (visualization spec §3, V1).
+
+    The actor Sankey needs a *node* for every end of every ribbon, and the timeline names only
+    one of the two: the payer. This table supplies the other one — the external counterparty the
+    money goes to or comes from — as a fixed, reviewable mapping from cost category onto the five
+    node labels the owner approved (Q3): "market" for contractors and vendors, "suppliers" for
+    energy, operation and insurance, "state" for taxes and support, "bank" for the loan, and
+    "grid operator" for feed-in revenue.
+
+    Two properties make the mapping safe to trust. It is *declared*, not inferred: a category the
+    table does not name raises `CostDataError` rather than landing in a default bucket, so a
+    category added to the engine cannot silently disappear into an unlabelled ribbon. And
+    inter-actor transfers are declared separately in `TRANSFER_CATEGORIES` instead of being
+    detected by summing to zero at runtime — a transfer that fails to net out is then a reported
+    defect rather than a pair of ribbons that quietly stopped being a transfer.
+    """
+
+    #: Contractors and vendors: the capital side, including the residual value written back.
+    MARKET = "market"
+    #: Energy, maintenance, fixed operation and insurance suppliers.
+    SUPPLIERS = "suppliers"
+    #: Taxes, carbon charges and public support.
+    STATE = "state"
+    #: The lender: disbursement in, debt service out.
+    BANK = "bank"
+    #: The buyer of exported electricity.
+    GRID_OPERATOR = "grid operator"
+
+    #: Cost category -> counterparty node. Total over the categories that are not transfers;
+    #: anything missing is a defect and raises (see `counterparty_of`).
+    BY_CATEGORY: Dict[CostCategory, str] = {
+        CostCategory.INVESTMENT: MARKET,
+        CostCategory.PLANNING: MARKET,
+        CostCategory.REMOVAL: MARKET,
+        CostCategory.REPLACEMENT: MARKET,
+        CostCategory.RESIDUAL_VALUE: MARKET,
+        CostCategory.ANYWAY_COST_CREDIT: MARKET,
+        # The §4.2 sinking fund pre-funds a future purchase from the market; it is money set
+        # aside rather than paid out, and the market end is where it is destined.
+        CostCategory.REPLACEMENT_RESERVE: MARKET,
+        CostCategory.MAINTENANCE: SUPPLIERS,
+        CostCategory.FIXED_OPERATION: SUPPLIERS,
+        CostCategory.ENERGY_WORKING: SUPPLIERS,
+        CostCategory.ENERGY_STANDING: SUPPLIERS,
+        CostCategory.ENERGY_CAPACITY_CHARGE: SUPPLIERS,
+        CostCategory.ENERGY_CO2_PRICE: STATE,
+        # A macroeconomic damage charge is not a payment at all; society is the counterparty, and
+        # "state" is the node that stands for it here (the perspective that carries it says so).
+        CostCategory.CO2_DAMAGE: STATE,
+        CostCategory.SUBSIDY: STATE,
+        CostCategory.LOAN_DISBURSEMENT: BANK,
+        CostCategory.LOAN_INTEREST: BANK,
+        CostCategory.LOAN_PRINCIPAL: BANK,
+        CostCategory.FEED_IN_REVENUE: GRID_OPERATOR,
+    }
+
+    #: Categories booked as *matched pairs* between two payers by the allocation rulesets. They
+    #: are drawn payer-to-payer instead of as two external stubs, and the view validates that
+    #: they net to zero across payers (fail-fast, D25).
+    TRANSFER_CATEGORIES = frozenset({CostCategory.MODERNIZATION_LEVY})
+
+    #: Ribbons smaller than this share of the gross flow volume are folded per node pair.
+    SMALL_FLOW_SHARE = 0.005
+
+    #: Label of the folded ribbon; named so the caption and the data agree on the wording.
+    OTHER_LABEL = "other"
+
+    @classmethod
+    def counterparty_of(cls, category: CostCategory) -> str:
+        """The counterparty node of one category, or `CostDataError` if none is declared.
+
+        The fail-fast half of the taxonomy: an unmapped category means the Sankey would have to
+        invent a node, and inventing one would silently misattribute real money. The message
+        names the category and the class to extend, because that is the whole fix.
+        """
+        counterparty = cls.BY_CATEGORY.get(category)
+        if counterparty is None:
+            raise CostDataError(
+                f"No actor-flow counterparty declared for cost category {category.value!r}; add it "
+                "to views.FlowCounterparties.BY_CATEGORY (or to TRANSFER_CATEGORIES if it is an "
+                "inter-actor transfer) before it can be drawn."
+            )
+        return counterparty
+
+
+@dataclass(frozen=True)
+class ActorFlow:
+    """One ribbon of the actor Sankey: nominal euros moving from one node to another.
+
+    Direction is already resolved — `source` pays `target` — so the renderer never has to look
+    at a sign: an entry booked positive (a cost) becomes payer -> counterparty, a negative one
+    (support, revenue, a disbursement) becomes counterparty -> payer, and `amount_in_euro` is
+    always the positive magnitude. `category` is the flow's cost category, which the renderer
+    turns into a display-group hue; it is None for the folded "other" ribbon, which has no single
+    category left.
+    """
+
+    source: str
+    target: str
+    amount_in_euro: float
+    category: Optional[CostCategory] = None
+    is_transfer: bool = False
+
+
+@dataclass(frozen=True)
+class ActorFlowMatrix:
+    """Who pays whom over the whole horizon, as ribbons plus the node columns (V1).
+
+    Nominal lifetime sums of the **full** allocated timeline in the BEST_ESTIMATE slot, which is
+    the only reading under which the §6.5 zero-sum property stays checkable: a scoped timeline
+    would show one leg of every transfer and none of the counter-party's. `total_band` carries
+    the grand total as a band so the title can state the uncertainty the ribbons themselves
+    cannot.
+
+    Reconciliation: `net_by_actor()` of an actor equals the nominal sum of that actor's scoped
+    timeline, and the transfer ribbons net to zero across payers (validated in the view).
+    """
+
+    flows: List[ActorFlow]
+    #: Payer nodes, in the order they first appear on the timeline. Each gets a column of its own
+    #: in the drawing; `actor_columns` decides in which order (Q23).
+    actors: List[str]
+    #: Counterparty nodes that appear as a ribbon source (left column).
+    sources: List[str]
+    #: Counterparty nodes that appear as a ribbon target (right column).
+    sinks: List[str]
+    #: Nominal lifetime total of the whole timeline, as a band, for the title.
+    total_band: UncertainValue
+    #: How many ribbons were folded into "other" and how many euros they carried.
+    folded_ribbon_count: int = 0
+    folded_amount_in_euro: float = 0.0
+
+    def actor_columns(self) -> List[List[str]]:
+        """One column per internal party, ordered so transfers between them run left to right.
+
+        The layout decision (Q23), made here rather than in a renderer because it is a property
+        of the flows and both renderers have to reach the same answer. Every actor used to share
+        one middle column, which meant the tenant-to-landlord levy had nowhere to go: it was drawn
+        as a band looping out of the column and back into it, a special case in both Sankey
+        renderers and the only ribbon on the page that did not read left to right. Giving each
+        party its own column removes the case entirely — the levy becomes an ordinary ribbon
+        between two adjacent columns.
+
+        The order is a topological sort of the transfer graph: an edge runs from each payer to each
+        payee of a declared inter-actor transfer, and a payer's column is placed before its payee's.
+        Ties — actors with no transfer between them, which is every pair in a run without a levy —
+        keep the timeline order the payers first appeared in, so the layout is deterministic and a
+        re-rendered report stays byte-identical. A cycle (A pays B, B pays A) has no topological
+        order at all; the remaining actors are then appended in timeline order rather than raising,
+        because a mutual transfer is a legitimate allocation and a picture whose columns are merely
+        in an arbitrary order is much better than no picture.
+
+        Returns:
+            One single-actor column per party, left to right.
+        """
+        payers_of: Dict[str, Set[str]] = {actor: set() for actor in self.actors}
+        for flow in self.flows:
+            if flow.is_transfer and flow.source in payers_of and flow.target in payers_of:
+                payers_of[flow.target].add(flow.source)
+        ordered: List[str] = []
+        remaining = list(self.actors)
+        while remaining:
+            ready = [actor for actor in remaining if not payers_of[actor] - set(ordered)]
+            if not ready:  # a transfer cycle: keep the input order for what is left
+                ready = remaining[:1]
+            ordered.append(ready[0])
+            remaining.remove(ready[0])
+        return [[actor] for actor in ordered]
+
+    def net_by_actor(self) -> Dict[str, float]:
+        """Outflows minus inflows per actor — the actor's nominal lifetime cost.
+
+        The reconciliation handle: this must equal the nominal sum of the actor's scoped
+        timeline, which is what makes the picture an accounting statement rather than an
+        illustration.
+        """
+        nets: Dict[str, float] = {actor: 0.0 for actor in self.actors}
+        for flow in self.flows:
+            if flow.source in nets:
+                nets[flow.source] += flow.amount_in_euro
+            if flow.target in nets:
+                nets[flow.target] -= flow.amount_in_euro
+        return nets
+
+
+# ------------------------------------------------------------------ story chapters (Q24)
+
+
+@dataclass(frozen=True)
+class StoryPerspectives:
+    """Which evaluated perspectives belong to which chapter of the report (owner decision Q24).
+
+    The report tells three stories — the owner lives here, the owner rents it out, and what it
+    means for the economy — and each is told with its own perspectives. Deciding which is which is
+    a classification of the *results*, not a rendering choice, which is why it lives here: a
+    renderer that picked perspectives by matching their id against strings would silently tell the
+    wrong story for any bundle whose ids differ from the shipped ones.
+
+    Each list may be empty, and an empty one means the chapter is skipped with a log line rather
+    than rendered as an empty box: a run of an owner-occupied house genuinely has no landlord
+    story, and inventing one would be worse than omitting it.
+    """
+
+    owner: Tuple[LifecycleCostResult, ...]
+    rented: Tuple[LifecycleCostResult, ...]
+    society: Tuple[LifecycleCostResult, ...]
+
+
+def has_macroeconomic_accounting(result: LifecycleCostResult) -> bool:
+    """Whether this perspective is the macroeconomic one, by what it books rather than by its id.
+
+    CO2 at its damage cost is the structural signature of §4.5 accounting: no financial
+    perspective books a `CO2_DAMAGE` flow, and the macroeconomic one always does whenever the
+    building emits anything at all. Reading the timeline for it keeps presentation from having to
+    know that the shipped bundle happens to call that perspective "macroeconomic".
+    """
+    return any(entry.category == CostCategory.CO2_DAMAGE for entry in result.timeline.entries)
+
+
+def story_perspectives(results: Iterable[LifecycleCostResult]) -> StoryPerspectives:
+    """Sorts an evaluated matrix's perspectives into the three story chapters (Q24).
+
+    Three rules, applied in this order because the classes overlap at the edges. A perspective
+    that books CO2 damage is the **society** story. One scoped to a landlord or a tenant is the
+    **rented-out** story. Of what is left, the **owner-occupied** story takes the ones an owner
+    would actually be shown: an explicitly owner-scoped perspective, or a net one — a perspective
+    that books support, i.e. the after-subsidy view a household pays out of its own account. The
+    gross perspectives stay out of it, because their whole purpose is the perspective-free "what
+    does the technology cost" question the common chapter answers.
+
+    A run with no support at all would leave the owner story empty by that rule, which would be
+    wrong rather than honest — a cash purchase without subsidies is still an owner's story — so
+    the remaining perspectives are used in that case.
+
+    Args:
+        results: The evaluated perspectives, in bundle order (the order they are rendered in).
+
+    Returns:
+        The three lists, each in the input's order.
+    """
+    society: List[LifecycleCostResult] = []
+    rented: List[LifecycleCostResult] = []
+    rest: List[LifecycleCostResult] = []
+    for result in results:
+        if has_macroeconomic_accounting(result):
+            society.append(result)
+        elif result.scope_payer in (Actor.LANDLORD, Actor.TENANT):
+            rented.append(result)
+        else:
+            rest.append(result)
+    owner = tuple(
+        result for result in rest
+        if result.scope_payer == Actor.OWNER_OCCUPIER
+        or any(entry.category == CostCategory.SUBSIDY for entry in result.scoped_timeline().entries)
+    )
+    return StoryPerspectives(owner=owner or tuple(rest), rented=tuple(rented), society=tuple(society))
+
+
+# ------------------------------------------- party statements (Q21 landlord, Q26 F4 the rest)
+
+
+class LandlordStatementCategories:
+    """Which cost categories are cash and which are accounting credits, plus the row labels (Q21).
+
+    The whole content of a two-sided statement is this split, so it is data rather than a chain of
+    `if`s inside a renderer. **Cash** categories move money through an account in the year they are
+    booked: the investment and the replacements paid to contractors, the maintenance, the levy
+    received from the tenant, the subsidies, the feed-in revenue, the loan flows. **Accounting
+    credits** value something without any money moving — the residual worth of hardware at the
+    horizon and the anyway credit for a renovation the building would have needed regardless. Both
+    belong in a lifecycle NPV; only one of them pays bills, and a landlord perspective can look
+    strongly advantageous on the strength of the half that does not.
+
+    Anything the engine one day books onto a party that is not named here counts as cash, which is
+    the conservative direction: an unclassified flow is then *understated* as an advantage rather
+    than being silently promoted into the accounting half.
+
+    The class keeps its Q21 name because it is the landlord statement's own vocabulary and the
+    charts and tests address it by that name; the generalization to the owner, the tenant and
+    society (Q26 F4) reuses `ACCOUNTING_CREDIT_CATEGORIES` and `LABELS` through
+    `StatementPartitions` rather than restating them.
+    """
+
+    ACCOUNTING_CREDIT_CATEGORIES = (CostCategory.RESIDUAL_VALUE, CostCategory.ANYWAY_COST_CREDIT)
+    #: Labels for the statement rows, so the table reads as a statement rather than as an enum
+    #: dump. A category with no entry here falls back to its own name.
+    LABELS = {
+        CostCategory.INVESTMENT: "investment paid",
+        CostCategory.PLANNING: "planning paid",
+        CostCategory.REMOVAL: "removal of the old system",
+        CostCategory.REPLACEMENT: "replacements paid",
+        CostCategory.MAINTENANCE: "maintenance paid",
+        CostCategory.FIXED_OPERATION: "fixed operation paid",
+        CostCategory.MODERNIZATION_LEVY: "levy income (from the tenant)",
+        CostCategory.SUBSIDY: "subsidies received",
+        CostCategory.ENERGY_WORKING: "energy, working price",
+        CostCategory.ENERGY_STANDING: "energy, standing charge",
+        CostCategory.ENERGY_CO2_PRICE: "energy, CO2 price",
+        CostCategory.ENERGY_CAPACITY_CHARGE: "energy, capacity charge",
+        CostCategory.REPLACEMENT_RESERVE: "replacement reserve paid in",
+        CostCategory.CO2_DAMAGE: "CO2 at damage cost",
+        CostCategory.FEED_IN_REVENUE: "feed-in revenue",
+        CostCategory.LOAN_INTEREST: "loan interest paid",
+        CostCategory.LOAN_PRINCIPAL: "loan principal repaid",
+        CostCategory.LOAN_DISBURSEMENT: "loan disbursed",
+        CostCategory.RESIDUAL_VALUE: "residual value at the horizon",
+        CostCategory.ANYWAY_COST_CREDIT: "anyway credit (avoided renovation)",
+    }
+    #: The node id of the party the income Sankey centres on, and of the terminal node the
+    #: leftover ribbon runs into.
+    LANDLORD_NODE = "landlord"
+    NET_POSITION_NODE = "net position"
+
+
+@dataclass(frozen=True)
+class StatementPartition:
+    """How one party's NPV is split into two named sides (owner decision Q26 F4).
+
+    The generalization of the Q21 landlord statement: every party the report states — the
+    owner-occupier, the landlord, the tenant, society — gets the same two-sided treatment, and the
+    only thing that differs between them is *which* categories belong on the second side and what
+    the two sides are called. Making that a value rather than four near-identical functions is
+    what keeps the reconciliation invariant (the sides sum exactly to the perspective's NPV) a
+    single implementation instead of four chances to get it wrong.
+
+    Fields worth a word. `secondary_categories` are the categories of the second side — the two
+    accounting credits for the household parties, the transfer categories for society.
+    `secondary_is_transfer` switches the second side from "value, not payment" to "money that
+    moves between parties without using resources", which the report renders paired and with an
+    explicit zero-sum line. `labels` is consulted before `LandlordStatementCategories.LABELS`, so
+    a party can rename a row that means something different from its side of the same flow: the
+    levy is *income* to the landlord and a *payment* to the tenant.
+    """
+
+    id: str
+    party_label: str
+    primary_label: str
+    secondary_label: str
+    secondary_categories: Tuple[CostCategory, ...]
+    secondary_is_transfer: bool = False
+    labels: Mapping[CostCategory, str] = field(default_factory=dict)
+
+    def label_of(self, category: CostCategory) -> str:
+        """The row label of one category under this partition, falling back to the shared table."""
+        if category in self.labels:
+            return self.labels[category]
+        return LandlordStatementCategories.LABELS.get(category, category.value)
+
+    def is_secondary(self, category: CostCategory) -> bool:
+        """Whether a category belongs on the second side of this partition."""
+        return category in self.secondary_categories
+
+
+class StatementPartitions:
+    """The four party statements the report publishes (Q21 landlord, Q26 F4 the other three).
+
+    One partition per chapter of the report. The three household parties share the cash /
+    accounting-credit split — it is the same distinction between money that moved and value that
+    was merely booked — and differ only in the row labels and in which flows their perspective
+    carries at all. Society is the structurally different one: its second side is not a book value
+    but the *transfers*, which are the whole point of the macroeconomic view.
+
+    `TENANT` deliberately declares an empty second side. A tenant receives nothing back in this
+    ledger, and the authored prose says so explicitly: where the renovation lowers the energy
+    bill, the relief shows up as a smaller cost line, never as a credit. An empty side is
+    therefore the honest partition rather than a missing feature, and the report renders its
+    subtotal as the zero it is.
+    """
+
+    #: Categories that move money between parties without consuming resources (§4.5). Society's
+    #: second side; the macroeconomic accounting removes every one of them at source, which is
+    #: why they reach the statement summing to zero.
+    TRANSFER_CATEGORIES = (
+        CostCategory.SUBSIDY,
+        CostCategory.MODERNIZATION_LEVY,
+        CostCategory.FEED_IN_REVENUE,
+        CostCategory.ENERGY_CO2_PRICE,
+    )
+
+    LANDLORD = StatementPartition(
+        id="landlord",
+        party_label="landlord",
+        primary_label="cash flows",
+        secondary_label="accounting credits",
+        secondary_categories=LandlordStatementCategories.ACCOUNTING_CREDIT_CATEGORIES,
+    )
+    OWNER = StatementPartition(
+        id="owner",
+        party_label="owner",
+        primary_label="cash flows",
+        secondary_label="accounting credits",
+        secondary_categories=LandlordStatementCategories.ACCOUNTING_CREDIT_CATEGORIES,
+        labels={
+            # The two halves are separate rows rather than one netted figure: the prose speaks of
+            # "the investment net of subsidies", and the honest way to show a net is to show both
+            # numbers that make it.
+            CostCategory.INVESTMENT: "investment paid (gross)",
+            CostCategory.SUBSIDY: "subsidies received (deducted from the investment)",
+            CostCategory.MODERNIZATION_LEVY: "modernization levy",
+        },
+    )
+    TENANT = StatementPartition(
+        id="tenant",
+        party_label="tenant",
+        primary_label="what the tenant pays",
+        secondary_label="credits (none in this ledger)",
+        secondary_categories=(),
+        labels={
+            CostCategory.MODERNIZATION_LEVY: "modernization levy (added to the rent)",
+            CostCategory.ENERGY_WORKING: "energy, working price",
+            CostCategory.ENERGY_STANDING: "energy, standing charge",
+            CostCategory.ENERGY_CO2_PRICE: "energy, CO2 price",
+            CostCategory.MAINTENANCE: "apportioned operating costs",
+            CostCategory.FIXED_OPERATION: "apportioned fixed operation",
+        },
+    )
+    SOCIETY = StatementPartition(
+        id="society",
+        party_label="society",
+        primary_label="real resource costs",
+        secondary_label="transfers",
+        secondary_categories=TRANSFER_CATEGORIES,
+        secondary_is_transfer=True,
+        labels={
+            CostCategory.INVESTMENT: "hardware and installation",
+            CostCategory.REPLACEMENT: "replacements",
+            CostCategory.MAINTENANCE: "maintenance performed",
+            CostCategory.RESIDUAL_VALUE: "residual value at the horizon",
+            CostCategory.ANYWAY_COST_CREDIT: "anyway credit (avoided renovation)",
+            CostCategory.CO2_DAMAGE: "CO2 at damage cost",
+            CostCategory.SUBSIDY: "subsidies (transfer)",
+            CostCategory.MODERNIZATION_LEVY: "modernization levy (transfer)",
+            CostCategory.FEED_IN_REVENUE: "feed-in remuneration (transfer)",
+            CostCategory.ENERGY_CO2_PRICE: "CO2 price on the bill (transfer)",
+        },
+    )
+
+
+@dataclass(frozen=True)
+class StatementLine:
+    """One row of a party statement: a category, its present value and which side it is on.
+
+    `npv_in_euro` keeps the report's sign convention — positive is a cost to the party, negative
+    is money or value arriving — so a reader comparing this row against the perspectives table or
+    the category pivot sees the same number with the same sign, not a re-signed one.
+
+    `is_accounting_credit` says the row sits on the *second* side of its partition. For the three
+    household parties that side is the accounting credits, which is what the flag is named after
+    and what the landlord Sankey styles differently; for society it is the transfers, and the
+    society statement labels the side itself rather than leaning on the flag's name.
+    """
+
+    label: str
+    category: CostCategory
+    npv_in_euro: float
+    is_accounting_credit: bool
+    #: For a paired transfer row: the party that carries this half of the pair, or None for an
+    #: ordinary row. The society statement renders both halves of every transfer so their sum is
+    #: visibly zero (Q26 F4), and the two halves are otherwise indistinguishable.
+    payer: Optional[Actor] = None
+
+
+@dataclass(frozen=True)
+class PerspectiveStatement:
+    """One party's NPV as a two-sided statement (Q21 for the landlord, Q26 F4 for the rest).
+
+    Answers the question the headline NPV cannot: a perspective can show a strongly negative net
+    position — an advantage — while very little of it ever reaches a bank account, because the
+    residual value of the hardware and the anyway credit for a renovation the building needed
+    anyway are book entries, not payments. The statement states each side's bottom line before
+    combining them. Under the society partition the same shape answers a different question: what
+    of the result is real resource use and what is a transfer that nets to zero.
+
+    Reconciliation, validated in :func:`perspective_statement`: `cash_subtotal +
+    accounting_subtotal == net_position == the perspective's total NPV`. It is not new arithmetic
+    — the split is by category over the same discounted timeline everything else in the report
+    reads — which is exactly why the identity has to hold exactly rather than approximately.
+
+    The two side fields keep the Q21 names (`cash_lines`, `accounting_lines`) because that is what
+    they are for three of the four partitions and what the landlord Sankey and its tests address;
+    `partition` carries the labels a renderer should print, so the society statement's sides are
+    titled "real resource costs" and "transfers" without any renderer special-casing.
+    """
+
+    perspective_id: str
+    cash_lines: Tuple[StatementLine, ...]
+    accounting_lines: Tuple[StatementLine, ...]
+    cash_subtotal_in_euro: float
+    accounting_subtotal_in_euro: float
+    net_position_in_euro: float
+    #: The net position as the band the perspectives table publishes, for the caption.
+    net_position_band: UncertainValue
+    #: The levy summary of this perspective, when it has one — the caption's "X EUR/a, cap
+    #: binding" clause reads it. None for a party with no rent increase.
+    levy: Optional[ModernizationLevySummary] = None
+    #: Which partition produced the two sides; supplies the side labels and the transfer flag.
+    partition: StatementPartition = StatementPartitions.LANDLORD
+
+    def income_flows(self) -> Tuple[Tuple[Tuple[str, str, float, bool, Optional[CostCategory]], ...], bool]:
+        """The income-statement Sankey: `(source, target, amount, is_accounting_credit)` + a flag.
+
+        The earnings-Sankey convention (Q25): everything that arrives flows into the landlord node
+        from the left, everything that is spent leaves to the right, and **the ribbon left over is
+        the bottom line** — it runs on to a terminal node named for the net position. Because the
+        report's sign convention is cost-positive, an income line is a category with a negative NPV
+        and an expense line one with a positive NPV.
+
+        Both signs of the net position are handled, which is the case the convention makes easy to
+        get wrong. When the renovation is advantageous for the landlord (negative NPV, income
+        exceeds expenses) the leftover leaves the landlord node to the right, like a profit. When
+        it is a net cost (positive NPV) the picture is a loss: the missing money has to come from
+        somewhere, so the net position enters from the *left* as a source and the flag says so.
+
+        Returns:
+            The ribbons as `(source, target, amount, is_accounting_credit, category)` — the
+            category so the renderer can hue a ribbon like the same money everywhere else, and
+            `None` on the net-position ribbon, which is a result rather than a category — and
+            `True` when the net-position ribbon is an inflow (a net cost) rather than the usual
+            leftover outflow. Ribbon amounts are magnitudes; a Sankey ribbon has no sign.
+        """
+        node = LandlordStatementCategories.LANDLORD_NODE
+        net_node = LandlordStatementCategories.NET_POSITION_NODE
+        flows: List[Tuple[str, str, float, bool, Optional[CostCategory]]] = []
+        for line in list(self.cash_lines) + list(self.accounting_lines):
+            if line.npv_in_euro < 0:
+                flows.append((line.label, node, -line.npv_in_euro, line.is_accounting_credit, line.category))
+            elif line.npv_in_euro > 0:
+                flows.append((node, line.label, line.npv_in_euro, line.is_accounting_credit, line.category))
+        net_is_inflow = self.net_position_in_euro > 0
+        if abs(self.net_position_in_euro) > ViewTolerances.RECONCILIATION_EPSILON:
+            if net_is_inflow:
+                flows.append((net_node, node, self.net_position_in_euro, False, None))
+            else:
+                flows.append((node, net_node, -self.net_position_in_euro, False, None))
+        return tuple(flows), net_is_inflow
+
+
+def landlord_statement(result: LifecycleCostResult) -> PerspectiveStatement:
+    """The landlord's NPV split into money that moves and value that is merely booked (Q21).
+
+    The Q21 statement under its own name: :func:`perspective_statement` with the landlord
+    partition. It stays a named function because the landlord statement is the one that also
+    carries an income Sankey and because three call sites and a test class address it directly.
+
+    Args:
+        result: The landlord perspective's result. Any result is accepted — the split is defined
+            for every perspective — but only a landlord one is meaningful, and the report only
+            renders it for that chapter.
+
+    Returns:
+        The two-sided statement with both subtotals and the net position.
+
+    Raises:
+        CostDataError: If the two sides do not sum to the perspective's total NPV.
+    """
+    return perspective_statement(result, StatementPartitions.LANDLORD)
+
+
+def perspective_statement(
+    result: LifecycleCostResult, partition: StatementPartition
+) -> PerspectiveStatement:
+    """One party's NPV as a two-sided statement, under the given partition (Q21, Q26 F4).
+
+    One pass over `npv_by_category` of the perspective, sorting each category onto the first or
+    the second side of `partition` and subtotalling both. No number is recomputed: the lines are
+    the same present values the category pivot and the perspectives table publish, which is what
+    lets the two sides be added back into the headline figure and checked against it — the whole
+    reason the report may publish a decomposition at all (rule 2.9).
+
+    A transfer partition (society) additionally renders **both halves of every transfer pair**,
+    read from the full allocated timeline rather than the scoped one: a transfer is only visibly
+    zero when the payer and the receiver are on the page together. The two halves cancel, so the
+    reconciliation identity is unaffected — which is exactly the claim the society chapter makes
+    and this is where it is checked rather than asserted.
+
+    Args:
+        result: The perspective to state; its `npv_by_category` and, for a transfer partition,
+            its full `timeline`.
+        partition: Which two sides to split into and what to call them.
+
+    Returns:
+        The two-sided statement with both subtotals and the net position.
+
+    Raises:
+        CostDataError: If the two sides do not sum to the perspective's total NPV. That can only
+            happen if a category was dropped between the pivot and this split, which would make
+            the statement a picture of a business case that is not the one being reported.
+    """
+    primary: List[StatementLine] = []
+    secondary: List[StatementLine] = []
+    for category, band in result.npv_by_category.items():
+        if not band.best_estimate:
+            continue
+        is_secondary = partition.is_secondary(category)
+        line = StatementLine(
+            label=partition.label_of(category),
+            category=category,
+            npv_in_euro=band.best_estimate,
+            is_accounting_credit=is_secondary,
+        )
+        (secondary if is_secondary else primary).append(line)
+    if partition.secondary_is_transfer:
+        secondary = _transfer_statement_lines(result, partition)
+    primary_subtotal = sum(line.npv_in_euro for line in primary)
+    secondary_subtotal = sum(line.npv_in_euro for line in secondary)
+    net = primary_subtotal + secondary_subtotal
+    total = result.total_npv_in_euro.best_estimate
+    if abs(net - total) > ViewTolerances.RECONCILIATION_EPSILON:
+        raise CostDataError(
+            f"{partition.party_label.capitalize()} statement does not reconcile for perspective "
+            f"{result.perspective_id!r}: {partition.primary_label} {primary_subtotal:,.2f} EUR + "
+            f"{partition.secondary_label} {secondary_subtotal:,.2f} EUR = {net:,.2f} EUR, but the "
+            f"perspective's NPV is {total:,.2f} EUR. The two sides are a partition of "
+            "`npv_by_category`, so a difference means a category was lost."
+        )
+    return PerspectiveStatement(
+        perspective_id=result.perspective_id,
+        cash_lines=tuple(primary),
+        accounting_lines=tuple(secondary),
+        cash_subtotal_in_euro=primary_subtotal,
+        accounting_subtotal_in_euro=secondary_subtotal,
+        net_position_in_euro=net,
+        net_position_band=result.total_npv_in_euro,
+        levy=result.modernization_levy,
+        partition=partition,
+    )
+
+
+def _transfer_statement_lines(
+    result: LifecycleCostResult, partition: StatementPartition
+) -> List[StatementLine]:
+    """Both halves of every transfer, from the full timeline, so their sum is visibly zero (F4).
+
+    The society statement's second side. It reads the **full** allocated timeline rather than the
+    perspective's scoped pivot, because a transfer's two halves are booked on two different
+    payers: the scoped view of one of them is not a transfer at all, it is a cost. Every declared
+    transfer category is emitted per payer, in payer order, so a reader sees the tenant's payment
+    beside the landlord's receipt and can add them to zero on the page.
+
+    The macroeconomic accounting removes transfers at source (§4.5) — no subsidy, no feed-in
+    revenue and no CO2 price is ever booked on that perspective — so on a macroeconomic result
+    this returns an empty list, whose subtotal is the zero the statement prints. That is the
+    honest rendering of "the transfers cancel": they never entered.
+
+    Args:
+        result: The perspective whose full timeline is read.
+        partition: Supplies the transfer categories and their labels.
+
+    Returns:
+        One line per (category, payer) with a non-zero present value, in timeline order.
+    """
+    interest = result.parameters.interest_rate
+    per_pair: Dict[Tuple[CostCategory, Actor], float] = {}
+    for entry in result.timeline.entries:
+        if entry.category not in partition.secondary_categories:
+            continue
+        key = (entry.category, entry.payer)
+        per_pair[key] = per_pair.get(key, 0.0) + entry.amount_in_euro.best_estimate * discount_factor(
+            interest, entry.year
+        )
+    lines: List[StatementLine] = []
+    for (category, payer), value in per_pair.items():
+        if abs(value) <= ViewTolerances.RECONCILIATION_EPSILON:
+            continue
+        lines.append(
+            StatementLine(
+                label=f"{partition.label_of(category)} — {payer.value}",
+                category=category,
+                npv_in_euro=value,
+                is_accounting_credit=True,
+                payer=payer,
+            )
+        )
+    return lines
+
+
+def actor_flow_matrix(result: LifecycleCostResult) -> ActorFlowMatrix:
+    """Every timeline entry classified into a (source, target, amount) ribbon (V1).
+
+    Reads `result.timeline` — the FULL allocated timeline, deliberately, because the chart's
+    subject *is* the split between payers; the scoped timeline would draw a tenant paying a levy
+    to nobody. Amounts are nominal (undiscounted) lifetime sums of the BEST_ESTIMATE slot (Q2): a
+    banded Sankey is unreadable, so the band travels in `total_band` and is stated in the title
+    instead.
+
+    Three rules decide a ribbon. The counterparty comes from `FlowCounterparties`, declared per
+    category and raising for anything unmapped. The direction comes from the entry's sign, so
+    costs leave the payer and credits arrive. And a category declared in `TRANSFER_CATEGORIES` —
+    the §559e modernization levy today — is drawn payer to payer instead of as two external
+    stubs; the view checks that those legs net to zero across all payers and raises if they do
+    not, since a transfer that creates money is a defect in the allocation ruleset, not something
+    to render.
+
+    Reconciliation: per-actor net (outflows − inflows) equals the nominal sum of that actor's
+    scoped timeline; the transfer ribbons net to zero.
+
+    Raises:
+        CostDataError: On a category with no declared counterparty, or on declared transfers that
+            do not net to zero across payers.
+    """
+    horizon = result.parameters.observation_period_in_years
+    ribbons: Dict[Tuple[str, str, Optional[CostCategory]], float] = {}
+    transfer_net: Dict[str, float] = {}
+    actors: List[str] = []
+    for entry in result.timeline.entries:
+        if not 0 <= entry.year <= horizon:
+            continue
+        actor = entry.payer.value
+        if actor not in actors:
+            actors.append(actor)
+        amount = entry.amount_in_euro.best_estimate
+        if entry.category in FlowCounterparties.TRANSFER_CATEGORIES:
+            transfer_net[actor] = transfer_net.get(actor, 0.0) + amount
+            continue
+        counterparty = FlowCounterparties.counterparty_of(entry.category)
+        key = (
+            (actor, counterparty, entry.category) if amount >= 0 else (counterparty, actor, entry.category)
+        )
+        ribbons[key] = ribbons.get(key, 0.0) + abs(amount)
+    transfer_flows = _transfer_ribbons(transfer_net)
+    matrix_flows = [
+        ActorFlow(source=source, target=target, amount_in_euro=amount, category=category)
+        for (source, target, category), amount in ribbons.items()
+        if amount > ViewTolerances.RECONCILIATION_EPSILON
+    ]
+    matrix_flows, folded_count, folded_amount = _fold_small_flows(matrix_flows)
+    matrix_flows.extend(transfer_flows)
+    sources = [flow.source for flow in matrix_flows if flow.source not in actors]
+    sinks = [flow.target for flow in matrix_flows if flow.target not in actors]
+    return ActorFlowMatrix(
+        flows=matrix_flows,
+        actors=actors,
+        sources=list(dict.fromkeys(sources)),
+        sinks=list(dict.fromkeys(sinks)),
+        total_band=UncertainValue.sum(
+            entry.amount_in_euro for entry in result.timeline.entries if 0 <= entry.year <= horizon
+        ),
+        folded_ribbon_count=folded_count,
+        folded_amount_in_euro=folded_amount,
+    )
+
+
+def _transfer_ribbons(transfer_net: Dict[str, float]) -> List[ActorFlow]:
+    """Payer-to-payer ribbons for the declared transfer categories, validated to net to zero.
+
+    Splits the payers into the ones a transfer category leaves (positive net, the paying leg) and
+    the ones it reaches (negative net, the receiving leg) and connects them, distributing
+    proportionally when there is more than one of either — today there is exactly one of each
+    (tenant pays, landlord receives), and the general form exists so a second transfer pair does
+    not need new code.
+
+    Raises:
+        CostDataError: If the declared transfers do not net to zero across payers, i.e. if the
+            allocation created or destroyed money.
+    """
+    total = sum(transfer_net.values())
+    if abs(total) > ViewTolerances.RECONCILIATION_EPSILON:
+        raise CostDataError(
+            f"Declared inter-actor transfer categories do not net to zero across payers "
+            f"(residual {total:,.2f} EUR): {transfer_net}. A transfer pair that does not cancel "
+            "means the allocation ruleset created or destroyed money (§6.5)."
+        )
+    payers = {actor: value for actor, value in transfer_net.items() if value > 0}
+    receivers = {actor: -value for actor, value in transfer_net.items() if value < 0}
+    receiver_total = sum(receivers.values())
+    flows: List[ActorFlow] = []
+    for payer, paid in payers.items():
+        for receiver, received in receivers.items():
+            share = received / receiver_total if receiver_total else 0.0
+            amount = paid * share
+            if amount > ViewTolerances.RECONCILIATION_EPSILON:
+                flows.append(
+                    ActorFlow(
+                        source=payer,
+                        target=receiver,
+                        amount_in_euro=amount,
+                        category=CostCategory.MODERNIZATION_LEVY,
+                        is_transfer=True,
+                    )
+                )
+    return flows
+
+
+def _fold_small_flows(flows: List[ActorFlow]) -> Tuple[List[ActorFlow], int, float]:
+    """Folds ribbons below `FlowCounterparties.SMALL_FLOW_SHARE` into one "other" per node pair.
+
+    A Sankey with fifty hairline ribbons is unreadable, but dropping them would be a silent cap,
+    so the small ones are merged per (source, target) pair into a single categoryless ribbon and
+    the count and total euros are returned for the caption to name. Folding preserves every node
+    pair's total exactly, which is why the per-actor net reconciliation survives it.
+    """
+    return _fold_small(
+        flows,
+        lambda flow: flow.amount_in_euro,
+        FlowCounterparties.SMALL_FLOW_SHARE,
+        lambda flow: (flow.source, flow.target),
+        lambda key, amount: ActorFlow(source=key[0], target=key[1], amount_in_euro=amount),
+    )
+
+
+# ============================================================================ V2 liquidity fan
+
+def band_zero_crossings(series_by_slot: Mapping[Any, List[float]]) -> Dict[Any, Optional[int]]:
+    """First non-negative year of each slot's series; None where it never crosses (V2).
+
+    The band form of `results.discounted_payback_year`, and it *calls* that function per slot
+    rather than re-implementing the crossing rule, so the fan's annotated interval and the
+    printed payback year cannot disagree about what a crossing is (year 0 excluded, first
+    crossing only). Keys are whatever the caller's series dict uses — `Slot` members for the
+    view-side series, the `"low"/"best_estimate"/"high"` strings a `VariantComparison` carries.
+
+    Returns:
+        One crossing year per input key, None meaning "never within the horizon" — which is a
+        real answer the fan annotates rather than omits.
+    """
+    return {key: discounted_payback_year(series) for key, series in series_by_slot.items()}
+
+
+def cumulative_nominal_cost_series(result: LifecycleCostResult) -> Dict[Slot, List[float]]:
+    """Cumulative *nominal* cost per slot over years 0..T — the liquidity fan's upper panel (V2).
+
+    The undiscounted counterpart of `cumulative_discounted_cost_series`: a slot-wise running sum
+    of `result.annual_cost_series_nominal_in_euro`, so the last point of each slot is that slot's
+    nominal lifetime cost and the highest point is the deepest out-of-pocket position. Summing
+    slot-wise is legitimate precisely because a slot is a coherent world — the LOW curve is "the
+    whole horizon in the cheap world", not a lower confidence bound.
+
+    It exists as a view rather than as a cumsum in the chart because a renderer that adds numbers
+    is a renderer that can disagree with the engine (seam 4).
+    """
+    series: Dict[Slot, List[float]] = {}
+    for slot in Slot:
+        running = 0.0
+        curve: List[float] = []
+        for value in result.annual_cost_series_nominal_in_euro:
+            running += value.slot(slot)
+            curve.append(running)
+        series[slot] = curve
+    return series
+
+
+def worst_liquidity_position(result: LifecycleCostResult) -> Tuple[int, float]:
+    """Year and amount of the deepest out-of-pocket position (BEST_ESTIMATE slot, nominal) (V2).
+
+    The annotation the nominal panel carries and the lifecycle-milestone lane restates: the
+    maximum of the cumulative nominal cost curve, i.e. the point at which the most money has left
+    the account and not come back. Cost is positive here (owner decision Q4), so "deepest" is the
+    curve's maximum, and the reading is carried by the annotation rather than by the axis
+    direction.
+
+    Returns:
+        `(year, cumulative nominal cost in euro)` — year 0 with 0.0 for an empty series.
+    """
+    curve = cumulative_nominal_cost_series(result)[Slot.BEST_ESTIMATE]
+    if not curve:
+        return 0, 0.0
+    worst_year = max(range(len(curve)), key=lambda year: curve[year])
+    return worst_year, curve[worst_year]
+
+
+# ============================================================================ V3 attribution
+
+class AttributionThresholds:
+    """Cut-offs of the uncertainty attribution tornado (V3).
+
+    Only one number, but it decides what a reader sees: how many subjects get their own bar
+    before the rest are folded into a single row. The fold keeps the sum invariant exact, so the
+    cut-off is a readability choice and never a hidden cap.
+    """
+
+    #: Subjects shown individually; everything below is folded into one row.
+    TOP_N = 10
+
+    #: Label of the folded row, shared by the view and every caption that mentions it.
+    FOLD_LABEL = "all other subjects"
+
+
+@dataclass(frozen=True)
+class AttributionRow:
+    """One subject's contribution to the width of the total NPV band (V3).
+
+    `low_delta_in_euro` and `high_delta_in_euro` are the subject's own NPV in the LOW resp. HIGH
+    world minus its NPV in the BEST_ESTIMATE world — signed, and *not* absolute widths. For a
+    mirrored revenue subject (feed-in, support) the LOW delta can be positive, which puts the
+    whole bar on one side of the axis; that is correct and is what the caption explains.
+    """
+
+    subject: str
+    best_estimate_npv_in_euro: float
+    low_delta_in_euro: float
+    high_delta_in_euro: float
+    #: True for the single folded row that carries every subject below the cut-off.
+    is_fold: bool = False
+
+    @property
+    def width_in_euro(self) -> float:
+        """How much of the total band's width this subject accounts for (the sort key)."""
+        return self.high_delta_in_euro - self.low_delta_in_euro
+
+
+def uncertainty_attribution(result: LifecycleCostResult) -> List[AttributionRow]:
+    """Per-subject decomposition of the total NPV band (V3) — attribution, not sensitivity.
+
+    Nothing is re-evaluated here. Because all engine arithmetic is slot-wise, the LOW and HIGH
+    totals decompose *exactly* into per-subject contributions under the same assembly rules the
+    total uses, and this view is that decomposition: `timeline.npv_by(subject)` on the scoped
+    timeline, each subject's LOW and HIGH read against its own BEST_ESTIMATE. The chart title has
+    to say "uncertainty attribution" rather than "sensitivity" for exactly this reason — no input
+    was varied one at a time.
+
+    Rows are sorted by band width descending, and everything below `AttributionThresholds.TOP_N`
+    is folded into one row so that the bars still sum to the total.
+
+    Reconciliation: `sum(low_delta) == total.minimum − total.best_estimate` and
+    `sum(high_delta) == total.maximum − total.best_estimate`, including the folded row —
+    validated here, not only in the tests, because a tornado whose bars do not sum to the total
+    lies quietly.
+
+    Raises:
+        CostDataError: If the per-subject deltas do not sum to the total band's edges.
+    """
+    interest = result.parameters.interest_rate
+    per_subject = result.scoped_timeline().npv_by(interest, lambda entry: entry.subject)
+    rows = [
+        AttributionRow(
+            subject=subject,
+            best_estimate_npv_in_euro=band.best_estimate,
+            low_delta_in_euro=band.minimum - band.best_estimate,
+            high_delta_in_euro=band.maximum - band.best_estimate,
+        )
+        for subject, band in per_subject.items()
+    ]
+    rows.sort(key=lambda row: row.width_in_euro, reverse=True)
+    shown, folded = rows[: AttributionThresholds.TOP_N], rows[AttributionThresholds.TOP_N:]
+    if folded:
+        shown.append(
+            AttributionRow(
+                subject=AttributionThresholds.FOLD_LABEL,
+                best_estimate_npv_in_euro=sum(row.best_estimate_npv_in_euro for row in folded),
+                low_delta_in_euro=sum(row.low_delta_in_euro for row in folded),
+                high_delta_in_euro=sum(row.high_delta_in_euro for row in folded),
+                is_fold=True,
+            )
+        )
+    total = result.total_npv_in_euro
+    for name, actual, expected in (
+        ("low", sum(row.low_delta_in_euro for row in shown), total.minimum - total.best_estimate),
+        ("high", sum(row.high_delta_in_euro for row in shown), total.maximum - total.best_estimate),
+    ):
+        if abs(actual - expected) > ViewTolerances.RECONCILIATION_EPSILON:
+            raise CostDataError(
+                f"Uncertainty attribution does not reconcile with the total band: the {name} "
+                f"deltas sum to {actual:,.2f} EUR but the total's {name} edge is {expected:,.2f} "
+                "EUR away from its best estimate."
+            )
+    return shown
+
+
+# ============================================================================ V4 bridge
+
+@dataclass(frozen=True)
+class BridgeStep:
+    """One floating bar of the comparison bridge: a display group's NPV delta (V4).
+
+    `group` is whatever key the caller's category mapping produces (the display-group index for
+    every caller in this package), and `delta_in_euro` is variant minus reference in the
+    BEST_ESTIMATE slot. Deltas deliberately carry no band: `high(variant − reference)` is not
+    `high(variant) − high(reference)`, so a whisker on a delta bar would be arithmetic that means
+    nothing (spec §3 V4).
+    """
+
+    group: Any
+    delta_in_euro: float
+
+
+def comparison_bridge(
+    reference: LifecycleCostResult,
+    variant: LifecycleCostResult,
+    mapping: Mapping[CostCategory, GroupKey],
+) -> List[BridgeStep]:
+    """Why the variant's NPV differs from the reference's, decomposed by display group (V4).
+
+    The bridge between two published totals: each display group's NPV in the variant minus the
+    same group's NPV in the reference, BEST_ESTIMATE slot, in the fixed group order rather than
+    sorted by magnitude — a bridge whose bars reorder between two reports cannot be read side by
+    side (IBCS). A group present in only one variant folds in naturally, because a missing group
+    is an explicit zero on that side.
+
+    It takes the two *results* rather than the `VariantComparison` because the comparison object
+    publishes deltas per subject and in total, never per category, and re-deriving a category
+    split from subject deltas is not possible. The grouping mapping is passed in for the usual
+    reason (`fold_categories`): grouping is a display concept, the sums are not.
+
+    Reconciliation: `sum(step.delta) == variant.total_npv − reference.total_npv` in the
+    BEST_ESTIMATE slot, validated here.
+
+    Raises:
+        CostDataError: If the steps do not sum to the published NPV delta.
+    """
+    variant_groups = fold_categories(variant.npv_by_category, mapping)
+    reference_groups = fold_categories(reference.npv_by_category, mapping)
+    present: Set[Any] = set(variant_groups) | set(reference_groups)
+    try:
+        # Display-group indices sort into the fixed order every chart stacks them in; a mapping
+        # whose keys are not orderable keeps first-appearance order instead, which is still fixed.
+        keys: List[Any] = sorted(present)
+    except TypeError:
+        keys = [key for key in list(variant_groups) + list(reference_groups) if key in present]
+        keys = list(dict.fromkeys(keys))
+    zero = UncertainValue.exact(0.0)
+    steps = [
+        BridgeStep(
+            group=key,
+            delta_in_euro=(
+                variant_groups.get(key, zero).best_estimate - reference_groups.get(key, zero).best_estimate
+            ),
+        )
+        for key in keys
+    ]
+    expected = variant.total_npv_in_euro.best_estimate - reference.total_npv_in_euro.best_estimate
+    actual = sum(step.delta_in_euro for step in steps)
+    if abs(actual - expected) > ViewTolerances.RECONCILIATION_EPSILON:
+        raise CostDataError(
+            f"Comparison bridge does not reconcile: the steps sum to {actual:,.2f} EUR but the "
+            f"published NPV delta is {expected:,.2f} EUR."
+        )
+    return steps
+
+
+# ============================================================================ V5 cost of credit
+
+@dataclass(frozen=True)
+class TotalCostOfCredit:
+    """The consumer-credit disclosure of a financed perspective (V5's companion panel).
+
+    "You borrow 50,000 and pay back 63,400", in the four parts a loan document states: the
+    principal, the interest it costs, any fees, and the repayment grant that comes back off it.
+    All figures are nominal (undiscounted) euros of the BEST_ESTIMATE slot, because that is what a
+    loan contract quotes; `effective_annual_rate` is the internal rate of the loan's own flow
+    sequence (disbursement and grant in, debt service out), i.e. the Effektivzins a reader can
+    compare with a bank's offer.
+
+    `fees_in_euro` is structurally zero today: the engine books no loan fee category, and the
+    field exists so that the disclosure is complete and a future fee flows straight in rather
+    than being bolted onto the interest. `unrepaid_principal_in_euro` is the part of the
+    disbursement whose repayment falls beyond the observation horizon — a truncated schedule,
+    not a defect, but one the panel has to state or its total would look wrong.
+    """
+
+    principal_in_euro: float
+    interest_in_euro: float
+    fees_in_euro: float
+    grants_in_euro: float
+    unrepaid_principal_in_euro: float
+    effective_annual_rate: Optional[float]
+
+    @property
+    def total_repaid_in_euro(self) -> float:
+        """Principal repaid plus interest plus fees — what actually leaves the account."""
+        return self.principal_in_euro - self.unrepaid_principal_in_euro + self.interest_in_euro + self.fees_in_euro
+
+    @property
+    def net_cost_of_credit_in_euro(self) -> float:
+        """What borrowing cost, net of the repayment grant: interest + fees − grants."""
+        return self.interest_in_euro + self.fees_in_euro - self.grants_in_euro
+
+
+def total_cost_of_credit(result: LifecycleCostResult) -> TotalCostOfCredit:
+    """Principal, interest, fees and grants of the perspective's loan, plus its effective rate.
+
+    Read off the same scoped timeline entries `loan_amortization_series` stacks, so the panel and
+    the bars beside it cannot disagree. The repayment grant is picked up from the SUBSIDY entries
+    booked under the financing subject — that is where `calculators/financing_application.py`
+    puts a Tilgungszuschuss — and it enters the effective-rate calculation as money received at
+    year 0, which is exactly why a grant lowers the rate.
+
+    Reconciliation: the nominal sum of every loan-category entry plus the repayment grant equals
+    `net_cost_of_credit_in_euro` minus the unrepaid principal — validated here.
+
+    Returns:
+        The disclosure. `effective_annual_rate` is None when there is no loan at all or when the
+        flow sequence has no sign change to solve for (a grant larger than the debt service).
+
+    Raises:
+        CostDataError: If the loan entries do not reconcile with the disclosure's parts.
+    """
+    amortization = loan_amortization_series(result)
+    horizon = result.parameters.observation_period_in_years
+    interest_total = sum(amortization.interest_in_euro)
+    principal_repaid = sum(amortization.principal_in_euro)
+    grants = -sum(
+        entry.amount_in_euro.best_estimate
+        for entry in result.scoped_timeline().entries
+        if entry.category == CostCategory.SUBSIDY
+        and entry.subject == FinancingConstants.FINANCING_SUBJECT
+        and 0 <= entry.year <= horizon
+    )
+    disbursement = amortization.disbursement_in_euro
+    nominal_loan_flows = sum(
+        entry.amount_in_euro.best_estimate
+        for entry in result.scoped_timeline().entries
+        if 0 <= entry.year <= horizon
+        and (
+            entry.category in (
+                CostCategory.LOAN_INTEREST, CostCategory.LOAN_PRINCIPAL, CostCategory.LOAN_DISBURSEMENT
+            )
+            or (
+                entry.category == CostCategory.SUBSIDY
+                and entry.subject == FinancingConstants.FINANCING_SUBJECT
+            )
+        )
+    )
+    disclosure = TotalCostOfCredit(
+        principal_in_euro=disbursement,
+        interest_in_euro=interest_total,
+        fees_in_euro=0.0,
+        grants_in_euro=grants,
+        unrepaid_principal_in_euro=disbursement - principal_repaid,
+        effective_annual_rate=_effective_annual_rate(amortization, grants),
+    )
+    expected = disclosure.net_cost_of_credit_in_euro - disclosure.unrepaid_principal_in_euro
+    if abs(nominal_loan_flows - expected) > ViewTolerances.RECONCILIATION_EPSILON:
+        raise CostDataError(
+            f"Total cost of credit does not reconcile with the timeline: the loan entries sum to "
+            f"{nominal_loan_flows:,.2f} EUR nominal, the disclosure implies {expected:,.2f} EUR "
+            "(interest + fees − grants − unrepaid principal)."
+        )
+    return disclosure
+
+
+def _effective_annual_rate(
+    amortization: LoanAmortization, grants_in_euro: float
+) -> Optional[float]:
+    """Internal rate of the loan's own flows: disbursement and grant in, debt service out.
+
+    The Effektivzins, found by bisection on the same `discount_factor` every other present value
+    in the package uses — one flow sequence instead of a grid. For a fee-free, grant-free annuity
+    with annual periods it returns the nominal rate exactly, which is the null test the spec asks
+    for; a repayment grant strictly lowers it because the borrower received money without owing
+    more.
+
+    Returns:
+        The rate as a fraction, or None when there is no loan or the sequence has no zero
+        crossing inside the searched window (a grant exceeding the whole debt service).
+    """
+    if not amortization.has_flows() or amortization.disbursement_in_euro <= 0:
+        return None
+    inflow = amortization.disbursement_in_euro + grants_in_euro
+    service = [
+        interest + principal
+        for interest, principal in zip(amortization.interest_in_euro, amortization.principal_in_euro)
+    ]
+
+    def present_value(rate: float) -> float:
+        return inflow - sum(
+            amount * discount_factor(rate, year) for year, amount in enumerate(service) if amount
+        )
+
+    low, high = -0.99, 5.0
+    if present_value(low) * present_value(high) > 0:
+        return None
+    for _iteration in range(200):
+        middle = (low + high) / 2.0
+        if present_value(low) * present_value(middle) <= 0:
+            high = middle
+        else:
+            low = middle
+    return (low + high) / 2.0
+
+
+# ============================================================================ V7 event strip
+
+class EventKinds:
+    """The three things that can happen to a component on its lifetime strip (V7).
+
+    Named constants rather than an enum because they are compared and printed and nothing else;
+    keeping them together states the vocabulary of the strip in one place — a component is
+    bought, is replaced, or is worth something at the horizon, and nothing on the chart means
+    anything else.
+    """
+
+    INVESTMENT = "investment"
+    REPLACEMENT = "replacement"
+    RESIDUAL = "residual"
+
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    """One dated event on a component's strip: what happened, when, and for how much.
+
+    Amounts are nominal BEST_ESTIMATE-slot euros as the timeline booked them, so an investment is
+    positive and a residual value negative — the sign is the reader's cue that the residual is a
+    credit, and the renderer does not flip it.
+    """
+
+    year: int
+    amount_in_euro: float
+    kind: str
+
+
+@dataclass(frozen=True)
+class ServiceSpan:
+    """One interval a component was in service, derived from the events the timeline booked.
+
+    Derived from the *booked* events and never from the catalog lifetime: the chart shows what
+    the timeline charged, and a span that disagrees with the database service life is exactly
+    the mismatch a reviewer should be able to see. Spans run from an install or replacement year
+    to the next event, or to the horizon for the last one.
+    """
+
+    start_year: int
+    end_year: int
+
+
+@dataclass(frozen=True)
+class EventStripRow:
+    """One component's lifetime lane: its purchases, its replacements and its residual (V7).
+
+    The row makes the tightened residual rule visible: `residual` may only be set when the row
+    also has at least one investment or replacement event, because only an installation the
+    timeline actually charged may be written down. `component_event_strip` validates that and
+    raises, which turns a calculator-internal gate into a checked property of the output.
+    """
+
+    subject: str
+    events: List[LifecycleEvent]
+    spans: List[ServiceSpan]
+    residual: Optional[LifecycleEvent] = None
+
+    @property
+    def year_zero_investment_in_euro(self) -> float:
+        """Year-0 investment of this row — the sort key that puts the biggest asset first."""
+        return sum(event.amount_in_euro for event in self.events if event.year == 0)
+
+
+def component_event_strip(result: LifecycleCostResult) -> List[EventStripRow]:
+    """When each component was bought, replaced and written down (V7).
+
+    One row per COMPONENT-kind subject of the scoped timeline, built from the INVESTMENT,
+    REPLACEMENT and RESIDUAL_VALUE entries in the BEST_ESTIMATE slot. Service spans are *derived
+    from those events* — install or replacement to the next event, last one to the horizon —
+    rather than from the database service life, so a component whose booked replacement interval
+    disagrees with the catalog is visible instead of being drawn as the catalog claims.
+
+    Rows are sorted by year-0 investment descending, biggest asset first.
+
+    Reconciliation: every event amount is a timeline entry of the named category, so the row
+    sums equal the per-subject `npv_by_component` figures before discounting.
+
+    Raises:
+        CostDataError: If a subject carries a residual-value credit without any investment or
+            replacement the timeline charged (the package-A residual gate, as an output property).
+    """
+    horizon = result.parameters.observation_period_in_years
+    by_subject: Dict[str, List[CashFlowEntry]] = {}
+    for entry in result.scoped_timeline().entries:
+        if entry.subject_kind != SubjectKind.COMPONENT or not 0 <= entry.year <= horizon:
+            continue
+        if entry.category in (
+            CostCategory.INVESTMENT, CostCategory.REPLACEMENT, CostCategory.RESIDUAL_VALUE
+        ):
+            by_subject.setdefault(entry.subject, []).append(entry)
+    rows: List[EventStripRow] = []
+    for subject, entries in by_subject.items():
+        events: List[LifecycleEvent] = []
+        residual: Optional[LifecycleEvent] = None
+        for category, kind in (
+            (CostCategory.INVESTMENT, EventKinds.INVESTMENT),
+            (CostCategory.REPLACEMENT, EventKinds.REPLACEMENT),
+        ):
+            years = sorted({entry.year for entry in entries if entry.category == category})
+            for year in years:
+                amount = sum(
+                    entry.amount_in_euro.best_estimate
+                    for entry in entries
+                    if entry.category == category and entry.year == year
+                )
+                events.append(LifecycleEvent(year=year, amount_in_euro=amount, kind=kind))
+        residual_amount = sum(
+            entry.amount_in_euro.best_estimate
+            for entry in entries
+            if entry.category == CostCategory.RESIDUAL_VALUE
+        )
+        if residual_amount:
+            residual = LifecycleEvent(
+                year=horizon, amount_in_euro=residual_amount, kind=EventKinds.RESIDUAL
+            )
+        if residual is not None and not events:
+            raise CostDataError(
+                f"Subject {subject!r} carries a residual-value credit of "
+                f"{residual.amount_in_euro:,.2f} EUR without any investment or replacement the "
+                "timeline charged; only an installation charged inside the horizon may be "
+                "written down (§4.1, review package A)."
+            )
+        events.sort(key=lambda event: event.year)
+        spans = [
+            ServiceSpan(
+                start_year=event.year,
+                end_year=events[index + 1].year if index + 1 < len(events) else horizon,
+            )
+            for index, event in enumerate(events)
+        ]
+        rows.append(EventStripRow(subject=subject, events=events, spans=spans, residual=residual))
+    rows.sort(key=lambda row: row.year_zero_investment_in_euro, reverse=True)
+    return rows

--- a/tests/test_economics_views.py
+++ b/tests/test_economics_views.py
@@ -348,7 +348,7 @@ class TestDetailTable:
         timeline_total = sum(
             entry.amount_in_euro.best_estimate for entry in result.scoped_timeline().entries
         )
-        assert table_total == pytest.approx(timeline_total, abs=views.ViewThresholds.DETAIL_ROW_EPSILON * 50)
+        assert table_total == pytest.approx(timeline_total, abs=views.ViewTolerances.DETAIL_ROW_EPSILON * 50)
 
     def test_years_are_ordered_and_rows_sorted_by_amount(self, result):
         """Presentation relies on the order; it is part of the view's contract."""

--- a/tests/test_economics_views_charts_a.py
+++ b/tests/test_economics_views_charts_a.py
@@ -1,0 +1,868 @@
+"""Unit tests for the chart views V1-V7 of the visualization extension (visualization spec §5).
+
+Every chart of the V1-V15 set gets its numbers from a view function, and every one of those views
+either carries an invariant it validates at runtime or has a reconciliation a reviewer is expected
+to check by hand. This module is the first half of that promise — the actor Sankey, the liquidity
+fan, the uncertainty tornado, the comparison bridge, the cost of credit, the ledger heatmap's
+numbers and the component event strip — with one test per row of the visualization spec's §5
+invariant table, on **hand-built timelines** rather than on evaluated runs, so that the expected
+figures are arithmetic a reader can redo on paper. The V8-V15 views are tested in
+`tests/test_economics_views_charts_b.py`, and the rendering of all of them in the renderer tests.
+
+**Why hand-built.** `tests/test_economics_views.py` pins the older views against an evaluated
+result, which is the right shape for views that re-arrange a real evaluation. The chart views are
+different: most of them *validate* something (a transfer that must net to zero, bars that must sum
+to a band, a statement whose two sides must be a partition), and a validation is only tested by
+feeding it data that violates it — which an evaluator will not produce on request. Building the
+timeline directly, in the style of `tests/test_economics_kernel.py`, is what makes both the
+passing and the failing case expressible.
+
+**What a failure means.** A failure here is a *derivation* failure in the chart layer: the engine's
+numbers are unaffected, but a chart would draw something that does not reconcile with them — which
+is exactly the class of defect the self-validating views exist to make impossible. It is distinct
+from a rendering failure (`tests/test_economics_reporting.py`, the goldens) and from an engine
+failure (`tests/test_economics_engine.py`).
+
+The one deliberate exception to "hand-built" is `TestWorkedExampleActorFlows`, which re-states the
+§559e worked example's expected actor-flow matrix as a direct assertion (owner decision Q7); see
+its docstring for why the figures live here rather than in the workbook.
+"""
+
+# clean
+
+import dataclasses
+
+import pytest
+
+from hisim.economics import views
+from hisim.economics.calculators.aggregation import aggregate_timeline
+from hisim.economics.catalog_entries import CostDataError
+from hisim.economics.parameters import EconomicParameters
+from hisim.economics.perspectives import ActorScope
+from hisim.economics.presentation_style import PresentationStyle
+from hisim.economics.results import (
+    CashFlowTimeline,
+    LifecycleCo2Result,
+    LifecycleCostResult,
+    discounted_payback_year,
+)
+from hisim.economics.timeline import Actor, CashFlowEntry, CostCategory, SubjectKind
+from hisim.economics.uncertainty import Slot, UncertainValue
+
+pytestmark = pytest.mark.base
+
+
+def entry(
+    year: int,
+    amount: float,
+    category: CostCategory,
+    subject: str = "HeatPump",
+    payer: Actor = Actor.SYSTEM,
+    band: float = 0.0,
+    subject_kind: SubjectKind = SubjectKind.COMPONENT,
+    scheme_id: str = "",
+) -> CashFlowEntry:
+    """One timeline entry, with an optional symmetric band around the best estimate.
+
+    `band` is a half-width in euros applied on both sides, which keeps the fixtures readable: a
+    100 EUR entry with `band=20` is 80/100/120 for a cost and mirrors correctly for a credit,
+    because the credit fixtures pass negative best estimates and a negative half-width is not
+    needed — the constructor's own min <= best_estimate <= max check catches any fixture that gets
+    it wrong.
+    """
+    amount_band = (
+        UncertainValue.exact(amount)
+        if not band
+        else UncertainValue(best_estimate=amount, minimum=amount - band, maximum=amount + band)
+    )
+    return CashFlowEntry(
+        year=year,
+        amount_in_euro=amount_band,
+        category=category,
+        subject=subject,
+        subject_kind=subject_kind,
+        payer=payer,
+        subsidy_scheme_id=scheme_id or None,
+    )
+
+
+def make_result(
+    entries,
+    horizon: int = 20,
+    interest: float = 0.03,
+    scope: ActorScope = ActorScope.SYSTEM,
+) -> LifecycleCostResult:
+    """A `LifecycleCostResult` built from a hand-written timeline, with consistent aggregates.
+
+    The KPIs are derived through `calculators.aggregation.aggregate_timeline`, i.e. through the
+    engine's own pivot rather than through hand-written totals: a fixture whose `total_npv_in_euro`
+    disagreed with its timeline would make every reconciliation test meaningless. Nothing else of
+    the evaluator runs — no cost database, no subsidy catalog, no calculators — so the entries are
+    exactly what the test wrote.
+
+    Args:
+        entries: The timeline entries; sign validation is on, as it is for engine timelines.
+        horizon: Observation period T.
+        interest: Discount rate.
+        scope: Which payer the perspective reports on.
+
+    Returns:
+        The result, ready to hand to any view.
+    """
+    parameters = EconomicParameters(observation_period_in_years=horizon, interest_rate=interest)
+    timeline = CashFlowTimeline()
+    timeline.extend(entries)
+    aggregation = aggregate_timeline(
+        timeline=timeline,
+        actor_scope=scope,
+        facts_by_subject={},
+        co2_result=LifecycleCo2Result(),
+        parameters=parameters,
+        annual_heat_demand_in_kwh=None,
+    )
+    return LifecycleCostResult(
+        perspective_id="test",
+        parameters=parameters,
+        total_npv_in_euro=aggregation.total_npv_in_euro,
+        equivalent_annual_cost_in_euro=aggregation.equivalent_annual_cost_in_euro,
+        npv_by_category=aggregation.npv_by_category,
+        npv_by_component=aggregation.npv_by_component,
+        npv_by_payer=aggregation.npv_by_payer,
+        component_breakdowns=aggregation.component_breakdowns,
+        annual_cost_series_nominal_in_euro=aggregation.annual_cost_series_nominal_in_euro,
+        monthly_cost_year1_in_euro=aggregation.monthly_cost_year1_in_euro,
+        levelized_cost_of_heat_in_euro_per_kwh=aggregation.levelized_cost_of_heat_in_euro_per_kwh,
+        timeline=timeline,
+        lifecycle_co2_result=LifecycleCo2Result(),
+        scope_payer=aggregation.scope_payer,
+    )
+
+
+def simple_investment_timeline(horizon: int = 20):
+    """A one-component fixture: buy in year 0, run it, get a residual credit at the horizon.
+
+    The smallest timeline that still exercises the investment, energy and residual machinery the
+    strip and the fan read, and the base most tests below extend.
+    """
+    entries = [entry(0, 20000.0, CostCategory.INVESTMENT)]
+    entries += [entry(year, 1000.0, CostCategory.ENERGY_WORKING, subject="ELECTRICITY",
+                      subject_kind=SubjectKind.CARRIER) for year in range(1, horizon + 1)]
+    entries.append(entry(horizon, -5000.0, CostCategory.RESIDUAL_VALUE))
+    return entries
+
+
+class TestActorFlowMatrix:
+    """V1: transfers net to zero, per-actor nets reconcile, an unmapped category raises."""
+
+    def make_levy_result(self) -> LifecycleCostResult:
+        """A landlord/tenant case: the landlord invests, the tenant pays energy and the levy."""
+        entries = [
+            entry(0, 20000.0, CostCategory.INVESTMENT, payer=Actor.LANDLORD),
+            entry(0, -6000.0, CostCategory.SUBSIDY, payer=Actor.LANDLORD, scheme_id="SCHEME_A"),
+            entry(1, 900.0, CostCategory.ENERGY_WORKING, subject="ELECTRICITY",
+                  subject_kind=SubjectKind.CARRIER, payer=Actor.TENANT),
+            entry(1, 600.0, CostCategory.MODERNIZATION_LEVY, payer=Actor.TENANT),
+            entry(1, -600.0, CostCategory.MODERNIZATION_LEVY, payer=Actor.LANDLORD),
+        ]
+        return make_result(entries)
+
+    def test_transfer_ribbons_net_to_zero_across_payers(self):
+        """The levy is drawn tenant -> landlord once, not as two external stubs."""
+        matrix = views.actor_flow_matrix(self.make_levy_result())
+        transfers = [flow for flow in matrix.flows if flow.is_transfer]
+        assert len(transfers) == 1
+        assert (transfers[0].source, transfers[0].target) == (Actor.TENANT.value, Actor.LANDLORD.value)
+        assert transfers[0].amount_in_euro == pytest.approx(600.0)
+
+    def test_per_actor_net_equals_the_scoped_nominal_sum(self):
+        """Outflows minus inflows per actor is that actor's nominal lifetime cost."""
+        result = self.make_levy_result()
+        nets = views.actor_flow_matrix(result).net_by_actor()
+        for actor in (Actor.LANDLORD, Actor.TENANT):
+            expected = sum(
+                item.amount_in_euro.best_estimate
+                for item in result.timeline.entries
+                if item.payer == actor
+            )
+            assert nets[actor.value] == pytest.approx(expected, abs=0.01)
+
+    def test_unbalanced_transfer_raises(self):
+        """A levy pair that does not cancel means the allocation created money."""
+        entries = [
+            entry(0, 20000.0, CostCategory.INVESTMENT, payer=Actor.LANDLORD),
+            entry(1, 600.0, CostCategory.MODERNIZATION_LEVY, payer=Actor.TENANT),
+            entry(1, -400.0, CostCategory.MODERNIZATION_LEVY, payer=Actor.LANDLORD),
+        ]
+        with pytest.raises(CostDataError, match="net to zero"):
+            views.actor_flow_matrix(make_result(entries))
+
+    def test_unmapped_category_raises(self):
+        """A category with no declared counterparty is a defect, not a default bucket."""
+        with pytest.raises(CostDataError, match="counterparty"):
+            views.FlowCounterparties.counterparty_of(CostCategory.MODERNIZATION_LEVY)
+
+    def test_every_non_transfer_category_has_a_counterparty(self):
+        """The taxonomy is total: no engine category can fall through it unnoticed."""
+        for category in CostCategory:
+            if category in views.FlowCounterparties.TRANSFER_CATEGORIES:
+                continue
+            assert views.FlowCounterparties.counterparty_of(category)
+
+    def test_single_actor_result_has_one_node(self):
+        """The skip condition of the chart is visible in the view's own output."""
+        matrix = views.actor_flow_matrix(make_result(simple_investment_timeline()))
+        assert matrix.actors == [Actor.SYSTEM.value]
+
+    def test_actor_columns_put_the_payer_before_the_payee(self):
+        """The transfer graph is sorted topologically, so the levy reads left to right (Q23)."""
+        matrix = views.actor_flow_matrix(self.make_levy_result())
+        columns = matrix.actor_columns()
+        assert all(len(column) == 1 for column in columns)
+        flat = [actor for column in columns for actor in column]
+        assert flat.index(Actor.TENANT.value) < flat.index(Actor.LANDLORD.value)
+
+
+class TestStoryPerspectives:
+    """Q24: the three chapters are decided by what a result books, never by its id."""
+
+    def test_a_co2_damage_flow_makes_a_perspective_the_society_story(self):
+        """CO2 at damage cost is the structural signature of §4.5 accounting."""
+        macro = make_result(
+            [entry(0, 10000.0, CostCategory.INVESTMENT),
+             entry(1, 200.0, CostCategory.CO2_DAMAGE, subject="co2 damage")],
+            horizon=5,
+        )
+        assert views.has_macroeconomic_accounting(macro)
+        stories = views.story_perspectives([macro])
+        assert stories.society == (macro,) and not stories.owner and not stories.rented
+
+    def test_landlord_and_tenant_scopes_are_the_rented_story(self):
+        """A perspective scoped to either party of a tenancy belongs to that chapter."""
+        entries = [entry(0, 10000.0, CostCategory.INVESTMENT, payer=Actor.LANDLORD)]
+        landlord = make_result(entries, horizon=5, scope=ActorScope.LANDLORD)
+        stories = views.story_perspectives([landlord])
+        assert stories.rented == (landlord,)
+
+    def test_a_run_without_support_still_has_an_owner_story(self):
+        """A cash purchase without subsidies is an owner's story, not an empty chapter."""
+        gross = make_result([entry(0, 10000.0, CostCategory.INVESTMENT)], horizon=5)
+        stories = views.story_perspectives([gross])
+        assert stories.owner == (gross,)
+
+    def test_a_net_perspective_is_preferred_over_the_gross_one(self):
+        """With support on the page the owner chapter shows the after-subsidy view only."""
+        gross = make_result([entry(0, 10000.0, CostCategory.INVESTMENT)], horizon=5)
+        net = make_result(
+            [entry(0, 10000.0, CostCategory.INVESTMENT),
+             entry(0, -2000.0, CostCategory.SUBSIDY, scheme_id="S")],
+            horizon=5,
+        )
+        stories = views.story_perspectives([gross, net])
+        assert stories.owner == (net,)
+
+
+class TestLiquidityFanSeries:
+    """V2: the cumulative series re-sums the annual one; the crossing helper agrees with payback."""
+
+    def test_cumulative_nominal_matches_the_annual_series_slotwise(self):
+        """Slot-wise cumsum of the published annual series, recomputed the dumb way."""
+        result = make_result(
+            [entry(0, 10000.0, CostCategory.INVESTMENT, band=1000.0)]
+            + [entry(year, 500.0, CostCategory.MAINTENANCE, band=50.0) for year in range(1, 6)],
+            horizon=5,
+        )
+        series = views.cumulative_nominal_cost_series(result)
+        for slot in Slot:
+            running = 0.0
+            for year, band in enumerate(result.annual_cost_series_nominal_in_euro):
+                running += band.slot(slot)
+                assert series[slot][year] == pytest.approx(running)
+
+    def test_zero_crossing_helper_agrees_with_discounted_payback_year(self):
+        """`band_zero_crossings` is `discounted_payback_year` applied per slot, not a copy of it."""
+        curves = {
+            "low": [-100.0, -50.0, 10.0, 40.0],
+            "best_estimate": [-100.0, -80.0, -20.0, 5.0],
+            "high": [-100.0, -90.0, -70.0, -60.0],
+        }
+        assert views.band_zero_crossings(curves) == {"low": 2, "best_estimate": 3, "high": None}
+        # The crossing rule itself (year 0 excluded, first crossing only) is pinned once, on the
+        # function both the fan and the printed payback year read.
+        assert discounted_payback_year(curves["low"]) == 2
+
+    def test_worst_liquidity_position_is_the_curve_maximum(self):
+        """Cost is plotted upward, so the deepest out-of-pocket point is the maximum (Q4)."""
+        result = make_result(
+            [entry(0, 10000.0, CostCategory.INVESTMENT)]
+            + [entry(year, -3000.0, CostCategory.FEED_IN_REVENUE, subject="ELECTRICITY",
+                     subject_kind=SubjectKind.CARRIER) for year in range(1, 5)],
+            horizon=4,
+        )
+        assert views.worst_liquidity_position(result) == (0, pytest.approx(10000.0))
+
+
+class TestUncertaintyAttribution:
+    """V3: the deltas sum to the band edges, fold included, and mirrored revenue lands correctly."""
+
+    def make_banded_result(self, subjects: int = 12) -> LifecycleCostResult:
+        """Enough subjects to trigger the top-N fold, plus one mirrored revenue subject."""
+        entries = [
+            entry(0, 1000.0 * (index + 1), CostCategory.INVESTMENT, subject=f"Device{index}",
+                  band=100.0 * (index + 1))
+            for index in range(subjects)
+        ]
+        entries.append(
+            CashFlowEntry(
+                year=1,
+                amount_in_euro=UncertainValue(best_estimate=-500.0, minimum=-700.0, maximum=-300.0),
+                category=CostCategory.FEED_IN_REVENUE,
+                subject="PV",
+                subject_kind=SubjectKind.CARRIER,
+            )
+        )
+        return make_result(entries)
+
+    def test_deltas_sum_to_the_total_band_including_the_fold(self):
+        """The invariant the view validates, checked independently of the view's own check."""
+        result = self.make_banded_result()
+        rows = views.uncertainty_attribution(result)
+        total = result.total_npv_in_euro
+        assert sum(row.low_delta_in_euro for row in rows) == pytest.approx(
+            total.minimum - total.best_estimate, abs=0.005
+        )
+        assert sum(row.high_delta_in_euro for row in rows) == pytest.approx(
+            total.maximum - total.best_estimate, abs=0.005
+        )
+
+    def test_rows_are_folded_to_the_declared_cut_off(self):
+        """Thirteen subjects become ten rows plus one fold — no silent dropping."""
+        rows = views.uncertainty_attribution(self.make_banded_result())
+        assert len(rows) == views.AttributionThresholds.TOP_N + 1
+        assert rows[-1].is_fold and rows[-1].subject == views.AttributionThresholds.FOLD_LABEL
+
+    def test_mirrored_revenue_subject_lands_on_the_correct_side(self):
+        """A credit's optimistic world is the one where it earns more, so its LOW delta is negative."""
+        result = make_result(
+            [
+                entry(0, 10000.0, CostCategory.INVESTMENT, band=1000.0),
+                CashFlowEntry(
+                    year=1,
+                    amount_in_euro=UncertainValue(best_estimate=-500.0, minimum=-700.0, maximum=-300.0),
+                    category=CostCategory.FEED_IN_REVENUE,
+                    subject="PV",
+                    subject_kind=SubjectKind.CARRIER,
+                ),
+            ]
+        )
+        rows = {row.subject: row for row in views.uncertainty_attribution(result)}
+        assert rows["PV"].low_delta_in_euro < 0 < rows["PV"].high_delta_in_euro
+        assert rows["HeatPump"].low_delta_in_euro < 0 < rows["HeatPump"].high_delta_in_euro
+
+    def test_degenerate_band_attributes_nothing(self):
+        """An exact result yields all-zero deltas rather than raising — the renderer skips it."""
+        rows = views.uncertainty_attribution(make_result(simple_investment_timeline()))
+        assert all(row.low_delta_in_euro == 0.0 and row.high_delta_in_euro == 0.0 for row in rows)
+
+
+class TestComparisonBridge:
+    """V4: the steps sum to the NPV delta, and a one-sided subject folds in."""
+
+    def test_steps_sum_to_the_published_npv_delta(self):
+        """The bridge's own validation, checked against the two results' published totals."""
+        reference = make_result(
+            [entry(0, 10000.0, CostCategory.INVESTMENT)]
+            + [entry(year, 2000.0, CostCategory.ENERGY_WORKING, subject="GAS",
+                     subject_kind=SubjectKind.CARRIER) for year in range(1, 11)],
+            horizon=10,
+        )
+        variant = make_result(
+            [entry(0, 25000.0, CostCategory.INVESTMENT)]
+            + [entry(year, 900.0, CostCategory.ENERGY_WORKING, subject="ELECTRICITY",
+                     subject_kind=SubjectKind.CARRIER) for year in range(1, 11)],
+            horizon=10,
+        )
+        steps = views.comparison_bridge(reference, variant, PresentationStyle.CATEGORY_TO_GROUP)
+        expected = variant.total_npv_in_euro.best_estimate - reference.total_npv_in_euro.best_estimate
+        assert sum(step.delta_in_euro for step in steps) == pytest.approx(expected, abs=0.005)
+
+    def test_group_present_in_one_variant_only_folds_in(self):
+        """A group the reference does not have is its own step, at its full variant value."""
+        reference = make_result([entry(0, 10000.0, CostCategory.INVESTMENT)], horizon=5)
+        variant = make_result(
+            [entry(0, 10000.0, CostCategory.INVESTMENT),
+             entry(0, -2000.0, CostCategory.SUBSIDY, scheme_id="S")],
+            horizon=5,
+        )
+        steps = {step.group: step.delta_in_euro for step in views.comparison_bridge(
+            reference, variant, PresentationStyle.CATEGORY_TO_GROUP
+        )}
+        subsidy_group = PresentationStyle.CATEGORY_TO_GROUP[CostCategory.SUBSIDY]
+        assert steps[subsidy_group] == pytest.approx(-2000.0)
+
+    def test_step_order_is_the_display_group_order(self):
+        """IBCS: stable semantics across reports, so steps are never sorted by magnitude."""
+        reference = make_result([entry(0, 10000.0, CostCategory.INVESTMENT)], horizon=5)
+        variant = make_result(
+            [entry(0, 12000.0, CostCategory.INVESTMENT),
+             entry(1, 500.0, CostCategory.MAINTENANCE),
+             entry(0, -2000.0, CostCategory.SUBSIDY, scheme_id="S")],
+            horizon=5,
+        )
+        groups = [step.group for step in views.comparison_bridge(
+            reference, variant, PresentationStyle.CATEGORY_TO_GROUP
+        )]
+        assert groups == sorted(groups)
+
+
+class TestLoanViews:
+    """V5: the balance runs to zero for both plan shapes, and the grant shows up as a credit."""
+
+    def annuity_entries(self, principal: float = 10000.0, rate: float = 0.04, term: int = 10):
+        """A textbook annuity schedule booked the way `financing_application` books it."""
+        from hisim.economics.financing import FinancingPlan, loan_flows
+
+        plan = FinancingPlan(nominal_interest_rate=rate, term_in_years=term)
+        disbursement, schedule = loan_flows(plan, UncertainValue.exact(principal))
+        entries = [
+            entry(0, principal, CostCategory.INVESTMENT),
+            entry(0, -disbursement.best_estimate, CostCategory.LOAN_DISBURSEMENT, subject="financing"),
+        ]
+        for year, interest, repayment in schedule:
+            entries.append(
+                entry(year, interest.best_estimate, CostCategory.LOAN_INTEREST, subject="financing")
+            )
+            entries.append(
+                entry(year, repayment.best_estimate, CostCategory.LOAN_PRINCIPAL, subject="financing")
+            )
+        return entries
+
+    def bullet_entries(self, principal: float = 10000.0, rate: float = 0.05, term: int = 8):
+        """An interest-only loan with the whole principal repaid in the final year."""
+        entries = [
+            entry(0, principal, CostCategory.INVESTMENT),
+            entry(0, -principal, CostCategory.LOAN_DISBURSEMENT, subject="financing"),
+        ]
+        for year in range(1, term + 1):
+            entries.append(entry(year, principal * rate, CostCategory.LOAN_INTEREST, subject="financing"))
+        entries.append(entry(term, principal, CostCategory.LOAN_PRINCIPAL, subject="financing"))
+        return entries
+
+    def test_annuity_balance_ends_at_zero(self):
+        """A fully amortizing annuity leaves no debt at the end of its term."""
+        amortization = views.loan_amortization_series(make_result(self.annuity_entries()))
+        assert amortization.disbursement_in_euro == pytest.approx(10000.0)
+        assert amortization.outstanding_balance_in_euro[-1] == pytest.approx(0.0, abs=0.01)
+        assert amortization.loan_free_year() == 10
+
+    def test_bullet_balance_stays_flat_and_then_drops(self):
+        """An interest-only plan repays nothing until the bullet year."""
+        amortization = views.loan_amortization_series(make_result(self.bullet_entries()))
+        assert amortization.outstanding_balance_in_euro[7] == pytest.approx(10000.0)
+        assert amortization.outstanding_balance_in_euro[8] == pytest.approx(0.0, abs=0.01)
+        assert amortization.loan_free_year() == 8
+
+    def test_total_cost_of_credit_decomposes_the_repayment(self):
+        """Principal + interest + fees - grants is what the loan entries add up to."""
+        result = make_result(self.annuity_entries())
+        credit = views.total_cost_of_credit(result)
+        interest = sum(
+            item.amount_in_euro.best_estimate
+            for item in result.timeline.entries
+            if item.category == CostCategory.LOAN_INTEREST
+        )
+        assert credit.principal_in_euro == pytest.approx(10000.0)
+        assert credit.interest_in_euro == pytest.approx(interest)
+        assert credit.fees_in_euro == 0.0
+        assert credit.total_repaid_in_euro == pytest.approx(10000.0 + interest)
+
+    def test_effective_rate_equals_the_nominal_rate_for_a_plain_annuity(self):
+        """The null test: no fees, no grant, annual periods — Effektivzins == nominal rate."""
+        credit = views.total_cost_of_credit(make_result(self.annuity_entries(rate=0.04)))
+        assert credit.effective_annual_rate == pytest.approx(0.04, abs=1e-6)
+
+    def test_a_repayment_grant_strictly_lowers_the_effective_rate(self):
+        """A grant is money received without more debt, so the borrower's rate falls."""
+        entries = self.annuity_entries()
+        entries.append(entry(0, -1500.0, CostCategory.SUBSIDY, subject="financing", scheme_id="SOFT"))
+        credit = views.total_cost_of_credit(make_result(entries))
+        assert credit.grants_in_euro == pytest.approx(1500.0)
+        assert credit.effective_annual_rate is not None
+        assert credit.effective_annual_rate < 0.04
+
+    def test_unfinanced_result_has_no_flows(self):
+        """The skip condition every loan chart shares."""
+        amortization = views.loan_amortization_series(make_result(simple_investment_timeline()))
+        assert not amortization.has_flows()
+        assert amortization.loan_free_year() is None
+
+
+class TestTimelineHeatmapNumbers:
+    """V6: the matrix the ledger heatmap draws reconciles by rows and by columns."""
+
+    def test_column_sums_equal_the_nominal_annual_series(self):
+        """Each year's column adds up to that year's published nominal figure."""
+        result = make_result(simple_investment_timeline(horizon=6), horizon=6)
+        matrix = views.nominal_annual_matrix_by_category(result)
+        for year, row in enumerate(matrix):
+            assert sum(row.values()) == pytest.approx(
+                result.annual_cost_series_nominal_in_euro[year].best_estimate
+            )
+
+    def test_row_sums_equal_the_per_category_nominal_totals(self):
+        """Each category's row adds up to what that category booked over the horizon."""
+        result = make_result(simple_investment_timeline(horizon=6), horizon=6)
+        matrix = views.nominal_annual_matrix_by_category(result)
+        for category in {item.category for item in result.timeline.entries}:
+            expected = sum(
+                item.amount_in_euro.best_estimate
+                for item in result.timeline.entries
+                if item.category == category
+            )
+            assert sum(row.get(category, 0.0) for row in matrix) == pytest.approx(expected)
+
+
+class TestComponentEventStrip:
+    """V7: the residual gate is an output property, and spans tile the horizon per row."""
+
+    def test_residual_without_an_investment_raises(self):
+        """The package-A gate: only a charged installation may be written down."""
+        entries = [
+            entry(1, 500.0, CostCategory.MAINTENANCE, subject="Kept"),
+            entry(20, -3000.0, CostCategory.RESIDUAL_VALUE, subject="Kept"),
+        ]
+        with pytest.raises(CostDataError, match="residual"):
+            views.component_event_strip(make_result(entries))
+
+    def test_service_spans_tile_the_horizon_without_overlap(self):
+        """Spans run event to event and the last one to the horizon; none overlap."""
+        entries = [
+            entry(0, 20000.0, CostCategory.INVESTMENT),
+            entry(15, 22000.0, CostCategory.REPLACEMENT),
+            entry(20, -5000.0, CostCategory.RESIDUAL_VALUE),
+        ]
+        rows = views.component_event_strip(make_result(entries))
+        spans = rows[0].spans
+        assert [(span.start_year, span.end_year) for span in spans] == [(0, 15), (15, 20)]
+        for left, right in zip(spans, spans[1:]):
+            assert left.end_year <= right.start_year
+
+    def test_rows_are_sorted_by_year_zero_investment(self):
+        """Biggest asset first, so the row order is a statement rather than an accident."""
+        entries = [
+            entry(0, 5000.0, CostCategory.INVESTMENT, subject="Small"),
+            entry(0, 30000.0, CostCategory.INVESTMENT, subject="Large"),
+        ]
+        rows = views.component_event_strip(make_result(entries))
+        assert [row.subject for row in rows] == ["Large", "Small"]
+
+    def test_carrier_subjects_are_not_rows(self):
+        """Energy is billed per carrier, not per device; only components get a lane."""
+        rows = views.component_event_strip(make_result(simple_investment_timeline()))
+        assert [row.subject for row in rows] == ["HeatPump"]
+
+
+class TestLandlordStatement:
+    """Q21/Q25: the landlord's cash and his book value are separated, and both pictures agree.
+
+    The section exists because a landlord perspective can publish a strongly negative NPV — an
+    advantage — of which only part is money. The invariant that makes the split trustworthy is
+    that it is a *partition*: cash subtotal plus accounting subtotal is the perspective's NPV, to
+    the cent, because nothing is recomputed. The Sankey below the table draws the same partition,
+    so its ribbons have to reconcile with it as well.
+    """
+
+    def landlord_result(self, net_cost: bool = False):
+        """A landlord perspective: investment and maintenance out, levy, subsidy and credits in.
+
+        With `net_cost` the levy is small enough that the renovation is a net cost to the
+        landlord, which is the other sign of the income Sankey's leftover ribbon.
+        """
+        levy = 400.0 if net_cost else 3000.0
+        entries = [
+            entry(0, 20000.0, CostCategory.INVESTMENT, payer=Actor.LANDLORD),
+            entry(0, -4000.0, CostCategory.SUBSIDY, payer=Actor.LANDLORD),
+            entry(5, 900.0, CostCategory.REPLACEMENT, payer=Actor.LANDLORD),
+            entry(20, -5000.0, CostCategory.RESIDUAL_VALUE, payer=Actor.LANDLORD),
+            entry(2, -3000.0, CostCategory.ANYWAY_COST_CREDIT, payer=Actor.LANDLORD),
+        ]
+        entries.extend(
+            entry(year, 300.0, CostCategory.MAINTENANCE, payer=Actor.LANDLORD) for year in range(1, 21)
+        )
+        entries.extend(
+            entry(year, -levy, CostCategory.MODERNIZATION_LEVY, subject="modernization levy",
+                  payer=Actor.LANDLORD)
+            for year in range(1, 21)
+        )
+        return make_result(entries, scope=ActorScope.LANDLORD)
+
+    def test_the_two_sides_partition_the_perspective_npv(self):
+        """The invariant: cash + accounting == the landlord's NPV, exactly."""
+        statement = views.landlord_statement(self.landlord_result())
+        assert statement.cash_subtotal_in_euro + statement.accounting_subtotal_in_euro == pytest.approx(
+            statement.net_position_in_euro
+        )
+        assert statement.net_position_in_euro == pytest.approx(
+            statement.net_position_band.best_estimate, abs=0.005
+        )
+
+    def test_the_accounting_side_is_exactly_the_two_non_cash_categories(self):
+        """Residual value and the anyway credit, and nothing else, are book entries."""
+        statement = views.landlord_statement(self.landlord_result())
+        assert {line.category for line in statement.accounting_lines} == {
+            CostCategory.RESIDUAL_VALUE, CostCategory.ANYWAY_COST_CREDIT
+        }
+        assert all(not line.is_accounting_credit for line in statement.cash_lines)
+        assert CostCategory.MODERNIZATION_LEVY in {line.category for line in statement.cash_lines}
+
+    def test_a_dropped_category_is_refused_rather_than_drawn(self):
+        """The partition is validated: a statement that does not reconcile raises (D25)."""
+        result = self.landlord_result()
+        broken = dataclasses.replace(
+            result,
+            npv_by_category={
+                category: band for category, band in result.npv_by_category.items()
+                if category != CostCategory.MAINTENANCE
+            },
+        )
+        with pytest.raises(CostDataError, match="does not reconcile"):
+            views.landlord_statement(broken)
+
+    def test_the_income_sankey_ribbons_reconcile_with_the_statement(self):
+        """Income minus expenses is the net position — the identity the picture rests on."""
+        statement = views.landlord_statement(self.landlord_result())
+        flows, net_is_inflow = statement.income_flows()
+        node = views.LandlordStatementCategories.LANDLORD_NODE
+        net_node = views.LandlordStatementCategories.NET_POSITION_NODE
+        income = sum(amount for _s, target, amount, _c, _cat in flows if target == node)
+        expense = sum(amount for source, _t, amount, _c, _cat in flows if source == node)
+        # The leftover ribbon *is* the bottom line, so it is one of the two sums above.
+        assert not net_is_inflow  # this fixture is advantageous for the landlord
+        assert income - expense == pytest.approx(0.0, abs=0.01)
+        leftover = [amount for _s, target, amount, _c, _cat in flows if target == net_node]
+        assert leftover and leftover[0] == pytest.approx(-statement.net_position_in_euro)
+
+    def test_a_net_cost_draws_the_bottom_line_as_an_inflow(self):
+        """The other sign: a loss enters from the left, because the money has to come from somewhere."""
+        statement = views.landlord_statement(self.landlord_result(net_cost=True))
+        assert statement.net_position_in_euro > 0
+        flows, net_is_inflow = statement.income_flows()
+        node = views.LandlordStatementCategories.LANDLORD_NODE
+        net_node = views.LandlordStatementCategories.NET_POSITION_NODE
+        assert net_is_inflow
+        assert any(source == net_node and target == node for source, target, _a, _c, _cat in flows)
+
+    def test_the_accounting_ribbons_are_drawn_in_the_credit_style(self):
+        """Hatched/translucent, so the cash-versus-book split is visible in the picture (Q25)."""
+        statement = views.landlord_statement(self.landlord_result())
+        flows, _net = statement.income_flows()
+        credit_categories = {
+            category for _s, _t, _a, is_credit, category in flows if is_credit
+        }
+        assert credit_categories == {CostCategory.RESIDUAL_VALUE, CostCategory.ANYWAY_COST_CREDIT}
+
+
+class TestWorkedExampleActorFlows:
+    """The §559e worked example's expected actor-flow matrix (owner decision Q7).
+
+    The spec asks for this attestation to live in the workbook
+    (`tests/worked_examples/end_to_end/heating_levy_559e_mixed_package.xlsx`) so that the Sankey's
+    numbers are attested like every other figure of that example. That workbook carries a content
+    fingerprint and a human review attestation (§3.8), which an automated edit cannot renew, so
+    the expected matrix is hand-computed **here** instead and the workbook extension is deferred.
+    The figures below are taken from that example's own yaml: a 30,000 EUR heat pump with a 9,000
+    EUR grant and a 50,000 EUR insulation with a 10,000 EUR grant, and a capped rent increase of
+    3,600 EUR a year over 20 years, which the tenant pays and the landlord receives.
+    """
+
+    HORIZON = 20
+    ANNUAL_LEVY = 3600.0
+
+    def make_worked_example_result(self) -> LifecycleCostResult:
+        """The §559e package as a timeline, landlord and tenant tagged as the ruleset tags them."""
+        entries = [
+            entry(0, 30000.0, CostCategory.INVESTMENT, subject="HeatPump", payer=Actor.LANDLORD),
+            entry(0, 50000.0, CostCategory.INVESTMENT, subject="WallInsulation", payer=Actor.LANDLORD),
+            entry(0, -9000.0, CostCategory.SUBSIDY, subject="HeatPump", payer=Actor.LANDLORD,
+                  scheme_id="HEATING_GRANT"),
+            entry(0, -10000.0, CostCategory.SUBSIDY, subject="WallInsulation", payer=Actor.LANDLORD,
+                  scheme_id="ENVELOPE_GRANT"),
+        ]
+        for year in range(1, self.HORIZON + 1):
+            entries.append(entry(year, self.ANNUAL_LEVY, CostCategory.MODERNIZATION_LEVY,
+                                 subject="HeatPump", payer=Actor.TENANT))
+            entries.append(entry(year, -self.ANNUAL_LEVY, CostCategory.MODERNIZATION_LEVY,
+                                 subject="HeatPump", payer=Actor.LANDLORD))
+        return make_result(entries, horizon=self.HORIZON, interest=0.03)
+
+    def test_expected_actor_flow_matrix(self):
+        """Every ribbon of the three-party case, hand-entered from the worked example."""
+        matrix = views.actor_flow_matrix(self.make_worked_example_result())
+        drawn = {
+            (flow.source, flow.target): flow.amount_in_euro
+            for flow in matrix.flows
+        }
+        expected = {
+            ("landlord", "market"): 80000.0,           # both investments, nominal
+            ("state", "landlord"): 19000.0,            # both grants, nominal
+            ("tenant", "landlord"): 20 * 3600.0,       # the capped levy over the horizon
+        }
+        assert set(drawn) == set(expected)
+        for pair, amount in expected.items():
+            assert drawn[pair] == pytest.approx(amount, abs=0.01)
+
+    def test_expected_actor_nets(self):
+        """Landlord and tenant nets, which must equal each side's nominal lifetime cost."""
+        result = self.make_worked_example_result()
+        nets = views.actor_flow_matrix(result).net_by_actor()
+        assert nets["tenant"] == pytest.approx(20 * self.ANNUAL_LEVY)
+        assert nets["landlord"] == pytest.approx(80000.0 - 19000.0 - 20 * self.ANNUAL_LEVY)
+        assert nets["landlord"] + nets["tenant"] == pytest.approx(80000.0 - 19000.0)
+
+
+class TestPartyStatements:
+    """Q26 F4: the owner, the tenant and society get the landlord's treatment, and it reconciles.
+
+    The rule-2.9 review found three of the four parties publishing a single number where the
+    landlord published a statement. The generalization is only worth anything if the invariant
+    generalizes with it, so what is checked here is the same one in all three: the two sides of
+    the partition are a partition — they sum to the perspective's NPV to the cent, because
+    nothing is recomputed on the way. The tenant additionally has to mirror the landlord's levy
+    income exactly, since the two are the halves of one booked transfer pair.
+    """
+
+    ANNUAL_LEVY = 3000.0
+
+    def rented_entries(self):
+        """One rented case with both parties on it: levy pair, investment, subsidy and bills."""
+        entries = [
+            entry(0, 20000.0, CostCategory.INVESTMENT, payer=Actor.LANDLORD),
+            entry(0, -4000.0, CostCategory.SUBSIDY, payer=Actor.LANDLORD),
+            entry(20, -5000.0, CostCategory.RESIDUAL_VALUE, payer=Actor.LANDLORD),
+            entry(2, -3000.0, CostCategory.ANYWAY_COST_CREDIT, payer=Actor.LANDLORD),
+        ]
+        for year in range(1, 21):
+            entries.append(entry(year, 300.0, CostCategory.MAINTENANCE, payer=Actor.LANDLORD))
+            entries.append(
+                entry(year, 800.0, CostCategory.ENERGY_WORKING, subject="electricity",
+                      payer=Actor.TENANT)
+            )
+            entries.append(
+                entry(year, -self.ANNUAL_LEVY, CostCategory.MODERNIZATION_LEVY,
+                      subject="modernization levy", payer=Actor.LANDLORD)
+            )
+            entries.append(
+                entry(year, self.ANNUAL_LEVY, CostCategory.MODERNIZATION_LEVY,
+                      subject="modernization levy", payer=Actor.TENANT)
+            )
+        return entries
+
+    def owner_result(self):
+        """An owner-occupier perspective with both cash flows and both accounting credits."""
+        entries = [
+            entry(0, 30000.0, CostCategory.INVESTMENT, payer=Actor.OWNER_OCCUPIER),
+            entry(0, -6000.0, CostCategory.SUBSIDY, payer=Actor.OWNER_OCCUPIER),
+            entry(20, -7000.0, CostCategory.RESIDUAL_VALUE, payer=Actor.OWNER_OCCUPIER),
+            entry(2, -2500.0, CostCategory.ANYWAY_COST_CREDIT, payer=Actor.OWNER_OCCUPIER),
+        ]
+        entries.extend(
+            entry(year, 900.0, CostCategory.ENERGY_WORKING, subject="electricity",
+                  payer=Actor.OWNER_OCCUPIER)
+            for year in range(1, 21)
+        )
+        return make_result(entries, scope=ActorScope.OWNER_OCCUPIER)
+
+    def society_result(self):
+        """A macroeconomic perspective: resources plus CO2 damage, with a levy pair on the side.
+
+        The levy pair is kept on the timeline deliberately, even though the shipped macroeconomic
+        perspective strips transfers at source: it is the case the society statement's transfer
+        side exists for, and a fixture without it could not show the two halves cancelling.
+        """
+        entries = [
+            entry(0, 30000.0, CostCategory.INVESTMENT),
+            entry(20, -7000.0, CostCategory.RESIDUAL_VALUE),
+        ]
+        for year in range(1, 21):
+            entries.append(entry(year, 700.0, CostCategory.ENERGY_WORKING, subject="electricity"))
+            entries.append(entry(year, 120.0, CostCategory.CO2_DAMAGE, subject="co2 damage"))
+        return make_result(entries, scope=ActorScope.SYSTEM)
+
+    def test_the_owner_statement_partitions_the_owner_npv(self):
+        """Cash + accounting credits == the owner's NPV, to the cent."""
+        statement = views.perspective_statement(
+            self.owner_result(), views.StatementPartitions.OWNER
+        )
+        assert statement.cash_subtotal_in_euro + statement.accounting_subtotal_in_euro == (
+            pytest.approx(statement.net_position_in_euro)
+        )
+        assert statement.net_position_in_euro == pytest.approx(
+            statement.net_position_band.best_estimate, abs=0.005
+        )
+        assert {line.category for line in statement.accounting_lines} == {
+            CostCategory.RESIDUAL_VALUE,
+            CostCategory.ANYWAY_COST_CREDIT,
+        }
+
+    def test_the_tenant_statement_partitions_the_tenant_npv_with_an_empty_credit_side(self):
+        """The tenant's sides sum to the NPV, and the credit side is empty by construction."""
+        result = make_result(self.rented_entries(), scope=ActorScope.TENANT)
+        statement = views.perspective_statement(result, views.StatementPartitions.TENANT)
+        assert not statement.accounting_lines
+        assert statement.accounting_subtotal_in_euro == 0.0
+        assert statement.cash_subtotal_in_euro == pytest.approx(statement.net_position_in_euro)
+        assert statement.net_position_in_euro == pytest.approx(
+            statement.net_position_band.best_estimate, abs=0.005
+        )
+
+    def test_the_tenant_levy_mirrors_the_landlord_levy_income(self):
+        """The two halves of one transfer pair: same magnitude, opposite sign, both stated."""
+        entries = self.rented_entries()
+        tenant = views.perspective_statement(
+            make_result(entries, scope=ActorScope.TENANT), views.StatementPartitions.TENANT
+        )
+        landlord = views.landlord_statement(make_result(entries, scope=ActorScope.LANDLORD))
+        tenant_levy = next(
+            line for line in tenant.cash_lines
+            if line.category == CostCategory.MODERNIZATION_LEVY
+        )
+        landlord_levy = next(
+            line for line in landlord.cash_lines
+            if line.category == CostCategory.MODERNIZATION_LEVY
+        )
+        assert tenant_levy.npv_in_euro == pytest.approx(-landlord_levy.npv_in_euro, abs=0.005)
+        assert tenant_levy.npv_in_euro > 0 > landlord_levy.npv_in_euro
+
+    def test_the_society_statement_partitions_the_macroeconomic_npv(self):
+        """Real resources + transfers == the macroeconomic NPV, with CO2 on the resource side."""
+        statement = views.perspective_statement(
+            self.society_result(), views.StatementPartitions.SOCIETY
+        )
+        assert statement.cash_subtotal_in_euro + statement.accounting_subtotal_in_euro == (
+            pytest.approx(statement.net_position_in_euro)
+        )
+        assert statement.net_position_in_euro == pytest.approx(
+            statement.net_position_band.best_estimate, abs=0.005
+        )
+        assert CostCategory.CO2_DAMAGE in {line.category for line in statement.cash_lines}
+        assert not statement.accounting_lines
+
+    def test_society_transfers_are_shown_paired_and_sum_to_zero(self):
+        """Both halves of a levy pair reach the transfer side, and the side nets to zero."""
+        result = make_result(self.rented_entries(), scope=ActorScope.SYSTEM)
+        statement = views.perspective_statement(result, views.StatementPartitions.SOCIETY)
+        levy_lines = [
+            line for line in statement.accounting_lines
+            if line.category == CostCategory.MODERNIZATION_LEVY
+        ]
+        assert {line.payer for line in levy_lines} == {Actor.TENANT, Actor.LANDLORD}
+        assert sum(line.npv_in_euro for line in levy_lines) == pytest.approx(0.0, abs=0.005)
+        assert statement.cash_subtotal_in_euro + statement.accounting_subtotal_in_euro == (
+            pytest.approx(statement.net_position_in_euro)
+        )
+
+    def test_a_broken_partition_raises_rather_than_drawing(self):
+        """A statement that does not reconcile is a defect, not a picture to render."""
+        result = self.owner_result()
+        result.total_npv_in_euro = result.total_npv_in_euro + UncertainValue.exact(1000.0)
+        with pytest.raises(CostDataError):
+            views.perspective_statement(result, views.StatementPartitions.OWNER)

--- a/tests/test_economics_views_charts_a.py
+++ b/tests/test_economics_views_charts_a.py
@@ -3,11 +3,12 @@
 Every chart of the V1-V15 set gets its numbers from a view function, and every one of those views
 either carries an invariant it validates at runtime or has a reconciliation a reviewer is expected
 to check by hand. This module is the first half of that promise — the actor Sankey, the liquidity
-fan, the uncertainty tornado, the comparison bridge, the cost of credit, the ledger heatmap's
-numbers and the component event strip — with one test per row of the visualization spec's §5
-invariant table, on **hand-built timelines** rather than on evaluated runs, so that the expected
-figures are arithmetic a reader can redo on paper. The V8-V15 views are tested in
-`tests/test_economics_views_charts_b.py`, and the rendering of all of them in the renderer tests.
+fan, the uncertainty tornado, the comparison bridge, the cost of credit and the component event
+strip — with one test per row of the visualization spec's §5 invariant table, on **hand-built
+timelines** rather than on evaluated runs, so that the expected figures are arithmetic a reader
+can redo on paper. The V8-V15 views arrive with the next slice of the cost stack and are tested in
+`tests/test_economics_views_charts_b.py`, which does not exist yet; the rendering of all of them
+lives in the renderer tests, which arrive with the renderers.
 
 **Why hand-built.** `tests/test_economics_views.py` pins the older views against an evaluated
 result, which is the right shape for views that re-arrange a real evaluation. The chart views are
@@ -22,6 +23,12 @@ numbers are unaffected, but a chart would draw something that does not reconcile
 is exactly the class of defect the self-validating views exist to make impossible. It is distinct
 from a rendering failure (`tests/test_economics_reporting.py`, the goldens) and from an engine
 failure (`tests/test_economics_engine.py`).
+
+The ledger heatmap (V6) has no class of its own here: its matrix view predates this chart set and
+is pinned against an evaluated result in `tests/test_economics_views.py`
+(`test_annual_category_matrix_matches_manual_accumulation` and
+`test_annual_matrix_row_sums_are_the_liquidity_view`), which is the stronger fixture; a hand-built
+copy of those two assertions lived here until the review removed it as a duplicate.
 
 The one deliberate exception to "hand-built" is `TestWorkedExampleActorFlows`, which re-states the
 §559e worked example's expected actor-flow matrix as a direct assertion (owner decision Q7); see
@@ -151,6 +158,30 @@ def simple_investment_timeline(horizon: int = 20):
     return entries
 
 
+def assert_sides_follow_the_partition(statement: views.PerspectiveStatement) -> None:
+    """Every line sits on the side its partition's own rule puts it on, and the net is published.
+
+    What a statement test must not do is re-state the constructor: `perspective_statement` builds
+    `net_position_in_euro` *as* `cash_subtotal + accounting_subtotal`, so asserting that identity
+    asserts an assignment. The property worth checking is the partition itself — each line's side
+    follows `StatementPartition.is_secondary` for that line's own category, independently of any
+    subtotal — plus the one number the split has to agree with something else about: the net
+    position is the band the perspectives table publishes for the same perspective.
+
+    Args:
+        statement: The statement to check, under any of the four partitions.
+    """
+    for line in statement.cash_lines:
+        assert not statement.partition.is_secondary(line.category), line.label
+        assert not line.is_accounting_credit, line.label
+    for line in statement.accounting_lines:
+        assert statement.partition.is_secondary(line.category), line.label
+        assert line.is_accounting_credit, line.label
+    assert statement.net_position_in_euro == pytest.approx(
+        statement.net_position_band.best_estimate, abs=0.005
+    )
+
+
 class TestActorFlowMatrix:
     """V1: transfers net to zero, per-actor nets reconcile, an unmapped category raises."""
 
@@ -221,6 +252,71 @@ class TestActorFlowMatrix:
         flat = [actor for column in columns for actor in column]
         assert flat.index(Actor.TENANT.value) < flat.index(Actor.LANDLORD.value)
 
+    def test_a_transfer_between_more_than_two_parties_is_refused(self):
+        """One payer, one receiver: a wider transfer would need a split the timeline does not carry."""
+        entries = [
+            entry(0, 20000.0, CostCategory.INVESTMENT, payer=Actor.LANDLORD),
+            entry(1, 600.0, CostCategory.MODERNIZATION_LEVY, payer=Actor.TENANT),
+            entry(1, 400.0, CostCategory.MODERNIZATION_LEVY, payer=Actor.OWNER_OCCUPIER),
+            entry(1, -1000.0, CostCategory.MODERNIZATION_LEVY, payer=Actor.LANDLORD),
+        ]
+        with pytest.raises(CostDataError, match="more than two parties"):
+            views.actor_flow_matrix(make_result(entries))
+
+    def test_a_counterparty_that_collides_with_an_actor_breaks_the_net_and_is_caught(self, monkeypatch):
+        """The per-actor reconciliation, on the defect it exists for: money drawn to the wrong node.
+
+        A counterparty label that happens to equal a payer's node name turns an external ribbon
+        into an inter-actor one, which the zero-sum transfer check cannot see — the entries are not
+        declared transfers at all. What catches it is the per-actor net: the tenant's ribbons then
+        credit him 6,000 EUR of the landlord's maintenance that the timeline never booked on him.
+        """
+        monkeypatch.setitem(
+            views.FlowCounterparties.BY_CATEGORY, CostCategory.MAINTENANCE, Actor.TENANT.value
+        )
+        entries = [entry(0, 20000.0, CostCategory.INVESTMENT, payer=Actor.LANDLORD)]
+        entries += [
+            entry(year, 300.0, CostCategory.MAINTENANCE, payer=Actor.LANDLORD) for year in range(1, 21)
+        ]
+        entries += [
+            entry(year, 900.0, CostCategory.ENERGY_WORKING, subject="ELECTRICITY",
+                  subject_kind=SubjectKind.CARRIER, payer=Actor.TENANT)
+            for year in range(1, 21)
+        ]
+        with pytest.raises(CostDataError, match="per-payer nominal sums"):
+            views.actor_flow_matrix(make_result(entries))
+
+    def test_small_ribbons_are_folded_per_node_pair_without_losing_euros(self):
+        """Hairlines are merged per (source, target) pair, and the pair's total is preserved.
+
+        The fold is a readability choice and never a cap, which is exactly why the per-actor net
+        survives it: three supplier ribbons and one feed-in ribbon fall below
+        `SMALL_FLOW_SHARE` of the 100,780 EUR gross volume and come back as one categoryless
+        ribbon per node pair, carrying the same euros the four carried.
+        """
+        entries = [
+            entry(0, 100000.0, CostCategory.INVESTMENT),
+            entry(1, 200.0, CostCategory.MAINTENANCE),
+            entry(1, 100.0, CostCategory.FIXED_OPERATION),
+            entry(1, 50.0, CostCategory.ENERGY_WORKING, subject="ELECTRICITY",
+                  subject_kind=SubjectKind.CARRIER),
+            entry(1, -80.0, CostCategory.FEED_IN_REVENUE, subject="ELECTRICITY",
+                  subject_kind=SubjectKind.CARRIER),
+        ]
+        matrix = views.actor_flow_matrix(make_result(entries, horizon=5))
+        system = Actor.SYSTEM.value
+        assert matrix.folded_ribbon_count == 4
+        assert matrix.folded_amount_in_euro == pytest.approx(430.0)
+        by_pair = {(flow.source, flow.target): flow for flow in matrix.flows}
+        assert len(by_pair) == len(matrix.flows)  # one ribbon per pair once the small ones merged
+        suppliers = by_pair[(system, views.FlowCounterparties.SUPPLIERS)]
+        assert suppliers.amount_in_euro == pytest.approx(350.0) and suppliers.category is None
+        grid = by_pair[(views.FlowCounterparties.GRID_OPERATOR, system)]
+        assert grid.amount_in_euro == pytest.approx(80.0) and grid.category is None
+        investment = by_pair[(system, views.FlowCounterparties.MARKET)]
+        assert investment.category == CostCategory.INVESTMENT
+        assert matrix.net_by_actor()[system] == pytest.approx(100270.0)
+
 
 class TestStoryPerspectives:
     """Q24: the three chapters are decided by what a result books, never by its id."""
@@ -260,6 +356,25 @@ class TestStoryPerspectives:
         stories = views.story_perspectives([gross, net])
         assert stories.owner == (net,)
 
+    def test_a_gross_perspective_beside_a_supported_rented_pair_is_not_promoted(self):
+        """The fallback is for a run without support, not for every run without an owner view.
+
+        The bundle the review names: a gross system perspective plus a rented-out pair, where the
+        support sits on the landlord. The owner rule correctly finds no owner perspective among
+        the leftovers, and the chapter has to stay empty — promoting the perspective-free gross
+        view would tell the owner story with the one perspective whose purpose is the common
+        chapter, and would tell it as if the run had no support.
+        """
+        gross = make_result([entry(0, 30000.0, CostCategory.INVESTMENT)], horizon=5)
+        rented_entries = [
+            entry(0, 30000.0, CostCategory.INVESTMENT, payer=Actor.LANDLORD),
+            entry(0, -9000.0, CostCategory.SUBSIDY, payer=Actor.LANDLORD, scheme_id="GRANT"),
+        ]
+        landlord = make_result(rented_entries, horizon=5, scope=ActorScope.LANDLORD)
+        stories = views.story_perspectives([gross, landlord])
+        assert stories.rented == (landlord,)
+        assert not stories.owner
+
 
 class TestLiquidityFanSeries:
     """V2: the cumulative series re-sums the annual one; the crossing helper agrees with payback."""
@@ -289,6 +404,38 @@ class TestLiquidityFanSeries:
         # The crossing rule itself (year 0 excluded, first crossing only) is pinned once, on the
         # function both the fan and the printed payback year read.
         assert discounted_payback_year(curves["low"]) == 2
+
+    def test_zero_crossings_of_a_cost_curve_are_not_a_payback_year(self):
+        """A cost-shaped curve has no payback crossing, and the helper says year 1 anyway.
+
+        `band_zero_crossings` is `discounted_payback_year` per slot, and that rule is written for
+        a *savings* curve: negative until the variant has paid for itself, so the first
+        non-negative year is the payback year. A cumulative **cost** curve has the opposite
+        orientation — it starts at the year-0 investment and falls as revenue arrives — so its
+        first non-negative year is simply year 1, whatever the curve does later. The fixture here
+        turns favourable in year 4 and the helper answers 1 for every slot.
+
+        This is why the liquidity fan feeds the helper the comparison's
+        `cumulative_discounted_savings_in_euro` and never the cost series it draws in the upper
+        panel. The behaviour is pinned rather than fixed: the crossing rule belongs to
+        `results.discounted_payback_year`, which the printed payback year reads as well, and
+        changing it here would let the two disagree. A view that ever wants "the year the cost
+        curve turns favourable" needs its own helper with its own name.
+        """
+        result = make_result(
+            [entry(0, 10000.0, CostCategory.INVESTMENT)]
+            + [entry(year, -3000.0, CostCategory.FEED_IN_REVENUE, subject="ELECTRICITY",
+                     subject_kind=SubjectKind.CARRIER) for year in range(1, 6)],
+            horizon=5,
+        )
+        curve = views.cumulative_nominal_cost_series(result)
+        assert curve[Slot.BEST_ESTIMATE] == [10000.0, 7000.0, 4000.0, 1000.0, -2000.0, -5000.0]
+        assert views.band_zero_crossings(curve) == {slot: 1 for slot in Slot}
+        # What a reader would mean by "when does it turn favourable" on this curve:
+        favourable = [
+            year for year, value in enumerate(curve[Slot.BEST_ESTIMATE]) if value < 0
+        ]
+        assert favourable[0] == 4
 
     def test_worst_liquidity_position_is_the_curve_maximum(self):
         """Cost is plotted upward, so the deepest out-of-pocket point is the maximum (Q4)."""
@@ -341,7 +488,13 @@ class TestUncertaintyAttribution:
         assert rows[-1].is_fold and rows[-1].subject == views.AttributionThresholds.FOLD_LABEL
 
     def test_mirrored_revenue_subject_lands_on_the_correct_side(self):
-        """A credit's optimistic world is the one where it earns more, so its LOW delta is negative."""
+        """A revenue subject's LOW delta follows its mirrored band, so it is negative like a cost's.
+
+        The band of a revenue-type amount is mirrored by `UncertainValue.as_revenue` before it
+        ever reaches the timeline, so its `minimum` is the world where the *most* money arrives.
+        Read against the subject's own best estimate that is a negative delta — the same side as a
+        cost subject's — which is what `AttributionRow` says and what the bar's geometry rests on.
+        """
         result = make_result(
             [
                 entry(0, 10000.0, CostCategory.INVESTMENT, band=1000.0),
@@ -413,6 +566,26 @@ class TestComparisonBridge:
         )]
         assert groups == sorted(groups)
 
+    def test_group_keys_that_cannot_be_ordered_are_refused(self):
+        """No orderable keys, no fixed bar order — and a bridge without one is not readable (IBCS).
+
+        A mapping mixing key types used to fall back to first-appearance order, which is stable
+        within one call and arbitrary between two: the same group could sit in a different place
+        in two reports of the same run. The refusal names the keys, which is the whole fix.
+        """
+        reference = make_result([entry(0, 10000.0, CostCategory.INVESTMENT)], horizon=5)
+        variant = make_result(
+            [entry(0, 12000.0, CostCategory.INVESTMENT),
+             entry(1, 500.0, CostCategory.MAINTENANCE)],
+            horizon=5,
+        )
+        mixed = {
+            category: (0 if category == CostCategory.INVESTMENT else "operation")
+            for category in CostCategory
+        }
+        with pytest.raises(CostDataError, match="cannot be ordered"):
+            views.comparison_bridge(reference, variant, mixed)
+
 
 class TestLoanViews:
     """V5: the balance runs to zero for both plan shapes, and the grant shows up as a credit."""
@@ -479,6 +652,7 @@ class TestLoanViews:
         """The null test: no fees, no grant, annual periods — Effektivzins == nominal rate."""
         credit = views.total_cost_of_credit(make_result(self.annuity_entries(rate=0.04)))
         assert credit.effective_annual_rate == pytest.approx(0.04, abs=1e-6)
+        assert credit.effective_annual_rate_note == ""
 
     def test_a_repayment_grant_strictly_lowers_the_effective_rate(self):
         """A grant is money received without more debt, so the borrower's rate falls."""
@@ -488,37 +662,54 @@ class TestLoanViews:
         assert credit.grants_in_euro == pytest.approx(1500.0)
         assert credit.effective_annual_rate is not None
         assert credit.effective_annual_rate < 0.04
+        assert credit.effective_annual_rate_note == ""
+
+    def test_a_grant_larger_than_the_debt_service_has_no_rate_and_says_why(self):
+        """Paying back less than was received has no non-negative rate; the panel is told so.
+
+        The search window is `[0, 5.0]`, and both ends of it price this sequence positively, so
+        there is no non-negative root. That is the honest answer: the borrower received 10,000
+        plus a grant bigger than the whole debt service, which is not a loan at an interest rate
+        at all. The window used to start at −0.99, where the present value is hugely negative, so
+        a root always existed and the disclosure printed a deeply negative "rate" instead.
+        """
+        entries = self.annuity_entries(rate=0.04, term=10)
+        interest_total = sum(
+            item.amount_in_euro.best_estimate
+            for item in entries
+            if item.category == CostCategory.LOAN_INTEREST
+        )
+        entries.append(
+            entry(0, -(10000.0 + interest_total + 500.0), CostCategory.SUBSIDY,
+                  subject="financing", scheme_id="VERY_SOFT")
+        )
+        credit = views.total_cost_of_credit(make_result(entries))
+        assert credit.effective_annual_rate is None
+        assert credit.effective_annual_rate_note == "the repayment grant exceeds the debt service"
+
+    def test_a_term_past_the_horizon_has_no_rate_and_leaves_no_loan_free_year(self):
+        """A schedule the horizon cuts off prices a loan nobody took, so no rate is published.
+
+        Four years of a ten-year 4 % annuity are on the timeline and six are not, which leaves
+        6,463 EUR of principal unrepaid at the horizon. Solving the truncated sequence used to
+        report about −23 %: the borrower appears to have received 10,000 and repaid barely half
+        of it. The disclosure now states the unrepaid principal, no rate, and the reason —
+        matching `loan_free_year`, which reports no milestone on the same test.
+        """
+        result = make_result(self.annuity_entries(rate=0.04, term=10), horizon=4)
+        amortization = views.loan_amortization_series(result)
+        assert amortization.has_flows()
+        assert amortization.loan_free_year() is None
+        credit = views.total_cost_of_credit(result)
+        assert credit.unrepaid_principal_in_euro == pytest.approx(6463.08, abs=0.01)
+        assert credit.effective_annual_rate is None
+        assert credit.effective_annual_rate_note == "the loan term reaches past the observation horizon"
 
     def test_unfinanced_result_has_no_flows(self):
         """The skip condition every loan chart shares."""
         amortization = views.loan_amortization_series(make_result(simple_investment_timeline()))
         assert not amortization.has_flows()
         assert amortization.loan_free_year() is None
-
-
-class TestTimelineHeatmapNumbers:
-    """V6: the matrix the ledger heatmap draws reconciles by rows and by columns."""
-
-    def test_column_sums_equal_the_nominal_annual_series(self):
-        """Each year's column adds up to that year's published nominal figure."""
-        result = make_result(simple_investment_timeline(horizon=6), horizon=6)
-        matrix = views.nominal_annual_matrix_by_category(result)
-        for year, row in enumerate(matrix):
-            assert sum(row.values()) == pytest.approx(
-                result.annual_cost_series_nominal_in_euro[year].best_estimate
-            )
-
-    def test_row_sums_equal_the_per_category_nominal_totals(self):
-        """Each category's row adds up to what that category booked over the horizon."""
-        result = make_result(simple_investment_timeline(horizon=6), horizon=6)
-        matrix = views.nominal_annual_matrix_by_category(result)
-        for category in {item.category for item in result.timeline.entries}:
-            expected = sum(
-                item.amount_in_euro.best_estimate
-                for item in result.timeline.entries
-                if item.category == category
-            )
-            assert sum(row.get(category, 0.0) for row in matrix) == pytest.approx(expected)
 
 
 class TestComponentEventStrip:
@@ -560,6 +751,35 @@ class TestComponentEventStrip:
         rows = views.component_event_strip(make_result(simple_investment_timeline()))
         assert [row.subject for row in rows] == ["HeatPump"]
 
+    def test_events_carry_the_declared_kinds(self):
+        """The strip's vocabulary is the enum, so a lane cannot be labelled with anything else."""
+        entries = [
+            entry(0, 20000.0, CostCategory.INVESTMENT),
+            entry(15, 22000.0, CostCategory.REPLACEMENT),
+            entry(20, -5000.0, CostCategory.RESIDUAL_VALUE),
+        ]
+        row = views.component_event_strip(make_result(entries))[0]
+        assert [event.kind for event in row.events] == [
+            views.EventKinds.INVESTMENT, views.EventKinds.REPLACEMENT
+        ]
+        assert row.residual is not None and row.residual.kind is views.EventKinds.RESIDUAL
+        # The str mixin keeps the members printable as the words the chart uses.
+        assert f"{row.residual.kind}" == "residual"
+
+    def test_a_row_whose_spans_do_not_align_to_its_events_is_refused(self):
+        """The lane's own invariant, checked by the row rather than trusted from its builder."""
+        events = [
+            views.LifecycleEvent(year=0, amount_in_euro=20000.0, kind=views.EventKinds.INVESTMENT),
+            views.LifecycleEvent(year=15, amount_in_euro=22000.0, kind=views.EventKinds.REPLACEMENT),
+        ]
+        with pytest.raises(CostDataError, match="do not align"):
+            views.EventStripRow(
+                subject="HeatPump",
+                events=events,
+                # The first span stops short of the replacement, leaving a hole in the lane.
+                spans=[views.ServiceSpan(0, 12), views.ServiceSpan(15, 20)],
+            )
+
 
 class TestLandlordStatement:
     """Q21/Q25: the landlord's cash and his book value are separated, and both pictures agree.
@@ -596,14 +816,9 @@ class TestLandlordStatement:
         return make_result(entries, scope=ActorScope.LANDLORD)
 
     def test_the_two_sides_partition_the_perspective_npv(self):
-        """The invariant: cash + accounting == the landlord's NPV, exactly."""
+        """Every row is on the side the landlord partition puts it on, and the net is published."""
         statement = views.landlord_statement(self.landlord_result())
-        assert statement.cash_subtotal_in_euro + statement.accounting_subtotal_in_euro == pytest.approx(
-            statement.net_position_in_euro
-        )
-        assert statement.net_position_in_euro == pytest.approx(
-            statement.net_position_band.best_estimate, abs=0.005
-        )
+        assert_sides_follow_the_partition(statement)
 
     def test_the_accounting_side_is_exactly_the_two_non_cash_categories(self):
         """Residual value and the anyway credit, and nothing else, are book entries."""
@@ -633,12 +848,12 @@ class TestLandlordStatement:
         flows, net_is_inflow = statement.income_flows()
         node = views.LandlordStatementCategories.LANDLORD_NODE
         net_node = views.LandlordStatementCategories.NET_POSITION_NODE
-        income = sum(amount for _s, target, amount, _c, _cat in flows if target == node)
-        expense = sum(amount for source, _t, amount, _c, _cat in flows if source == node)
+        income = sum(ribbon.amount_in_euro for ribbon in flows if ribbon.target == node)
+        expense = sum(ribbon.amount_in_euro for ribbon in flows if ribbon.source == node)
         # The leftover ribbon *is* the bottom line, so it is one of the two sums above.
         assert not net_is_inflow  # this fixture is advantageous for the landlord
         assert income - expense == pytest.approx(0.0, abs=0.01)
-        leftover = [amount for _s, target, amount, _c, _cat in flows if target == net_node]
+        leftover = [ribbon.amount_in_euro for ribbon in flows if ribbon.target == net_node]
         assert leftover and leftover[0] == pytest.approx(-statement.net_position_in_euro)
 
     def test_a_net_cost_draws_the_bottom_line_as_an_inflow(self):
@@ -649,23 +864,34 @@ class TestLandlordStatement:
         node = views.LandlordStatementCategories.LANDLORD_NODE
         net_node = views.LandlordStatementCategories.NET_POSITION_NODE
         assert net_is_inflow
-        assert any(source == net_node and target == node for source, target, _a, _c, _cat in flows)
+        assert any(
+            ribbon.source == net_node and ribbon.target == node and ribbon.category is None
+            for ribbon in flows
+        )
 
     def test_the_accounting_ribbons_are_drawn_in_the_credit_style(self):
         """Hatched/translucent, so the cash-versus-book split is visible in the picture (Q25)."""
         statement = views.landlord_statement(self.landlord_result())
         flows, _net = statement.income_flows()
         credit_categories = {
-            category for _s, _t, _a, is_credit, category in flows if is_credit
+            ribbon.category for ribbon in flows if ribbon.is_accounting_credit
         }
         assert credit_categories == {CostCategory.RESIDUAL_VALUE, CostCategory.ANYWAY_COST_CREDIT}
+
+    def test_the_income_sankey_refuses_a_statement_of_another_party(self):
+        """The node labels are the landlord's, so another partition's rows may not be drawn in them."""
+        statement = views.perspective_statement(
+            self.landlord_result(), views.StatementPartitions.OWNER
+        )
+        with pytest.raises(CostDataError, match="income Sankey"):
+            statement.income_flows()
 
 
 class TestWorkedExampleActorFlows:
     """The §559e worked example's expected actor-flow matrix (owner decision Q7).
 
     The spec asks for this attestation to live in the workbook
-    (`tests/worked_examples/end_to_end/heating_levy_559e_mixed_package.xlsx`) so that the Sankey's
+    (`tests/worked_examples/modernization_levy/heating_levy_559e_mixed_package.xlsx`) so that the Sankey's
     numbers are attested like every other figure of that example. That workbook carries a content
     fingerprint and a human review attestation (§3.8), which an automated edit cannot renew, so
     the expected matrix is hand-computed **here** instead and the workbook extension is deferred.
@@ -792,12 +1018,7 @@ class TestPartyStatements:
         statement = views.perspective_statement(
             self.owner_result(), views.StatementPartitions.OWNER
         )
-        assert statement.cash_subtotal_in_euro + statement.accounting_subtotal_in_euro == (
-            pytest.approx(statement.net_position_in_euro)
-        )
-        assert statement.net_position_in_euro == pytest.approx(
-            statement.net_position_band.best_estimate, abs=0.005
-        )
+        assert_sides_follow_the_partition(statement)
         assert {line.category for line in statement.accounting_lines} == {
             CostCategory.RESIDUAL_VALUE,
             CostCategory.ANYWAY_COST_CREDIT,
@@ -809,10 +1030,7 @@ class TestPartyStatements:
         statement = views.perspective_statement(result, views.StatementPartitions.TENANT)
         assert not statement.accounting_lines
         assert statement.accounting_subtotal_in_euro == 0.0
-        assert statement.cash_subtotal_in_euro == pytest.approx(statement.net_position_in_euro)
-        assert statement.net_position_in_euro == pytest.approx(
-            statement.net_position_band.best_estimate, abs=0.005
-        )
+        assert_sides_follow_the_partition(statement)
 
     def test_the_tenant_levy_mirrors_the_landlord_levy_income(self):
         """The two halves of one transfer pair: same magnitude, opposite sign, both stated."""
@@ -837,12 +1055,7 @@ class TestPartyStatements:
         statement = views.perspective_statement(
             self.society_result(), views.StatementPartitions.SOCIETY
         )
-        assert statement.cash_subtotal_in_euro + statement.accounting_subtotal_in_euro == (
-            pytest.approx(statement.net_position_in_euro)
-        )
-        assert statement.net_position_in_euro == pytest.approx(
-            statement.net_position_band.best_estimate, abs=0.005
-        )
+        assert_sides_follow_the_partition(statement)
         assert CostCategory.CO2_DAMAGE in {line.category for line in statement.cash_lines}
         assert not statement.accounting_lines
 
@@ -856,9 +1069,20 @@ class TestPartyStatements:
         ]
         assert {line.payer for line in levy_lines} == {Actor.TENANT, Actor.LANDLORD}
         assert sum(line.npv_in_euro for line in levy_lines) == pytest.approx(0.0, abs=0.005)
-        assert statement.cash_subtotal_in_euro + statement.accounting_subtotal_in_euro == (
-            pytest.approx(statement.net_position_in_euro)
-        )
+        assert_sides_follow_the_partition(statement)
+
+    def test_the_society_statement_refuses_an_actor_scoped_perspective(self):
+        """Its two sides read two different timelines, which only agree on a SYSTEM scope.
+
+        The resource side is the perspective's scoped pivot and the transfer side is the full
+        allocated timeline, because a transfer is only visibly zero with both halves on the page.
+        On a landlord-scoped result the two readings differ and the sum cannot close: the
+        statement used to raise a reconciliation error blaming a lost category for what is really
+        a misuse, so the misuse is named instead.
+        """
+        landlord = make_result(self.rented_entries(), scope=ActorScope.LANDLORD)
+        with pytest.raises(CostDataError, match="SYSTEM-scoped"):
+            views.perspective_statement(landlord, views.StatementPartitions.SOCIETY)
 
     def test_a_broken_partition_raises_rather_than_drawing(self):
         """A statement that does not reconcile is a defect, not a picture to render."""


### PR DESCRIPTION
﻿Fourth slice of the 9/9 port: the view functions for charts V1 to V7, pure functions on results with no rendering. Actor flow matrix and perspective statements (V1), cumulative nominal cost series with band zero crossings and the worst liquidity position (V2), uncertainty attribution (V3), the comparison bridge (V4), total cost of credit with the loan-free year (V5), and the component event strip (V7). Each is appended at the end of views.py under one marker so the second half of the views stacks on it without conflict; the shared tolerances, the actor counterparties and one generic fold-below-share helper live here for both halves. 47 new tests on hand-built timelines, including the hand-computed actor-flow matrix of the 559e worked example. Two adaptations to the current tree: slot names use best_estimate rather than average throughout, and the attribution row's field is renamed accordingly. No golden moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
