### PR TITLE
The usage sweep runs hourly, gives up on a record after a day, and says how much is still waiting

### DIFF
--- a/.github/actions/resource-monitor/action.yml
+++ b/.github/actions/resource-monitor/action.yml
@@ -1,7 +1,7 @@
 name: CI resource monitor
 description: >
   Measures how much of a runner a job actually used -- wall time, real CPU time and peak memory --
-  and leaves the numbers in the job summary and in an artifact the nightly ci-usage report collects.
+  and leaves the numbers in the job summary and in an artifact the hourly ci-usage report collects.
   Called twice, exactly like the hisim-cache action next to it: 'start' right after checkout, 'report'
   at the end of the job under if: always().
 
@@ -41,8 +41,9 @@ inputs:
     default: 'true'
   retention-days:
     description: >
-      How long the record is kept. The nightly report collects it within a day and keeps what it
-      needs in its own index, so this only has to outlive a run of failed nightly jobs.
+      How long the record is kept. The hourly report collects it within an hour or two, keeps what
+      it needs in its own index, and gives up on a record it has not collected within a day, so this
+      only has to outlive a run of failed sweeps.
     required: false
     default: '30'
 

--- a/.github/ci-monitoring.md
+++ b/.github/ci-monitoring.md
@@ -9,7 +9,7 @@ summary. That is the whole interface — nothing is committed to the repository.
 
 **To see one job's own numbers:** open the job and scroll to the bottom of its summary. Every
 job prints its own wall time, CPU time and peak memory the moment it ends, including jobs on
-pull-request branches, which the nightly trend does not sweep.
+pull-request branches, which the hourly trend does not sweep.
 
 ## What is measured where
 
@@ -76,22 +76,38 @@ GH_TOKEN=<a token with actions:read> python3 scripts/ci_usage_report.py \
 
 Without a token it runs unauthenticated at 60 requests/hour, which is enough to try but not
 to sweep. Useful flags: `--memory-branch ''` collects memory artifacts from every branch
-rather than `main` alone, `--max-requests` and `--max-artifact-downloads` cap the sweep.
+rather than `main` alone, `--max-requests` (500 by default) and `--max-artifact-downloads`
+(250) cap the sweep.
 
-## Why the sweep is incremental
+## Why the sweep is hourly and incremental
 
 At roughly 150 runs a day and ten jobs each, re-reading a month would want some 9,000 API
-requests; `GITHUB_TOKEN` allows 1,000 an hour. So each night downloads the previous night's
-index from its own artifact, reads only runs newer than its watermark (less an eight-hour
-overlap, for runs still in flight last night), prunes to the window and uploads it again. A
-typical night costs about 200 requests.
+requests; `GITHUB_TOKEN` allows 1,000 an hour, shared with every other workflow calling the
+API in that hour. So each sweep downloads the previous sweep's index from its own artifact,
+reads only runs newer than its watermark (less an eight-hour overlap, for runs still in flight
+during the last sweep), prunes to the window and uploads it again. An hour in which nothing
+was pushed costs a handful of requests, and the request cap is 500.
 
-Memory artifacts are the expensive half — one download each, about 1,500 a day — so they are
-collected for `main` and for flagged jobs rather than for everything. Pull-request jobs still
-produce and print their own numbers; they just don't feed the nightly trend.
+Hourly rather than nightly because of the artifacts. Memory artifacts are the expensive half —
+one download each, and the four golden workflows alone upload 88 per push to `main` — so a
+single sweep a day could never keep up with them, and they are collected for `main` and for
+flagged jobs rather than for everything. Pull-request jobs still produce and print their own
+numbers; they just don't feed the trend.
+
+A record whose artifact has not been collected within 24 hours
+(`RESOURCE_COLLECTION_DEADLINE`) is given up on: its `peak_memory_method` becomes `expired`,
+it leaves the list of runs worth downloading, and the report shows it as `expired` rather than
+as a missing number. Otherwise a run whose artifacts were deleted or missed would be asked for
+on every sweep for the whole thirty-day window. Should the artifact turn up after all, the
+join overwrites the marker with the real figures.
+
+The **Collection** section of the report says how far behind the sweep is: runs read, artifacts
+downloaded, artifacts still waiting on `main`, artifacts skipped because their run is on
+another branch, and records given up on this sweep and in total. A backlog that grows from hour
+to hour rather than draining is the signal that the caps are too tight.
 
 When the budget runs out mid-sweep the report says so under **Collection** and covers less
-than its window claims. That is deliberate: a partial report is worth having, and a nightly
+than its window claims. That is deliberate: a partial report is worth having, and a scheduled
 job that goes red because GitHub was busy trains everyone to ignore it.
 
 ## Known limits
@@ -105,5 +121,6 @@ job that goes red because GitHub was busy trains everyone to ignore it.
 - Where cgroup files are unreadable entirely, a 0.5 s sampler stands in. It measures the whole
   machine and misses shorter spikes, and every record says which method produced it —
   `peak_memory_method` — so sampled and exact numbers are never silently compared.
