### PR TITLE
The CHP controller's buffer factories share one helper; the thresholds stay as they were

### DIFF
--- a/hisim/components/controller_l1_chp.py
+++ b/hisim/components/controller_l1_chp.py
@@ -30,11 +30,39 @@ __maintainer__ = "Vitor Hugo Bellotto Zago"
 __email__ = "vitor.zago@rwth-aachen.de"
 __status__ = "development"
 
+#: Lower set temperature of the buffer storage, given in °C.
+BUFFER_T_MIN_HEATING_IN_CELSIUS = 35.0
+#: Upper set temperature of the buffer storage, given in °C.
+BUFFER_T_MAX_HEATING_IN_CELSIUS = 40.0
+#: Julian day the heating season begins on when a buffer storage is present.
+BUFFER_DAY_OF_HEATING_SEASON_BEGIN = 270 - 1
+
+
+def _with_buffer_storage(config: "L1CHPControllerConfig") -> "L1CHPControllerConfig":
+    """Applies the buffer storage overrides, which are the same ones for either fuel.
+
+    A buffer storage sits on the space heating side alone: it moves the regulated band from the
+    building's room temperature up to the buffer's water temperature, and it begins the heating
+    season one day early, so that the buffer heats up one day ahead and modelling to the building
+    works. It says nothing about the drain hot water storage, whose thresholds therefore stay put.
+    """
+    config.t_min_heating_in_celsius = BUFFER_T_MIN_HEATING_IN_CELSIUS
+    config.t_max_heating_in_celsius = BUFFER_T_MAX_HEATING_IN_CELSIUS
+    config.day_of_heating_season_begin = BUFFER_DAY_OF_HEATING_SEASON_BEGIN
+    return config
+
 
 @dataclass_json
 @dataclass
 class L1CHPControllerConfig(ConfigBase):
-    """CHP Controller Config."""
+    """CHP Controller Config.
+
+    The four default configurations are two fuels - gas and green hydrogen, which differ in ``use``
+    and in the hydrogen storage threshold that only the fuel cell reads - crossed with the one
+    buffer storage override in :func:`_with_buffer_storage`. Everything else, the drain hot water
+    band included, is the same for both fuels, because nothing the controller does with those
+    thresholds depends on what is burnt.
+    """
 
     component_id: ComponentID
     #: priority of the device in hierachy: the higher the number the lower the priority
@@ -101,7 +129,7 @@ class L1CHPControllerConfig(ConfigBase):
             h2_soc_threshold=8.0,
             t_min_heating_in_celsius=20.0,
             t_max_heating_in_celsius=20.5,
-            t_min_dhw_in_celsius=50,
+            t_min_dhw_in_celsius=42,
             t_max_dhw_in_celsius=60,
             day_of_heating_season_begin=270,
             day_of_heating_season_end=150,
@@ -115,50 +143,14 @@ class L1CHPControllerConfig(ConfigBase):
         component_id: Optional[ComponentID] = None,
     ) -> "L1CHPControllerConfig":
         """Returns default configuration for the CHP controller, when buffer storage for heating is available."""
-        # minus - 1 in heating season, so that buffer heats up one day ahead, and modelling to building works.
-        if component_id is None:
-            component_id = ComponentID(name="CHPController")
-        config = L1CHPControllerConfig(
-            component_id=component_id,
-            source_weight=1,
-            use=LoadTypes.GAS,
-            electricity_threshold=300,
-            h2_soc_threshold=0,
-            t_min_heating_in_celsius=35.0,
-            t_max_heating_in_celsius=40.0,
-            t_min_dhw_in_celsius=50,
-            t_max_dhw_in_celsius=60,
-            day_of_heating_season_begin=270 - 1,
-            day_of_heating_season_end=150,
-            min_operation_time_in_seconds=3600 * 4,
-            min_idle_time_in_seconds=3600 * 2,
-        )
-        return config
+        return _with_buffer_storage(L1CHPControllerConfig.get_default_config_chp(component_id=component_id))
 
     @staticmethod
     def get_default_config_fuel_cell_with_buffer(
         component_id: Optional[ComponentID] = None,
     ) -> "L1CHPControllerConfig":
         """Returns default configuration for the fuel cell controller, when buffer storage for heating is available."""
