### PR TITLE
Collect the Rust conversion thinking in roadmap/rust_ideas

### DIFF
--- a/roadmap/rust_ideas/feasibility_rust_hisim.md
+++ b/roadmap/rust_ideas/feasibility_rust_hisim.md
@@ -1,0 +1,536 @@
+# Feasibility Analysis: Converting HiSim from Python to Rust
+
+**Analyzed commit:** `67ba1ca9` (main, 2026-09) · **Repo:** FZJ-IEK3-VSA/HiSim (`/home/noah/HiSim`)
+**Method:** Each module is analyzed in isolation and this document is updated immediately after each module analysis, rather than one big retrospective. A cross-module synthesis is added at the end.
+
+---
+
+## 1. Repository Overview and Methodology
+
+### 1.1 Codebase at a glance
+
+| Module | Py files | LOC | Role |
+|---|---|---|---|
+| `hisim/components/` | 67 | 46,142 | Component library (devices, controllers, loads, weather, building) |
+| `hisim/economics/` | 51 | 21,623 | Lifecycle cost engine (new: financing, tariffs, subsidies, audit) |
+| `hisim/energy_system/` | 55 | 19,406 | Declarative YAML energy-system format: loader, schema, executor, sizing, recording, grouping |
+| `hisim/postprocessing/` | 16 | 6,472 | KPIs, charts, PDF/HTML/CSV reports |
+| `hisim/config/` | 12 | 3,896 | Config layer (`ConfigBase`, `ComponentID`, `DisplayConfig`) |
+| `hisim/renovisor/` | 8 | 1,636 | RenoVisor REST translator (measures → setup) |
+| `hisim/building_sizer_utils/` | 6 | 1,570 | Building-sizer interface configs |
+| `hisim/caching/` | 5 | 1,309 | Result caching client (local + remote tiers) |
+| `hisim/` top level | ~15 | ~7,700 | Core engine: `simulator.py`, `component.py`, `json_executor.py`, CLI |
+| `system_setups/` | 23 | 7,675 | One setup function per file + `.scenario.json` twins |
+| `tests/` | 208 | 55,322 | pytest suite (markers: base, buildingtest, system_setups, mpc, utsp, jsonconfig) |
+| `tools/` + `scripts/` | 61 | 12,966 | Worked-example converter, parity/golden tooling, HPC harness |
+| **Total Python** | **~560** | **~186,000** | |
+| `hisim/inputs/` | — | 569 MB | Reference data: weather (NSRDB/DWD), PV processed, TABULA, load profiles |
+| `system_setups/results/` + goldens | — | large | Regression reference outputs (do not regenerate) |
+
+### 1.2 What kind of system HiSim is
+
+HiSim is a discrete time-step co-simulation: components wired through typed input/output ports, iterated per time step until convergence, then post-processed. Three architectural layers matter for a language conversion:
+
+1. **Simulation core** — a small engine (`simulator.py`, `component.py`, `component_wrapper.py`, `sim_repository.py`) with a component base class and a generic per-timestep fixed-point loop. This is the *most Rust-friendly* part: it is a tight, imperative, allocation-heavy numeric loop.
+2. **Component library** — ~60 device/controller models, each a `Component` subclass with a `ConfigBase` dataclass config. Heterogeneous physics: ODEs, lookup tables, curve fits, control logic.
+3. **Ecosystem layers** — declarative YAML loading with reflection-based instantiation, JSON scenario execution, KPI/chart/PDF reporting, cost engine, LPG/UTSP network connector, caching, webtool JSON export.
+
+### 1.3 Global, cross-cutting findings (preview)
+
+These recur in nearly every module and dominate the total conversion cost — details per module below:
+
+- **Domain-library gap (the single biggest risk).** HiSim's physics is not self-contained. It directly imports `pvlib`, `hplib`, `bslib`, `oemof.thermal`, `windpowerlib`, `pygfunction`, `control` + `casadi` (MPC), `numpy_financial`, `pylpg` (load profiles), `utspclient` (network service). **None of these have production-grade Rust equivalents.** Converting HiSim means either reimplementing them (pvlib alone is a multi-person-year effort) or keeping a Python island via PyO3.
+- **Reflection-based instantiation.** `.scenario.json` files and YAML energy-system files name components by fully-qualified Python class path (`hisim.components.generic_heat_pump.GenericHeatPump`); `json_executor.py`/`energy_system/classes.py` do `importlib.import_module` + `getattr`. Rust has no reflection — this needs an explicit component registry (an inventory that today the language generates for free, and which ~60 components and ~25 setup files would need to join).
+- **Config layer is runtime-serialized dataclasses.** 141 files use `@dataclass`; configs round-trip to JSON via `dataclasses_json`/`pyhumps` with snake_case↔camelCase conversion and `get_default_*` factory classmethods. Rust maps this well (serde + defaults), but every config's *exact* field names, defaults, and enum spellings are public interface — the JSON files in `system_setups/` pin them.
+- **Dynamic Python in the seams.** 63 files use `getattr`/`setattr`/`hasattr`; 23 use `importlib`; `DynamicComponent` resolves ports at runtime by matching unit/type tags; 69 enum classes; the `SimRepository` is a shared mutable string-keyed dict (recently de-singleton'd, still duck-typed).
+- **Numeric-equivalence burden.** The golden/regression tests compare against committed CSV results computed with NumPy/pandas float semantics and library-internal curve fits. Bit-level reproduction in Rust is *not guaranteed* even for identical formulas (fma, libm differences, summation order); tolerances would have to be re-baselined.
+- **Moving target.** The last merge alone changed 859 files (+100k/−60k). A multi-year rewrite would chase a codebase under heavy active development — this is an organizational, not technical, feasibility factor.
+
+### 1.4 Rating scheme used below
+
+- **Challenge:** 🟢 Low (mechanical translation) / 🟡 Medium (design decisions needed) / 🟠 High (substantial redesign) / 🔴 Very High (no direct equivalent; reimplementation or interop required)
+- **Effort:** S (< 1 person-week) / M (weeks) / L (person-months) / XL (person-years)
+
+## 2. Core Simulation Engine
+
+**Files:** `hisim/simulator.py` (660), `component_wrapper.py` (257), `sim_repository.py` (125), `sim_repository_singleton.py` (236), `simulationparameters.py` (319), `utils.py`, `log.py`, `result_path_provider.py` — ~2,000 LOC total.
+
+### 2.1 What it does and how it maps
+
+The engine (`Simulator.process_one_timestep`, simulator.py:162–227) runs a fixed-point iteration per time step: save all component states → loop { restore state; `i_simulate` every component in registration order; check convergence } → `i_doublecheck`. Convergence = every output within **absolute 1e-4** of the previous iteration (`SingleTimeStepValues.is_close_enough_to_previous`, component.py:190–196); after >10 iterations convergence is forced, >100 raises.
+
+**This is the most Rust-friendly code in the repository:**
+
+- `SingleTimeStepValues` is already a flat float array indexed by a global output index — in Rust a `Vec<f64>` plus typed port handles. No allocation in the hot loop needed (two buffers swapped).
+- The `i_save_state`/`i_restore_state` checkpoint pattern (components keep a cloned copy or `deepcopy` themselves) maps 1:1 to a `#[derive(Clone)]` state struct + `std::mem::swap` — cleaner and much faster than Python's deepcopy.
+- Execution is single-threaded, deterministic, registration-order dependent — all trivially preserved. Rust would plausibly give a **10–50× speedup** on this loop (no interpreter, no boxing of floats), which is the main *performance* argument for the whole conversion.
+
+### 2.2 Challenges
+
+| Issue | Detail | Rust answer | Severity |
+|---|---|---|---|
+| Shared mutable state | `SimRepository` = `dict[str, Any]` + `dict[ComponentType, dict[int, Any]]` (sim_repository.py:15–16); a module-level `SingletonSimRepository` singleton carries weather forecasts → building, prices → MPC, PID coefficients | Typed `SimContext` struct (enum-keyed), passed explicitly; singleton becomes a field of the engine | 🟡 design work, not hard |
+| pandas seam at the end of the run | Whole-year results accumulate in `all_result_lines: List[List[float]]` (simulator.py:312, 337) → `pd.DataFrame` + `date_range` index → `resample()` to monthly/daily/hourly, split mean-vs-sum per unit via `UNITS_USING_MEAN_AGGREGATION` (simulator.py:492–585) | Own time-bucketing module over `Vec<f64>`, or Arrow/Polars; **DST/bucket-boundary semantics of pandas resample must be replicated** (tz-aware Europe/Berlin indices) | 🟠 the sneakiest part of the core |
+| Default-connection machinery | `connect_everything_automatically` (simulator.py:587–660): isinstance checks against `DynamicComponent`, class-name-keyed dicts | Registry keyed by a component-kind enum; resolves at wiring time | 🟡 |
+| Registration-time side effects | Output registration mutates `output.global_index`; duplicate-name checks; connection logging appends to a JSON file mid-wiring (component.py:392–447 rewrites the last byte of the file!) | Two-phase build (declare → resolve indices), buffered connection log | 🟢 |
+| Decorators/singleton utilities | `utils.measure_execution_time`, `ResultPathProviderSingleton` | Plain functions, `once_cell::sync::Lazy` or explicit config | 🟢 |
+
+### 2.3 Verdict
+
+**Challenge: 🟡 Medium. Effort: M (≈4–8 person-weeks)** including a test harness. The loop itself is a near-mechanical translation; the work is in the typed redesign of the repository/singleton and in reproducing the pandas resample seam. This module should be ported **first** — it is small, well-tested (`tests/test_component.py`, sim tests), and defines the contract everything else compiles against.
+
+---
+
+## 3. Component Model and Config Layer
+
+**Files:** `hisim/component.py` (736), `dynamic_component.py` (627), `loadtypes.py` (399), `units.py` (381), and the `hisim/config/` package (12 files, ~3,900 LOC: `base.py` 422, `sizing.py` 537, `engine.py` 500, `laws.py` 499, `channels.py` 465, `presets.py` 453, `introspection.py` 340, `names.py` 131, …).
+
+### 3.1 Component runtime contract (`component.py`)
+
+The `Component` base class defines: lifecycle hooks (`i_prepare_simulation`, `i_simulate`, `i_save_state`/`i_restore_state`, `i_doublecheck`), `add_input`/`add_output` ports, string-name-based `connect_input`, default connections, and the **cost/KPI hooks** `get_cost_opex`/`get_cost_capex`/`get_component_kpi_entries` — which take a `pd.DataFrame` parameter, so the pandas seam reaches into the component API itself. `MODELS_NO_DEVICE: ClassVar[bool]` gates whether a component may return zero costs.
+
+- **Rust mapping:** a `Component` trait with `simulate(&mut self, &mut TimestepValues, force_convergence: bool)`, `Clone`-based state, and a separate `CostModel` trait whose input is a typed results table (not a DataFrame). The ClassVar flag becomes a trait method or associated const. ~40 components override the cost hooks; the API redesign is felt repo-wide but each change is mechanical.
+- Ports matched by string names with identifier validation (`NameSyntax.require_identifier`) → in Rust, names remain the serialization surface, but wiring resolves to typed `(component_idx, port_idx)` handles.
+
+### 3.2 DynamicComponent — runtime-variable ports
+
+`DynamicComponent` (627 LOC) grows one input per participant (the electricity meter, the L2 EMS are subclasses). Ports are matched at runtime by load type, unit, `ComponentType`/`InandOutputType` tags, and `source_weight` (dynamic_component.py:62–88); a `CHANNELS` ClassVar declares accepted declarative feeds. It even injects attributes dynamically: `vars(self)[label] = label` (dynamic_component.py:167).
+
+- **Rust mapping:** a `Vec<ChannelDescriptor>` with tag-matched lookup — *no dynamic attributes needed*; the tag matching is a plain filter. The recently added `DuplicateComponentFeedError` (a double-feed protection) ports directly.
+- **Severity: 🟡** — conceptually simple, but the L2 EMS builds on it with `getattr`-based dispatch (see §5), so the typed redesign must be coherent across both.
+
+### 3.3 The config layer — the most "dynamic Python" in the codebase
+
+This is where a Rust port stops being a translation and becomes a **redesign**:
+
+- `ConfigBase` (config/base.py:238) uses `__init_subclass__` to validate builder declarations and to **complete enum codecs by reading class annotations textually** (base.py:48–134) — runtime metaprogramming Rust cannot do.
+- `@dataclass_json` injects `to_json`/`from_dict`/`from_json` at runtime; field names are dumped verbatim snake_case (base.py:246–249). The TYPE_CHECKING-only `__getattr__`/`__setattr__` escape hatches (base.py:282–312) exist purely because components store configs in base-typed slots.
+- The sizing subsystem: a copy-stable `AUTO` sentinel singleton with custom `__deepcopy__` (sizing.py:60–97), `Sizable[T]` unions, `sized_field` metadata, a `SizingLaw` algebra (laws.py), `@preset`/`@constructor` builders (presets.py), and a cross-component **fact engine** reading `SIZING_CONTRIBUTIONS` ClassVars by name (engine.py). `Component.__init__` hard-rejects configs that still carry AUTO (component.py:272–287).
+- `introspection.py` (340 LOC) reads annotations at runtime; `scripts/check_config_attrs.py` exists as an AST-based *external* checker compensating for the `Any`-typed escape hatch.
+
+**Rust redesign sketch:** serde structs with explicit `#[serde(default)]`; `enum Sizable<T> { Auto, Value(T) }` with the wire spelling `"AUTO"` preserved; sizing as an **explicit pre-pass** that takes unresolved configs + a facts context and returns resolved ones (the Python flow is already: resolve before construction — the check at component.py:272 just moves to compile time); presets = plain constructor functions; the fact engine = a typed registry of fact providers. The *wire format* (snake_case JSON) is stable and simple; what disappears is the runtime self-inspection, which Rust replaces with compile-time guarantees. Note the CI quality gate `check_config_attrs.py` becomes unnecessary — the type system does it.
+
+### 3.4 loadtypes and units
+
+69 enum classes (`LoadTypes`, `Units`, `ComponentType`, `InandOutputType`, `BuildingCodes`, …) → direct Rust enums with exact spelling preserved (`str`-Enums are pinned by every `.scenario.json`). `units.py` is a typed `Quantity` system (Watt, KiloWattHour, …) distinct from the I/O `Units` enum → newtypes with `std::ops`. 🟢 trivial.
+
+### 3.5 Verdict
+
+| Sub-area | Challenge | Effort |
+|---|---|---|
+| `component.py` contract + ports | 🟡 Medium | S–M |
+| `dynamic_component.py` | 🟡 Medium | S |
+| config layer (`config/`, 3.9k LOC) | 🟠 High — deliberate redesign of sizing/presets | M (weeks) |
+| loadtypes/units | 🟢 Low | S |
+
+**Overall: 🟠 High (because the config layer is the type-system backbone every one of ~60 components and every scenario file depends on). Effort: M–L.** Get this right and the rest of the port is repetitive; get it wrong and every later module pays. The existing `tests/test_config_contracts.py` (475 LOC) and `test_component_id.py` pin the wire behavior and translate almost directly to Rust tests.
+
+## 4. Component Library I — Thermal / Building / Weather (~22,900 LOC)
+
+**Scope:** 22 files: `building/` (building.py 2096, information.py 791, window.py, config.py), `weather.py` (1453), heat pumps (`generic_heat_pump.py` 868, `more_advanced_heat_pump_hplib.py` 2754), `generic_boiler.py` (1647 — oil/pellets/wood-chips/H₂ are presets at :199–246, not separate files), `generic_district_heating.py` (1238), `simple_water_storage.py` (2160), `heat_distribution_system.py` (1571), `solar_thermal_system.py` (1087), heating controllers, electric heating, air conditioners, `simple_heat_source.py`, `building_sizer_utils/` (1570).
+
+### 4.1 The headline: the physics is easy, the plumbing is hard
+
+**There is no ODE solver anywhere in this scope.** Every model is scalar f64 arithmetic: the building is closed-form Crank–Nicolson per ISO 13790 (building.py:1694–1732, 1851–1929); the water storage is a 0D fully-mixed tank; heat distribution is a first-order exponential lag (`np.exp(-dt/τ)`, heat_distribution_system.py:544–551); curve fits are degree-1 `np.polyfit` (generic_heat_pump.py:367, air_conditioner.py:458–467). NumPy is used as a calculator. Roughly 25–40% of the big files is KPI/cost/report boilerplate (`get_cost_capex/opex/...`), separable from physics.
+
+### 4.2 Library dependence audit
+
+| Library | Used for | Rust situation | Difficulty |
+|---|---|---|---|
+| **pvlib** | Solar position (weather.py:893, 1444; solar_thermal:670), extraterrestrial radiation (weather:891), AOI/total irradiance transposition (window.py:79,136; solar_thermal:716), GHI→DNI back-derivation with NaN-fill (solar_thermal:713–721) | No mature Rust solar stack (`spa` crate covers position only); must hand-port solar geometry + transposition (~300–600 LOC of well-documented formulas) | 🟠 **Medium — the numerical-parity linchpin**: small deviations propagate into every solar gain and heating demand |
+| **hplib** (==1.9) | `get_parameters` + `HeatPump.simulate` in 4 modes (more_advanced_heat_pump_hplib.py:369–370, 1528); HiSim *mutates* `heatpump.delta_t` across the boundary (:1020, :1049) | No equivalent; port the fit equations (~300–500 LOC) or precompute parameters offline in Python and ship as data | 🟠 Medium (M→L depending on approach) |
+| **oemof.thermal** | One function: `calc_eta_c_flate_plate` (solar_thermal:725) — a 10-line formula | Port verbatim | 🟢 |
+| **pygfunction** | Only `media.Fluid` for brine cp/ρ (simple_heat_source:407–412) | Correlation table | 🟢 |
+| **pandas** | Quirky CSV parsing (cp1252, `sep=";"`, `decimal=","` — information.py:274–280; fixed-width DWD `.dat` — weather.py:1228), tz-aware `resample().mean().interpolate("linear")` (weather:880–931, 1017–1031), KPI Series reductions | `csv`/`encoding_rs` + hand-written resample (~100 LOC) or `polars`; **DST bucket boundaries are the hazard** (`chrono-tz`) | 🟡 Low–Medium |
+| **numpy** | polyfit/polyval, `np.exp`, `np.pi`, one `np.transpose` | Closed-form least squares (~20 LOC) or `argmin` | 🟢 |
+| **utspclient** | LPG household registry in building_sizer_utils (archetype_config:280–295) | Static name table; external coupling remains | 🟢 |
+
+### 4.3 Python-specific obstacles
+
+- **`importlib` + `getattr` default connections — ~30 sites in 11 files** (building.py:498–540, more_advanced_heat_pump:892–928, ...). Exists solely to dodge circular imports; in Rust a static registry makes the dynamism evaporate. 🟡
+- **Optional-attribute duck typing**: `if hasattr(self, "solar_gain_through_windows") is False` (building.py:559, 588) → `Option<Vec<f64>>`. 🟢
+- **SingletonSimRepository data handoffs**: weather publishes 11 yearly forecast arrays (weather.py:976–1012) which the building reads at prepare time (building.py:795–806); AC publishes fit coefficients (air_conditioner:467–475) → typed context struct. 🟡
+- **Caches keyed by config hash** (class-level cached DataFrame — information.py:263–282; `lru_cache` on a method — window.py:103; sha256 result cache — more_advanced:1523) → `OnceLock`/HashMap; fine.
+- **Snapshot/rollback** via `self_copy`/clone → Rust `Clone` + swap. 🟢 (maps *better* than Python)
+- Thin inheritance only (`SimpleHotWaterStorage(SimpleWaterStorage)` — use composition). 🟢
+
+### 4.4 Numerics to preserve, not "fix"
+
+NaN semantics (`math.isnan(poa_direct)` → 0, window.py:147; `.fillna(0)`, solar_thermal:721); exact float comparisons in control flow (`water_mass_flow_rate == 0` — heat_distribution:442; `delta_t == 0` → set `1e-8` — more_advanced:1051–1052); `force_convergence` early-returns in controllers. Bit-level drift can change convergence iteration counts → golden-reference validation is mandatory.
+
+### 4.5 Verdict
+
+**Challenge: 🟠 High. Effort: L (≈3–5 person-months) for this scope alone**, excluding the engine it plugs into. Per-file ratings range 🟢 (controllers, idealized heater, meters: S) over 🟡 (boiler, district heating, electric heating, storage, building: M) to 🟠 (weather, hplib heat pump: M–L).
+
+**Top-3 problems:** (1) pvlib parity — port + regression harness against pvlib outputs; (2) hplib port incl. the `delta_t` mutation contract; (3) framework coupling — components lean on `Component`, `SingleTimeStepValues`, default connections, SimRepository, and the pandas-typed cost/KPI interfaces, so **the engine contract (§2–3) must exist first**.
+
+---
+
+## 5. Component Library II — Electrical / Hydrogen / Controls (~22,400 LOC)
+
+**Scope:** 42 files: PV (`generic_pv_system.py` 1279), wind (`generic_windturbine.py` 487), batteries (bslib ×2, generic), `generic_car.py` + `lpg_car_information.py`, the hydrogen chain (electrolyzers ×4, H₂ storage, fuel cells ×3, RSOC ×3, transformer_rectifier), CHP, controllers (L1 ×many, L2 EMS 1181, PTX, XTP, PID 667, **MPC 1469**), meters ×4, loads (csvloader, smart device, price signal, random_numbers), `configuration.py` (1030), examples/templates.
+
+### 5.1 Library dependence audit — where the real blockers live
+
+| Library | Used for | Rust situation | Difficulty |
+|---|---|---|---|
+| **casadi** | `controller_mpc.py`: multiple-shooting NLP over 24h horizon (`Opti`/MX, `ca.if_else` disjunctions, IPOPT+MUMPS/MA27, max_iter 500 — :729–991); ~57 s per optimization at 1-min sampling per code comment :968 | **No mature Rust NLP ecosystem.** Options: (a) `ipopt` crate bindings (stale), (b) casadi codegen→C+FFI, (c) **recommended: reformulate as MILP** — dynamics/cost are linear between disjunctions → binaries + big-M, solved by HiGHS via `good_lp` | 🔴 **Very High — the single hardest component in the entire codebase**; either path needs revalidation vs the `mpc` tests and accepts changed numerics |
+| **pvlib** | `generic_pv_system.py` only: SAM module/inverter databases, SAPM + CEC single-diode (incl. iterative MPP solve), Sandia inverter, Perez transposition, airmass (:842–1258); NaN/night handling under `np.errstate` (:1024, 1070–1078) | Hand-port ~10 functions (~1.5–3k LOC) + vendor SAM CSVs; community `pvlib-rs` is early-stage | 🟠 High, effort M (weeks) — output parity vs pvlib is the goal |
+| **bslib** | `ACBatMod(system_id, p_inv, e_bat).simulate(p_load, soc, dt)` (advanced_battery_bslib:194, 283; EV variant :134) | Tiny API but opaque internals + per-system parameter DB; bslib not vendored — port requires obtaining its source | 🟡 Medium, S–M |
+| **windpowerlib** | `ModelChain.run_model` (generic_windturbine:188–199): log-law hub extrapolation + density correction + power curve | Hand-port ~300 LOC + sha256 cache (:441) | 🟡 Low–Medium, S |
+| **control** | `controller_pid.py`: `TransferFunction` + `forced_response` on a *scalar first-order* system only (:251–255) | Closed-form response `y(t)=K(1−e^{at})` — ~30 LOC, no crate needed | 🟢 surprise finding: trivial |
+| **scipy** | `interp1d(kind="quadratic")` ×2 (electrolyzer_h2:557, fuel_cell:447) | Hand-roll quadratic spline (~50 LOC) | 🟢 |
+| **numpy** | `np.interp` (6+ sites: part-load curves), linspace/zeros/argmin, `np.where` NaN cleanup, `np.repeat` | `Vec<f64>` + helpers or `ndarray` | 🟢 |
+| **pandas** | `read_csv` (csvloader:310, price_signal:272), `read_excel` (advanced_fuel_cell:151 → `calamine`), and the cross-cutting `postprocessing_results: DataFrame` param in cost/KPI functions of 11 files (e.g. electricity_meter:665–745) | `polars`/`csv` crate; **the DataFrame-typed interface must be redesigned** to typed tables | 🟡 Low–Medium, mechanical |
+| **utspclient** | EV charge controller: static dataset constants only (:12–13) | Vendor as consts | 🟢 |
+
+### 5.2 Python-specific obstacles
+
+- **L2 EMS dynamic dispatch**: `getattr(self, inputs[i].source_component_class)` (controller_l2_energy_management_system.py:646) and dispatch by class-name-embedded-in-field-name sniffing, admitted fragile in its own docstring (:931–939); inherits `DynamicComponent`; iterative surplus dispatch over source-weight-sorted components (:700–778) whose **iteration order must be preserved** for float-identical accumulation. Needs a typed channel-registry redesign. 🟠
+- **SimRepository handoffs**: car profile handoff (`lpg_car_information.py:281–335`, consumed via `getattr(self, "simulation_repository", None)` in generic_car:290); price signal → ~20 MPC forecast keys (price_signal:230–234 → mpc:428–504); PID reads 6 thermal coefficients (:134–142). → typed context. 🟡
+- **Checkpointing** via `copy.deepcopy` of state (electrolyzer_h2:394–405, advanced_fuel_cell:271, 415) → `Clone` + swap; maps *perfectly*. 🟢
+- `CarDataProvider` Protocol → trait object. 39 configs → serde. 🟢
+- `random_numbers.py`: seeded Mersenne Twister (`random.Random`, :132) → `rand_mt` crate for bit-identical series, or accept different draws with `rand`. 🟢
+
+### 5.3 Numerics style
+
+No ODEs (all explicit Euler); interpolation dominates (linear `np.interp` + two quadratic splines); exact float comparisons in control flow (`control_signal == 0.0` — advanced_fuel_cell:438, 447; exact `==` in PID time-constant search :277) — replicate bit-for-bit, don't "improve". MPC is the only iterative solver.
+
+### 5.4 Verdict
+
+| Group | Challenge | Effort |
+|---|---|---|
+| MPC (casadi/IPOPT) | 🔴 Very High | L |
+| PV (pvlib port) | 🟠 High | M |
+| L2 EMS dispatch redesign | 🟡 Medium | M |
+| Wind, batteries (bslib) | 🟡 Medium | S–M |
+| Hydrogen chain (electrolyzers, storage, fuel cells, RSOC ~5.6k LOC) | 🟢–🟡 | M (mechanical, repetitive) |
+| L1 controllers, CHP, transformer, meters, loads, examples | 🟢 Low | M combined |
+
+**Overall: 🟠 High. Effort: L (≈4–7 person-months including validation).** Long pole: MPC without casadi. Runner-up: bslib source availability. Favorable: no ODEs; clone-based checkpointing maps 1:1; flat configs → serde.
+
+## 6. Postprocessing (6,513 LOC)
+
+**Files:** 16 files: `postprocessing_main.py` (1345, orchestrator dispatching 27 options flags), `charts.py` (293), `chartbase.py` (268), `chart_singleday.py` (221), `system_chart.py` (329, Graphviz wiring diagrams), `reportgenerator.py` (365, PDF), `kpi_computation/kpi_preparation.py` (1920, all KPI math), `kpi_structure.py` (155), `cost_and_emission_computation/` (~826).
+
+**Corrections to the dependency folklore:** `pyam` is **never imported** — `postprocessing_main.py:889–1110` hand-rolls the IAMC long format (model/scenario/region/variable/unit/year/value) from plain dicts, with fragile positional column-name parsing (:1074–1085). `html2image`, `seaborn`, `plotly`, `openpyxl` are not used in this module. Actual deps: matplotlib (Agg, dpi=600, 4 chart forms incl. carpet `pcolormesh`), reportlab (Platypus + auto-TOC via `multiBuild` two-pass, reportgenerator.py:83–91, 360–365), pydot (shells out to the Graphviz binary, failures swallowed — system_chart.py:159–165), pandas, `dataclasses_json` (camelCase KPI entries, kpi_structure.py:60–93), **pickle** (DataFrame export, postprocessing_main.py:542–575).
+
+### 6.1 The architectural blocker: it is not self-contained
+
+KPI collection calls `component.component_kpi_entries(all_outputs, results)` (kpi_preparation.py:1848); OPEX/CAPEX call `get_cost_opex`/`capital_cost_data` with **dynamic dispatch into ~50 component classes**, plus `isinstance` classification against concrete heat-pump/meter/EMS classes (opex_and_capex_cost_calculation.py:103–110). There is even a file-based feedback loop: KPI prep re-reads the cost CSVs that the OPEX step wrote earlier *in the same run*, keyed by magic row names `"Total"` etc. (kpi_preparation.py:732–776). **Postprocessing cannot be ported before the component trait (incl. its cost/KPI interface) exists.**
+
+### 6.2 Parity traps
+
+- **~100 magic-string KPI keys** matched by string equality across files (kpi_preparation.py:694–717); the building-sizer lookup matches whole sentences (postprocessing_main.py:1174+). Rust: extract to constants — mechanical, and turns silent KeyError into compile errors.
+- **Banker's rounding** on every KPI (`round(x, 1)`, kpi_preparation.py:160–202) vs Rust's half-away `f64::round` → implement Python-style rounding or goldens diff.
+- The self-consumption computation uses a delicate `pd.concat` + `groupby(level=0).sum()` **element-wise-min trick** (kpi_preparation.py:321–332) → rewrite as a plain zip loop (simpler in Rust, but parity must be proven).
+- Fixed 30-day months in single-day slicing (chart_singleday.py:120–121), regex camelCase title splitting feeding filenames (chartbase.py:159–181) — replicate verbatim for artifact-name parity.
+- matplotlib global state machine + explicit `gc.collect(2)` to survive hundreds of plots (charts.py:163–192) — becomes owned figure structs in Rust (better design, no port).
+
+### 6.3 Library equivalents
+
+pandas: only a small surface (iloc selection, clip, sum(axis=1), concat/groupby, resample, to_csv/read_csv) → polars or hand-rolled reductions; **CSV float formatting parity** matters for golden tests. matplotlib → `plotters` (no native heatmap/colorbar) or `plotly.rs`+kaleido (external binary); **pixel parity is unattainable** either way. reportlab → `printpdf`/`genpdf` (TOC needs manual two-pass) or typst subprocess. pydot → `graphviz` crate (same external binary as today). pickle → **no Rust equivalent; must become Parquet/CSV — a breaking change for downstream consumers** (decision, not port).
+
+### 6.4 Verdict
+
+- **Full-fidelity port (charts + PDF): 🟠 High, effort L (~3–5 person-months)** — much of it low-value visual re-implementation.
+- **Compute core (KPI + OPEX/CAPEX + CSV/JSON exports): 🟡 Medium, effort M (~4–8 person-weeks)**, *provided* the component cost/KPI interface is frozen or ported first.
+- **Recommendation: split it.** The codebase itself proves visualization is optional — Docker mode (postprocessing_main.py:160–177) disables every chart and the PDF, keeping only CSV/KPI/costs/JSON. A Rust core should emit CSV/Parquet + JSON artifacts (KPIs, IAMC-style, building-sizer, webtool) and leave visualization to external tooling; the PDF report is better generated from a JSON manifest (e.g. typst) than reimplemented.
+
+---
+
+## 7. Economics / Lifecycle-Cost Engine (21,623 LOC)
+
+**Files:** `hisim/economics/` (51 files) + `cost_database/` (20 JSON + spot-price CSVs) + `subsidy_catalog/` (5 JSON) + `tools/worked_examples/` (xlsx→YAML converter). The newest large module.
+
+### 7.1 Architecture — and why it maps so well
+
+A **self-contained post-simulation cost engine**: it prices a finished simulation's outputs into NPV/annuity lifecycle costs per perspective. Layering: kernel/value types (~3,100 LOC: `UncertainValue` band arithmetic, `CashFlowEntry` timeline, financing, provenance), data layer (~4,700: cost DB + overlays, tariffs, subsidy catalog with a tri-state condition **AST evaluated by an op table, no `eval`** — catalog.py:51, 79), engine (~3,600: `evaluator.py` 968 + 15 pure calculators), results/IO (~5,400 incl. `economic_inputs.json` round-trip — the seam contract), presentation (~3,150: self-contained HTML+inline-SVG report, markdown golden, matplotlib PNGs), CLI (649).
+
+**Crucial scope fact: it is a leaf.** Nothing in `hisim/` imports it (all 21 importers are tests/tools); its only core dependencies are two enum modules. **Library dependence is almost nil**: pure scalar f64 math — no numpy/pandas/numpy_financial at runtime (pandas in exactly one audit function; matplotlib only for PNGs). All JSON I/O is hand-rolled (31 `json.load/dump` sites) — no dataclasses_json/pyhumps magic to reverse-engineer.
+
+### 7.2 What a Rust port looks like
+
+Natural crate boundaries already exist (the spec's four "seams"); the evaluator is documented as a **pure function of a JSON file**. `Protocol` → trait; tagged benefit/condition unions → serde internally-tagged enums (the JSON already carries tags); `UncertainValue` → small linear algebra over `[f64; 3]`; 2ⁿ subsidy-cumulation solver is bounded and fine. Data-driven throughout — new countries/schemes need no code changes.
+
+### 7.3 The traps (why it's Medium, not Low)
+
+1. **Byte-exact report goldens** (`tests/goldens/cost_summary.md`, `lifecycle_report.html`, 237 KB incl. SVG coordinates; only today's date is normalized): every view/SVG computation must reproduce f64 op order, plus Python-identical float formatting (`:.1f`, SVG `:.4f`, magnitude-based `_fmt` in reporting/summary.py:40) and thousands separators. Attainable (both languages round-half-even on the same binary double) but unforgiving.
+2. **Silent numeric conventions**: Python banker's `round()` at **8 integer-year decision sites** (calculators/investment.py:185, 190; context_resolution.py:294, 313, 324, 444) — half-even vs half-away *changes replacement/credit years*, shifting the whole timeline; and the relative **1e-9 band snap** in `UncertainValue` (uncertainty.py:95–104). Both must be replicated exactly.
+3. **Insertion-ordered dicts** everywhere in pivots/exports → `IndexMap`/ordered structs or golden ordering drifts.
+4. **Worked-example Excel tooling**: openpyxl formula tokenizer + SHA-256 attestations has no drop-in Rust equivalent (`calamine` can't read formula strings). Recommendation: keep the converter in Python — its YAML output is the stable contract.
+
+### 7.4 Verdict
+
+**Challenge: 🟡 Medium (low end). Effort: L (~2 person-months full port incl. tests; ~1 person-month for engine+data+CLI without presentation).** The unusually strong test suite (376 tests: hand-computed worked examples at 0.01 tolerance, invariants at 1e-9, an independent `numpy_financial` cross-check, goldens) doubles directly as the Rust port's acceptance harness. Recommended cut line: kernel → data → engine → serialization/CLI first; presentation goldens second pass; xlsx converter stays Python. **If a Rust pilot is wanted, this module — or a slice of it — is the place to start.**
+
+## 8. Declarative Energy-System Layer and Setup Front Ends — NOT YET ANALYZED
+
+**Scope that belongs here:** `hisim/energy_system/` (55 files, 19,406 LOC — loader, schema, codec,
+executor, wiring, channel matching, feed resolution, sizing bridge, grouping, recording, audit,
+parity), `hisim/json_executor.py` (334), `hisim/hisim_main.py` + `hisim_convert_to_json.py`,
+`system_setups/` (25 files, 8,267 LOC) and the `energy_systems/*.yaml` corpus.
+
+This section is missing, and its absence is the largest hole in the document — see review item
+**R1** in §11. Every effort total below is therefore incomplete by the second-largest module in the
+repository. Nothing here should be read as "this layer is easy"; it is the layer where
+reflection-based instantiation, preset resolution, tag-matched wiring and the byte-identity
+freshness gates all live.
+
+---
+
+## 9. Input Data, Caching, and External Connectors (~5,800 LOC + 569 MB data)
+
+**Files:** `hisim/caching/` (5 files, 1,309), `hisim/utils.py` (675), `log.py` (205), `result_path_provider.py` (357), `sim_repository_singleton.py` (236), `loadprofilegenerator_utsp_connector.py` (2,364) + `pylpg_workspace.py` (561), `hisim/inputs/` (206 data files, 569 MB), `hisim/renovisor/` (8 files, 1,636).
+
+### 9.1 Caching — surprisingly Rust-friendly, one byte-parity trap
+
+The legacy scheme (the one every component actually uses; the new `caching/keys.py` scheme has no consumers yet) computes `sha256(config.cache_key_view().to_json() + sim_params.get_unique_key())` (utils.py:385–413): a deep-copied config with `component_id.building` cleared and per-config non-key fields stripped (config/base.py:333), plus start/end/resolution/year/country joined with `###`. **Cache entries are plain CSV (pandas `to_csv`), not pickle** — reads use `float_precision="round_trip"` because pandas' default parser loses bits (weather.py:834–839). Atomicity via `mkstemp` + `os.replace` with a `.meta` sha256 sidecar (caching/local.py:160–232). The remote HTTP/shared-directory tiers are parsed-but-**not-implemented** — greenfield for Rust.
+
+Rust: `sha2` + `serde_json` + `tempfile`/`fs2` — a clean S-sized port. The trap: **cache keys are hashes of `dataclasses_json` output**, so serde must reproduce that string byte-for-byte (field order, float repr, enum spelling) or the 250 MB of committed caches and every cross-machine share invalidate at once. The new scheme's AST import-closure fingerprinting is inherently Python-runtime-specific and must be redesigned as build-time hashing.
+
+### 9.2 Input data — parsing is easy, the computations behind it are not
+
+Runtime-parsed formats: DWD TRY fixed-width headers (`lat = lines[1][20:37]` — weather.py:1178–1183) + `skiprows=31` tables; NSRDB hourly/15-min CSVs; wetterdienst CSVs; LPG minute profiles (`sep=";"`, **cp1252 from UTSP vs utf-8 from disk**); TABULA housing (latin-1, `;`); CEC/Sandia PV CSVs (multi-level headers, read **at import time** — module_selection.py:116); battery `.xlsx`/`.npy`/`.npz`. Rust: `csv`/polars, `calamine`, `ndarray-npy`, `encoding_rs`, manual byte-slicing for fixed-width. Memory improves 10–20× (`Vec<f64>` vs Python float lists). The hard 80% is what happens *after* parsing: `resample("1min").interpolate` + **pvlib** solar position/irradiance (weather.py:862–915) — no Rust equivalent (see §4.2/§5.1).
+
+### 9.3 UTSP/LPG connector — trivial protocol, heavy ecosystem
+
+The wire protocol is plain HTTP POST + JSON with an API-key header (verified from the utspclient wheel; no protobuf); results arrive as base64-encoded, zlib-compressed files; the client polls by re-POSTing every 100 s (connector:1714–1716). reqwest + serde + base64 + flate2 covers it in a day. The real work: (a) re-declaring the generated .NET LPG JSON bindings (hundreds of catalogue classes) with byte-identical serialization — configs feed cache keys; (b) the **local mode depends on a closed-source .NET binary** (simengine2 + 51 MB sqlite) that pylpg shells out to; HiSim already contains a workaround layer (workspace claiming, fcntl flock serialization, locked-db retries, ETXTBSY-safe install — pylpg_workspace.py:187–283, 356–402) that a Rust port must faithfully re-implement against the same binary via `std::process::Command`. **The Python library is not the forever-dependency — the .NET binary is.** Note: `pytz`'s private `_utc_transition_times` is used for LPG→UTC conversion (utils.py:258, 296) — DST logic must be re-derived carefully with `chrono-tz`.
+
+### 9.4 RenoVisor — confirmed easy
+
+Manual schema validation, pure dict transforms, one cached CSV read, a REST uploader with a clean retry policy, argparse CLI with exit codes. Injectable `post_fn`/`sleep_fn`/runner-Protocol seams map directly to Rust traits — no monkeypatching. Textbook reqwest + serde + clap + anyhow port. One caveat: `runner.py` executes `hisim_main.main` in-process, so the "run a simulation" stage inherits the full simulator's difficulty. **🟢 Low, S.**
+
+### 9.5 Verdict
+
+| Sub-area | Challenge | Effort |
+|---|---|---|
+| `hisim/caching/` package | 🟢 Low | S (<1 pw) |
+| Cache-key byte parity (consumers) | 🟠 High | folded into the above port |
+| Input-data reading | 🟡 Medium | M (weeks); pvlib parity is the L–XL tail |
+| UTSP/LPG connector | 🟠 High | L (person-months) |
+| RenoVisor | 🟢 Low | S |
+| Supporting cast (utils/log/rpp/singleton) | 🟢 Low | S |
+
+**Top-3 problems:** cache-key byte compatibility; the LPG/.NET ecosystem; pvlib/pandas parity in the weather→PV pipeline. Overall this layer is unusually Rust-friendly for Python infrastructure — no pickle in the cache path, no monkeypatching, explicit locking, env-var config — the risks are ecosystem risks, not code-structure risks.
+
+---
+
+## 10. Test Suite and Tooling (55,322 LOC tests + ~13,000 LOC scripts/tools)
+
+### 10.1 Taxonomy
+
+190 test files, ~1,322 test functions. **153 files (~87% of functions) are `mark.base`** — the fast, network-free set. Remainder: `system_setups` (14 files), `buildingtest` (7), `extendedbase` (10), `utsp` (2, networked + credentials), `jsonconfig`, `postprocessingoptions` (28 tests), `hpcharness` (13 files, ~89 tests), `worked_examples`. By content: component unit tests ~20,000 LOC, economics ~8,430, declarative energy-system ~9,000, core ~5,200, config contracts ~2,500, e2e smoke tests ~2,250 (assert only `finished.flag` exists), caching ~1,830, HPC harness ~1,720, postprocessing ~1,810, golden/parity machinery ~3,330, CLI ~570.
+
+### 10.2 Five golden/regression mechanisms — and what survives a port
+
+1. **KPI goldens** (`golden_references/*.json`, 32 files): 22 setups × 2 param sets re-run via subprocess, `all_kpis.json` flattened, compared with `math.isclose` at **rel_tol=1e-9** (`scripts/golden_kpis.py:19–20`). Subprocess-driven and artifact-comparing → **survives a port intact and can drive a Rust binary as happily as `hisim_main.py`.**
+2. **Building snapshots**: whole TABULA catalogue (2.1 MB) + every output vector of a synthetic day, floats via Python `repr` (bit-exact round-trip), NaN/inf as string sentinels; missing golden = hard error. → needs float-formatting parity or re-baselining.
+3. **Economics report goldens**: byte-compared markdown/HTML (only the date normalized). → hardest parity case (see §7.3).
+4. **P3 parity rig** (`scripts/p3_parity_*.py`, `hisim/energy_system/parity.py`): compares a Python setup vs its declarative twin — wiring sets, then **every column of `all_results.csv` with exact equality by default** (tolerance = "a finding"). → **this is precisely the template for a Python-vs-Rust parity rig.**
+5. **Freshness gates**: two *blocking* byte-identity gates regenerating every `.scenario.json` / `.energy_system.yaml`. → Python-artifact generators; need a Rust recorder with byte-identical output or semantic comparison.
+
+CSV byte-comparison also pins **pandas' shortest-round-trip float formatting** (postprocessing_main.py:520) — the sane move is switching all comparisons to parsed-value numeric comparison.
+
+### 10.3 pytest features with no Rust equivalent — and what they force
+
+- **monkeypatching (21 files)**: patches `utils.get_cache_file` (solar-gain cache isolation — without it, runs are order-dependent via the shared disk cache), `subprocess.run`, env vars. Rust has no monkeypatching → forces **dependency-injection seams in the core** (cache backend trait, injected clock, env at construction). This is a core-architecture change billed to the test scope.
+- **Autouse fixtures**: per-test `HISIM_CACHE_*` scrubbing and a `git status --porcelain` stray-file guard around *every* test (conftest.py:29, 181) → per-test helpers or (better) a CI-level post-suite check.
+- **Singleton resets** (`SingletonSimRepository` fixtures), **`__dict__`-scanning** output-index assignment in the test helper (functions_for_testing.py) → both evaporate with the typed core redesign (§2–3).
+- Mechanics: `parametrize`→`rstest`, `tmp_path`→`tempfile`, `capsys`→`assert_cmd`, `pytest.approx` (beware the hidden default rel_tol=1e-6 that many tests lean on)→`approx` crate, `raises`→`#[should_panic]`, `hypothesis` (1 file)→`proptest`, **markers as test selection**→test binaries/features + `cargo-nextest` filters, xdist → cargo parallelism.
+
+### 10.4 CI and HPC harness
+
+14 workflows. The golden family (check/year/json/update) survives as a pattern (subprocess + artifacts). `quality.yml`'s mypy/pylint/AST-config-check map to clippy/rustfmt — and `scripts/check_config_attrs.py` (which exists to compensate for untyped config escape hatches) becomes free. The **HPC harness** (~6,300 LOC FastAPI queue server + SQLite + worker fleet + ~89 tests) ports route-for-route to axum/tokio/rusqlite at M effort — and its warm-pool fork-server layer (~700 LOC), which exists solely to amortize Python interpreter startup, **can be deleted outright** in Rust (`tokio::process` spawn is ~ms).
+
+### 10.5 Verdict
+
+**Challenge: 🟠 High. Effort: L→XL boundary (≈0.5–0.75 person-years)** — parity rig + golden tooling 4–6 pw; base-suite rewrite (~1,150 functions, mostly mechanical once the Rust API exists) 10–14 pw; slow/e2e + freshness gates 4–6 pw; HPC harness 3–4 pw; CI 2–3 pw. Of the 55k test LOC, **~25–30% is behavior-pinning** (the rest is scaffolding that must be rewritten against the new API regardless). The most portable safety nets: the worked examples (oracle is *Excel*, an independent implementation) and the subprocess-driven golden corpus. **The trap:** during any incremental port the Python goldens stop guarding the Rust code, and re-blessing them against Rust output removes protection for Python — hence the parity rig must come first.
+
+<!-- APPEND -->
+
+
+
+
+## 11. Critical Review of This Document
+
+**Review date:** 2026-09-09 · **Reviewed at:** `f91c3eb1` (the analysis was written at `67ba1ca9`)
+**Note for the author's workflow:** new module analyses should be inserted *above* the `<!-- APPEND -->`
+marker; this review is deliberately last so it can be re-run against a grown document.
+
+The per-module method worked and the document's specificity is its main strength — file-and-line
+citations, the "corrections to folklore" pass, and the surprise findings (`control` collapsing to a
+30-line closed form; `hisim/economics/` being a leaf with no numpy/pandas at runtime) are the kind of
+thing only a real read produces. Spot-checks against the current tree confirmed the load-bearing
+structural claims: the convergence test really is a hardcoded absolute `0.0001` over every output
+(`hisim/component.py:194`), `pyam` really is never imported anywhere under `hisim/`, `casadi` really
+is confined to `hisim/components/controller_mpc.py`, `pickle` really is on the result-export path
+(`postprocessing_main.py:50,493,621`), and `pvlib` really is used by exactly four component modules
+(the other four hits are a comment, a docstring and two warning-filter mentions).
+
+What follows is what the document still needs before it can carry a decision. Items are ordered by
+how much they change the answer, not by page order.
+
+### R1 — §8 is missing, and it is the module that matters most for a port
+
+The heading sequence jumps 7 → 9. The gap is `hisim/energy_system/` (55 files, 19,406 LOC), plus
+`json_executor.py`, `hisim_main.py` and `system_setups/` (25 files, 8,267 LOC) — together the
+second-largest body of code in the repository and, by the document's own §1.3 reasoning, the most
+Rust-hostile: reflection-based instantiation, preset and sizing resolution, tag-matched wiring
+(`channel_matching.py`, `feed_resolution.py`, `wiring.py`), the recording/grouping passes, the audit
+trail, and the two *blocking byte-identity* freshness gates. A stub has been inserted at §8 so the
+hole is visible in the structure. Until it is filled, every total in this document is incomplete by
+roughly 15% of the repository's Python and by an unknown share of its difficulty.
+
+Also uncovered, in descending order of importance: the **webtool JSON export contract**
+(`MAKE_RESULT_JSON_FOR_WEBTOOL` — an external consumer whose format is a public interface),
+`hisim/building_sizer_utils/` (listed in §1.1, analyzed nowhere), Docker packaging and the PyPI
+distribution story, and the CI-only Python under `scripts/` and `.github/` — the last of which
+should be explicitly declared *out of scope* rather than silently folded into §10's 13,000 LOC,
+since a Rust core does not require porting its own CI tooling.
+
+### R2 — There is no total, and §1's promised synthesis does not exist
+
+The method paragraph promises "a cross-module synthesis is added at the end"; there is none. Adding
+the per-module verdicts as stated gives roughly **20–30 person-months**, and that figure *excludes*
+§8, excludes the physics-library reimplementation tails the document itself calls multi-person-year
+(§1.3), and excludes any hardening, documentation or migration period. Stated honestly with those
+exclusions restored, this is a **3–5 person-year program with a wide band** — a categorically
+different conversation from what a column of "M" and "L" letters conveys to a reader skimming
+verdicts. The document should say the number out loud, with its uncertainty and its exclusions
+listed underneath, and should lead with it.
+
+### R3 — The benefit side is never quantified, so there is no case to weigh
+
+The entire performance argument is one sentence: a "plausible 10–50× speedup" on the timestep loop
+(§2.1), with no measurement behind it. Nothing in the document establishes **where a representative
+run actually spends its wall time**. That profile is a day of work and it gates everything else: if a
+year-long minutely run spends most of its time in pvlib/hplib calls, CSV/weather parsing, pandas
+resampling and waiting on UTSP, then a Rust core delivers a small fraction of that 10–50× and the
+program's justification collapses regardless of feasibility. Required addition: a profile of two or
+three representative setups broken down into timestep loop / library calls / input parsing /
+postprocessing / external waiting, with the resulting Amdahl ceiling computed explicitly. Also state
+the actual goal — is it speed, memory, deployability, type safety, or maintainability? Different
+goals pick different subsets of this work, and the document never commits to one.
+
+### R4 — The alternatives are not evaluated, so "convert to Rust" has nothing to be compared against
+
+A feasibility study offering only *do it* or *don't* is missing the options most likely to win:
+
+- **PyO3/maturin extension for the hot loop only**, keeping the Python ecosystem intact — the
+  document itself identifies the loop as small, well-tested and the most separable piece (§2).
+- **numba or Cython on the same loop**, at a fraction of the cost and with no FFI boundary.
+- **Vectorizing over timesteps in NumPy** — there is already a plan on the shelf
+  (`roadmap/pv_vectorization_plan.md`) that should be cross-referenced.
+- **Doing only the architecture cleanups** (typed context, no reflection, typed result tables), which
+  captures most of the design benefit in Python and is a prerequisite for the Rust path anyway.
+
+Each deserves a paragraph with rough effort and rough payoff. Without them the document reads as an
+answer to "how would we do this" when the open question is "should we".
+
+### R5 — The hybrid path is mentioned twice and designed nowhere
+
+§1.3 floats "keeping a Python island via PyO3" and §10.5 names the killer trap — during an
+incremental port the Python goldens stop guarding the Rust code, and re-blessing them against Rust
+output removes protection for Python. That is the most decision-relevant problem in the document and
+it gets one sentence. It needs a section: which direction the FFI boundary points (a Rust engine
+calling Python physics, versus a Python driver calling a Rust engine), the **per-timestep FFI cost
+for a component that must call pvlib** — at 525,600 timesteps a year, a boundary crossing per
+component per iteration can erase the entire speedup — whether both implementations can live in one
+CI, and what the abort criteria are. A rewrite without a designed strangler path is a rewrite that
+must complete or be thrown away, and that should be stated as a risk.
+
+### R6 — The parity target is self-contradictory, and several ratings depend on resolving it
+
+The document asserts bit-exactness as a requirement in at least a dozen places ("replicate
+bit-for-bit, don't improve" — §5.3, §4.4) while simultaneously conceding in §1.3 that bit-level
+reproduction "is *not guaranteed* even for identical formulas". Both cannot stand. Pick a policy —
+for example: re-baseline every golden once against declared tolerances (relative 1e-6 for physics,
+1e-9 for financial invariants), and keep byte comparison only where byte identity is itself the point
+(the freshness gates) — then **re-rate the modules whose colour comes from parity fear rather than
+from complexity**: the §6 chart/PDF work, the §7 report goldens, and the §9 cache-key hash. At least
+two of those plausibly drop a severity level, which materially changes R2's total.
+
+Related and missing entirely: **the "port the bugs" question.** Bit-parity as a goal means faithfully
+reproducing things this document itself flags as defects — fixed 30-day months
+(`chart_singleday.py:120`), exact float `==` in control flow, banker's rounding of *integer decision
+years* (§7.3), `delta_t == 0 → 1e-8`. Each needs a per-item ruling: reproduce, or fix and re-bless.
+Any "fix" answer forces the re-baseline of R6 anyway, which is an argument for deciding the policy
+first.
+
+### R7 — The estimates have no stated basis and no calibration
+
+"≈3–5 person-months" for 22,900 LOC implies a translation rate that is never given, never validated
+against a measured pilot, and never risk-adjusted. Recommendation: add an explicit LOC/week
+assumption per severity class so the arithmetic is auditable, and then **run one calibration pilot**
+before anyone believes the totals. §7.4 nominates the economics module; that is the wrong pilot for
+this purpose precisely because it is a leaf with no library dependence and no framework coupling — it
+would measure the easiest case. The informative pilot is a *component plus the engine contract it
+needs* (`simple_water_storage.py` or `generic_boiler.py` on top of a minimal §2/§3 core), because it
+exercises the trait design, the config layer, the state checkpoint and the golden harness at once.
+Until a pilot exists, mark every number as ±2×.
+
+### R8 — Team, contribution model and distribution are absent
+
+Nothing in the document addresses who would write and maintain the Rust. HiSim's contributors are
+energy-systems researchers whose most common contribution is *adding a component* — often a PhD
+student with a physics model and one semester. A Rust core changes the cost of that contribution and
+the size of the contributor pool, which is a larger programme risk than casadi. The document should
+state the required Rust headcount and ramp-up, what happens to external contributions, and what
+`pip install hisim` becomes (maturin wheels per platform, or a Python front end over a Rust core).
+
+### R9 — The moving-target risk is named but not sized
+
+§1.3 makes the point with one anecdote ("the last merge alone changed 859 files"). Size it properly:
+commits per month touching `hisim/components/` and `hisim/economics/` over the last six months, and
+what fraction would have required a parallel change on the Rust side. A multi-year rewrite against
+that rate either freezes the Python side — organizationally impossible for a research group with
+funded deliverables — or doubles the cost of every change for the duration. This is the factor most
+likely to actually decide the answer, and it deserves numbers rather than an aside.
+
+### R10 — Stale and unsourced specifics
+
+The structural claims held up; several numbers have drifted or need sourcing.
+
+- **Line counts have moved** in three commits: `simulator.py` is 783 (doc: 660), `component.py` 804
+  (736), `hisim/components/` 47,057 (46,142), `tests/` 60,834 in 220 files (55,322 in 208). Either
+  stamp each number with its commit or drop to orders of magnitude — precise LOC in a long-lived
+  planning document is a maintenance liability. The `hisim/` top-level row of §1.1 is already
+  approximate ("~15 files, ~7,700") where the rest is exact; make the whole table one or the other.
+- **`hisim/inputs/` is stated as 569 MB.** Git-tracked content is ~319 MB; this working copy holds
+  1.7 GB because generated caches live *inside* the data directory. Distinguish tracked reference
+  data from generated cache — the conflation matters for the §9 caching analysis and for the
+  clone-size argument.
+- **`module_selection.py:116`** (§9.2, "read at import time") is worth an explicit path: it is
+  `hisim/inputs/photovoltaic/module_selection.py` — executable Python living inside the *data*
+  directory. A reader will not find it under `hisim/components/`.
+- **Three load-bearing numbers carry no evidence**: the 10–50× speedup (§2.1), "pvlib alone is a
+  multi-person-year effort" (§1.3), and the ~57 s per MPC optimization (§5.1 — that one at least
+  cites a code comment, which should be said in the text). The pvlib claim is cheap to ground: state
+  pvlib's own LOC and the subset HiSim actually calls, since §4.2 and §5.1 already scope that subset
+  to roughly 2–4k LOC of formulas, which is *not* multi-person-year and quietly contradicts §1.3.
+- §6's header says 6,513 LOC where §1.1's table says 6,472 (current: 6,551). Minor, but the document
+  should not disagree with itself.
+- The `seaborn`/`plotly`/`html2image` correction in §6 is right about the module but should note that
+  all three are still declared in `requirements.txt` — the folklore has a source, and the dependency
+  list is itself a cleanup target.
+
+### R11 — The rating scheme hides the axis that matters
+
+🟢–🔴 conflates "no Rust equivalent exists" with "needs a redesign decision", and a module can be
+trivially portable yet blocked on a human choice. Add two columns to every verdict table: **risk**
+(probability the estimate is wrong by more than 2×) and, more importantly, **decision** — the choices
+this work would force on someone. Collected, those decisions are the actual output a roadmap document
+should produce: the MPC formulation, pickle → parquet, charts in or out of core scope, the parity
+policy, the FFI direction, whether the LPG/.NET subprocess may remain a core dependency. Right now
+they are scattered through nine sections as asides inside effort estimates.
+
+### R12 — Presentation
+
+Add a one-page executive summary at the top: verdict, total with band, top five blockers,
+recommendation, and the decision this document feeds. Nobody reads 350 lines to find the answer, and
+the answer is currently nowhere — the document ends mid-analysis. Date each module section
+individually (they will rot at different rates, and §7's economics analysis is already the freshest).
+State who the document is for. And keep the two habits that make it good: the folklore-correction
+pass and the per-site line citations.
+

--- a/roadmap/rust_ideas/hisim_rust_recommended_cleanup_steps.md
+++ b/roadmap/rust_ideas/hisim_rust_recommended_cleanup_steps.md
@@ -1,0 +1,216 @@
+# Cleanups and Architecture Work to Do Before Any Rust Conversion
+
+**Date:** 2026-09-09 · **Owner:** Noah Pflugradt · **Surveyed at:** `f91c3eb1`
+**Companion to:** `roadmap/rust_ideas/feasibility_rust_hisim.md` (the feasibility analysis and its §11 review)
+
+## What this list is, and the rule it follows
+
+Every item below is worth doing to HiSim as a Python codebase. That is the entrance criterion, not a
+coincidence: a cleanup justified only by a hypothetical rewrite is a cleanup that will be abandoned
+the first time the rewrite slips, and it will have cost real review time in the meantime. Each item
+therefore states its payoff *now* separately from its payoff *for a port* — and if the port never
+happens, nothing here was wasted.
+
+The second reason for the rule is that this list is also the cheapest available test of the
+feasibility question. Most of the conversion cost the companion document identifies is not
+translation cost; it is the cost of untangling Python-specific coupling — reflection, shared mutable
+globals, DataFrame-typed interfaces, string-keyed lookups. Doing that untangling in Python is
+strictly less risky than doing it while simultaneously changing language, and afterwards the
+feasibility estimate can be re-derived against a codebase whose seams are visible. If the cleanups
+turn out to be too expensive to finish, that is itself the answer to the Rust question.
+
+Nothing here is sequenced against a conversion start date. This is long-term work, to be picked up
+between features.
+
+---
+
+## Step 0 — Measure before changing anything
+
+- [ ] **Profile a representative run and publish the breakdown.** Two or three setups (one minutely
+  full year, one 15-min short run, one with MPC), broken into: timestep loop, third-party library
+  calls (pvlib/hplib/bslib/windpowerlib), input parsing, postprocessing, external waiting
+  (UTSP/LPG). This is a day of work and it is the gate on every performance argument in the
+  companion document — including whether Tier 1 should be reordered around whatever actually
+  dominates. **Payoff now:** it will almost certainly find optimizable Python nobody has looked at.
+  **Payoff for a port:** it converts "10–50× on the loop" into an Amdahl ceiling for the whole run.
+
+---
+
+## Tier 1 — The four boundaries that decide whether a second implementation is possible at all
+
+These are the items that a port cannot route around, and each one improves the Python codebase on its
+own terms. If only one tier is ever done, it should be this one.
+
+- [ ] **A physics-library adapter layer.** Today `pvlib`, `hplib`, `bslib`, `windpowerlib`,
+  `oemof.thermal` and `pygfunction` are called inline from the components that need them —
+  `weather.py`, `generic_pv_system.py`, `building/window.py`, `solar_thermal_system.py`,
+  `more_advanced_heat_pump_hplib.py`, `simple_heat_source.py` — and library objects cross the
+  boundary in both directions (HiSim mutates `heatpump.delta_t` on an hplib object mid-simulation).
+  Give each library one HiSim-owned module with typed scalar/array inputs and outputs and no library
+  type in its signatures. **Payoff now:** upgrading or pinning pvlib stops being a repo-wide risk
+  (the pin in `requirements.txt` is commented out, which is its own finding); the calls become
+  mockable, so component tests stop needing real solar-position math; and one place can record
+  reference inputs/outputs per library call. **Payoff for a port:** this boundary *is* the FFI seam,
+  and it is the difference between a hybrid being designable and not.
+
+- [ ] **A typed simulation context, replacing `SingletonSimRepository` and the string-keyed
+  `SimRepository`.** 17 modules under `hisim/` still reach for the singleton, including the
+  weather → building forecast handoff (11 yearly arrays), price signal → MPC (~20 forecast keys), the
+  air-conditioner fit coefficients and the PID thermal coefficients; `generic_car.py:293` reads its
+  repository through `getattr(self, "simulation_repository", None)`. Replace with an explicit typed
+  context constructed by the engine and passed to components. **Payoff now:** mypy sees these
+  handoffs, a missing publisher fails at wiring time instead of as a `KeyError` in timestep 0, test
+  fixtures that reset a global disappear, and run isolation stops depending on discipline.
+  **Payoff for a port:** removes the single largest piece of untyped shared mutable state.
+
+- [ ] **A typed results table, replacing `pd.DataFrame` in the component cost/KPI hooks.** 92
+  signatures under `hisim/components/` take `postprocessing_results: pd.DataFrame`, so pandas is
+  part of the component API and every cost/KPI implementation depends on column-name conventions.
+  Introduce a narrow view type (per-output series accessor plus the reductions actually used) and
+  migrate the hooks behind it. **Payoff now:** KPI and cost code becomes unit-testable without
+  constructing a DataFrame; the column-name coupling that §6.2 of the companion document describes as
+  "positional column-name parsing" becomes a compile-time-visible interface. **Payoff for a port:**
+  removes pandas from the component trait, which is otherwise a hard blocker for porting any
+  component before porting all of postprocessing.
+
+- [ ] **A static component registry, replacing reflection-based instantiation.** 29 `importlib`
+  call sites across 9 component modules exist purely to dodge circular imports in default
+  connections; 22 `.scenario.json` files and 28 `.energy_system.yaml` files name components by
+  fully-qualified Python path (`class: hisim.components.weather.Weather`). Add a name → constructor
+  table with a test that pins its contents, keep the fully-qualified paths accepted as aliases, and
+  let the declarative loaders resolve through the table. **Payoff now:** a typo in a scenario file
+  fails at load with a suggestion instead of an `ImportError` from deep inside `importlib`; the
+  circular-import dodges can be deleted; the component inventory becomes enumerable for docs, the
+  webtool and `hisim energy-system describe`. **Payoff for a port:** this is the inventory Rust
+  cannot generate for itself, and building it in Python proves the list is complete.
+
+---
+
+## Tier 2 — Interfaces a second implementation would have to honour
+
+- [ ] **Decide the numeric-parity policy, then make the goldens implement it.** Today the regression
+  corpus mixes byte comparison of CSV and markdown with `math.isclose` at rel_tol 1e-9 and
+  `pytest.approx` at its implicit 1e-6 default. Byte comparison pins pandas' float formatting, which
+  is why pandas is pinned to an exact version. Move comparisons to parsed-value numeric comparison at
+  declared per-domain tolerances, and keep byte identity only where byte identity is the point (the
+  `.scenario.json` / `.energy_system.yaml` freshness gates). **Payoff now:** goldens stop breaking on
+  formatting changes in a dependency, and every tolerance becomes a stated decision rather than a
+  library default nobody chose. **Payoff for a port:** this is the acceptance harness; see review item
+  R6 in the companion document for why the current contradiction blocks the estimate itself.
+
+- [ ] **Retire the magic-string KPI keys.** The companion document counts ~100 KPI names matched by
+  string equality across files, with a building-sizer lookup matching whole sentences. Work is
+  already specified in `roadmap/kpi_address_spec.md` — align with it rather than forking a second
+  scheme. **Payoff now:** a renamed KPI fails loudly instead of silently zeroing a downstream number.
+
+- [ ] **Kill the intra-run file feedback loop in postprocessing.** KPI preparation re-reads the cost
+  CSVs that the OPEX step wrote earlier *in the same run*, keyed by magic row names such as `"Total"`
+  (`kpi_preparation.py:732–776`). Pass the values in memory. **Payoff now:** removes an ordering
+  dependency between postprocessing options and a whole class of "works alone, fails in the full
+  run" bugs.
+
+- [ ] **Replace the pickle result export with parquet or CSV+JSON.** `postprocessing_main.py`
+  pickles a DataFrame; pickle has no cross-language reader and is a security and
+  version-compatibility liability in Python too. This one has external consumers, so it needs an
+  announcement and a deprecation window — start it early precisely because of that.
+
+- [ ] **Separate physics from reporting boilerplate in the large component modules.** §4.1 of the
+  companion document estimates 25–40% of the big files is cost/KPI/report code. Split per component,
+  one PR each, no behaviour change. **Payoff now:** `building.py` at 2,099 lines and
+  `more_advanced_heat_pump_hplib.py` at ~2,750 become reviewable, and the physics gets testable
+  without the reporting stack.
+
+- [ ] **Stop the byte surgery in the connection log.** `component.py:447` seeks to
+  `st_size - 1` and overwrites the closing bracket of `component_connections.json` to append an
+  entry. Buffer the connections and write the file once when wiring completes. **Payoff now:** an
+  interrupted run stops leaving a syntactically broken JSON file behind.
+
+- [ ] **Make the convergence criterion explicit and unit-aware.** `component.py:194` compares every
+  output against a hardcoded absolute `0.0001` — watts, joules, kelvin, euros and dimensionless
+  ratios on one scale — and the forced-convergence thresholds (>10 iterations, >100 raises) are
+  hardcoded next to it. At minimum make all three configurable and document the choice; ideally scale
+  per unit. **Payoff now:** the tolerance becomes a modelling decision that can be justified, and
+  the "runs converge but nobody knows how tightly" question gets an answer.
+
+---
+
+## Tier 3 — Removing Python-only crutches
+
+- [ ] **Explicit state structs for `i_save_state` / `i_restore_state`.** Five component modules
+  `deepcopy` themselves or their state each iteration. An explicit small state object is faster in
+  Python and removes the "which attributes are state?" ambiguity. **Payoff now:** measurable — this
+  runs once per component per convergence iteration per timestep.
+
+- [ ] **Inject the cache backend, the clock and the RNG instead of patching them in tests.** 22 test
+  files use `monkeypatch`, 8 of them around `utils.get_cache_file`; without that patching, runs are
+  order-dependent through the shared on-disk cache, and `conftest.py` scrubs `HISIM_CACHE_*` around
+  every test. Turn these into constructor parameters. **Payoff now:** order-independent tests, less
+  autouse machinery, and the stale-cache class of false failures loses its main route in.
+
+- [ ] **Make the cache key an explicit versioned serializer.** The key is
+  `sha256(dataclasses_json output + sim-params string)`, so field order, float repr and enum spelling
+  from a third-party library are load-bearing for ~319 MB of committed cache and every cross-machine
+  share. Write an owned key serializer with a stable field order, a schema version in the key, and a
+  test that pins the exact string for a fixture config. **Payoff now:** upgrading `dataclasses_json`
+  or `pyhumps` stops silently invalidating every cache entry in the fleet.
+
+- [ ] **Audit the exact float comparisons in control flow.** Roughly 60 `== 0`-style comparisons sit
+  in component control paths (`water_mass_flow_rate == 0`, `control_signal == 0.0`, `delta_t == 0`
+  patched to `1e-8`). Replace with documented epsilons and re-bless the goldens once. Do this in
+  Python, where re-blessing is cheap and reviewable, rather than discovering it during a port where
+  the change is indistinguishable from a translation bug.
+
+- [ ] **Move executable code out of the data directory and stop reading data at import time.**
+  `hisim/inputs/photovoltaic/module_selection.py` is Python inside `hisim/inputs/`, and it reads PV
+  module databases at import. Relocate to `hisim/components/` and make the read lazy. **Payoff now:**
+  import time, and the data directory becomes purely data.
+
+- [ ] **Separate tracked reference data from generated cache.** `hisim/inputs/` holds ~319 MB of
+  git-tracked reference data; on a working copy it reaches 1.7 GB because generated caches live in
+  the same tree. Move the cache out of `hisim/inputs/`, and consider distributing the reference data
+  as a versioned package or download. **Payoff now:** clone size, and cache from one branch stops
+  masquerading as input data in another.
+
+- [ ] **Prune `requirements.txt`.** `seaborn`, `plotly` and `html2image` are declared but imported
+  nowhere under `hisim/`, `tests/`, `tools/`, `scripts/` or `system_setups/`; there are
+  commented-out pins (`pvlib`, `windpowerlib`,
+  `wetterdienst`) and a migration TODO. An accurate dependency list is a prerequisite for reasoning
+  about the domain-library gap at all.
+
+- [ ] **Converge on one front end.** There are three ways to describe a system: 23 setup functions in
+  `system_setups/*.py`, 22 `.scenario.json` twins, and 28 `.energy_system.yaml` files, with byte-
+  identity freshness gates keeping the generated ones in sync. Per the declarative-energy-systems
+  plan the YAML is the intended survivor; finish that migration and retire the others. **Payoff now:**
+  one loader to keep correct instead of three, and one place where a new component must be
+  registered. **Payoff for a port:** the single largest reduction in porting surface available
+  anywhere in this list.
+
+---
+
+## Tier 4 — Decisions to take before a port, not cleanups
+
+These need a human ruling. None of them is coding work; all of them block estimation.
+
+- [ ] **MPC and casadi.** Reformulate as a MILP (the companion document argues the dynamics are
+  linear between disjunctions), accept a permanent Python island, or declare MPC out of core scope.
+  This is the only 🔴 in the whole analysis; leaving it open leaves the total open.
+- [ ] **Charts and the PDF report.** Docker mode already runs with every chart and the PDF disabled,
+  which proves they are optional. Decide whether they are in core scope; if not, formalize the JSON
+  manifest that external tooling would render.
+- [ ] **The LPG/.NET dependency.** The forever-dependency is the closed-source .NET binary, not the
+  Python wrapper. Decide whether the core simulator may depend on a subprocess at all.
+- [ ] **The parity policy** (Tier 2, first item) and **the FFI direction** (review item R5) — both are
+  decisions masquerading as engineering tasks.
+
+---
+
+## Explicitly not recommended
+
+- **Do not chase bit-exactness.** It is unattainable across languages and, per review item R6, it also
+  means faithfully reproducing known defects. Decide tolerances instead.
+- **Do not rewrite tests ahead of a parity rig.** The P3 parity rig
+  (`scripts/p3_parity_*.py`, `hisim/energy_system/parity.py`) is the template; it compares two
+  implementations of the same setup, which is exactly the Python-versus-Rust question.
+- **Do not start any cleanup whose only justification is the port.** See the rule at the top.
+- **Do not freeze feature work for this.** Review item R9 makes the point quantitatively: the repo's
+  change rate is the factor most likely to decide the Rust question, and a freeze is not available.

--- a/roadmap/rust_ideas/rust_simulator_spec.md
+++ b/roadmap/rust_ideas/rust_simulator_spec.md
@@ -1,0 +1,310 @@
+# Simulator Hot-Path Redesign — Options Register and Measurement Plan
+
+**Date:** 2026-09-09 · **Owner:** Noah Pflugradt · **Surveyed at:** `f91c3eb1`
+**Related:** `roadmap/rust_ideas/feasibility_rust_hisim.md` (§2, §11), `roadmap/rust_ideas/hisim_rust_recommended_cleanup_steps.md`
+
+## What this document is
+
+An options register, not a decision. Every option below is a candidate for the value-exchange
+path between the simulator and its components — the `SingleTimeStepValues` write path, the
+convergence check, and the boundary a Rust implementation would sit on. Each option records what it
+is, what it is expected to buy, what it costs, and **which measurement has to exist before it can be
+judged**. Nothing here should be implemented before its gating measurement is in hand: one plausible
+idea in this space has already been benchmarked and lost (numpy storage), which is the reason this
+document exists.
+
+The ordering is deliberate: measurements first, then options, then the ideas that were considered and
+discarded — with reasons, so they are not proposed again.
+
+---
+
+## 1. Verified ground truth
+
+Established by inspection at `f91c3eb1`. Re-check before relying on any of it, since the hot path is
+under active development.
+
+| Fact | Source |
+|---|---|
+| `SingleTimeStepValues.values` is a **Python list** of boxed floats (`[0.0] * n`) | `hisim/component.py:168` |
+| Writes go through a method frame plus an attribute deref: `set_output_value(output, v)` → `values[output.global_index] = v` | `hisim/component.py:187–189` |
+| Convergence is an **interpreted loop** over **every** output at **absolute 1e-4** | `hisim/component.py:191–197` |
+| Convergence is forced after >10 iterations and raises after >100 | `hisim/simulator.py:266–270` |
+| Per iteration the engine also does one full-array `copy_values_from_other`, and two `clone()` per timestep | `hisim/component.py:171–179`, `hisim/simulator.py:239–241` |
+| **484** `set_output_value` and **233** `get_input_value` call sites under `hisim/components/` | grep |
+| `stsv.values` has exactly **one** consumer outside `component.py` | `hisim/simulator.py:460` |
+| An output's `global_index` is assigned in registration order per wrapper → **each component's outputs occupy a contiguous block** | `hisim/component_wrapper.py:105` |
+| An input reads `component_input.source_output.global_index` → **input reads are scattered by construction** | `hisim/component.py:181–185` |
+| A real 14-component setup registers **141 outputs**, has **55 connections** drawing on **41 distinct source outputs** — i.e. ~71% of outputs are read by no component | `pr9_results/1_germany_heatpump_pv_battery_retrofit/{hisim_simulation.log,component_connections.json}` |
+| All `SimRepository` **reads** in components happen in `i_prepare_simulation`, before the loop; the 7 writes inside `i_simulate` (weather, price signal, tariff provider, PV, LPG) are read by nobody during iteration → **the wiring graph is the complete intra-timestep coupling graph** | AST scan of `hisim/components/**` |
+| Converting the value store to numpy was benchmarked and came out **slower**: the vectorized compare gain is smaller than the loss on hundreds of individual scalar stores | prior measurement (team) |
+
+---
+
+## 2. Measurement program
+
+These gate everything in §3. All of them are small, and none requires a Rust toolchain except **M2**.
+
+- [ ] **M0 — per-element container costs on our CPython.** Read and write cost for `list`,
+  `array.array('d')`, `memoryview` format `'d'`, and numpy scalar indexing. Establishes where the
+  boxing conversion is cheapest to pay. Expected ordering (to be confirmed, not assumed): list
+  fastest per element, every unboxed buffer slower, numpy slowest — which is why an unboxed buffer
+  handed to Python is the wrong shape.
+- [ ] **M1 — call-site variants.** One representative component, four `i_simulate` bodies:
+  (a) current `stsv.set_output_value(self.channel, v)`; (b) `o[self.channel.local_index] = v`;
+  (c) `o[self.IDX_X] = v` with a class-level int; (d) `o[2] = v` with the index hoisted to a local.
+  Decides whether rewriting 717 call sites earns its churn, and which spelling to rewrite them to.
+- [ ] **M2 — PyO3 boundary stub.** One extension call that gathers 10 scattered f64 into a Python
+  list and scatters 7 back. Yields the real crossing cost and the real per-float boxing cost on our
+  platform, which every estimate in §3 depends on. This is also the cheapest available probe of the
+  Rust build and wheel story.
+- [ ] **M3 — loop profile.** Per-iteration time split into component physics versus value plumbing
+  (writes + reads + compare + copies), on two or three representative setups. Without this, every
+  speedup figure below is unanchored.
+- [ ] **M4 — residual argmax.** Per timestep, log which output index fails
+  `is_close_enough_to_previous` last. Answers two questions at once: whether the outputs driving the
+  iteration count are wired signals or write-only diagnostics, and whether any output's magnitude
+  makes the **absolute** 1e-4 threshold unsatisfiable (a counter at 1e9 needs ~1e-13 relative, so it
+  would fail on every iteration and silently force the 10-iteration cutoff on every timestep).
+- [ ] **M5 — iteration histogram and memory high-water.** Distribution of iterations per timestep,
+  and the peak size of `all_result_lines`. A year at 1 min × 141 outputs is ~593 MB as raw f64 but
+  roughly 2–3 GB as a Python list of lists of boxed floats; at 500 outputs it is ~2 GB versus
+  ~10 GB. Given the 16 GB runner ceiling tracked by `ci-usage`, this may be worth more than any CPU
+  figure here.
+- [ ] **M6 — state-leak test (correctness, not performance).** Run a timestep, then force one extra
+  iteration, and assert the outputs are identical. This checks the premise that `i_restore_state`
+  undoes everything `i_simulate` mutates. If it fails anywhere, the loop is not a fixed-point
+  iteration, iteration count changes results, and several arguments in §3 and Appendix A do not
+  hold. Worth having regardless of this whole programme.
+
+---
+
+## 3. Options register
+
+Effect columns are **estimates to be replaced by measurements**, computed for the 141-output,
+14-component setup at ~3 iterations per timestep and a minutely year. They are order-of-magnitude
+claims, not commitments.
+
+### O1 — Double-buffer swap instead of per-iteration copy (pure Python)
+
+Alternate which of two lists the engine hands to components, instead of calling
+`copy_values_from_other` each iteration. Safe because components hold no reference to `stsv` between
+calls.
+
+- **Effect:** removes ~5.6 µs/iteration, ~9 s/run. **Cost:** a few lines in `simulator.py`.
+- **Gate:** none. **Status:** do it; it is free and it shrinks the delta for O2.
+
+### O2 — Rust `SingleTimeStepValues` drop-in
+
+A PyO3 `#[pyclass]` with the same constructor and method names, owning a `Vec<f64>`. Carries:
+double buffering with an internal **swap** rather than a copy; `converged()` doing the comparison in
+Rust; an optional **per-output tolerance vector**; `commit_row()` accumulating the run's results in
+Rust and handing back one array at the end; `values` and `set_output_value` kept as compatibility
+shims.
+
+- **Effect:** compare ~8.5 µs → ~0.2 µs per iteration; copies → ~0; the single external `.values`
+  consumer (`simulator.py:460`) becomes `commit_row()`, removing 525,600 list appends and the
+  list-of-lists → DataFrame construction. Estimated ~55 s → ~19 s of plumbing per run, plus the
+  memory reduction in **M5**.
+- **Non-effect, important:** the write path barely improves. A **per-value** Rust setter would be
+  *slower* than today — see D3.
+- **Cost:** the whole Rust build burden (toolchain in CI, maturin wheels per platform × Python
+  version, a second build path for contributors) for one class. The counter-argument is that this is
+  the cheapest possible way to find out what that burden costs, on an artifact small enough to throw
+  away.
+- **Gate:** M2, M3, M5. **Status:** leading candidate for the first Rust artifact.
+
+### O3 — Batched per-component gather/scatter over list buffers
+
+Each component gets two preallocated Python **lists** (`_i` of length M_in, `_o` of length M_out) at
+wiring time; Rust holds `Py<PyList>` handles plus the component's input source indices and its
+contiguous output offset. Per component per iteration the engine gathers into `_i`, calls
+`i_simulate`, and scatters `_o` into its `Vec`.
+
+The elegance: **gather and scatter add zero crossings**, because they happen on the Rust side of the
+call the engine already makes. The list is deliberately *not* a buffer view — per M0, an unboxed
+buffer is slower for Python's per-element access, so the conversion is better paid once per component
+in a tight Rust loop.
+
+- **Effect:** for a 10-in/7-out component, ~2.2 µs → ~1.2 µs of plumbing, ≈2×. Beats naive
+  tuple-passing (~1.3×) because the component writes into a preallocated list rather than building
+  one per call.
+- **Floor to be aware of:** every float crossing into or out of Python is boxed at ~25–30 ns, which
+  no boundary design removes. At 20 components × ~17 ports × 3 iterations × 525,600 timesteps that is
+  **~16 s/run of irreducible boxing tax** for as long as the components are Python. Only porting a
+  component removes its share.
+- **Cost:** rewrites all 717 call sites and requires local indices — see O6 for the spelling.
+- **Gate:** M1, M2. **Status:** the natural successor to O2; do not start before M1 says the rewrite
+  pays.
+
+### O4 — Functional component signature
+
+`def i_simulate(self, timestep, inputs: XInputs, force_convergence: bool) -> XOutputs`, with slotted
+record types, the engine doing gather and scatter.
+
+- **Why it pays three times:** fastest write path per unit of elegance; it is **literally the Rust
+  trait signature**, so the boundary never has to be redesigned; and it makes each component a pure
+  function of `(state, inputs)`, which is what the differential-verification plan in
+  `hisim_rust_recommended_cleanup_steps.md` needs — record inputs and state, replay, compare.
+- **Cost:** the largest migration on this list. It rewrites every `i_simulate` **body**, not just its
+  write statements.
+- **Gate:** M1, M3, and O3 in place. **Status:** the endgame shape; not a near-term step.
+
+### O5 — Slotted output object as the write surface
+
+`self.out.thermal_power = value`, where `self.out` is a `__slots__` dataclass instance allocated once
+per component. A slot store is a C-level offset write, so **names cost nothing** — the current
+~130 ns is the method frame plus the `global_index` deref, not the naming.
+
+- **Effect:** ~130 ns → ~45 ns per write, with types visible to mypy.
+- **Open question:** whether the slot object is canonical storage (readers then need wiring-resolved
+  accessors) or a front for the flat array (one bulk sync per component per iteration). O3 makes the
+  second cheap.
+- **Gate:** M1 (variant (b)/(c) approximate it). **Status:** an alternative spelling for O3's
+  component side; measure both.
+
+### O6 — Generate the port plumbing
+
+Ports are already declared with name, load type, unit and description. Declare once and generate the
+local-index constants, the `Inputs`/`Outputs` record types, and eventually the Rust struct — behind a
+byte-identity freshness gate, the pattern already used for `.scenario.json` and
+`.energy_system.yaml`.
+
+- **Why:** it is the only way to get O3's full win (`o[2] = v`, ~35 ns) while keeping the code
+  readable, and it is the same generator that later emits the Rust side. Fits the
+  generated-artifact-plus-gate discipline the repo already runs.
+- **Gate:** M1 shows the gap between spellings (b)/(c) and (d) is worth a generator.
+
+### O7 — Rust `process_one_timestep`
+
+Port the run loop only: the fixed-point iteration and the value arrays. **Leave in Python:** wiring
+and `connect_everything_automatically` (runs once, no payoff, needs the component registry first),
+the results/pandas resample seam (`simulator.py:492–585`, tz-aware, mean-vs-sum per unit),
+`SimulationParameters`, logging, result paths. The Rust engine receives an already-wired component
+list.
+
+- **Effect:** with all components still Python, the win is the compare, the copies and loop overhead
+  minus added marshalling — **plausibly break-even**. Its value is that it establishes and measures
+  the boundary, not that it is fast. Do not sell it internally as a speedup.
+- **Mechanics that will bite:** hold the GIL across the timestep rather than re-acquiring per call;
+  call `Python::check_signals()` once per timestep or Ctrl-C stops working on long runs; decide how
+  `PyErr` from a component becomes a Rust error and back with the traceback intact, including the
+  existing raise at 100 iterations.
+- **Gate:** O2 shipped, M2, M3. **Status:** the step after O2 proves the boundary.
+
+### O8 — Per-output tolerance vector
+
+Replace the single absolute 1e-4 with a per-output (or per-unit) tolerance, supplied at construction.
+
+- **Why:** it is the cheap, targeted fix for the real defect M4 is looking for — an absolute
+  threshold applied across watts, joules, kelvin, euros and dimensionless ratios. Near-free inside
+  O2; also implementable in Python alone.
+- **Caution:** it changes iteration counts and therefore results. Needs a one-time golden re-bless
+  and a stated policy, per §11/R6 of the feasibility document.
+- **Gate:** M4. **Status:** ship inside O2, or standalone if O2 is deferred.
+
+### O9 — Signal/record classification (deprioritized)
+
+Classify outputs from the wiring graph: **signals** are read by another component and drive the
+convergence test; **records** are read by nobody, are written once per timestep after convergence,
+and are checked once at exit rather than every iteration. Derivable automatically — the wiring pass
+already knows the connection set — so no annotation of 484 call sites is needed.
+
+- **Why deprioritized:** O2 moves the compare from ~8.5 µs to ~0.2 µs, at which point shrinking the
+  compared vector from 141 to 41 buys nothing measurable. What remains is the write-volume cut
+  (~3.4× fewer hot-loop writes on the measured setup), and O8 addresses the semantic half more
+  cheaply.
+- **Do not implement the naive form.** Excluding records from the termination test *without* an exit
+  check is unsound: see Appendix A.
+- **Gate:** M4 and the post-O2 re-measurement. **Status:** parked; revive only if M4 shows records
+  are driving iteration counts, or if M3 shows write volume still dominates after O2 and O3.
+
+### O10 — Mixed tree: Rust components behind the same registry
+
+The long-term path — Rust components as drop-in implementations swapped by name per run, with
+per-component harness verification. Specified in `hisim_rust_recommended_cleanup_steps.md`; recorded
+here only because O2/O3/O4 are its prerequisites and their designs should not foreclose it. Note the
+direction: Python owns the process (cdylib built with maturin), and the Rust engine calls back out to
+Python components — **not** a Rust binary embedding CPython (see D6).
+
+---
+
+## 4. Invariants any option must preserve
+
+- Registration-order iteration, single-threaded, deterministic.
+- The fixed-point semantics as they stand: force convergence after >10 iterations, raise after >100.
+- `stsv.values` compatibility, or the one consumer at `simulator.py:460` migrated deliberately.
+- Golden-corpus parity at declared tolerances. O8 and O9 change iteration counts and therefore
+  require an explicit one-time re-bless, not a silent drift.
+- The public interface is untouched: class-level port name constants, wiring by string name, and the
+  `.scenario.json` / `.energy_system.yaml` wire formats. Every option here changes only how a name
+  binds to storage on the hot path.
+- Ctrl-C responsiveness, once any loop runs in Rust.
+
+---
+
+## 5. Discarded, with reasons
+
+Recorded so they are not re-proposed.
+
+- **D1 — numpy as the value store.** Measured slower. The vectorized compare gain (~60 ns/element →
+  ~1) is outweighed by hundreds of individual scalar stores per iteration going from ~35 ns (list) to
+  ~130 ns (numpy scalar assignment). The write path dominates once the compare is cheap.
+- **D2 — zero-copy numpy view over a Rust-owned buffer for Python components.** Same defect as D1:
+  the Python side pays the numpy per-element penalty on every access. This was proposed earlier in
+  the discussion and is wrong.
+- **D3 — a per-value Rust setter.** Crossing into Rust to extract a `ComponentOutput`, read its
+  `global_index` through a Python attribute lookup, and store one float costs more than the ~130 ns
+  Python frame it replaces. Batch or do not cross.
+- **D4 — moving derived or summed outputs into postprocessing.** Withdrawn. A running sum is *state*
+  with a recurrence, not a readout; reconstructing it downstream is valid only for an unconditional
+  cumulative sum of a fully recorded quantity — any clamp, reset, saturation or branch makes the
+  reconstruction silently wrong. Even where valid it changes summation order and breaks golden
+  parity. And anything read inside the loop is a signal by construction, so it was never a
+  candidate. The narrow surviving case (pointwise same-timestep functions of recorded outputs) buys
+  a multiply and risks silent wrongness.
+- **D5 — excluding records from convergence with no exit check.** Unsound; see Appendix A.
+- **D6 — a Rust binary embedding CPython** (`pyo3` with `auto-initialize`). Buys nothing during
+  transition and costs interpreter discovery, venv/site-packages resolution and a new deployment
+  story. Build a cdylib with maturin instead and let Python own the process.
+
+---
+
+## Appendix A — Why unwired outputs may leave the termination test, and what that does not license
+
+The provable part. Within a timestep every iteration begins with `restore_state()`, so component
+state is constant across iterations and `timestep` is fixed; each component is therefore a map from
+its inputs to its outputs. An input can only bind to a `ComponentOutput`, and the one plausible
+bypass — the `SimRepository` side channel — was checked: all component reads of it happen in
+`i_prepare_simulation`, before the loop, and the seven writes inside `i_simulate` are read by nobody
+during iteration. So the wiring graph is the complete intra-timestep coupling graph.
+
+Partition the outputs into wired `S` and unwired `R`. The iteration is then
+
+```
+S_{k+1} = g(S_k)
+R_{k+1} = h(S_k)
+```
+
+and `R` appears on no right-hand side. It follows rigorously that **`R` cannot influence whether the
+iteration converges or where the fixed point lies** — including `R` in the termination test can only
+add iterations or manufacture a spurious failure. That is the entire legitimate argument, and it
+concerns the termination criterion only.
+
+What does **not** follow is that a tolerance on `S` bounds the error in `R`. At exit
+`R = h(S_k)` while the converged value is `h(S*)`, so the error is bounded by
+`L_h · ‖S_k − S*‖`: a record with high sensitivity — a difference of two large near-equal signals, a
+division by something small, a value near a mode threshold — can be badly or qualitatively wrong
+while `S` looks settled to 1e-4. Today such a record is *loud*, because it holds the loop open;
+dropping it from the test makes it silent. Hence O9's exit check, and hence O8 being the better first
+move.
+
+Three premises the argument rests on, each worth verifying rather than assuming:
+
+- **`force_convergence` makes `g` non-stationary** — it changes at iteration 11. The
+  `R`-does-not-feed-back argument survives, but any exit check must use the same `force_convergence`
+  value as the accepted iterate or it compares two different maps.
+- **State constancy assumes `i_restore_state` undoes everything `i_simulate` mutates.** That is
+  measurement **M6**, and if it fails the loop is not a fixed-point iteration at all.
+- **Classification is per-setup, not per-component.** An output unwired in one setup is wired in
+  another, so the criterion becomes setup-dependent and must be recorded in the run artifacts for
+  reproducibility.


### PR DESCRIPTION
Three documents, none of them a decision:

feasibility_rust_hisim.md is the existing per-module analysis, now with a §8 stub
where the declarative energy-system layer belongs -- the heading sequence jumped
7 to 9 -- and a §11 critical review. The review holds what survived a spot-check
against the tree (the hardcoded 1e-4 convergence test, pyam never imported,
casadi confined to controller_mpc, pickle on the export path, pvlib in four
component modules) and records what the document still needs before it can carry
a decision: the missing 19k-LOC module, a stated total, a measured benefit, the
alternatives it never weighs, a designed hybrid path, a parity policy that does
not contradict itself, and the stale line counts.

hisim_rust_recommended_cleanup_steps.md is the Python-side work to do first,
under the rule that every item must pay for itself without the port -- a cleanup
justified only by a rewrite gets abandoned when the rewrite slips. Tier 1 is the
four boundaries a second implementation cannot route around: the physics-library
adapter layer, a typed simulation context, a typed results table in place of the
92 DataFrame-typed cost hooks, and a static component registry for the 29
importlib sites.

rust_simulator_spec.md is the hot-path options register, written measurements
first because one idea in this space has already been benchmarked and lost.
Ground truth carries file:line so it can be rechecked as the hot path moves; the
options record what each is expected to buy and which measurement gates it; and
the discard list keeps the reasons, including the numpy store, the zero-copy view
that repeats its mistake, and the sums-to-postprocessing idea that mistook state
for a readout. Appendix A keeps the fixed-point argument for why unwired outputs
may leave the termination test, with the three premises it rests on.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