-- The index lives in an artifact with a 14-day retention. Losing it costs a cold start, not
-  the history: the API still holds the runs, and the following nights fill the window back in.
+- The index lives in an artifact with a 7-day retention — 24 of them are written a day, and a
+  week outlasts a weekend of failed runs. Losing it costs a cold start, not the history: the
+  API still holds the runs, and the following sweeps fill the window back in.

--- a/.github/workflows/ci-usage.yml
+++ b/.github/workflows/ci-usage.yml
@@ -1,25 +1,28 @@
-# Reports what the repository's CI cost overnight and, more usefully, what changed: which
-# jobs have got slower or hungrier than they were, which are close to the runner's memory
-# limit, and where the runner-minutes go. The numbers come from two places -- job durations
-# from the jobs API, which reports them for free, and peak memory and real CPU time from the
-# artifacts the resource-monitor action uploads from every job, because GitHub reports
-# neither anywhere.
+# Reports what the repository's CI has cost and, more usefully, what changed: which jobs have
+# got slower or hungrier than they were, which are close to the runner's memory limit, and
+# where the runner-minutes go. The numbers come from two places -- job durations from the jobs
+# API, which reports them for free, and peak memory and real CPU time from the artifacts the
+# resource-monitor action uploads from every job, because GitHub reports neither anywhere.
 #
 # The report lands in this workflow's own job summary, which is the whole user interface:
 # open the newest run and read it. Nothing is committed to the repository.
 #
-# The sweep is incremental, and has to be. At roughly 150 runs a day it would take some 9000
-# API requests to re-read the last month, against the 1000 an hour GITHUB_TOKEN allows, so
-# each night downloads the previous night's index, reads only what is newer, and uploads the
-# index again. The first run after the index expires or is deleted starts cold and covers
-# only as far back as its request budget reaches; the following nights fill in from there.
+# The sweep runs hourly and is incremental, which is what makes hourly affordable. At roughly
+# 150 runs a day it would take some 9000 API requests to re-read the last month, against the
+# 1000 an hour GITHUB_TOKEN allows, so each sweep downloads the previous sweep's index, reads
+# only what is newer, and uploads the index again: an hour in which nothing was pushed costs a
+# handful of requests. Hourly rather than nightly because of the artifacts -- the four golden
+# workflows upload 88 of them per push to main, far more than one sweep a day can collect, and
+# a record whose artifact is still uncollected a day later is given up on. The first run after
+# the index expires or is deleted starts cold and covers only as far back as its request
+# budget reaches; the following sweeps fill in from there.
 
 name: ci-usage
 
 on:
   schedule:
-    # Nightly, off the hour: scheduled runs queue behind everyone else's on the hour.
-    - cron: '17 4 * * *'
+    # Hourly, off the hour: scheduled runs queue behind everyone else's on the hour.
+    - cron: '17 * * * *'
   workflow_dispatch:
     inputs:
       window-days:
@@ -89,15 +92,17 @@ jobs:
             --index ci-usage-index.json \
             --out ci-usage-report.md
 
-      # A fixed name, so tomorrow night knows what to look for. Kept short: it is rewritten
-      # every night and only has to outlive a run of failed ones.
-      - name: Save the index for tomorrow
+      # A fixed name, so the next sweep knows what to look for. Kept short: it is rewritten
+      # every hour and only has to outlive a run of failed sweeps. Seven days rather than
+      # fourteen because there are now 24 of these a day, and a week still survives a weekend
+      # of failed runs -- and losing it costs a cold start, not the history.
+      - name: Save the index for the next sweep
         if: always()
         uses: actions/upload-artifact@v6
         with:
           name: ci-usage-index
           path: ci-usage-index.json
-          retention-days: 14
+          retention-days: 7
           if-no-files-found: warn
 
       - name: Upload the report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Provides a typed `Quantity` system (`Watt`, `KiloWattHour`, etc.) for stronger u
 ### CI resource monitoring (`.github/actions/resource-monitor/`, `scripts/ci_*.py`)
 Every CI job measures its own wall time, CPU time and peak memory (cgroup v2) via the
 `resource-monitor` composite action, called `mode: start` after checkout and `mode: report`
-under `if: always()`. The nightly `ci-usage` workflow sweeps the jobs API plus those
+under `if: always()`. The hourly `ci-usage` workflow sweeps the jobs API plus those
 artifacts and writes an overview — per-workflow runner-minutes, jobs that got slower or
 hungrier, jobs near the 16 GB runner limit — into its own job summary. Nothing is committed.
 See `.github/ci-monitoring.md`; the probe never fails the job it measures.

--- a/scripts/ci_usage_report.py
+++ b/scripts/ci_usage_report.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Collect what the repository's CI actually costs and report what changed.
 
-Run nightly by ``.github/workflows/ci-usage.yml``, and runnable by hand::
+Run hourly by ``.github/workflows/ci-usage.yml``, and runnable by hand::
 
     GH_TOKEN=... python3 scripts/ci_usage_report.py --window-days 30 --out report.md
 