-        # minus - 1 in heating season, so that buffer heats up one day ahead, and modelling to building works.
-        if component_id is None:
-            component_id = ComponentID(name="CHPController")
-        config = L1CHPControllerConfig(
-            component_id=component_id,
-            source_weight=1,
-            use=LoadTypes.GREEN_HYDROGEN,
-            electricity_threshold=300,
-            h2_soc_threshold=8.0,
-            t_min_heating_in_celsius=31.0,
-            t_max_heating_in_celsius=40.0,
-            t_min_dhw_in_celsius=42,
-            t_max_dhw_in_celsius=60,
-            day_of_heating_season_begin=270 - 1,
-            day_of_heating_season_end=150,
-            min_operation_time_in_seconds=3600 * 4,
-            min_idle_time_in_seconds=3600 * 2,
-        )
-        return config
+        return _with_buffer_storage(L1CHPControllerConfig.get_default_config_fuel_cell(component_id=component_id))
 
 
 class L1CHPControllerState:

--- a/hisim/components/controller_l1_chp.py
+++ b/hisim/components/controller_l1_chp.py
@@ -8,6 +8,7 @@ CHP is controlled by both (i) thermal demand and (ii) electricity demand - it is
 """
 
 # Owned
+import dataclasses
 import importlib
 from dataclasses import dataclass
 from typing import Optional, List
@@ -30,26 +31,40 @@ __maintainer__ = "Vitor Hugo Bellotto Zago"
 __email__ = "vitor.zago@rwth-aachen.de"
 __status__ = "development"
 
-#: Lower set temperature of the buffer storage, given in °C.
-BUFFER_T_MIN_HEATING_IN_CELSIUS = 35.0
+#: Julian day of the simulation year on which the heating season begins.
+_DAY_OF_HEATING_SEASON_BEGIN = 270
+#: Julian day on which the heating season begins when a buffer storage is present: one day before
+#: the building's, so that the buffer has heated up a day ahead of the building it feeds.
+_BUFFER_DAY_OF_HEATING_SEASON_BEGIN = _DAY_OF_HEATING_SEASON_BEGIN - 1
 #: Upper set temperature of the buffer storage, given in °C.
-BUFFER_T_MAX_HEATING_IN_CELSIUS = 40.0
-#: Julian day the heating season begins on when a buffer storage is present.
-BUFFER_DAY_OF_HEATING_SEASON_BEGIN = 270 - 1
+_BUFFER_T_MAX_HEATING_IN_CELSIUS = 40.0
 
 
-def _with_buffer_storage(config: "L1CHPControllerConfig") -> "L1CHPControllerConfig":
-    """Applies the buffer storage overrides, which are the same ones for either fuel.
+def _with_buffer_storage(
+    config: "L1CHPControllerConfig",
+    *,
+    t_min_heating_in_celsius: float,
+    t_min_dhw_in_celsius: float,
+) -> "L1CHPControllerConfig":
+    """Returns a copy of ``config`` regulated against a buffer storage rather than the building.
 
-    A buffer storage sits on the space heating side alone: it moves the regulated band from the
-    building's room temperature up to the buffer's water temperature, and it begins the heating
-    season one day early, so that the buffer heats up one day ahead and modelling to the building
-    works. It says nothing about the drain hot water storage, whose thresholds therefore stay put.
+    Two of the four changes are the same whichever fuel is burnt, and are taken from the module
+    constants here: the upper bound of the regulated band, which moves from the building's room
+    temperature up to the buffer's water temperature, and the start of the heating season, which
+    comes one day early so that the buffer is warm a day before the building calls for it.
+
+    The two lower bounds are *not* the same for both fuels - the gas and the hydrogen factory have
+    carried different ones since 2023, for reasons nothing on record explains, see
+    :class:`L1CHPControllerConfig` - so the caller passes them rather than this function choosing.
+    ``config`` itself is never modified.
     """
