### PR TITLE
A bless keeps every value the gate would have accepted, so its diff says only what moved

### DIFF
--- a/.github/workflows/golden-update.yml
+++ b/.github/workflows/golden-update.yml
@@ -6,8 +6,10 @@
 # The bless is sticky: a KPI whose fresh value the gate itself would still accept
 # keeps the value already committed, and a golden that comes out identical is not
 # rewritten, so the PR diff carries only what actually moved. When nothing moved at
-# all, the diff is the manifest alone. Someone who deliberately wants the stored
-# last-digit noise replaced by fresh values runs the script with --force-rewrite.
+# all, the diff is the manifest alone. Nothing is ever dropped: a KPI the run no
+# longer produces stays in its golden and the gate goes on reporting it as missing.
+# The force_rewrite input dumps the fresh values verbatim instead — the way to clear
+# accumulated noise, to retire a KPI, and to repair an unreadable golden.
 
 name: golden-update
 
@@ -18,6 +20,11 @@ on:
         description: "Why are you re-blessing the goldens?"
         required: true
         default: "intentional simulation-output change"
+      force_rewrite:
+        description: "Overwrite every stored value with the fresh one, dropping KPIs the runs no longer produce."
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write
@@ -72,7 +79,9 @@ jobs:
       - name: Install HiSim package
         run: uv pip install --system -e .
       - name: Regenerate golden for this pair
-        run: python scripts/golden_update.py --setup "${{ matrix.setup }}" --param "${{ matrix.param }}"
+        run: >-
+          python scripts/golden_update.py --setup "${{ matrix.setup }}" --param "${{ matrix.param }}"
+          ${{ inputs.force_rewrite && '--force-rewrite' || '' }}
       - name: Upload regenerated golden
         uses: actions/upload-artifact@v6
         with:
@@ -136,6 +145,7 @@ jobs:
           PR_REPO: ${{ github.repository }}
           PR_BASE: ${{ github.ref_name }}
           PR_REASON: ${{ github.event.inputs.reason }}
+          PR_FORCED: ${{ inputs.force_rewrite }}
         run: |
           branch="bless/golden-${{ github.run_id }}"
           git config user.name "github-actions[bot]"
@@ -151,12 +161,23 @@ jobs:
           PR_HEAD="$branch" python - <<'PY'
           import json, os, urllib.request
           repo = os.environ["PR_REPO"]
