### PR TITLE
A run without a Building writes no building-sizer JSON and says so, instead of dying on the floor area

### DIFF
--- a/hisim/building_sizer_utils/interface_configs/kpi_config.py
+++ b/hisim/building_sizer_utils/interface_configs/kpi_config.py
@@ -43,7 +43,9 @@ Fields whose name ends in ``_per_m2`` are normalized by the building's
 **conditioned floor area** (the "Conditioned floor area" KPI, in m2).
 Normalization is always per floor area, never per capita or per dwelling.
 Fields without the ``_per_m2`` suffix carry an absolute quantity for the whole
-building.
+building. A simulation that contains no :class:`~hisim.components.building.Building`
+computes no conditioned floor area, so post-processing writes no sizer JSON for it and
+logs that it skipped the building object.
 
 KPI formulas and units
 ----------------------

--- a/hisim/postprocessing/postprocessing_main.py
+++ b/hisim/postprocessing/postprocessing_main.py
@@ -68,6 +68,11 @@ if TYPE_CHECKING:
     from hisim.simulator import Simulator
 
 
+#: KPI that only a ``Building`` component produces. The building-sizer JSON normalizes almost
+#: every field by it, so a building object whose KPI collection lacks it has no Building at all.
+BUILDING_OWN_KPI_NAME: str = "Conditioned floor area"
+
+
 def _load_attribute(module_name: str, attribute_name: str) -> Any:
     """Import an optional postprocessing helper only when its feature is used."""
     return getattr(importlib.import_module(module_name), attribute_name)
@@ -1225,7 +1230,13 @@ class PostProcessor:
     def write_kpis_to_json_for_building_sizer(
         self, ppdt: PostProcessingDataTransfer, building_objects_in_district_list: list
     ) -> None:
-        """Write KPIs to json file for building sizer."""
+        """Write KPIs to json file for building sizer.
+
+        Every field of the sizer JSON that is normalized per square metre divides by the
+        "Conditioned floor area" KPI, which only a ``Building`` component produces. A building
+        object whose KPI collection carries no such entry therefore has no Building in the run,
+        and is skipped with one log line instead of writing a file the sizer cannot use.
+        """
 
         def get_kpi_entries_for_building_sizer(data, target_key):
             """Get kpi entries for building sizer."""
@@ -1241,6 +1252,14 @@ class PostProcessor:
                 raise KeyError(f"No key is matching the target key {target_key}.")
             return result
 
+        def building_kpis_were_computed(data) -> bool:
+            """Say whether a Building component contributed its own KPIs to this collection."""
+            try:
+                get_kpi_entries_for_building_sizer(data=data, target_key=BUILDING_OWN_KPI_NAME)
+            except KeyError:
+                return False
+            return True
+
         kpi_dict = {}
 
         # Check if important options were set
@@ -1249,9 +1268,15 @@ class PostProcessor:
                 # Get KPIs from ppdt
 
                 kpi_collection_dict = ppdt.kpi_collection_dict[building_object]