-    config.t_min_heating_in_celsius = BUFFER_T_MIN_HEATING_IN_CELSIUS
-    config.t_max_heating_in_celsius = BUFFER_T_MAX_HEATING_IN_CELSIUS
-    config.day_of_heating_season_begin = BUFFER_DAY_OF_HEATING_SEASON_BEGIN
-    return config
+    return dataclasses.replace(
+        config,
+        t_min_heating_in_celsius=t_min_heating_in_celsius,
+        t_max_heating_in_celsius=_BUFFER_T_MAX_HEATING_IN_CELSIUS,
+        t_min_dhw_in_celsius=t_min_dhw_in_celsius,
+        day_of_heating_season_begin=_BUFFER_DAY_OF_HEATING_SEASON_BEGIN,
+    )
 
 
 @dataclass_json
@@ -57,11 +72,16 @@ def _with_buffer_storage(config: "L1CHPControllerConfig") -> "L1CHPControllerCon
 class L1CHPControllerConfig(ConfigBase):
     """CHP Controller Config.
 
-    The four default configurations are two fuels - gas and green hydrogen, which differ in ``use``
-    and in the hydrogen storage threshold that only the fuel cell reads - crossed with the one
-    buffer storage override in :func:`_with_buffer_storage`. Everything else, the drain hot water
-    band included, is the same for both fuels, because nothing the controller does with those
-    thresholds depends on what is burnt.
+    The four default configurations cross two fuels - gas and green hydrogen, which differ in
+    ``use`` and in the hydrogen storage threshold that is only non-zero for the fuel cell - with
+    the presence of a buffer storage. Each of the four carries the temperature thresholds it was
+    written with in 2023, and they are not symmetric: the lower drain hot water bound runs 42 / 50
+    / 50 / 42 °C over chp, fuel cell, chp-with-buffer and fuel-cell-with-buffer, and a buffer
+    raises the lower heating bound to 35.0 °C on the gas axis but to 31.0 °C on the hydrogen one,
+    so the buffer axis differs per fuel. Nothing in this module, in the sibling controllers, in the
+    tests or in the commit history says why, and the values are kept as they stand rather than
+    guessed at: normalising them would change the behaviour of every simulation that uses them on
+    inference alone.
     """
 
     component_id: ComponentID
@@ -90,6 +110,34 @@ class L1CHPControllerConfig(ConfigBase):
     # minimal resting time of heat source
     min_idle_time_in_seconds: int
 
+    def __post_init__(self) -> None:
+        """Refuses a set temperature band whose bounds are equal or the wrong way round.
+
+        :meth:`L1CHPController.determine_heating_mode` reads both bands as a state of charge - the
+        measured temperature's position inside the band, divided by the band's width - to decide
+        which of the two vessels is the emptier one and gets the heat. Equal bounds make that a
+        division by zero, and inverted bounds flip its sign, so the controller would quietly serve
+        whichever vessel is the fuller one instead. Neither surfaces as a failure later, so the
+        configuration is where both stop. The check covers the deserialising path and
+        :func:`dataclasses.replace` as well, because both route through ``__init__``.
+
+        Raises:
+            ValueError: If either band's lower bound is not strictly below its upper one, naming
+                the pair and both of its values.
+        """
+        if self.t_min_heating_in_celsius >= self.t_max_heating_in_celsius:
+            raise ValueError(
+                "The lower heating set temperature must be strictly below the upper one, but "
+                f"t_min_heating_in_celsius is {self.t_min_heating_in_celsius} °C and "
+                f"t_max_heating_in_celsius is {self.t_max_heating_in_celsius} °C."
+            )
+        if self.t_min_dhw_in_celsius >= self.t_max_dhw_in_celsius:
+            raise ValueError(
+                "The lower drain hot water set temperature must be strictly below the upper one, "
+                f"but t_min_dhw_in_celsius is {self.t_min_dhw_in_celsius} °C and "
+                f"t_max_dhw_in_celsius is {self.t_max_dhw_in_celsius} °C."
+            )
+
     @staticmethod
     def get_default_config_chp(
         component_id: Optional[ComponentID] = None,
@@ -107,7 +155,7 @@ class L1CHPControllerConfig(ConfigBase):
             t_max_heating_in_celsius=20.5,
             t_min_dhw_in_celsius=42,
             t_max_dhw_in_celsius=60,
-            day_of_heating_season_begin=270,
+            day_of_heating_season_begin=_DAY_OF_HEATING_SEASON_BEGIN,
             day_of_heating_season_end=150,
             min_operation_time_in_seconds=3600 * 4,
             min_idle_time_in_seconds=3600 * 2,
@@ -129,9 +177,9 @@ class L1CHPControllerConfig(ConfigBase):
             h2_soc_threshold=8.0,
             t_min_heating_in_celsius=20.0,
             t_max_heating_in_celsius=20.5,
-            t_min_dhw_in_celsius=42,
+            t_min_dhw_in_celsius=50,
             t_max_dhw_in_celsius=60,
-            day_of_heating_season_begin=270,
+            day_of_heating_season_begin=_DAY_OF_HEATING_SEASON_BEGIN,
             day_of_heating_season_end=150,
             min_operation_time_in_seconds=3600 * 4,
             min_idle_time_in_seconds=3600 * 2,
@@ -143,14 +191,22 @@ class L1CHPControllerConfig(ConfigBase):
         component_id: Optional[ComponentID] = None,
     ) -> "L1CHPControllerConfig":
         """Returns default configuration for the CHP controller, when buffer storage for heating is available."""