@@ -21,11 +21,18 @@ and the concurrency other work has to wait behind.
 
 The sweep is incremental because it has to be. At roughly 150 runs a day, each with about ten
 jobs, a full re-read would want some 9000 requests where ``GITHUB_TOKEN`` allows 1000 an hour.
-So the previous night's index is downloaded from its own artifact, only runs newer than its
-watermark are fetched, and the result is pruned to the window and uploaded again. Memory
-records are swept for the default branch and for flagged jobs rather than for everything,
-which keeps a night's work near 200 requests instead of 1500; a pull request's own numbers are
-still in its own job summaries the moment the job ends.
+So the previous sweep's index is downloaded from its own artifact, only runs newer than its
+watermark are fetched, and the result is pruned to the window and uploaded again. That is also
+why it runs hourly rather than nightly: the four golden workflows alone upload 88 resource
+artifacts per push to main, which one sweep a day cannot collect, while an hour in which
+nothing was pushed costs a handful of requests. Memory records are swept for the default
+branch and for flagged jobs rather than for everything; a pull request's own numbers are in
+its own job summaries the moment the job ends.
+
+A record whose artifact has not been collected within a day is given up on: its memory method
+becomes ``expired``, it leaves the wanted list, and the report counts it instead of re-listing
+it on every sweep forever. What is still outstanding is counted too, under Collection, so a
+backlog that is growing rather than draining is visible from the report alone.
 """
 from __future__ import annotations
 
@@ -43,12 +50,24 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
 
 
+RESOURCE_COLLECTION_DEADLINE = timedelta(hours=24)
+"""How long a record on the memory branch waits for its resource artifact before it is expired.
+
+The sweep only reads artifacts newer than its watermark, so an artifact that was never
+collected -- because a sweep failed, because the download cap cut it off, or because the
+artifact was deleted -- would otherwise leave its record in the wanted list of every later
+sweep for the whole thirty-day window, costing requests that can never succeed. A day is well
+past the point where a further attempt would find anything: every sweep in between has already
+had its chance.
+"""
+
+
 class RateLimitExhausted(RuntimeError):
     """Raised when the request budget or the API's own rate limit is used up.
 
     Caught by the collector, which stops sweeping and marks the report partial rather than
-    failing: a report covering four of the last five days is worth having, and a nightly job
-    that goes red because GitHub was busy trains everyone to ignore it.
+    failing: a report covering four of the last five days is worth having, and a sweep that
+    goes red because GitHub was busy trains everyone to ignore it.
     """
 
 
@@ -57,8 +76,8 @@ class GitHubApi:
 
     Counts every request it makes and refuses to exceed either the budget it was given or the
     rate limit the API reports back, so a sweep degrades into a partial one instead of
-    spending an hour blocked on a 403. Standard library only, to keep the nightly job free of
-    an install step.
+    spending an hour blocked on a 403. Standard library only, to keep the sweep free of an
+    install step.
 
     Attributes:
         requests_made: how many HTTP requests have been issued.
@@ -295,6 +314,12 @@ class JobRecord:
             "labels": job.get("labels", []),
         }
 
+    # The one value of ``peak_memory_method`` this script writes itself. Every other value comes
+    # from the probe's MeasurementMethod enum, which is the producer side and says how a real
+    # reading was obtained; this one says that no reading arrived within the deadline and that
+    # none is coming, which is a different thing from a job that was never measured at all.
+    MEASUREMENT_EXPIRED = "expired"
+
     # The fields a resource-monitor artifact contributes, listed once so attaching them from an
     # artifact and carrying them across a re-sweep can never drift apart.
     RESOURCE_FIELDS = (
@@ -304,9 +329,27 @@ class JobRecord:
     )
 
     @classmethod
+    def is_expired(cls, record: Dict[str, Any]) -> bool:
+        """Return whether this record has given up waiting for its resource artifact."""
+        return record.get("peak_memory_method") == cls.MEASUREMENT_EXPIRED
+
+    @classmethod
+    def mark_expired(cls, record: Dict[str, Any]) -> None:
+        """Record that no measurement is coming for this job, so nothing keeps asking for one.
+
+        Only the method is written. The memory fields stay absent, because inventing a zero
+        would put the job into every median as a job that used no memory.
+        """
+        record["peak_memory_method"] = cls.MEASUREMENT_EXPIRED
+
+    @classmethod
     def carry_resources(cls, source: Dict[str, Any], target: Dict[str, Any]) -> None:
         """Copy resource measurements from an indexed record onto its freshly fetched twin."""
         if source.get("peak_memory_bytes") is None:
+            # An expired marker is the one thing worth carrying without a measurement behind
+            # it: losing it in the overlap would put the record back in the wanted list.
+            if cls.is_expired(source):
+                cls.mark_expired(target)
             return
         for field in cls.RESOURCE_FIELDS:
             if field in source:
@@ -333,7 +376,7 @@ class JobRecord:
 
 
 class UsageIndex:
-    """The rolling store of job records, carried between nightly runs as an artifact.
+    """The rolling store of job records, carried between hourly sweeps as an artifact.
 
     Holds one entry per (run, job) inside the reporting window and the watermark that says how
     far the last sweep got, which together are what make the next sweep cheap. Pruned to the
@@ -355,7 +398,7 @@ class UsageIndex:
         """Return the index stored at ``path``, or an empty one if there is nothing usable.
 
         A missing, unreadable or wrong-schema file is not an error: it is what the very first