+                if not building_kpis_were_computed(kpi_collection_dict):
+                    log.information(
+                        f"Skipping the building-sizer KPI JSON for {building_object}: the run has no "
+                        "Building component, so there is nothing for the building sizer to consume."
+                    )
+                    continue
                 # conditioned floor area
                 conditioned_floor_area_in_m2 = get_kpi_entries_for_building_sizer(
-                    data=kpi_collection_dict, target_key="Conditioned floor area"
+                    data=kpi_collection_dict, target_key=BUILDING_OWN_KPI_NAME
                 )
                 # Total costs
                 annualized_total_costs_in_euro = get_kpi_entries_for_building_sizer(

--- a/hisim/postprocessingoptions.py
+++ b/hisim/postprocessingoptions.py
@@ -33,6 +33,8 @@ class PostProcessingOptions(IntEnum):
     COMPUTE_KPIS = 19
     PREPARE_OUTPUTS_FOR_SCENARIO_EVALUATION = 20
     WRITE_COMPONENT_CONFIGS_TO_JSON = 21
+    # A run without a Building component writes no sizer JSON at all: its KPIs carry no
+    # conditioned floor area, which every per-m2 field of that file is normalized by.
     WRITE_KPIS_TO_JSON_FOR_BUILDING_SIZER = 22
     WRITE_KPIS_TO_JSON = 23
     EXPORT_TO_PKL = 24

--- a/tests/test_building_sizer_kpi_writer.py
+++ b/tests/test_building_sizer_kpi_writer.py
@@ -1,0 +1,133 @@
+"""Tests for the building-sizer KPI JSON writer.
+
+The writer normalizes almost every field it exports by the "Conditioned floor area" KPI,
+which only a ``Building`` component produces. These tests pin the two halves of that rule:
+a run without a Building is skipped with a log line and leaves no file behind, while a run
+with a Building still writes the file with the values the sizer expects.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+import pytest
+
+from hisim import log
+from hisim.postprocessing.postprocessing_datatransfer import PostProcessingDataTransfer
+from hisim.postprocessing.postprocessing_main import PostProcessor
+from hisim.postprocessingoptions import PostProcessingOptions
+from hisim.simulationparameters import SimulationParameters
+
+
+BUILDING_OBJECT = "BUI1"
+CONDITIONED_FLOOR_AREA_IN_M2 = 120.0
+TOTAL_COSTS_IN_EURO = 2400.0
+
+#: Every KPI the writer reads apart from the building's own ones, each with a distinct value
+#: so a wrongly wired field shows up as a wrong number rather than as a coincidence.
+COST_AND_ENERGY_KPIS: Dict[str, float] = {
+    "Total costs for simulated period": TOTAL_COSTS_IN_EURO,
+    "Investment costs for equipment per simulated period": 1000.0,
+    "Investment costs for equipment per simulated period minus subsidies": 900.0,
+    "Investment costs upfront for equipment period minus subsidies": 8000.0,
+    "Energy grid costs for simulated period": 700.0,
+    "Costs of grid electricity for simulated period": 400.0,
+    "Costs of grid gas for simulated period": 200.0,
+    "Costs of other heating fuels for simulated period": 100.0,
+    "Maintenance costs for simulated period": 60.0,
+    "Total CO2 emissions for simulated period": 1200.0,
+    "CO2 footprint for equipment per simulated period": 300.0,
+    "CO2 footprint of grid electricity for simulated period": 500.0,
+    "CO2 footprint of grid gas for simulated period": 250.0,
+    "CO2 footprint of other heating fuels for simulated period": 150.0,
+    "Self-sufficiency rate according to solar htw berlin": 45.0,
+    "Total energy self-suffiency rate": 35.0,
+    "Purchased energy consumption for simulated period": 9000.0,
+    "Total energy to grid": 2000.0,
+    "Total energy from grid": 5000.0,
+}
+
+#: The KPIs that only a ``Building`` component computes.
+BUILDING_KPIS: Dict[str, float] = {
+    "Conditioned floor area": CONDITIONED_FLOOR_AREA_IN_M2,
+    "Minimum building indoor air temperature reached": 18.5,
+    "Maximum building indoor air temperature reached": 26.5,
+    "Temperature deviation of building indoor air temperature being below set temperature 20.0 Celsius": 12.0,
+    "Temperature deviation of building indoor air temperature being above set temperature 25.0 Celsius": 3.0,
+}
+
+
+def _kpi_collection(values: Dict[str, float]) -> Dict[str, Any]:
+    """Wrap plain numbers in the ``{"value": ...}`` shape the KPI collection uses."""
+    return {name: {"value": value} for name, value in values.items()}
+
+
+def _data_transfer(result_directory: Path, kpi_collection: Dict[str, Any]) -> PostProcessingDataTransfer:
+    """Build the smallest data transfer object the sizer writer reads from."""
+    simulation_parameters = SimulationParameters(
+        start_date=datetime.datetime(2021, 1, 1),
+        end_date=datetime.datetime(2021, 1, 2),
+        seconds_per_timestep=60,
+        result_directory=str(result_directory),
+        post_processing_options=[PostProcessingOptions.COMPUTE_KPIS],
+    )
+    return PostProcessingDataTransfer(
+        results=pd.DataFrame(),
+        all_outputs=[],
+        simulation_parameters=simulation_parameters,
+        wrapped_components=[],
+        mode=1,
+        setup_function="setup_function",
+        module_filename="test_building_sizer_kpi_writer",
+        module_config=None,
+        execution_time_in_s=0.0,
+        results_monthly=None,
+        results_hourly=None,
+        results_cumulative=None,
+        results_daily=None,
+        kpi_collection_dict={BUILDING_OBJECT: kpi_collection},
+    )
+
+
+@pytest.fixture(name="log_into_tmp_path")
+def fixture_log_into_tmp_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the log file HiSim writes alongside its printed lines inside the test's directory."""
+    monkeypatch.setattr(log.logger, "logging_path", str(tmp_path))
+
+
+@pytest.mark.base
+@pytest.mark.usefixtures("log_into_tmp_path")
+def test_a_run_without_a_building_writes_no_sizer_json_and_says_so(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """A KPI collection without the building's own floor area is skipped, not crashed on."""
+    ppdt = _data_transfer(tmp_path, _kpi_collection(COST_AND_ENERGY_KPIS))
+
+    PostProcessor().write_kpis_to_json_for_building_sizer(ppdt, [BUILDING_OBJECT])
+
+    assert not list(tmp_path.glob("*_kpi_config_for_building_sizer.json"))
+    printed = capsys.readouterr().out
+    assert "Skipping the building-sizer KPI JSON for BUI1" in printed
+    assert "no Building component" in printed
+
+
+@pytest.mark.base
+@pytest.mark.usefixtures("log_into_tmp_path")
+def test_a_run_with_a_building_still_writes_the_sizer_json(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    """The guard must not skip a building object whose Building did compute its KPIs."""
+    ppdt = _data_transfer(tmp_path, _kpi_collection({**COST_AND_ENERGY_KPIS, **BUILDING_KPIS}))
+
+    PostProcessor().write_kpis_to_json_for_building_sizer(ppdt, [BUILDING_OBJECT])
+
+    written = list(tmp_path.glob("*_kpi_config_for_building_sizer.json"))
+    assert [path.name for path in written] == [f"{BUILDING_OBJECT}_kpi_config_for_building_sizer.json"]
+    kpi_config = json.loads(written[0].read_text(encoding="utf-8"))
+    assert kpi_config["annualized_total_costs_in_euro_per_m2"] == TOTAL_COSTS_IN_EURO / CONDITIONED_FLOOR_AREA_IN_M2
+    assert kpi_config["minimum_indoor_temperature_in_celsius"] == BUILDING_KPIS[
+        "Minimum building indoor air temperature reached"
+    ]
+    assert "Skipping the building-sizer KPI JSON" not in capsys.readouterr().out

--- a/tests/test_system_setups_electrolyzer_with_renewables.py
+++ b/tests/test_system_setups_electrolyzer_with_renewables.py
@@ -9,6 +9,7 @@ from typing import Iterator
 import pytest
 
 from hisim import hisim_main
+from hisim.postprocessingoptions import PostProcessingOptions
 from hisim.result_path_provider import ResultPathProviderSingleton
 from hisim import utils
 
@@ -75,10 +76,15 @@ def test_electrolyzer_with_renewables(isolated_result_directory: str) -> None:
     setup died in COMPUTE_OPEX before any KPI was computed. The cost tables asserted below are
     what catches that regression -- the log and the flag alone would not, because they are
     written even by a run whose cost stage was never asked to answer.
+
+    WRITE_KPIS_TO_JSON_FOR_BUILDING_SIZER is switched on here on top of those options because
+    this setup has no Building component: the sizer writer used to die on the missing
+    "Conditioned floor area" KPI, and now skips the building object with a log line instead.
     """
     path = ELECTROLYZER_SETUP_PATH
 
     sim_params = SetupTestParameters.one_day_with_kpis(year=2021, seconds_per_timestep=60)
+    sim_params.post_processing_options.append(PostProcessingOptions.WRITE_KPIS_TO_JSON_FOR_BUILDING_SIZER)
     # Route results into the isolated, test-scoped directory provided by the fixture so
     # that stale artefacts from a previous run cannot mask a regression and so the test
     # cleans up after itself.
@@ -120,4 +126,13 @@ def test_electrolyzer_with_renewables(isolated_result_directory: str) -> None:
     # WRITE_KPIS_TO_JSON is on, so the KPI stage after the cost stages ran too.
     assert (results_dir / "all_kpis.json").is_file(), (
         f"all_kpis.json missing in results directory: {results_dir}"
+    )
+    # No Building means no conditioned floor area, so the building-sizer writer has nothing to
+    # normalize by: it must skip the building object out loud rather than write a file or raise.
+    assert not list(results_dir.glob("*_kpi_config_for_building_sizer.json")), (
+        f"A building-sizer KPI JSON was written for a setup without a Building: {results_dir}"
+    )
+    simulation_log = (results_dir / "hisim_simulation.log").read_text(encoding="utf-8")
+    assert "Skipping the building-sizer KPI JSON" in simulation_log, (
+        f"The skipped building object was not reported in the simulation log: {results_dir}"
     )


### PR DESCRIPTION
﻿The building-sizer KPI writer (WRITE_KPIS_TO_JSON_FOR_BUILDING_SIZER) looked up "Conditioned floor area" and three indoor-temperature KPIs that only a Building component produces, and raised a bare KeyError on any setup without one. The option reaches such setups easily: it sits in the generic 2021_minutely_full.simulation.json, the recorder files it under the "kpis" purpose family, the RenoVisor runner sets it unconditionally, and Docker allows it. The electrolyzer-with-renewables setup died in post-processing that way.

A building object whose KPI collection has no conditioned floor area now gets one info line ("Skipping the building-sizer KPI JSON for BUI1: the run has no Building component, so there is nothing for the building sizer to consume.") and no file, and the writer moves on. Every other key is still looked up strictly, so a missing derived KPI on a real building still fails loudly. A run with a Building writes a byte-identical file.

Tests: the writer is driven directly on a collection without the floor area (no file, the skip line) and on a full collection (file written, per-m2 normalization and the temperature field round-trip). The electrolyzer setup test switches the option on and asserts the run finishes with no sizer JSON and the skip line in the simulation log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