-        return _with_buffer_storage(L1CHPControllerConfig.get_default_config_chp(component_id=component_id))
+        return _with_buffer_storage(
+            L1CHPControllerConfig.get_default_config_chp(component_id=component_id),
+            t_min_heating_in_celsius=35.0,
+            t_min_dhw_in_celsius=50,
+        )
 
     @staticmethod
     def get_default_config_fuel_cell_with_buffer(
         component_id: Optional[ComponentID] = None,
     ) -> "L1CHPControllerConfig":
         """Returns default configuration for the fuel cell controller, when buffer storage for heating is available."""
-        return _with_buffer_storage(L1CHPControllerConfig.get_default_config_fuel_cell(component_id=component_id))
+        return _with_buffer_storage(
+            L1CHPControllerConfig.get_default_config_fuel_cell(component_id=component_id),
+            t_min_heating_in_celsius=31.0,
+            t_min_dhw_in_celsius=42,
+        )
 
 
 class L1CHPControllerState:

--- a/tests/test_generic_chp.py
+++ b/tests/test_generic_chp.py
@@ -4,16 +4,18 @@ Covers integration of ``generic_chp.SimpleCHP`` with ``controller_l1_chp.L1CHPCo
 under various demand/hydrogen scenarios, plus unit checks of ``CHPConfig``
 default-config builders and ``GenericCHPState.clone``.
 
-The ``L1CHPControllerConfig`` defaults used here changed with P4 decision D-4: the four
-factories used to cross fuel with buffer inconsistently - ``t_min_dhw_in_celsius`` ran
-42/50/50/42 over chp, fuel cell, chp-with-buffer and fuel-cell-with-buffer, and the buffer
-raised ``t_min_heating_in_celsius`` to 35.0 for gas but to 31.0 for hydrogen. No comment, test
-or commit ever gave a reason for either flip, so they were read as copy errors and normalised
-onto the first-written values. The last two tests here pin the normalised vocabulary, so that
-the declarative conversion can mint a ``gas`` and a ``hydrogen`` preset plus one buffer override.
+``L1CHPControllerConfig`` carries four default configurations whose thresholds are not
+symmetric: ``t_min_dhw_in_celsius`` runs 42/50/50/42 over chp, fuel cell, chp-with-buffer and
+fuel-cell-with-buffer, and a buffer raises ``t_min_heating_in_celsius`` to 35.0 for gas but to
+31.0 for hydrogen. Nothing in the module, the tests or the commit history explains either, so
+the values stand as they were written in 2023 and ``test_chp_controller_default_thresholds``
+pins all four as literals - a pin that read its expectation off a sibling factory would agree
+with any drift that happened to move both.
 """
 
 # -*- coding: utf-8 -*-
+import dataclasses
+
 import pytest
 from tests import functions_for_testing as fft
 
@@ -40,18 +42,24 @@ def test_chp_system() -> None:
       - CHP shuts down when heat is not needed (temperatures above thresholds).
       - CHP shuts down when electricity is not needed (electricity target positive).
 
-    The fuel cell with buffer now regulates the buffer between 35.0 °C and 40.0 °C rather than
-    between 31.0 °C and 40.0 °C (D-4), and two things this test used to lean on had to be put
-    right for the second scenario to keep meaning what it says:
+    The controller is the fuel cell with a buffer storage, which regulates the buffer between
+    31.0 °C and 40.0 °C. Two things this test used to lean on had to be put right for the second
+    scenario to keep meaning what it says:
 
-    * The CHP's on/off input was wired to the controller's *heating mode* channel, so ``state.state``
-      was the mode and every "shuts down" assertion below was really an assertion about which vessel
-      was being heated. With the old 31.0 °C the second scenario's two states of charge came out
-      exactly equal - ``(30 - 31) / (40 - 31)`` and ``(40 - 42) / (60 - 42)`` are both -1/9, to the
-      last bit - so the mode fell to 0 and the outputs read as zero. At 35.0 °C the tie is gone.
-      The input is now wired to the on/off channel, which is what the assertions talk about.
+    * The CHP's on/off input was wired to the controller's *heating mode* channel, so what arrived
+      at the CHP as "run" was really "heat the building rather than the water", and every "shuts
+      down" assertion below was an assertion about which vessel was being served. In the second
+      scenario the two states of charge tie exactly - ``(30 - 31) / (40 - 31)`` and
+      ``(40 - 42) / (60 - 42)`` are both -1/9, to the last bit - so the mode fell to 0 and every
+      output read as zero whatever the hydrogen store did. The input is now wired to the on/off
+      channel, which is what the assertions talk about.
     * The second scenario then has to run long enough for the machine to be allowed to stop: the
       minimum *operation* time, not the minimum idle time, is what holds a running CHP on.
+
+    The scenario's temperatures are left exactly as they were, tie included: once the on/off
+    channel is the one being read, the tie only decides which vessel would be served, not whether
+    the machine runs, and the second scenario's assertions fail when the hydrogen state of charge
+    below is raised from 0 to 50 - which is the check they were always meant to be.
     """
     seconds_per_timestep = 60
     thermal_power = 500  # thermal power in Watt