-        nightly run sees, and what every run sees after the index artifact expires.
+        sweep sees, and what every sweep sees after the index artifact expires.
         """
         if not path or not os.path.exists(path):
             return cls()
@@ -408,8 +451,9 @@ class UsageIndex:
     def sweep_start(self, window_start: datetime) -> datetime:
         """Return the time a sweep should start reading from.
 
-        The watermark less an overlap, so runs that were still in flight last night are picked
-        up tonight; or the start of the window when there is no index to build on.
+        The watermark less an overlap, so runs that were still in flight during the last sweep
+        are picked up by this one; or the start of the window when there is no index to build
+        on.
         """
         mark = self.watermark()
         if mark is None:
@@ -419,6 +463,9 @@ class UsageIndex:
     def runs_missing_resources(self, branch: Optional[str]) -> Dict[int, List[Dict[str, Any]]]:
         """Group records that still lack resource data by run, optionally filtered to a branch.
 
+        Records already given up on are left out: they are exactly the ones a further sweep
+        would spend requests on and find nothing for.
+
         Args:
             branch: only consider runs of this branch; None considers every branch.
 
@@ -427,7 +474,7 @@ class UsageIndex:
         """
         grouped: Dict[int, List[Dict[str, Any]]] = {}
         for record in self.records.values():
-            if record.get("peak_memory_bytes") is not None:
+            if record.get("peak_memory_bytes") is not None or JobRecord.is_expired(record):
                 continue
             if branch is not None and record.get("branch") != branch:
                 continue
@@ -435,6 +482,37 @@ class UsageIndex:
             if isinstance(run_id, int):
                 grouped.setdefault(run_id, []).append(record)
         return grouped
+
+    def expire_stale_resource_records(self, branch: Optional[str], now: datetime) -> int:
+        """Give up on records whose artifact never arrived, and return how many were marked.
+
+        Only records of the memory branch are considered. A pull-request job is not waiting for
+        anything -- its artifact is deliberately never collected, and its own job summary has
+        the numbers -- so calling it expired would say something untrue about it.
+
+        Args:
+            branch: the branch whose artifacts are collected; None considers every branch.
+            now: the moment the deadline is measured against.
+
+        Returns:
+            How many records were marked expired by this call.
+        """
+        marked = 0
+        for record in self.records.values():
+            if record.get("peak_memory_bytes") is not None or JobRecord.is_expired(record):
+                continue
+            if branch is not None and record.get("branch") != branch:
+                continue
+            created = Timestamps.parse(record.get("created_at"))
+            if created is None or now - created < RESOURCE_COLLECTION_DEADLINE:
+                continue
+            JobRecord.mark_expired(record)
+            marked += 1
+        return marked
+
+    def expired_count(self) -> int:
+        """Return how many records in the index have been given up on altogether."""
+        return sum(1 for record in self.records.values() if JobRecord.is_expired(record))
 
     def values(self) -> Iterable[Dict[str, Any]]:
         """Return every record in the index."""
@@ -493,8 +571,9 @@ class UsageCollector:
     the index keeps whatever was already collected.
 
     Attributes:
-        diagnostics: counters describing what the sweep managed, rendered into the report so a
-            partial night is visible rather than silently thinner.
+        diagnostics: counters describing what the sweep managed and what it left behind,
+            rendered into the report so a partial sweep is visible rather than silently
+            thinner, and so a backlog that grows instead of draining can be seen.
     """
 
     ARTIFACT_PREFIX = "ci-usage-"
@@ -511,6 +590,13 @@ class UsageCollector:
             "jobs_recorded": 0,
             "artifacts_downloaded": 0,
             "artifacts_unjoined": 0,
+            # Artifacts of runs that still want one and that this sweep did not get to: the
+            # backlog the next sweeps have to drain.
+            "artifacts_waiting": 0,
+            # Artifacts passed over because their run is not on the memory branch. Counted
+            # from the listing, never downloaded.
+            "artifacts_off_branch": 0,
+            "records_expired": 0,
             "partial": False,
             "stopped_because": None,
         }
@@ -553,13 +639,23 @@ class UsageCollector:
             self.index.add(record)
             self.diagnostics["jobs_recorded"] += 1
 
