### PR TITLE
The parity summary keeps the checker's exit code without a pipeline, because the container runs sh

### DIFF
--- a/.github/workflows/p3-parity.yml
+++ b/.github/workflows/p3-parity.yml
@@ -169,20 +169,15 @@ jobs:
           path: verdicts
           merge-multiple: false
       - name: Print one table covering every triple
-        # No pipeline here: GitHub runs this step with 'sh' inside the test container, which
-        # rejects the bash-only `set -o pipefail` ("Illegal option -o pipefail") and expands
-        # PIPESTATUS to "Bad substitution". Redirect, then show the file, so the step keeps the
-        # checker's own exit code — the summarize path returns 1 when any triple missed parity
-        # or when no verdicts were collected at all, and `tee` would otherwise replace that
-        # with its own 0.
+        # bash by name: this step once fell back to sh in this container and died on the bash-only
+        # `set -o pipefail` ("Illegal option -o pipefail"), yet bash is installed here — the
+        # resource-monitor steps of this same job ask for it and run. pipefail keeps the checker's
+        # own exit code (1 when a triple missed parity, or when no verdicts were collected at all),
+        # which `tee` would otherwise replace with its own 0.
+        shell: bash
         run: |
-          set +e
-          python3 scripts/p3_parity_check.py --summarize verdicts > parity_summary.md 2>&1
-          rc=$?
-          set -e
-          cat parity_summary.md
-          cat parity_summary.md >> "$GITHUB_STEP_SUMMARY"
-          exit "$rc"
+          set -o pipefail
+          python3 scripts/p3_parity_check.py --summarize verdicts | tee "$GITHUB_STEP_SUMMARY"
       - name: Fail if any triple did not reach parity
         run: '[ "${{ needs.parity.result }}" = "success" ] || exit 1'
       # Kept on failure too: a job killed for running out of memory is the one

--- a/.github/workflows/p3-parity.yml
+++ b/.github/workflows/p3-parity.yml
@@ -169,12 +169,20 @@ jobs:
           path: verdicts
           merge-multiple: false
       - name: Print one table covering every triple
-        # pipefail keeps the checker's own exit code — the summarize path returns 1 when any
-        # triple missed parity or when no verdicts were collected at all, and `tee` would
-        # otherwise replace that with its own 0.
+        # No pipeline here: GitHub runs this step with 'sh' inside the test container, which
+        # rejects the bash-only `set -o pipefail` ("Illegal option -o pipefail") and expands
+        # PIPESTATUS to "Bad substitution". Redirect, then show the file, so the step keeps the
+        # checker's own exit code — the summarize path returns 1 when any triple missed parity
+        # or when no verdicts were collected at all, and `tee` would otherwise replace that
+        # with its own 0.
         run: |
-          set -o pipefail
-          python3 scripts/p3_parity_check.py --summarize verdicts | tee "$GITHUB_STEP_SUMMARY"
+          set +e
+          python3 scripts/p3_parity_check.py --summarize verdicts > parity_summary.md 2>&1
+          rc=$?
+          set -e
+          cat parity_summary.md
+          cat parity_summary.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$rc"
       - name: Fail if any triple did not reach parity
         run: '[ "${{ needs.parity.result }}" = "success" ] || exit 1'
       # Kept on failure too: a job killed for running out of memory is the one

--- a/tests/test_p3_parity.py
+++ b/tests/test_p3_parity.py
@@ -591,3 +591,42 @@ def test_an_unavailable_stage_fails_its_triple_and_a_negative_tolerance_is_refus
     assert not verdict.passed
     with pytest.raises(ValueError):
         Tolerance(relative=-1.0)
+
+
+@pytest.mark.base
+def test_summarizing_a_dispatch_exits_nonzero_unless_every_collected_triple_reached_parity(
+    tmp_path: Path,
+) -> None:
+    """Catches the summary job reading green over a dispatch that did not reach parity.
+
+    The workflow's summary step is a pipeline — the table is teed into the step summary — so the
+    only thing that can still turn the job red is the checker's own exit code surviving the pipe.
+    That is what `set -o pipefail` under an explicitly requested bash is there for, and it protects
+    nothing if the ``--summarize`` path itself stops returning 1. Both failing shapes are pinned:
+    a triple that missed parity, and a dispatch whose verdict directory is empty — a run that
+    covered nothing must never read as a pass. The verdict files are written the way the run path
+    writes them, ``json.dumps`` over ``TripleVerdict.to_json()`` into a per-triple file under the
+    collection directory, so a change to the verdict's JSON shape reaches this test too.
+    """
+
+    def dispatch(name: str, *verdicts: TripleVerdict) -> Path:
+        directory = tmp_path / name
+        for verdict in verdicts:
+            written = directory / f"p3-parity-verdict-{verdict.stem}-{verdict.window}"
+            written.mkdir(parents=True, exist_ok=True)
+            (written / "verdict.json").write_text(
+                json.dumps([verdict.to_json()], indent=2), encoding="utf-8"
+            )
+        directory.mkdir(parents=True, exist_ok=True)
+        return directory
+
+    reached = TripleVerdict(
+        stem=Rig.FIXTURE, window="january", wiring=Verdict.OK, results=Verdict.OK, kpis=Verdict.OK
+    )
+    missed = TripleVerdict(
+        stem="other", window="january", wiring=Verdict.OK, results=Verdict.FAILED, kpis=Verdict.OK
+    )
+
+    assert parity_main(["--summarize", str(dispatch("parity", reached))]) == 0
+    assert parity_main(["--summarize", str(dispatch("one_missed", reached, missed))]) == 1
+    assert parity_main(["--summarize", str(dispatch("nothing_collected"))]) == 1


### PR DESCRIPTION
Run 34504646328 passed all 22 parity triples and still went red: the summary step runs inside the test container, where GitHub uses sh, and sh rejects the bash-only set -o pipefail before the table is printed. The step now takes the freshness job's form: the checker writes to a file, its exit code is kept, the file is shown and appended to the step summary. No other workflow carries the pattern. Verified with an empty verdicts directory that the redirect form still exits 1 when the checker does.