@@ -307,55 +315,106 @@ def test_generic_chp_state_clone_independence() -> None:
 
 
 @pytest.mark.base
-def test_chp_controller_fuels_differ_only_in_the_fuel() -> None:
-    """The gas and hydrogen defaults agree on every threshold that is not about the fuel (D-4).
+def test_chp_controller_default_thresholds() -> None:
+    """Pins every threshold that the four default controller configurations carry.
 
-    Before D-4 the fuel cell asked for 50 °C of drain hot water where the CHP asked for 42 °C.
-    Nothing the controller computes from that threshold - the storage's state of charge and the
-    decision to heat water rather than the building - knows what is burnt, so the two now agree.
+    They cross two fuels with the presence of a buffer storage, and the numbers are not
+    symmetric: the lower drain hot water bound runs 42 / 50 / 50 / 42 °C down the list below, and
+    a buffer raises the lower heating bound to 35.0 °C for gas but to 31.0 °C for hydrogen.
+    Nothing on record says why, so the values are kept as they were written in 2023 rather than
+    guessed at, and pinned here so that any later change to one of them has to be deliberate.
+
+    Every expectation is a literal. Checking one factory against another would pass just as
+    happily if both of them drifted, which is the change this is meant to catch.
     """
-    gas = controller_l1_chp.L1CHPControllerConfig.get_default_config_chp()
-    hydrogen = controller_l1_chp.L1CHPControllerConfig.get_default_config_fuel_cell()
+    config_class = controller_l1_chp.L1CHPControllerConfig
+    expected: dict[str, dict[str, object]] = {
+        "chp": {
+            "component_name": "CHPController",
+            "use": lt.LoadTypes.GAS,
+            "h2_soc_threshold": 0,
+            "t_min_heating_in_celsius": 20.0,
+            "t_max_heating_in_celsius": 20.5,
+            "t_min_dhw_in_celsius": 42,
+            "t_max_dhw_in_celsius": 60,
+            "day_of_heating_season_begin": 270,
+            "day_of_heating_season_end": 150,
+            "min_operation_time_in_seconds": 3600 * 4,
+            "min_idle_time_in_seconds": 3600 * 2,
+        },
+        "fuel_cell": {
+            "component_name": "FuelCellController",
+            "use": lt.LoadTypes.GREEN_HYDROGEN,
+            "h2_soc_threshold": 8.0,
+            "t_min_heating_in_celsius": 20.0,
+            "t_max_heating_in_celsius": 20.5,
+            "t_min_dhw_in_celsius": 50,
+            "t_max_dhw_in_celsius": 60,
+            "day_of_heating_season_begin": 270,
+            "day_of_heating_season_end": 150,
+            "min_operation_time_in_seconds": 3600 * 4,
+            "min_idle_time_in_seconds": 3600 * 2,
+        },
+        "chp_with_buffer": {
+            "component_name": "CHPController",
+            "use": lt.LoadTypes.GAS,
+            "h2_soc_threshold": 0,
+            "t_min_heating_in_celsius": 35.0,
+            "t_max_heating_in_celsius": 40.0,
+            "t_min_dhw_in_celsius": 50,
+            "t_max_dhw_in_celsius": 60,
+            "day_of_heating_season_begin": 269,
+            "day_of_heating_season_end": 150,
+            "min_operation_time_in_seconds": 3600 * 4,
+            "min_idle_time_in_seconds": 3600 * 2,
+        },
+        "fuel_cell_with_buffer": {
+            "component_name": "FuelCellController",
+            "use": lt.LoadTypes.GREEN_HYDROGEN,
+            "h2_soc_threshold": 8.0,
+            "t_min_heating_in_celsius": 31.0,
+            "t_max_heating_in_celsius": 40.0,
+            "t_min_dhw_in_celsius": 42,
+            "t_max_dhw_in_celsius": 60,
+            "day_of_heating_season_begin": 269,
+            "day_of_heating_season_end": 150,
+            "min_operation_time_in_seconds": 3600 * 4,
+            "min_idle_time_in_seconds": 3600 * 2,
+        },
+    }
 
-    assert gas.use == lt.LoadTypes.GAS
-    assert hydrogen.use == lt.LoadTypes.GREEN_HYDROGEN
-    assert gas.h2_soc_threshold == 0
-    assert hydrogen.h2_soc_threshold == 8.0
-    assert gas.t_min_dhw_in_celsius == hydrogen.t_min_dhw_in_celsius == 42
-
-    differing_fields = {"component_id", "use", "h2_soc_threshold"}
-    for field in gas.to_dict():
-        if field in differing_fields:
-            continue
-        assert gas.to_dict()[field] == hydrogen.to_dict()[field], field
+    for factory_name, fields in expected.items():
+        config = getattr(config_class, "get_default_config_" + factory_name)()
+        actual: dict[str, object] = {
+            field: config.component_id.name if field == "component_name" else getattr(config, field)
+            for field in fields
+        }
+        assert actual == fields, factory_name
 
 
 @pytest.mark.base
-def test_chp_controller_buffer_override_is_one_thing() -> None:
-    """The buffer changes the same three fields by the same values for either fuel (D-4).
+def test_chp_controller_config_refuses_a_heating_band_of_zero_width() -> None:
+    """Equal heating bounds are refused at construction, rather than dividing by zero later.
 
-    Before D-4 the buffer meant 35.0 °C for gas and 31.0 °C for hydrogen, and it also moved the
-    drain hot water threshold, in opposite directions per fuel. A buffer storage sits on the space
-    heating side only, so it may move the heating band and the start of the heating season, and
-    nothing else.
+    ``determine_heating_mode`` reads the building's heating level as the measured temperature's
+    position inside the band divided by the band's width, so a band of zero width would raise
+    only in the middle of a simulation, if at all.
     """