-    def sweep_resources(self, since: datetime, wanted_runs: Sequence[int], max_downloads: int) -> None:
-        """Download and join the resource artifacts of ``wanted_runs``.
+    def sweep_resources(self, since: datetime, wanted_runs: Sequence[int], max_downloads: int,
+                        memory_branch: Optional[str] = None) -> None:
+        """Download and join the resource artifacts of ``wanted_runs``, counting the rest.
+
+        The listing is read to the same depth whether or not the download cap is reached,
+        because what it says about the artifacts that were not downloaded -- how many are
+        waiting for a later sweep, how many belong to branches whose memory is deliberately
+        not collected -- is the only cheap measure of whether the sweep is keeping up. Counting
+        them costs the page requests the sweep was already prepared to spend; downloading them
+        is what costs.
 
         Args:
             since: ignore artifacts older than this.
             wanted_runs: the runs whose artifacts are worth spending requests on.
             max_downloads: hard cap on artifact downloads for this sweep.
+            memory_branch: the branch whose artifacts are collected, for counting the ones
+                skipped because they belong to another; None counts none as skipped.
         """
         if not wanted_runs or max_downloads <= 0:
             return
@@ -576,15 +672,20 @@ class UsageCollector:
                 created = Timestamps.parse(artifact.get("created_at"))
                 if created is not None and created < since:
                     break
-                if downloaded >= max_downloads:
-                    self._stop(f"artifact download cap of {max_downloads} reached")
-                    return
                 if not str(artifact.get("name", "")).startswith(self.ARTIFACT_PREFIX):
                     continue
                 if artifact.get("expired"):
                     continue
-                run_id = (artifact.get("workflow_run") or {}).get("id")
+                run = artifact.get("workflow_run") or {}
+                run_id = run.get("id")
+                branch = run.get("head_branch")
+                if memory_branch and branch is not None and branch != memory_branch:
+                    self.diagnostics["artifacts_off_branch"] += 1
+                    continue
                 if run_id not in by_run:
+                    continue
+                if downloaded >= max_downloads:
+                    self.diagnostics["artifacts_waiting"] += 1
                     continue
                 metrics = self._read_metrics(artifact)
                 downloaded += 1
@@ -598,6 +699,10 @@ class UsageCollector:
                 JobRecord.attach_resources(target, metrics)
         except RateLimitExhausted as error:
             self._stop(str(error))
+        if downloaded >= max_downloads and not self.diagnostics["partial"]:
+            # Said after the listing rather than instead of reading it, and never over a
+            # budget message: running out of requests is the more urgent of the two.
+            self._stop(f"artifact download cap of {max_downloads} reached")
 
     def _read_metrics(self, artifact: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Download one artifact and return the metrics record inside it, or None."""
@@ -692,6 +797,10 @@ class JobStatistics:
         ranked = sorted(counts.items(), key=lambda item: item[1], reverse=True)
         return [branch for branch, _ in ranked[:limit]]
 
+    def expired_count(self) -> int:
+        """Return how many of these records gave up waiting for their measurement."""
+        return sum(1 for record in self.recent + self.baseline if JobRecord.is_expired(record))
+
     def median_efficiency(self) -> Optional[float]:
         """Return the median CPU efficiency across every measured record."""
         values = [float(record["cpu_efficiency"]) for record in self.recent + self.baseline
@@ -765,7 +874,7 @@ class RegressionRules:
 
 
 class UsageReport:
-    """Turns the index into the markdown the nightly job writes to its summary.
+    """Turns the index into the markdown the hourly job writes to its summary.
 
     Ordered by what a reader needs first: what changed, then what is close to a limit, then
     where the time goes, and only then the totals and the diagnostics. The regression tables
@@ -812,6 +921,18 @@ class UsageReport:
     def _gib(cls, value: Optional[float]) -> str:
         """Format bytes as a GiB figure with its unit, or ``n/a`` when there is no reading."""
         return "n/a" if value is None else f"{value / cls.BYTES_PER_GIB:.2f} GiB"
+
+    @classmethod
+    def _memory_cell(cls, stats: JobStatistics, peak: Optional[float]) -> str:
+        """Format a job's memory column: a figure, ``expired``, or ``n/a``.
+
+        A job whose records were given up on is not a job that used no memory, and rendering it
+        as ``n/a`` beside the jobs nobody measures would hide the difference between a gap that
+        the next sweep closes and one that never closes.
+        """
+        if peak is not None:
+            return cls._gib(peak)
+        return "expired" if stats.expired_count() else "n/a"
 
     def _workflow_totals(self) -> List[Tuple[str, Dict[str, Any]]]:
         """Return per-workflow totals, most expensive first."""
@@ -971,7 +1092,7 @@ class UsageReport:
             lines.append(
                 f"| {stats.workflow} | {stats.job_name} | {len(stats.recent) + len(stats.baseline)} "
                 f"| {self._minutes(median)} min | {stats.total_runner_seconds() / 60:,.0f} "
-                f"| {self._gib(peak)} "
+                f"| {self._memory_cell(stats, peak)} "
                 f"| {'n/a' if efficiency is None else f'{efficiency * 100:.0f}%'} |"
             )
         lines.append("")
@@ -1001,9 +1122,18 @@ class UsageReport:
                        for record in stats.recent + stats.baseline
                        if record.get("peak_memory_bytes") is not None)
         total = sum(len(stats.recent) + len(stats.baseline) for stats in self.statistics.values())