+          forced = os.environ.get("PR_FORCED", "false") == "true"
+          how = (
+              "This bless was FORCED (--force-rewrite): every value was overwritten with\n"
+              "the fresh one and any KPI the runs no longer produce was dropped.\n\n"
+              if forced
+              else
+              "Only KPIs that moved beyond the gate's tolerance were rewritten, so a\n"
+              "manifest-only diff means every value reproduced within the gate's tolerance.\n\n"
+              "Any key the per-pair logs list as absent is still in its golden file: a bless\n"
+              "never removes a KPI, so the gate keeps reporting it as missing until someone\n"
+              "retires it deliberately by re-running this workflow with force_rewrite.\n\n"
+          )
           body = (
               "Re-ran the golden KPI references in the CI container.\n\n"
               f"Reason: {os.environ['PR_REASON']}\n\n"
-              "Only KPIs that moved beyond the gate's tolerance were rewritten, so a\n"
-              "manifest-only diff means every value reproduced. Review the per-KPI\n"
-              "diff before merging."
+              f"{how}"
+              "Review the per-KPI diff before merging."
           )
           payload = json.dumps({
               "title": "Bless golden references",

--- a/.github/workflows/golden-update.yml
+++ b/.github/workflows/golden-update.yml
@@ -1,7 +1,13 @@
-# Manual "bless" of the golden KPI references. Regenerates EVERY pair (both the
-# week and full-year horizons) in the CI container — so the reference environment
+# Manual "bless" of the golden KPI references. Re-runs EVERY pair (both the week
+# and full-year horizons) in the CI container — so the reference environment
 # matches the check environment — and opens a pull request with the updated
 # golden_references/ for review. This is the only sanctioned way to update goldens.
+#
+# The bless is sticky: a KPI whose fresh value the gate itself would still accept
+# keeps the value already committed, and a golden that comes out identical is not
+# rewritten, so the PR diff carries only what actually moved. When nothing moved at
+# all, the diff is the manifest alone. Someone who deliberately wants the stored
+# last-digit noise replaced by fresh values runs the script with --force-rewrite.
 
 name: golden-update
 
@@ -146,9 +152,11 @@ jobs:
           import json, os, urllib.request
           repo = os.environ["PR_REPO"]
           body = (
-              "Regenerated golden KPI references in the CI container.\n\n"
+              "Re-ran the golden KPI references in the CI container.\n\n"
               f"Reason: {os.environ['PR_REASON']}\n\n"
-              "Review the per-KPI diff before merging."
+              "Only KPIs that moved beyond the gate's tolerance were rewritten, so a\n"
+              "manifest-only diff means every value reproduced. Review the per-KPI\n"
+              "diff before merging."
           )
           payload = json.dumps({
               "title": "Bless golden references",

--- a/golden_ref_spec.md
+++ b/golden_ref_spec.md
@@ -118,6 +118,11 @@ tests/
 ### 6.4 `golden_update.py`
 - Run all (or `--setup`/`--param`-filtered) pairs; write each pair's KPIs to
   `golden_references/<setup>__<param>.json` (sorted keys, indented).
+- **Sticky bless**: where a golden already exists, keep the stored value of every
+  KPI whose fresh value `compare` accepts at the gate's own tolerances (§7), and
+  write the file only when its content changes — so a bless diff shows what moved,
+  not the container's last-digit float noise. `--force-rewrite` dumps the fresh
+  values verbatim for the rare deliberate noise clear-out.
 - Write `manifest.json` (commit, python, platform, config hash, timestamp) as
   informational sidecar.
 - Print a summary; this is the deliberate "bless" button, **invoked only by the

--- a/golden_ref_spec.md
+++ b/golden_ref_spec.md
@@ -120,9 +120,20 @@ tests/
   `golden_references/<setup>__<param>.json` (sorted keys, indented).
 - **Sticky bless**: where a golden already exists, keep the stored value of every
   KPI whose fresh value `compare` accepts at the gate's own tolerances (§7), and
-  write the file only when its content changes — so a bless diff shows what moved,
-  not the container's last-digit float noise. `--force-rewrite` dumps the fresh
-  values verbatim for the rare deliberate noise clear-out.
+  write the file only when its values change — so a bless diff shows what moved,
+  not the container's last-digit float noise. The file always carries the full
+  mapping; only the *diff* is limited to the keys that moved or appeared.
+- **Never drop**: a KPI the fresh run no longer produces keeps its stored value
+  instead of disappearing, so the gate goes on failing with "missing KPI" until
+  someone retires it deliberately. Such keys are reported as `absent` in the pair's
+  summary line, always by name.
+- A stored golden that exists but cannot be merged onto — unreadable, not a JSON
+  object, or not the flat scalar mapping `flatten` produces — fails its pair like a
+  failed run (counted as errored, named with its reason, non-zero exit), rather than
+  being silently replaced.
+- `--force-rewrite` dumps the fresh values verbatim, ignoring whatever is on disk:
+  the deliberate noise clear-out, the only sanctioned way to retire a KPI, and the
+  repair path for a golden that has become unusable.
 - Write `manifest.json` (commit, python, platform, config hash, timestamp) as
   informational sidecar.
 - Print a summary; this is the deliberate "bless" button, **invoked only by the

--- a/golden_references/README.md
+++ b/golden_references/README.md
@@ -65,4 +65,7 @@ reference environment matches the check environment:
 It regenerates every pair (week and year) in the CI container and opens a PR with
 the updated `golden_references/`. Review the per-KPI diff, then merge — that merge
 is the bless. (`scripts/golden_update.py` can be run locally for inspection, but
-locally produced goldens are not the canonical committed ones.)
+locally produced goldens are not the canonical committed ones. A local run is
+sticky like the CI one — every value the gate would still accept stays exactly as
+committed, and nothing is dropped — so add `--force-rewrite` to see the fresh
+values verbatim.)

--- a/scripts/golden_update.py
+++ b/scripts/golden_update.py
@@ -6,14 +6,18 @@ run's ``all_kpis.json``, and writes one committed golden file per pair to
 ``golden_references/<setup_id>__<param_id>.json`` plus an informational
 ``manifest.json``.
 
-The bless is *sticky*: where a golden already exists, every key whose fresh value
-the gate itself would accept (:func:`scripts.golden_kpis.compare` at the very
-tolerances ``golden_check.py`` applies) keeps its stored value. Only keys that
-genuinely moved, appeared, or disappeared reach the file, and a file whose content
-comes out identical is not rewritten at all. Last-digit float noise from the
-container therefore stays out of the bless diff, which then says only what changed.
-Pass ``--force-rewrite`` to dump the fresh mapping verbatim instead — the rare case
-where someone wants the accumulated noise cleared deliberately.
+Every golden file always carries the full KPI mapping; what the bless limits is
+the *diff*. The bless is *sticky*: where a golden already exists, every key whose
+fresh value the gate itself would accept (:func:`scripts.golden_kpis.compare` at
+the very tolerances ``golden_check.py`` applies) keeps its stored value, so only
+keys that genuinely moved or appeared reach the diff, and a file whose values come
+out identical is not rewritten at all. Nothing ever disappears: a key the fresh run
+no longer produces stays in the file (the gate then keeps failing with "missing
+KPI" until someone retires it deliberately) and is named in the pair's summary.
+
+Pass ``--force-rewrite`` to dump the fresh mapping verbatim instead, ignoring
+whatever is on disk — the way to clear accumulated noise, to drop a retired KPI,
+and to repair a golden that has become unreadable.
 
 Blessing is deliberate and, per spec, driven by the ``golden-update.yml`` CI job
 so the reference environment matches the check environment. It may be run locally
@@ -62,9 +66,24 @@ DEFAULT_RESULTS_ROOT = DEFAULT_REPO_ROOT / "results"
 
 RunFn = Callable[[GoldenConfig, Path, Path, str], list[RunResult]]
 
-#: How many moved keys a summary line still names one by one. Beyond that the line
-#: only counts them; the diff itself is the place to read a long list.
+#: How many moved/new keys a summary line still names one by one. Beyond that the
+#: line only counts them; the diff itself is the place to read a long list. Absent
+#: keys are named regardless — they are the ones nobody would otherwise notice.
 MAX_NAMED_KEYS = 10
+
+#: The value types a flattened KPI mapping may hold (see ``scripts.golden_kpis.flatten``:
+#: numbers become ``float``, other leaves — strings, ``None`` — are kept as they are).
+_SCALAR_TYPES = (str, int, float, bool, type(None))
+
+
+class UnusableGoldenError(RuntimeError):
+    """The golden file for a pair exists but cannot be merged onto.
+
+    Raised for a file that will not parse, that does not hold a JSON object, or
+    whose values are not the flat scalars a golden consists of. Merging onto such
+    a file would quietly produce nonsense, so the pair fails like a failed run;
+    ``--force-rewrite`` bypasses the load and is the sanctioned repair path.
+    """
 
 
 def golden_filename(setup_id: str, parameter_set_id: str) -> str:
@@ -72,84 +91,148 @@ def golden_filename(setup_id: str, parameter_set_id: str) -> str:
     return f"{setup_id}__{parameter_set_id}.json"
 
 
-@dataclass
+@dataclass(frozen=True)
+class MergeRecord:
+    """What merging a fresh KPI mapping onto a stored golden did, key by key."""
+
+    merged: dict[str, Any]
+    moved: tuple[str, ...]
+    new: tuple[str, ...]
+    absent: tuple[str, ...]
+    kept: int
+
+    @property
+    def changed(self) -> bool:
+        """True when some value in the file itself moved or newly appeared."""
+        return bool(self.moved or self.new)
+
+
+@dataclass(frozen=True)
 class BlessOutcome:
-    """What blessing one pair did to its golden file."""
+    """What blessing one pair did to its golden file.
+
+    ``record`` is ``None`` when there was nothing to merge onto — a first bless, or
+    a ``--force-rewrite`` that ignored the stored values — and the fresh mapping was
+    written verbatim.
+    """
 
     path: Path
     rewritten: bool
-    summary: str
+    record: Optional[MergeRecord]
 
 
 def _load_existing_golden(path: Path) -> Optional[dict[str, Any]]:
-    """Return the golden mapping currently on disk, or ``None`` if there is no usable one.
+    """Return the golden mapping currently on disk, or ``None`` if the file is absent.
 
-    An absent, unreadable or structurally unexpected file simply means "no old
-    values to keep" — the fresh run is then written verbatim, as it always was.
+    An absent file simply means "no old values to keep" — the fresh run is then
+    written verbatim, as it always was.
+
+    Raises:
+        UnusableGoldenError: the file exists but cannot be merged onto (unreadable,
+            not a JSON object, or holding anything but flat scalar values).
     """
     if not path.is_file():
         return None
     try:
         stored = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        return None
-    return stored if isinstance(stored, dict) else None
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UnusableGoldenError(f"{path}: cannot be read as JSON ({exc})") from exc
+    if not isinstance(stored, dict):
+        raise UnusableGoldenError(
+            f"{path}: holds a JSON {type(stored).__name__}, not an object mapping KPI keys to values"
+        )
+    for key, value in stored.items():
+        if not isinstance(value, _SCALAR_TYPES):
+            raise UnusableGoldenError(
+                f"{path}: KPI '{key}' holds a {type(value).__name__}, not a scalar — a golden is the "
+                "flat mapping scripts.golden_kpis.flatten produces, one value per dotted key"
+            )
+    return stored
 
 
 def _within_tolerance(key: str, old_value: Any, new_value: Any) -> bool:
     """Whether the gate would accept ``new_value`` where the golden holds ``old_value``.
 
-    Asks :func:`scripts.golden_kpis.compare` itself, at the check's own tolerances,
-    so a value kept by a bless and a value passed by the gate can never drift apart.
+    The keep threshold is the gate's own default tolerance — ``REL_TOL``/``ABS_TOL``
+    of :mod:`scripts.golden_kpis`, the tolerances the CI gates run at — asked of
+    :func:`scripts.golden_kpis.compare` itself, one key at a time, so a value kept
+    by a bless and a value passed by the gate can never drift apart.
     """
     return not compare("bless", {key: new_value}, {key: old_value}, rel_tol=REL_TOL, abs_tol=ABS_TOL)
 
 
-def merge_into_golden(old: dict[str, Any], new: dict[str, Any]) -> tuple[dict[str, Any], str]:
-    """Merge a fresh KPI mapping onto an existing golden, and say what moved.
+def merge_into_golden(old: dict[str, Any], new: dict[str, Any]) -> MergeRecord:
+    """Merge a fresh KPI mapping onto an existing golden, and record what happened.
 
     Every key the gate would have accepted unchanged keeps its stored value; keys
     that deviate beyond tolerance or are new take the fresh value; keys the fresh
-    run no longer produces are dropped.
+    run no longer produces are **kept** with their stored value, so nothing is ever
+    silently removed from a golden — the gate goes on reporting them as missing
+    until someone retires them deliberately with ``--force-rewrite``.
 
     Args:
         old: the golden mapping currently committed for this pair.
         new: the freshly computed mapping.
 
     Returns:
-        tuple: the mapping to store, and a one-line human summary — ``"unchanged"``
-        or ``"N key(s) moved, M within tolerance kept"``, naming the keys while
-        there are at most :data:`MAX_NAMED_KEYS` of them.
+        MergeRecord: the mapping to store plus the moved/new/absent keys and the
+        number of keys kept within tolerance.
     """
     merged: dict[str, Any] = {}
     moved: list[str] = []
+    fresh: list[str] = []
     kept = 0
     for key, new_value in new.items():
-        if key in old and _within_tolerance(key, old[key], new_value):
+        if key not in old:
+            merged[key] = new_value
+            fresh.append(key)
+        elif _within_tolerance(key, old[key], new_value):
             merged[key] = old[key]
             kept += 1
         else:
             merged[key] = new_value
-            moved.append(key if key in old else f"{key} (new)")
-    dropped = [f"{key} (dropped)" for key in old if key not in new]
+            moved.append(key)
+    absent = [key for key in old if key not in new]
+    for key in absent:
+        merged[key] = old[key]
+    return MergeRecord(merged=merged, moved=tuple(moved), new=tuple(fresh), absent=tuple(absent), kept=kept)
 
-    changed = moved + dropped
-    if not changed:
-        return merged, "unchanged"
-    summary = f"{len(changed)} key(s) moved, {kept} within tolerance kept"
-    if len(changed) <= MAX_NAMED_KEYS:
-        summary += " — " + ", ".join(changed)
-    elif dropped:
-        summary += f", {len(dropped)} of them dropped"
-    return merged, summary
+
+def summarize_record(record: MergeRecord) -> str:
+    """Render one merge as the single human line a bless prints per pair.
+
+    ``"unchanged"`` when no value moved, appeared or went absent; otherwise the
+    counts — ``"N moved, M new, K absent (kept), J within tolerance kept"`` — naming
+    the moved and new keys while there are at most :data:`MAX_NAMED_KEYS` of them,
+    and always naming the absent ones.
+    """
+    if not record.changed and not record.absent:
+        return "unchanged"
+    summary = (
+        f"{len(record.moved)} moved, {len(record.new)} new, {len(record.absent)} absent (kept), "
+        f"{record.kept} within tolerance kept"
+    )
+    parts: list[str] = []
+    if len(record.moved) + len(record.new) <= MAX_NAMED_KEYS:
+        if record.moved:
+            parts.append("moved: " + ", ".join(record.moved))
+        if record.new:
+            parts.append("new: " + ", ".join(record.new))
+    if record.absent:
+        parts.append("absent: " + ", ".join(record.absent))
+    if not parts:
+        return summary
+    return summary + " — " + "; ".join(parts)
 
 
 def write_golden(golden_dir: Path, result: RunResult, force_rewrite: bool = False) -> BlessOutcome:
     """Write one pair's flattened KPIs to its golden file (sorted, indented).
 
     Values the gate would have accepted are carried over from the golden already on
-    disk (see :func:`merge_into_golden`), and a file whose content does not change
-    is left untouched, so a bless that found nothing leaves no diff behind.
+    disk (see :func:`merge_into_golden`), and a file whose values do not change is
+    left untouched — value-level, so a hand-formatted golden that says the same
+    thing keeps its formatting and its mtime and a bless that found nothing leaves
+    no diff behind.
 
     Args:
         golden_dir: directory holding the committed goldens.
@@ -157,21 +240,23 @@ def write_golden(golden_dir: Path, result: RunResult, force_rewrite: bool = Fals
         force_rewrite: dump the fresh mapping verbatim, ignoring the stored values.
 
     Returns:
-        BlessOutcome: the file's path, whether it was rewritten, and the summary line.
+        BlessOutcome: the file's path, whether it was rewritten, and the merge record.
+
+    Raises:
+        UnusableGoldenError: the stored golden exists but cannot be merged onto.
     """
     golden_dir.mkdir(parents=True, exist_ok=True)
     path = golden_dir / golden_filename(result.setup_id, result.parameter_set_id)
     old = None if force_rewrite else _load_existing_golden(path)
     if old is None:
-        payload, summary = result.kpis, "written"
-    else:
-        payload, summary = merge_into_golden(old, result.kpis)
+        path.write_text(json.dumps(result.kpis, indent=2, sort_keys=True))
+        return BlessOutcome(path, True, None)
 
-    text = json.dumps(payload, indent=2, sort_keys=True)
-    if path.is_file() and path.read_text() == text:
-        return BlessOutcome(path, False, "unchanged")
-    path.write_text(text)
-    return BlessOutcome(path, True, summary)
+    record = merge_into_golden(old, result.kpis)
+    if old == record.merged:
+        return BlessOutcome(path, False, record)
+    path.write_text(json.dumps(record.merged, indent=2, sort_keys=True))
+    return BlessOutcome(path, True, record)
 
 
 def write_manifest(golden_dir: Path, config_path: Path) -> Path:
@@ -206,7 +291,8 @@ def main(
     files already in ``golden_dir`` — used by the CI ``collect`` job after it has
     assembled per-pair goldens from artifacts. ``force_rewrite`` disables the
     sticky merge and dumps every fresh mapping verbatim. Returns non-zero if any
-    pair errored so a bless run fails visibly.
+    pair errored — a failed run, or a stored golden that cannot be merged onto —
+    so a bless run fails visibly.
     """
     config = load_config(config_path)  # fail hard on a missing/invalid config
 
@@ -220,28 +306,33 @@ def main(
 
     rewritten = 0
     unchanged = 0
-    errored = 0
+    failures: list[str] = []
     for result in results:
+        name = f"{result.setup_id}/{result.parameter_set_id}"
         if result.error is not None:
-            errored += 1
+            failures.append(f"  ERROR {name}:\n{result.error}")
             continue
-        outcome = write_golden(golden_dir, result, force_rewrite=force_rewrite)
+        try:
+            outcome = write_golden(golden_dir, result, force_rewrite=force_rewrite)
+        except UnusableGoldenError as exc:
+            print(f"  {name}: unusable golden — {exc}")
+            failures.append(f"  ERROR {name}: unusable golden — {exc} (bless it with --force-rewrite to repair)")
+            continue
         if outcome.rewritten:
             rewritten += 1
         else:
             unchanged += 1
-        print(f"  {result.setup_id}/{result.parameter_set_id}: {outcome.summary}")
+        summary = "written" if outcome.record is None else summarize_record(outcome.record)
+        print(f"  {name}: {summary}")
 
     manifest_path = write_manifest(golden_dir, config_path)
     print(
         f"Golden update: {len(results)} pair(s) — {rewritten} rewritten, {unchanged} unchanged, "
-        f"{errored} errored. Goldens: {golden_dir}  Manifest: {manifest_path}"
+        f"{len(failures)} errored. Goldens: {golden_dir}  Manifest: {manifest_path}"
     )
-    if errored:
-        for result in results:
-            if result.error is not None:
-                print(f"  ERROR {result.setup_id}/{result.parameter_set_id}:\n{result.error}")
-    return 1 if errored else 0
+    for failure in failures:
+        print(failure)
+    return 1 if failures else 0
 
 
 def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
@@ -258,7 +349,11 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--force-rewrite",
         action="store_true",
-        help="Write every fresh value verbatim instead of keeping stored values the gate accepts.",
+        help=(
+            "Write every fresh value verbatim instead of keeping stored values the gate accepts. "
+            "Ignores the stored file entirely, so this is also how a retired KPI is removed and how "
+            "a golden that has become unreadable is repaired."
+        ),
     )
     return parser.parse_args(argv)
 

--- a/scripts/golden_update.py
+++ b/scripts/golden_update.py
@@ -6,6 +6,15 @@ run's ``all_kpis.json``, and writes one committed golden file per pair to
 ``golden_references/<setup_id>__<param_id>.json`` plus an informational
 ``manifest.json``.
 
+The bless is *sticky*: where a golden already exists, every key whose fresh value
+the gate itself would accept (:func:`scripts.golden_kpis.compare` at the very
+tolerances ``golden_check.py`` applies) keeps its stored value. Only keys that
+genuinely moved, appeared, or disappeared reach the file, and a file whose content
+comes out identical is not rewritten at all. Last-digit float noise from the
+container therefore stays out of the bless diff, which then says only what changed.
+Pass ``--force-rewrite`` to dump the fresh mapping verbatim instead — the rare case
+where someone wants the accumulated noise cleared deliberately.
+
 Blessing is deliberate and, per spec, driven by the ``golden-update.yml`` CI job
 so the reference environment matches the check environment. It may be run locally
 for inspection, but locally produced goldens are not the canonical committed ones.
@@ -15,8 +24,9 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 # Make the repo root importable whether invoked as ``python scripts/golden_update.py``
 # or imported as ``scripts.golden_update`` (so ``hisim`` and siblings both resolve).
@@ -25,6 +35,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 try:  # run as a script from scripts/ ...
+    from golden_kpis import ABS_TOL, REL_TOL, compare  # type: ignore[import-not-found]
     from runner import (  # type: ignore[import-not-found]
         GoldenConfig,
         RunResult,
@@ -34,6 +45,7 @@ try:  # run as a script from scripts/ ...
         run_all,
     )
 except ModuleNotFoundError:  # ... or imported as scripts.golden_update (tests)
+    from scripts.golden_kpis import ABS_TOL, REL_TOL, compare
     from scripts.runner import (
         GoldenConfig,
         RunResult,
@@ -50,18 +62,116 @@ DEFAULT_RESULTS_ROOT = DEFAULT_REPO_ROOT / "results"
 
 RunFn = Callable[[GoldenConfig, Path, Path, str], list[RunResult]]
 
+#: How many moved keys a summary line still names one by one. Beyond that the line
+#: only counts them; the diff itself is the place to read a long list.
+MAX_NAMED_KEYS = 10
+
 
 def golden_filename(setup_id: str, parameter_set_id: str) -> str:
     """Return the committed golden filename for a pair."""
     return f"{setup_id}__{parameter_set_id}.json"
 
 
-def write_golden(golden_dir: Path, result: RunResult) -> Path:
-    """Write one pair's flattened KPIs to its golden file (sorted, indented)."""
+@dataclass
+class BlessOutcome:
+    """What blessing one pair did to its golden file."""
+
+    path: Path
+    rewritten: bool
+    summary: str
+
+
+def _load_existing_golden(path: Path) -> Optional[dict[str, Any]]:
+    """Return the golden mapping currently on disk, or ``None`` if there is no usable one.
+
+    An absent, unreadable or structurally unexpected file simply means "no old
+    values to keep" — the fresh run is then written verbatim, as it always was.
+    """
+    if not path.is_file():
+        return None
+    try:
+        stored = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return stored if isinstance(stored, dict) else None
+
+
+def _within_tolerance(key: str, old_value: Any, new_value: Any) -> bool:
+    """Whether the gate would accept ``new_value`` where the golden holds ``old_value``.
+
+    Asks :func:`scripts.golden_kpis.compare` itself, at the check's own tolerances,
+    so a value kept by a bless and a value passed by the gate can never drift apart.
+    """
+    return not compare("bless", {key: new_value}, {key: old_value}, rel_tol=REL_TOL, abs_tol=ABS_TOL)
+
+
+def merge_into_golden(old: dict[str, Any], new: dict[str, Any]) -> tuple[dict[str, Any], str]:
+    """Merge a fresh KPI mapping onto an existing golden, and say what moved.
+
+    Every key the gate would have accepted unchanged keeps its stored value; keys
+    that deviate beyond tolerance or are new take the fresh value; keys the fresh
+    run no longer produces are dropped.
+
+    Args:
+        old: the golden mapping currently committed for this pair.
+        new: the freshly computed mapping.
+
+    Returns:
+        tuple: the mapping to store, and a one-line human summary — ``"unchanged"``
+        or ``"N key(s) moved, M within tolerance kept"``, naming the keys while
+        there are at most :data:`MAX_NAMED_KEYS` of them.
+    """
+    merged: dict[str, Any] = {}
+    moved: list[str] = []
+    kept = 0
+    for key, new_value in new.items():
+        if key in old and _within_tolerance(key, old[key], new_value):
+            merged[key] = old[key]
+            kept += 1
+        else:
+            merged[key] = new_value
+            moved.append(key if key in old else f"{key} (new)")
+    dropped = [f"{key} (dropped)" for key in old if key not in new]
+
+    changed = moved + dropped
+    if not changed:
+        return merged, "unchanged"
+    summary = f"{len(changed)} key(s) moved, {kept} within tolerance kept"
+    if len(changed) <= MAX_NAMED_KEYS:
+        summary += " — " + ", ".join(changed)
+    elif dropped:
+        summary += f", {len(dropped)} of them dropped"
+    return merged, summary
+
+
+def write_golden(golden_dir: Path, result: RunResult, force_rewrite: bool = False) -> BlessOutcome:
+    """Write one pair's flattened KPIs to its golden file (sorted, indented).
+
+    Values the gate would have accepted are carried over from the golden already on
+    disk (see :func:`merge_into_golden`), and a file whose content does not change
+    is left untouched, so a bless that found nothing leaves no diff behind.
+
+    Args:
+        golden_dir: directory holding the committed goldens.
+        result: one pair's successful run.
+        force_rewrite: dump the fresh mapping verbatim, ignoring the stored values.
+
+    Returns:
+        BlessOutcome: the file's path, whether it was rewritten, and the summary line.
+    """
     golden_dir.mkdir(parents=True, exist_ok=True)
     path = golden_dir / golden_filename(result.setup_id, result.parameter_set_id)
-    path.write_text(json.dumps(result.kpis, indent=2, sort_keys=True))
-    return path
+    old = None if force_rewrite else _load_existing_golden(path)
+    if old is None:
+        payload, summary = result.kpis, "written"
+    else:
+        payload, summary = merge_into_golden(old, result.kpis)
+
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if path.is_file() and path.read_text() == text:
+        return BlessOutcome(path, False, "unchanged")
+    path.write_text(text)
+    return BlessOutcome(path, True, summary)
 
 
 def write_manifest(golden_dir: Path, config_path: Path) -> Path:
@@ -87,14 +197,16 @@ def main(
     setup_id: Optional[str] = None,
     param_id: Optional[str] = None,
     manifest_only: bool = False,
+    force_rewrite: bool = False,
     run_fn: RunFn = run_all,
 ) -> int:
     """Run the (filtered) pairs, write golden files + manifest. Return exit code.
 
     ``manifest_only`` skips running and just (re)writes the manifest from the
     files already in ``golden_dir`` — used by the CI ``collect`` job after it has
-    assembled per-pair goldens from artifacts. Returns non-zero if any pair
-    errored so a bless run fails visibly.
+    assembled per-pair goldens from artifacts. ``force_rewrite`` disables the
+    sticky merge and dumps every fresh mapping verbatim. Returns non-zero if any
+    pair errored so a bless run fails visibly.
     """
     config = load_config(config_path)  # fail hard on a missing/invalid config
 
@@ -106,19 +218,24 @@ def main(
     config = filter_config(config, setup_id=setup_id, param_id=param_id)
     results = run_fn(config, results_root, repo_root, "golden-update")
 
-    written = 0
+    rewritten = 0
+    unchanged = 0
     errored = 0
     for result in results:
         if result.error is not None:
             errored += 1
             continue
-        write_golden(golden_dir, result)
-        written += 1
+        outcome = write_golden(golden_dir, result, force_rewrite=force_rewrite)
+        if outcome.rewritten:
+            rewritten += 1
+        else:
+            unchanged += 1
+        print(f"  {result.setup_id}/{result.parameter_set_id}: {outcome.summary}")
 
     manifest_path = write_manifest(golden_dir, config_path)
     print(
-        f"Golden update: {len(results)} pair(s) — {written} written, {errored} errored. "
-        f"Goldens: {golden_dir}  Manifest: {manifest_path}"
+        f"Golden update: {len(results)} pair(s) — {rewritten} rewritten, {unchanged} unchanged, "
+        f"{errored} errored. Goldens: {golden_dir}  Manifest: {manifest_path}"
     )
     if errored:
         for result in results:
@@ -138,6 +255,11 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--manifest-only", action="store_true", help="Only (re)write manifest.json from existing goldens."
     )
+    parser.add_argument(
+        "--force-rewrite",
+        action="store_true",
+        help="Write every fresh value verbatim instead of keeping stored values the gate accepts.",
+    )
     return parser.parse_args(argv)
 
 
@@ -152,5 +274,6 @@ if __name__ == "__main__":
             setup_id=args.setup_id,
             param_id=args.param_id,
             manifest_only=args.manifest_only,
+            force_rewrite=args.force_rewrite,
         )
     )

--- a/tests/test_golden_update.py
+++ b/tests/test_golden_update.py
@@ -2,7 +2,8 @@
 
 ``main`` runs the (filtered) pairs via an injected ``run_fn`` and writes one golden
 file per pair plus an informational manifest, keeping every stored value the gate
-would still accept. No HiSim simulation runs and no I/O happens outside ``tmp_path``.
+would still accept and never dropping a key. No HiSim simulation runs and no I/O
+happens outside ``tmp_path``.
 """
 from __future__ import annotations
 
@@ -13,7 +14,14 @@ from typing import Any, NoReturn
 
 import pytest
 
-from scripts.golden_update import golden_filename, main
+from scripts.golden_update import (
+    MAX_NAMED_KEYS,
+    MergeRecord,
+    golden_filename,
+    main,
+    merge_into_golden,
+    summarize_record,
+)
 from scripts.runner import GoldenConfig, RunResult
 
 pytestmark = pytest.mark.base
@@ -157,9 +165,7 @@ def _bless(tmp_path: Path, golden_dir: Path, kpis: dict[str, Any], force_rewrite
     )
 
 
-def test_value_within_tolerance_keeps_the_stored_one_and_the_file_is_not_rewritten(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_value_within_tolerance_keeps_the_stored_one_and_the_file_is_not_rewritten(tmp_path: Path) -> None:
     """Container float noise (1e-13 relative) never reaches the golden or its mtime."""
     golden_dir = tmp_path / "golden_references"
     stored = {"BUI1.Battery.Energy": 2589.664650339977}
@@ -171,44 +177,37 @@ def test_value_within_tolerance_keeps_the_stored_one_and_the_file_is_not_rewritt
     assert path.read_text() == before_text
     assert path.stat().st_mtime_ns == before_mtime
     assert json.loads(path.read_text()) == stored
-    assert "setup_a/one_week_60s: unchanged" in capsys.readouterr().out
 
 
-def test_value_beyond_tolerance_is_replaced_and_the_file_is_rewritten(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """A KPI that genuinely moved takes the fresh value and is named in the log."""
+def test_value_beyond_tolerance_is_replaced_and_the_file_is_rewritten(tmp_path: Path) -> None:
+    """A KPI that genuinely moved takes the fresh value; one within tolerance is kept."""
     golden_dir = tmp_path / "golden_references"
     path = _write_existing_golden(golden_dir, {"BUI1.Battery.Energy": 1000.0, "BUI1.General.x": 1.0})
 
     assert _bless(tmp_path, golden_dir, {"BUI1.Battery.Energy": 1001.0, "BUI1.General.x": 1.0}) == 0
 
     assert json.loads(path.read_text()) == {"BUI1.Battery.Energy": 1001.0, "BUI1.General.x": 1.0}
-    out = capsys.readouterr().out
-    assert "1 key(s) moved, 1 within tolerance kept" in out
-    assert "BUI1.Battery.Energy" in out
 
 
-def test_new_key_is_added_and_removed_key_is_dropped_both_logged(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """A KPI the run gained is stored, one it no longer produces disappears, and the log says so."""
+def test_a_new_key_is_added_and_an_absent_key_is_kept(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A KPI the run gained is stored; one it no longer produces stays and is named."""
     golden_dir = tmp_path / "golden_references"
     path = _write_existing_golden(golden_dir, {"BUI1.General.x": 1.0, "BUI1.Retired.y": 2.0})
 
     assert _bless(tmp_path, golden_dir, {"BUI1.General.x": 1.0, "BUI1.Fresh.z": 3.0}) == 0
 
-    assert json.loads(path.read_text()) == {"BUI1.General.x": 1.0, "BUI1.Fresh.z": 3.0}
-    out = capsys.readouterr().out
-    assert "2 key(s) moved, 1 within tolerance kept" in out
-    assert "BUI1.Fresh.z (new)" in out
-    assert "BUI1.Retired.y (dropped)" in out
+    assert json.loads(path.read_text()) == {
+        "BUI1.General.x": 1.0,
+        "BUI1.Fresh.z": 3.0,
+        "BUI1.Retired.y": 2.0,  # kept: only --force-rewrite retires a KPI
+    }
+    assert "BUI1.Retired.y" in capsys.readouterr().out
 
 
 def test_force_rewrite_writes_the_fresh_values_verbatim(tmp_path: Path) -> None:
-    """``--force-rewrite`` clears the stored noise instead of keeping it."""
+    """``--force-rewrite`` clears the stored noise, and drops what the run no longer produces."""
     golden_dir = tmp_path / "golden_references"
-    path = _write_existing_golden(golden_dir, {"BUI1.Battery.Energy": 2589.664650339977})
+    path = _write_existing_golden(golden_dir, {"BUI1.Battery.Energy": 2589.664650339977, "BUI1.Retired.y": 2.0})
     fresh = {"BUI1.Battery.Energy": 2589.664650339977 * (1 + 1e-13)}
 
     assert _bless(tmp_path, golden_dir, fresh, force_rewrite=True) == 0
@@ -216,13 +215,112 @@ def test_force_rewrite_writes_the_fresh_values_verbatim(tmp_path: Path) -> None:
     assert json.loads(path.read_text()) == fresh
 
 
-def test_unparsable_existing_golden_is_written_verbatim(tmp_path: Path) -> None:
-    """A golden that cannot be read offers no values to keep, so the fresh run wins."""
+def test_a_value_identical_but_differently_formatted_golden_is_left_alone(tmp_path: Path) -> None:
+    """Stickiness is decided on values, so hand formatting survives a bless untouched."""
     golden_dir = tmp_path / "golden_references"
     golden_dir.mkdir()
     path = golden_dir / golden_filename("setup_a", "one_week_60s")
-    path.write_text("not json at all")
+    path.write_text('{"BUI1.General.x": 1.0,\n  "BUI1.Battery.Energy":    2.5}')
+    before_text, before_mtime = path.read_text(), path.stat().st_mtime_ns
 
-    assert _bless(tmp_path, golden_dir, {"BUI1.General.x": 1.0}) == 0
+    assert _bless(tmp_path, golden_dir, {"BUI1.General.x": 1.0, "BUI1.Battery.Energy": 2.5}) == 0
+
+    assert path.read_text() == before_text
+    assert path.stat().st_mtime_ns == before_mtime
+
+
+def test_a_string_kpi_is_kept_when_equal_and_moves_when_it_differs(tmp_path: Path) -> None:
+    """Non-numeric KPIs are compared exactly, like the gate compares them."""
+    golden_dir = tmp_path / "golden_references"
+    path = _write_existing_golden(golden_dir, {"BUI1.General.code": "DE.N.SFH.05"})
+
+    assert _bless(tmp_path, golden_dir, {"BUI1.General.code": "DE.N.SFH.05"}) == 0
+    assert json.loads(path.read_text()) == {"BUI1.General.code": "DE.N.SFH.05"}
+
+    assert _bless(tmp_path, golden_dir, {"BUI1.General.code": "DE.N.SFH.06"}) == 0
+    assert json.loads(path.read_text()) == {"BUI1.General.code": "DE.N.SFH.06"}
+
+
+def test_a_near_zero_kpi_moves_because_the_gate_allows_no_absolute_slack(tmp_path: Path) -> None:
+    """``ABS_TOL`` is 0.0, so 0.0 -> 1e-15 is a move the gate would fail on."""
+    golden_dir = tmp_path / "golden_references"
+    path = _write_existing_golden(golden_dir, {"BUI1.General.x": 0.0})
+
+    assert _bless(tmp_path, golden_dir, {"BUI1.General.x": 1e-15}) == 0
+
+    assert json.loads(path.read_text()) == {"BUI1.General.x": 1e-15}
+
+
+# --------------------------------------------------------------------------- #
+# The merge record itself
+# --------------------------------------------------------------------------- #
+def test_merge_record_names_what_moved_appeared_and_went_absent() -> None:
+    """One merge, one record: moved, new, absent (kept) and the within-tolerance count."""
+    record = merge_into_golden(
+        {"kept": 1.0, "moved": 10.0, "gone": 5.0},
+        {"kept": 1.0 * (1 + 1e-13), "moved": 11.0, "fresh": 3.0},
+    )
+
+    assert record.merged == {"kept": 1.0, "moved": 11.0, "fresh": 3.0, "gone": 5.0}
+    assert record.moved == ("moved",)
+    assert record.new == ("fresh",)
+    assert record.absent == ("gone",)
+    assert record.kept == 1
+    assert record.changed is True
+
+
+def test_a_merge_that_only_kept_values_is_unchanged() -> None:
+    """Nothing moved, nothing appeared, nothing absent — one word."""
+    record = merge_into_golden({"kept": 1.0}, {"kept": 1.0 * (1 + 1e-13)})
+
+    assert record.merged == {"kept": 1.0}
+    assert (record.moved, record.new, record.absent, record.kept) == ((), (), (), 1)
+    assert record.changed is False
+    assert summarize_record(record) == "unchanged"
+
+
+def test_a_summary_names_every_absent_key_even_past_the_naming_cap() -> None:
+    """Moved keys stop being listed when there are many; absent ones never do."""
+    many = tuple(f"moved_{i}" for i in range(MAX_NAMED_KEYS + 1))
+    record = MergeRecord(merged={}, moved=many, new=(), absent=("gone",), kept=7)
+
+    line = summarize_record(record)
+
+    assert line.startswith(f"{len(many)} moved, 0 new, 1 absent (kept), 7 within tolerance kept")
+    assert "absent: gone" in line
+    assert "moved_0" not in line
+
+
+# --------------------------------------------------------------------------- #
+# A golden that cannot be merged onto fails its pair
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "stored",
+    [
+        pytest.param('{"BUI1.General.x": 1.0', id="truncated_json"),
+        pytest.param("[1, 2, 3]", id="json_list"),
+        pytest.param('{"BUI1": {"General": {"x": 1.0}}}', id="nested_not_flat"),
+    ],
+)
+def test_an_unusable_golden_errors_the_pair_and_leaves_the_file_alone(tmp_path: Path, stored: str) -> None:
+    """Merging onto nonsense would produce nonsense, so the pair fails like a failed run."""
+    golden_dir = tmp_path / "golden_references"
+    golden_dir.mkdir()
+    path = golden_dir / golden_filename("setup_a", "one_week_60s")
+    path.write_text(stored)
+
+    assert _bless(tmp_path, golden_dir, {"BUI1.General.x": 1.0}) == 1
+
+    assert path.read_text() == stored
+
+
+def test_force_rewrite_repairs_an_unusable_golden(tmp_path: Path) -> None:
+    """The sanctioned repair path: ``--force-rewrite`` never reads the broken file."""
+    golden_dir = tmp_path / "golden_references"
+    golden_dir.mkdir()
+    path = golden_dir / golden_filename("setup_a", "one_week_60s")
+    path.write_text('{"BUI1.General.x": 1.0')
+
+    assert _bless(tmp_path, golden_dir, {"BUI1.General.x": 1.0}, force_rewrite=True) == 0
 
     assert json.loads(path.read_text()) == {"BUI1.General.x": 1.0}

--- a/tests/test_golden_update.py
+++ b/tests/test_golden_update.py
@@ -1,8 +1,8 @@
 """Unit tests for ``scripts/golden_update.py``.
 
 ``main`` runs the (filtered) pairs via an injected ``run_fn`` and writes one golden
-file per pair plus an informational manifest. No HiSim simulation runs and no I/O
-happens outside ``tmp_path``.
+file per pair plus an informational manifest, keeping every stored value the gate
+would still accept. No HiSim simulation runs and no I/O happens outside ``tmp_path``.
 """
 from __future__ import annotations
 
@@ -132,3 +132,97 @@ def test_main_missing_config_raises(tmp_path: Path) -> None:
             repo_root=tmp_path,
             run_fn=_run_fn_returning([]),
         )
+
+
+# --------------------------------------------------------------------------- #
+# Sticky bless: values the gate would accept stay exactly as committed
+# --------------------------------------------------------------------------- #
+def _write_existing_golden(golden_dir: Path, kpis: dict[str, Any]) -> Path:
+    """Write a golden for the ``setup_a``/``one_week_60s`` pair the way the script does."""
+    golden_dir.mkdir(parents=True, exist_ok=True)
+    path = golden_dir / golden_filename("setup_a", "one_week_60s")
+    path.write_text(json.dumps(kpis, indent=2, sort_keys=True))
+    return path
+
+
+def _bless(tmp_path: Path, golden_dir: Path, kpis: dict[str, Any], force_rewrite: bool = False) -> int:
+    """Run one fake pair through ``main`` and return its exit code."""
+    return main(
+        config_path=_write_config(tmp_path),
+        golden_dir=golden_dir,
+        results_root=tmp_path,
+        repo_root=tmp_path,
+        force_rewrite=force_rewrite,
+        run_fn=_run_fn_returning([RunResult("setup_a", "one_week_60s", "rd", kpis=kpis)]),
+    )
+
+
+def test_value_within_tolerance_keeps_the_stored_one_and_the_file_is_not_rewritten(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Container float noise (1e-13 relative) never reaches the golden or its mtime."""
+    golden_dir = tmp_path / "golden_references"
+    stored = {"BUI1.Battery.Energy": 2589.664650339977}
+    path = _write_existing_golden(golden_dir, stored)
+    before_text, before_mtime = path.read_text(), path.stat().st_mtime_ns
+
+    assert _bless(tmp_path, golden_dir, {"BUI1.Battery.Energy": 2589.664650339977 * (1 + 1e-13)}) == 0
+
+    assert path.read_text() == before_text
+    assert path.stat().st_mtime_ns == before_mtime
+    assert json.loads(path.read_text()) == stored
+    assert "setup_a/one_week_60s: unchanged" in capsys.readouterr().out
+
+
+def test_value_beyond_tolerance_is_replaced_and_the_file_is_rewritten(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A KPI that genuinely moved takes the fresh value and is named in the log."""
+    golden_dir = tmp_path / "golden_references"
+    path = _write_existing_golden(golden_dir, {"BUI1.Battery.Energy": 1000.0, "BUI1.General.x": 1.0})
+
+    assert _bless(tmp_path, golden_dir, {"BUI1.Battery.Energy": 1001.0, "BUI1.General.x": 1.0}) == 0
+
+    assert json.loads(path.read_text()) == {"BUI1.Battery.Energy": 1001.0, "BUI1.General.x": 1.0}
+    out = capsys.readouterr().out
+    assert "1 key(s) moved, 1 within tolerance kept" in out
+    assert "BUI1.Battery.Energy" in out
+
+
+def test_new_key_is_added_and_removed_key_is_dropped_both_logged(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A KPI the run gained is stored, one it no longer produces disappears, and the log says so."""
+    golden_dir = tmp_path / "golden_references"
+    path = _write_existing_golden(golden_dir, {"BUI1.General.x": 1.0, "BUI1.Retired.y": 2.0})
+
+    assert _bless(tmp_path, golden_dir, {"BUI1.General.x": 1.0, "BUI1.Fresh.z": 3.0}) == 0
+
+    assert json.loads(path.read_text()) == {"BUI1.General.x": 1.0, "BUI1.Fresh.z": 3.0}
+    out = capsys.readouterr().out
+    assert "2 key(s) moved, 1 within tolerance kept" in out
+    assert "BUI1.Fresh.z (new)" in out
+    assert "BUI1.Retired.y (dropped)" in out
+
+
+def test_force_rewrite_writes_the_fresh_values_verbatim(tmp_path: Path) -> None:
+    """``--force-rewrite`` clears the stored noise instead of keeping it."""
+    golden_dir = tmp_path / "golden_references"
+    path = _write_existing_golden(golden_dir, {"BUI1.Battery.Energy": 2589.664650339977})
+    fresh = {"BUI1.Battery.Energy": 2589.664650339977 * (1 + 1e-13)}
+
+    assert _bless(tmp_path, golden_dir, fresh, force_rewrite=True) == 0
+
+    assert json.loads(path.read_text()) == fresh
+
+
+def test_unparsable_existing_golden_is_written_verbatim(tmp_path: Path) -> None:
+    """A golden that cannot be read offers no values to keep, so the fresh run wins."""
+    golden_dir = tmp_path / "golden_references"
+    golden_dir.mkdir()
+    path = golden_dir / golden_filename("setup_a", "one_week_60s")
+    path.write_text("not json at all")
+
+    assert _bless(tmp_path, golden_dir, {"BUI1.General.x": 1.0}) == 0
+
+    assert json.loads(path.read_text()) == {"BUI1.General.x": 1.0}


### PR DESCRIPTION
﻿The first three gate decisions of the P4 component sweep, executed one per commit, plus the record of the six physics decisions taken in the same interview.

- D-2: the last zombie heat-pump controller (controller_l1_heatpump, zero users) moves to obsolete/.
- D-8: the fuel-cell controller, whose control methods read an undefaulted dataclass as class attributes and cannot run, moves to obsolete/ with its test and the three legacy configuration.py dataclasses it was the only user of, which unblocks the deletion of that legacy block.
- D-16, decided beyond the survey's recommendation: everything to obsolete/, nothing deleted. The MPC and PID controllers, the wind turbine and the price signal move with their tests; the storage controller and the four dead legacy configs are moved out of the files they shared into their own files; only the two dead factories are deleted. HouseholdWarmWaterDemandConfig stays, its class constants are live.
- The economic example's prose no longer describes the MPC controller as the library's price consumer.
- D-4, D-7, D-9, D-11, D-12 and D-21 are recorded as answered in the requirements document and the survey; their gate commits follow separately, each with its result diffs.

Verified: no setup instantiates any retired class, the energy-management system declares no default connection for them (the F-1 defect is not triggered), the full fleet re-records byte-identical, no golden or twin moves, and the quality gates already exclude obsolete/. The roadmap's two energy-system mockups still name the retired L1 controller, so the class-validation test now pins those entries as a missing module; repointing them is a batch-2 decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