-    config_class = controller_l1_chp.L1CHPControllerConfig
-    pairs = [
-        (config_class.get_default_config_chp(), config_class.get_default_config_chp_with_buffer()),
-        (config_class.get_default_config_fuel_cell(), config_class.get_default_config_fuel_cell_with_buffer()),
-    ]
-    overrides = []
-    for without_buffer, with_buffer in pairs:
-        assert with_buffer.t_min_heating_in_celsius == 35.0
-        assert with_buffer.t_max_heating_in_celsius == 40.0
-        assert with_buffer.day_of_heating_season_begin == 269
-        assert with_buffer.t_min_dhw_in_celsius == without_buffer.t_min_dhw_in_celsius
-        plain, buffered = without_buffer.to_dict(), with_buffer.to_dict()
-        overrides.append({field: buffered[field] for field in plain if plain[field] != buffered[field]})
+    config = controller_l1_chp.L1CHPControllerConfig.get_default_config_chp()
 
-    assert overrides[0] == overrides[1]
-    assert set(overrides[0]) == {
-        "t_min_heating_in_celsius",
-        "t_max_heating_in_celsius",
-        "day_of_heating_season_begin",
-    }
+    with pytest.raises(ValueError, match="t_min_heating_in_celsius"):
+        dataclasses.replace(config, t_min_heating_in_celsius=config.t_max_heating_in_celsius)
+
+
+@pytest.mark.base
+def test_chp_controller_config_refuses_an_inverted_dhw_band() -> None:
+    """A lower drain hot water bound above the upper one is refused at construction.
+
+    An inverted band does not fail anywhere later: it flips the sign of the storage's heating
+    level, so the controller would quietly serve the fuller vessel and the run would look like a
+    working simulation of a differently configured house.
+    """
+    config = controller_l1_chp.L1CHPControllerConfig.get_default_config_chp()
+
+    with pytest.raises(ValueError, match="t_min_dhw_in_celsius"):
+        dataclasses.replace(config, t_min_dhw_in_celsius=config.t_max_dhw_in_celsius + 1)