+        deadline_hours = RESOURCE_COLLECTION_DEADLINE.total_seconds() / 3600
         lines = ["\n## Collection\n",
-                 f"- runs swept tonight: {self.diagnostics.get('runs_fetched', 0)}",
+                 f"- runs read this sweep: {self.diagnostics.get('runs_fetched', 0)}",
                  f"- jobs in window: {total}, of which {measured} carry memory data",
+                 f"- resource artifacts downloaded: {self.diagnostics.get('artifacts_downloaded', 0)}",
+                 f"- resource artifacts still waiting on the memory branch: "
+                 f"{self.diagnostics.get('artifacts_waiting', 0)} (the backlog the next sweeps drain)",
+                 f"- artifacts skipped, their run is not on the memory branch: "
+                 f"{self.diagnostics.get('artifacts_off_branch', 0)}",
+                 f"- records given up on after {deadline_hours:.0f} h: "
+                 f"{self.diagnostics.get('records_expired', 0)} this sweep, "
+                 f"{self.index.expired_count()} in the index",
                  f"- API requests used: {self.diagnostics.get('requests_made', 0)}"]
         if self.diagnostics.get("artifacts_unjoined"):
             lines.append(f"- resource artifacts that matched no job: {self.diagnostics['artifacts_unjoined']}")
@@ -1044,8 +1174,11 @@ class ReportCommand:
         print(f"sweeping runs of {self.args.repository} created since {Timestamps.format(sweep_start)}")
         collector.sweep_runs(sweep_start)
 
+        collector.diagnostics["records_expired"] = index.expire_stale_resource_records(
+            self.args.memory_branch, now)
         wanted = self._runs_wanting_resources(index, window_start)
-        collector.sweep_resources(sweep_start, wanted, self.args.max_artifact_downloads)
+        collector.sweep_resources(sweep_start, wanted, self.args.max_artifact_downloads,
+                                  self.args.memory_branch)
 
         collector.diagnostics["requests_made"] = api.requests_made
         report = UsageReport(index, window_start, recent_start, collector.diagnostics)
@@ -1079,7 +1212,8 @@ class ReportCommand:
         The default branch first, since that is the trend line everything is compared against
         and a pull request's own numbers are already in its own job summaries. Runs of flagged
         jobs are added on top, so a regression that shows up in the timings brings its memory