--- a/tests/test_generic_chp.py
+++ b/tests/test_generic_chp.py
@@ -3,6 +3,14 @@
 Covers integration of ``generic_chp.SimpleCHP`` with ``controller_l1_chp.L1CHPController``
 under various demand/hydrogen scenarios, plus unit checks of ``CHPConfig``
 default-config builders and ``GenericCHPState.clone``.
+
+The ``L1CHPControllerConfig`` defaults used here changed with P4 decision D-4: the four
+factories used to cross fuel with buffer inconsistently - ``t_min_dhw_in_celsius`` ran
+42/50/50/42 over chp, fuel cell, chp-with-buffer and fuel-cell-with-buffer, and the buffer
+raised ``t_min_heating_in_celsius`` to 35.0 for gas but to 31.0 for hydrogen. No comment, test
+or commit ever gave a reason for either flip, so they were read as copy errors and normalised
+onto the first-written values. The last two tests here pin the normalised vocabulary, so that
+the declarative conversion can mint a ``gas`` and a ``hydrogen`` preset plus one buffer override.
 """
 
 # -*- coding: utf-8 -*-
@@ -31,6 +39,19 @@ def test_chp_system() -> None:
       - CHP shuts down when hydrogen SOC is zero.
       - CHP shuts down when heat is not needed (temperatures above thresholds).
       - CHP shuts down when electricity is not needed (electricity target positive).
+
+    The fuel cell with buffer now regulates the buffer between 35.0 °C and 40.0 °C rather than
+    between 31.0 °C and 40.0 °C (D-4), and two things this test used to lean on had to be put
+    right for the second scenario to keep meaning what it says:
+
+    * The CHP's on/off input was wired to the controller's *heating mode* channel, so ``state.state``
+      was the mode and every "shuts down" assertion below was really an assertion about which vessel
+      was being heated. With the old 31.0 °C the second scenario's two states of charge came out
+      exactly equal - ``(30 - 31) / (40 - 31)`` and ``(40 - 42) / (60 - 42)`` are both -1/9, to the
+      last bit - so the mode fell to 0 and the outputs read as zero. At 35.0 °C the tie is gone.
+      The input is now wired to the on/off channel, which is what the assertions talk about.
+    * The second scenario then has to run long enough for the machine to be allowed to stop: the
+      minimum *operation* time, not the minimum idle time, is what holds a running CHP on.
     """
     seconds_per_timestep = 60
     thermal_power = 500  # thermal power in Watt
@@ -94,7 +115,7 @@ def test_chp_system() -> None:
     my_chp_controller.building_temperature_channel.source_output = buffer_temperature
     my_chp_controller.dhw_temperature_channel.source_output = boiler_temperature
 
-    my_chp.chp_onoff_signal_channel.source_output = my_chp_controller.chp_heatingmode_signal_channel
+    my_chp.chp_onoff_signal_channel.source_output = my_chp_controller.chp_onoff_signal_channel
     my_chp.chp_heatingmode_signal_channel.source_output = my_chp_controller.chp_heatingmode_signal_channel
 
     # Add Global Index and set values for fake Inputs