-        figures with it rather than needing a second night.
+        figures with it rather than needing a second sweep. Records already given up on are
+        left out by the index, so a run whose artifacts never arrived stops being asked for.
         """
         wanted: List[int] = []
         by_run = index.runs_missing_resources(self.args.memory_branch)
@@ -1117,8 +1251,10 @@ def build_parser() -> argparse.ArgumentParser:
                         help="the rolling index file, carried between runs as an artifact")
     parser.add_argument("--out", default="ci-usage-report.md",
                         help="where the markdown report is written")
-    parser.add_argument("--max-requests", type=int, default=800,
-                        help="hard cap on API requests, kept under the 1000/hour GITHUB_TOKEN allows")
+    parser.add_argument("--max-requests", type=int, default=500,
+                        help="hard cap on API requests, kept well under the 1000/hour GITHUB_TOKEN "
+                             "allows, which is shared with every other workflow calling the API in "
+                             "the same hour")
     parser.add_argument("--max-artifact-downloads", type=int, default=250,
                         help="hard cap on resource artifacts downloaded in one sweep")
     parser.add_argument("--memory-branch", default="main",

--- a/tests/test_ci_usage.py
+++ b/tests/test_ci_usage.py
@@ -20,12 +20,14 @@ Each test states the failure mode it catches.
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import sys
+import zipfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterator, List, Optional
 
 import pytest
 
@@ -337,6 +339,138 @@ class TestIndexBookkeeping:
         assert collector.JobRecord.from_api(run, skipped) is None
 
 
+class TestGivingUpOnAMeasurement:
+    """A record whose artifact never arrives has to stop being asked for.
+
+    The sweep only reads artifacts newer than its watermark, so one that was missed -- a failed
+    sweep, a download cap, a deleted artifact -- is missed for good. Without a deadline its
+    record would sit in the wanted list of every sweep for the whole window, spending requests
+    that cannot succeed and standing in the report as a measurement still to come.
+    """
+
+    GIB = 1024 ** 3
+
+    @staticmethod
+    def _record(created: datetime, run_id: int, branch: str = "main", **extra: Any) -> Dict[str, Any]:
+        """Return a record of ``branch`` that carries no measurement."""
+        record = {
+            "run_id": run_id,
+            "job_id": run_id * 10,
+            "created_at": collector.Timestamps.format(created),
+            "workflow": "tests",
+            "job_name": "pytest (base)",
+            "conclusion": "success",
+            "wall_seconds": 100.0,
+            "branch": branch,
+        }
+        record.update(extra)
+        return record
+
+    def test_a_record_that_waited_a_day_is_given_up_on(self) -> None:
+        """Catches a wanted list that keeps asking for artifacts that will never be there.
+
+        Every sweep would re-list the same runs, spend its download budget on them, find
+        nothing, and have less of that budget left for the runs whose artifacts do still exist.
+        """
+        now = collector.Timestamps.now()
+        index = collector.UsageIndex()
+        index.add(self._record(now - timedelta(hours=25), run_id=1))
+        index.add(self._record(now - timedelta(hours=2), run_id=2))
+
+        marked = index.expire_stale_resource_records("main", now)
+
+        assert marked == 1
+        assert sorted(index.runs_missing_resources("main")) == [2], "the stale run is still wanted"
+        stale = next(record for record in index.values() if record["run_id"] == 1)
+        assert stale["peak_memory_method"] == collector.JobRecord.MEASUREMENT_EXPIRED
+        assert "peak_memory_bytes" not in stale, "a missing measurement was invented as a number"
+
+    def test_a_branch_nobody_collects_is_not_called_expired(self) -> None:
+        """Catches a deadline applied to records that were never waiting for anything.
+
+        Pull-request artifacts are deliberately not collected; the numbers are in the job's own
+        summary. Marking them expired would report a failure of collection where there was a
+        decision not to collect.
+        """
+        now = collector.Timestamps.now()
+        index = collector.UsageIndex()
+        index.add(self._record(now - timedelta(hours=48), run_id=3, branch="feature-x"))
+
+        assert index.expire_stale_resource_records("main", now) == 0
+        assert index.expired_count() == 0
+
+    def test_a_late_artifact_still_wins_over_the_marker(self) -> None:
+        """Catches a marker that outranks a real measurement.
+
+        The join is by name matching, so an artifact for a record already given up on should
+        not turn up -- but if one does, the number it carries is worth more than the note
+        saying no number was expected.
+        """
+        now = collector.Timestamps.now()
+        record = self._record(now - timedelta(hours=30), run_id=4)
+        collector.JobRecord.mark_expired(record)
+
+        collector.JobRecord.attach_resources(record, {
+            "peak_memory_bytes": 3 * self.GIB, "peak_memory_method": "cgroup.memory.peak",
+            "cpu_seconds": 12.0,
+        })
+
+        assert record["peak_memory_bytes"] == 3 * self.GIB
+        assert record["peak_memory_method"] == "cgroup.memory.peak"
+        assert not collector.JobRecord.is_expired(record)
+
+    def test_the_marker_survives_a_re_sweep(self) -> None:
+        """Catches an overlap that quietly puts a given-up record back into the wanted list.
+
+        The sweep re-reads the last few hours and replaces each record with its fresh API twin.
+        A twin that lost the marker would be wanted again, and would be given up on again the
+        next hour, forever.
+        """
+        now = collector.Timestamps.now()
+        existing = self._record(now - timedelta(hours=30), run_id=5)
+        collector.JobRecord.mark_expired(existing)
+        fresh = self._record(now - timedelta(hours=30), run_id=5)
+
+        collector.JobRecord.carry_resources(existing, fresh)
+
+        assert collector.JobRecord.is_expired(fresh)
+
+
+def _metrics_zip(metrics: Dict[str, Any]) -> bytes:
+    """Return the bytes of a resource-monitor artifact holding one ``metrics.json``."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("metrics.json", json.dumps(metrics))
+    return buffer.getvalue()
+
+
+class _FakeArtifactApi:
+    """A GitHubApi stand-in that serves a fixed artifact listing out of memory.
+
+    What the sweep does *not* download is what the Collection section reports, so the counting
+    is exercised through the real sweep with a listing the test controls, rather than by
+    setting the counters by hand.
+    """
+
+    def __init__(self, artifacts: List[Dict[str, Any]], payloads: Dict[int, bytes]) -> None:
+        self.artifacts = artifacts
+        self.payloads = payloads
+        self.calls: List[Any] = []
+        self.requests_made = 0
+
+    def paginate(self, path: str, item_key: str, params: Optional[Dict[str, Any]] = None,
+                 max_pages: int = 100) -> Iterator[Dict[str, Any]]:
+        """Yield the whole fixed listing as one page."""
+        self.calls.append((path, item_key, params, max_pages))
+        self.requests_made += 1
+        yield from self.artifacts
+
+    def download_artifact(self, artifact_id: int) -> Optional[bytes]:
+        """Return the zip prepared for ``artifact_id``, or None when there is none."""
+        self.requests_made += 1
+        return self.payloads.get(artifact_id)
+
+
 class TestReportRendering:
     """The report is the entire user interface, so it has to render whatever the sweep produced."""
 
@@ -376,8 +510,81 @@ class TestReportRendering:
         report = collector.UsageReport(self._index([]), now - timedelta(days=30),
                                        now - timedelta(days=3),
                                        {"partial": True, "stopped_because": "budget used up",
-                                        "requests_made": 800})
+                                        "requests_made": 500})
         assert "partial sweep" in report.render()