@@ -132,7 +153,7 @@ def test_chp_system() -> None:
 
     for timestep_t in range(
         timestep,
-        timestep + int((chp_controller_config.min_idle_time_in_seconds / seconds_per_timestep) + 2),
+        timestep + int((chp_controller_config.min_operation_time_in_seconds / seconds_per_timestep) + 2),
     ):
         my_chp_controller.i_simulate(timestep_t, single_timestep_values, False)
         my_chp.i_simulate(timestep_t, single_timestep_values, False)
@@ -283,3 +304,58 @@ def test_generic_chp_state_clone_independence() -> None:
     cloned.state = 5
     assert original.state == 1
     assert cloned.state == 5
+
+
+@pytest.mark.base
+def test_chp_controller_fuels_differ_only_in_the_fuel() -> None:
+    """The gas and hydrogen defaults agree on every threshold that is not about the fuel (D-4).
+
+    Before D-4 the fuel cell asked for 50 °C of drain hot water where the CHP asked for 42 °C.
+    Nothing the controller computes from that threshold - the storage's state of charge and the
+    decision to heat water rather than the building - knows what is burnt, so the two now agree.
+    """
+    gas = controller_l1_chp.L1CHPControllerConfig.get_default_config_chp()
+    hydrogen = controller_l1_chp.L1CHPControllerConfig.get_default_config_fuel_cell()
+
+    assert gas.use == lt.LoadTypes.GAS
+    assert hydrogen.use == lt.LoadTypes.GREEN_HYDROGEN
+    assert gas.h2_soc_threshold == 0
+    assert hydrogen.h2_soc_threshold == 8.0
+    assert gas.t_min_dhw_in_celsius == hydrogen.t_min_dhw_in_celsius == 42
+
+    differing_fields = {"component_id", "use", "h2_soc_threshold"}
+    for field in gas.to_dict():
+        if field in differing_fields:
+            continue
+        assert gas.to_dict()[field] == hydrogen.to_dict()[field], field
+
+
+@pytest.mark.base
+def test_chp_controller_buffer_override_is_one_thing() -> None:
+    """The buffer changes the same three fields by the same values for either fuel (D-4).
+
+    Before D-4 the buffer meant 35.0 °C for gas and 31.0 °C for hydrogen, and it also moved the
+    drain hot water threshold, in opposite directions per fuel. A buffer storage sits on the space
+    heating side only, so it may move the heating band and the start of the heating season, and
+    nothing else.
+    """
+    config_class = controller_l1_chp.L1CHPControllerConfig
+    pairs = [
+        (config_class.get_default_config_chp(), config_class.get_default_config_chp_with_buffer()),
+        (config_class.get_default_config_fuel_cell(), config_class.get_default_config_fuel_cell_with_buffer()),
+    ]
+    overrides = []
+    for without_buffer, with_buffer in pairs:
+        assert with_buffer.t_min_heating_in_celsius == 35.0
+        assert with_buffer.t_max_heating_in_celsius == 40.0
+        assert with_buffer.day_of_heating_season_begin == 269
+        assert with_buffer.t_min_dhw_in_celsius == without_buffer.t_min_dhw_in_celsius
+        plain, buffered = without_buffer.to_dict(), with_buffer.to_dict()
+        overrides.append({field: buffered[field] for field in plain if plain[field] != buffered[field]})
+
+    assert overrides[0] == overrides[1]
+    assert set(overrides[0]) == {
+        "t_min_heating_in_celsius",
+        "t_max_heating_in_celsius",
+        "day_of_heating_season_begin",
+    }


### PR DESCRIPTION
﻿## D-4: the CHP controller's buffer factories share one helper; the thresholds stay as they were

The four default configurations of `L1CHPControllerConfig` cross a fuel with a buffer storage. The two buffer factories now derive from their fuel's base factory through one pure helper that applies the shared buffer parts and takes the per-fuel lower bounds. The original 2023 thresholds are kept unchanged and their asymmetry is recorded as unexplained. A `__post_init__` check refuses a band whose lower bound is not strictly below its upper one, and the four factories are pinned as literals in the tests. No setup, energy-system file or golden reference instantiates the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