+
+    def test_a_job_given_up_on_is_not_rendered_as_never_measured(self) -> None:
+        """Catches a report that renders an abandoned measurement as an ordinary gap.
+
+        ``n/a`` says nobody measures this job; ``expired`` says somebody meant to and the
+        artifact never arrived. Reading the second as the first hides a collection that has
+        stopped working, and reading it as a number would be worse still.
+        """
+        now = collector.Timestamps.now()
+        record = {
+            "run_id": 4, "job_id": 40, "created_at": collector.Timestamps.format(now - timedelta(hours=30)),
+            "workflow": "tests", "job_name": "pytest (utsp)", "conclusion": "success",
+            "wall_seconds": 900.0, "branch": "main",
+        }
+        index = self._index([record])
+        index.expire_stale_resource_records("main", now)
+
+        rendered = collector.UsageReport(index, now - timedelta(days=30), now - timedelta(days=3),
+                                         {"requests_made": 4}).render()
+
+        assert "| expired |" in rendered, "an abandoned record was rendered as n/a or as a number"
+
+    def test_the_collection_section_says_how_far_behind_the_sweep_is(self) -> None:
+        """Catches a backlog that only shows up as a report that is quietly thinner.
+
+        Four golden workflows upload 88 records per push to main, and each sweep downloads at
+        most a few hundred artifacts. Whether the sweep is draining that or falling behind it
+        is invisible in the tables -- the jobs simply have no memory figures yet -- so the
+        counts are the only place it can be read.
+        """
+        now = collector.Timestamps.now()
+        stamp = collector.Timestamps.format(now)
+        index = self._index([
+            {"run_id": 1, "job_id": 10, "created_at": stamp, "workflow": "tests",
+             "job_name": "pytest (base)", "conclusion": "success", "wall_seconds": 300.0,
+             "branch": "main", "runner_name": "runner-a"},
+            {"run_id": 2, "job_id": 20, "created_at": stamp, "workflow": "quality",
+             "job_name": "mypy", "conclusion": "success", "wall_seconds": 120.0,
+             "branch": "main", "runner_name": "runner-b"},
+            {"run_id": 3, "job_id": 30,
+             "created_at": collector.Timestamps.format(now - timedelta(hours=25)),
+             "workflow": "tests", "job_name": "pytest (utsp)", "conclusion": "success",
+             "wall_seconds": 800.0, "branch": "main", "runner_name": "runner-c"},
+        ])
+        api = _FakeArtifactApi(
+            artifacts=[
+                {"id": 11, "name": "ci-usage-tests-pytest-base-attempt1", "created_at": stamp,
+                 "expired": False, "workflow_run": {"id": 1, "head_branch": "main"}},
+                {"id": 12, "name": "ci-usage-quality-mypy-attempt1", "created_at": stamp,
+                 "expired": False, "workflow_run": {"id": 2, "head_branch": "main"}},
+                {"id": 13, "name": "ci-usage-tests-pytest-base-attempt1", "created_at": stamp,
+                 "expired": False, "workflow_run": {"id": 9, "head_branch": "feature-x"}},
+                {"id": 14, "name": "coverage-html", "created_at": stamp,
+                 "expired": False, "workflow_run": {"id": 1, "head_branch": "main"}},
+            ],
+            payloads={11: _metrics_zip({"runner_name": "runner-a", "job": "pytest", "scope": "base",
+                                        "peak_memory_bytes": 5 * 1024 ** 3,
+                                        "peak_memory_method": "cgroup.memory.peak"})},
+        )
+        sweep = collector.UsageCollector(api, index)
+        sweep.diagnostics["records_expired"] = index.expire_stale_resource_records("main", now)
+        sweep.sweep_resources(now - timedelta(hours=8), [1, 2], 1, "main")
+        sweep.diagnostics["requests_made"] = api.requests_made
+
+        rendered = collector.UsageReport(index, now - timedelta(days=30),
+                                         now - timedelta(days=3), sweep.diagnostics).render()
+
+        assert "- resource artifacts downloaded: 1" in rendered
+        assert "- resource artifacts still waiting on the memory branch: 1" in rendered
+        assert "- artifacts skipped, their run is not on the memory branch: 1" in rendered
+        assert "- records given up on after 24 h: 1 this sweep, 1 in the index" in rendered
+        joined = next(record for record in index.values() if record["run_id"] == 1)
+        assert joined["peak_memory_bytes"] == 5 * 1024 ** 3, "the one downloaded artifact was not joined"
 
     def test_the_index_round_trips_through_json(self, tmp_path: Path) -> None:
         """Catches an index that cannot be written and read back, which breaks every later night."""


### PR DESCRIPTION
﻿The ci-usage sweep is incremental, so an hour with nothing new costs a handful of requests, while the nightly cadence could not keep up with the 88 resource artifacts a push to main produces across the four golden workflows. The sweep now runs hourly with a per-run request cap of 500, half of what the repository's token allows in an hour, so other API callers keep their share. A record on main whose artifact has not been collected 24 hours after its run is marked expired and no longer re-listed; a late artifact still overwrites the marker. The report gains a Collection section stating what the sweep read and downloaded, how many artifacts still wait on the memory branch, how many were skipped for being off it, and how many records were given up on. The index artifact is kept for seven days instead of fourteen, since there are now twenty-four a day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
