### PR TITLE
D-12: a scaled PV system records the share it was scaled by, so its record re-executes

### DIFF
--- a/hisim/components/generic_pv_system.py
+++ b/hisim/components/generic_pv_system.py
@@ -16,7 +16,7 @@ economic and CO2-footprint figures used in post-processing.
 import datetime
 import enum
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -139,11 +139,32 @@ class PVSystemConfig(ConfigBase):
     #: See ``roadmap/pylpg_flakiness.md`` F7.
     weather_identity: Sizable[str] = sized_field(rule=Size.WEATHER_IDENTITY, value_type=str)
 
+    def __post_init__(self) -> None:
+        """Refuses a share of the rooftop maximum that is not a share.
+
+        The field is a fraction in ``[0, 1]``: both factories multiply the array's maximum by it,
+        so a percentage typed as ``50`` sizes a fifty-fold rooftop and a negative share sizes a
+        generator that consumes -- each producing a run that finishes and reports plausible
+        numbers for a question nobody asked. It is also the provenance a record carries beside the
+        power it explains, so a value outside the range is a record that cannot be read back as
+        one. Only the share is checked here: ``power_in_watt`` is a sizable field and may still
+        hold ``AUTO`` or a law at construction time.
+
+        Raises:
+            ValueError: If ``share_of_maximum_pv_potential`` lies outside ``[0, 1]``.
+        """
+        if not 0.0 <= self.share_of_maximum_pv_potential <= 1.0:
+            raise ValueError(
+                "The share of the maximum PV potential is a fraction between 0 and 1, not "
+                f"{self.share_of_maximum_pv_potential}. It is multiplied onto the array's maximum "
+                "power, so a percentage or a negative value would size a different array in silence."
+            )
+
     @classmethod
     def get_default_pv_system(
         cls,
         name: str = "PVSystem",
-        power_in_watt: float = 10e3,
+        maximum_power_in_watt: float = 10e3,
         source_weight: int = 0,
         share_of_maximum_pv_potential: float = 1.0,
         location: str = "Aachen",
@@ -155,19 +176,14 @@ class PVSystemConfig(ConfigBase):
     ) -> "PVSystemConfig":
         """Gets a default PV system.
 
-        ``power_in_watt`` is the array's *maximum*, not its result: the share is applied to it
-        here, and the field the returned config carries is what the share left of it. That is the
-        same meaning ``get_scaled_pv_system`` records, reached from the other side - there the
-        maximum comes from the rooftop area instead of from an argument.
-
-        The consequence is worth stating where it is easy to trip over: the ``(power_in_watt,
-        share_of_maximum_pv_potential)`` pair a *record* carries is a result and its provenance,
-        so handing a recorded pair back to this factory would apply the share a second time. A
-        record is rebuilt from its fields, never by replaying a factory over them.
+        ``maximum_power_in_watt`` is the array's maximum; the share is applied to it here, exactly
+        once, and the ``power_in_watt`` field of the returned config is the result. A *record*
+        therefore carries a result beside its provenance, so it is rebuilt from its fields and
+        never replayed through this factory, which would apply the share a second time.
         """
         if component_id is None:
             component_id = ComponentID(name=name)
-        power_in_watt = power_in_watt * share_of_maximum_pv_potential
+        power_in_watt = maximum_power_in_watt * share_of_maximum_pv_potential
         return PVSystemConfig(
             time=2019,
             power_in_watt=power_in_watt,
@@ -226,16 +242,20 @@ class PVSystemConfig(ConfigBase):
         config = PVSystemConfig.get_default_pv_system(
             component_id=component_id,
             location=location,
-            power_in_watt=total_pv_power_in_watt,
+            maximum_power_in_watt=total_pv_power_in_watt,
             module_name=module_name,
             module_database=module_database,
             inverter_name=inverter_name,
             inverter_database=inverter_database,
         )
         # Stamped after the fact, not passed in above: the power already carries the share.
-        config.share_of_maximum_pv_potential = share_of_maximum_pv_potential
-        config.load_module_data = load_module_data
-        return config
+        # Through ``replace`` rather than by assignment, so that the share meets the range check
+        # in ``__post_init__`` on this path too.
+        return replace(
+            config,
+            share_of_maximum_pv_potential=share_of_maximum_pv_potential,
+            load_module_data=load_module_data,
+        )
 
     @classmethod
     def size_pv_system(

--- a/hisim/components/generic_pv_system.py
+++ b/hisim/components/generic_pv_system.py
@@ -153,7 +153,18 @@ class PVSystemConfig(ConfigBase):
         inverter_name: str = "Enphase Energy Inc : IQ8P-3P-72-E-DOM-US [208V]",
         inverter_database: PVLibModuleAndInverterEnum = PVLibModuleAndInverterEnum.CEC_INVERTER_DATABASE,  # noqa: E501
     ) -> "PVSystemConfig":
-        """Gets a default PV system."""
+        """Gets a default PV system.
+
+        ``power_in_watt`` is the array's *maximum*, not its result: the share is applied to it
+        here, and the field the returned config carries is what the share left of it. That is the
+        same meaning ``get_scaled_pv_system`` records, reached from the other side - there the
+        maximum comes from the rooftop area instead of from an argument.
+
+        The consequence is worth stating where it is easy to trip over: the ``(power_in_watt,
+        share_of_maximum_pv_potential)`` pair a *record* carries is a result and its provenance,
+        so handing a recorded pair back to this factory would apply the share a second time. A
+        record is rebuilt from its fields, never by replaying a factory over them.
+        """
         if component_id is None:
             component_id = ComponentID(name=name)
         power_in_watt = power_in_watt * share_of_maximum_pv_potential

--- a/hisim/renovisor/spec.md
+++ b/hisim/renovisor/spec.md
@@ -160,7 +160,7 @@ building types `SFH`, `TH`, `AB` and age bands `01`–`10`, each in refurbishmen
 |---|---|---|
 | `heating_system` | setup selection | The `HeatingSystems` enum member matching §4.1. |
 | `heat_distribution_system` | `heating.emitter` | `underfloor`→`HEAT_DISTRIBUTION_SYSTEM_FLOORHEATING`, `steel_panel_radiators`/`cast_iron`→`HEAT_DISTRIBUTION_SYSTEM_RADIATOR`, absent→floor heating (building-sizer default). |
-| `share_of_maximum_pv_potential` | `pv.kWp` | `0.0` if `kWp == 0`, else `1.0` (the rooftop capacity in ArcheTypeConfig carries the size). Only those two values are ever emitted, so no RenoVisor run is touched by the share the scaled photovoltaic factory records; the array's `PVSystemConfig` states the share it was really sized with, and its power is that share applied exactly once. |
+| `share_of_maximum_pv_potential` | `pv.kWp` | `0.0` if `kWp == 0`, else `1.0` (the rooftop capacity in ArcheTypeConfig carries the size). Only those two values are ever emitted, so no RenoVisor simulation *result* changes now that the scaled photovoltaic factory records the share it applied: for a payload with `pv.kWp == 0` the recorded provenance field reads `0.0` instead of the former `1.0`, and the power is zero either way. The array's `PVSystemConfig` states the share it was really sized with, and its power is that share applied exactly once. |
 | `use_battery_and_ems` | `battery.kWh` | `kWh > 0` → `True`, else `False`. Battery **size** is auto-sized by the setup; the requested `kWh` is recorded as approximated. |
 
 ### 4.4 Occupancy lookup

--- a/hisim/renovisor/spec.md
+++ b/hisim/renovisor/spec.md
@@ -160,7 +160,7 @@ building types `SFH`, `TH`, `AB` and age bands `01`–`10`, each in refurbishmen
 |---|---|---|
 | `heating_system` | setup selection | The `HeatingSystems` enum member matching §4.1. |
 | `heat_distribution_system` | `heating.emitter` | `underfloor`→`HEAT_DISTRIBUTION_SYSTEM_FLOORHEATING`, `steel_panel_radiators`/`cast_iron`→`HEAT_DISTRIBUTION_SYSTEM_RADIATOR`, absent→floor heating (building-sizer default). |
-| `share_of_maximum_pv_potential` | `pv.kWp` | `0.0` if `kWp == 0`, else `1.0` (the rooftop capacity in ArcheTypeConfig carries the size). |
+| `share_of_maximum_pv_potential` | `pv.kWp` | `0.0` if `kWp == 0`, else `1.0` (the rooftop capacity in ArcheTypeConfig carries the size). Only those two values are ever emitted, so no RenoVisor run is touched by the share the scaled photovoltaic factory records; the array's `PVSystemConfig` states the share it was really sized with, and its power is that share applied exactly once. |
 | `use_battery_and_ems` | `battery.kWh` | `kWh > 0` → `True`, else `False`. Battery **size** is auto-sized by the setup; the requested `kWh` is recorded as approximated. |
 
 ### 4.4 Occupancy lookup

--- a/roadmap/declarative_energy_systems/p4_class_survey.md
+++ b/roadmap/declarative_energy_systems/p4_class_survey.md
@@ -722,10 +722,15 @@ Added by inspection of `ls hisim/components`: `dual_circuit_system.py` (`SetTemp
 
 ## B‑c — Electricity generation and storage
 
-### `PVSystemConfig` (`hisim/components/generic_pv_system.py:98`) → `PVSystem` (`:267`)
+### `PVSystemConfig` (`hisim/components/generic_pv_system.py:100`) → `PVSystem` (`:293`)
+
+*(The `file:line` references in the numbered items below are the ones the survey recorded and have
+drifted since; only the numbers quoted in item 2 and item 7 are against today's file.)*
 
 1. The pvlib rooftop array; 17 instantiations, the most‑used unconverted class in the fleet (`p3 §3b`).
-2. **status: to convert — and it carries a recording defect that must be decided first (D‑12).**
+2. **status: to convert.** The recording defect it carried is fixed: D‑12 is answered (a) and
+   executed in the code (`:236-237`, test `tests/test_generic_pv_system.py`). What is left for B5 is the
+   law form, not the physics.
 3. **Factories.**
    - `get_default_pv_system(name="PVSystem", power_in_watt=10e3, source_weight=0, share_of_maximum_pv_potential=1.0, location="Aachen", component_id=None, module_name="Trina Solar TSM-435NE09RC.05", module_database=CEC_MODULE_DATABASE, inverter_name="Enphase Energy Inc : IQ8P-3P-72-E-DOM-US [208V]", inverter_database=CEC_INVERTER_DATABASE)` — `:136`. setups **15**, tests **3** + 1 method reference (`test_config_enum_serialization.py:70`), hisim **1** (its own caller at `:202`). Four of the 15 call it with **no arguments at all** and thus depend on the 10 kW default: `basic_household.py:86`, `basic_household_with_weather_data_request.py:119`, `default_connections.py:77`, `dynamic_components.py:101`.
    - `get_scaled_pv_system(rooftop_area_in_m2, name="PVSystem", share_of_maximum_pv_potential=1.0, …)` — `:180`. setups **12**, tests **7** (`test_controller_l2_energy_management_system.py:125`, `test_heating_meter.py:92`, `test_gas_meter.py:91`, `test_fuel_meter.py:96`, `test_electricity_meter.py:60`, `test_time_resolution.py:376`, `test_sizing_energy_systems.py:147`), hisim **0**.
@@ -742,13 +747,20 @@ Added by inspection of `ls hisim/components`: `dual_circuit_system.py` (`SetTemp
    - `share_of_maximum_pv_potential` stays a **plain field** (an author/consumer choice, default 1.0 — `hisim/building_sizer_utils/interface_configs/system_config.py:181`). §6's "1 − ST_area/roof" is the roof‑contention many‑reader, deferred.
    - `location: str` is a second hand‑typed copy of the weather location (§6, confidence high); all 12 sizer setups pass `location=weather_location`. Group C owns the Weather side; leave a plain field in B5.
 6. **Facts provided.** `pv_peak_power_in_watt` = resolved `power_in_watt` (inventory §3) — **the fact does not exist in `SizingContext` yet**, and `PVSystemConfig` has no `SIZING_CONTRIBUTIONS`. Its only consumer is the battery.
-7. **Behaviour: neutral for the golden fleet, NOT neutral in general — a recording defect.** `get_scaled_pv_system` applies the share inside `size_pv_system` and then calls `get_default_pv_system` **without forwarding it** (`:202-211`), so the field records `1.0` regardless. Verified:
+7. **Behaviour: the recording defect is fixed; both factories now record the share they applied.** As surveyed, `get_scaled_pv_system` applied the share inside `size_pv_system` and then called `get_default_pv_system` **without forwarding it**, so the field recorded `1.0` regardless:
    ```
+   surveyed (before #638)
    get_scaled_pv_system(rooftop_area_in_m2=100, share_of_maximum_pv_potential=0.5)  -> power 6593.33, share recorded 1.0
    get_scaled_pv_system(rooftop_area_in_m2=100, share_of_maximum_pv_potential=1.0)  -> power 13186.67, share recorded 1.0
    get_default_pv_system(power_in_watt=10000, share_of_maximum_pv_potential=0.5)    -> power 5000.0, share recorded 0.5
    ```
-   The two factories therefore disagree on what the field *means*. Any law that reads `Self("share_of_maximum_pv_potential")` reproduces the `get_default_*` semantics, i.e. it **changes** every `get_scaled_*` result whose share ≠ 1. The golden fleet is safe because `share_of_maximum_pv_potential` defaults to `1.0`; RenoVisor and building‑sizer payloads that set it are not. Also: a realized record written today is **not re‑executable** for share ≠ 1 (EAC2/UC5), because replaying `share=1.0` with the recorded power double‑counts nothing but loses the provenance. → **D‑12.**
+   D‑12 was answered **(a)** and the fix shipped inside #638 (`d50e85de`), which needed an honest share to record its `half_pv` probe column. The scaled factory now stamps the share onto the finished config **after** delegating (`:226-237`) — after, because passing it to `get_default_pv_system` would multiply the power a second time. Re‑verified on `527129eb`:
+   ```
+   get_scaled_pv_system(rooftop_area_in_m2=100, share_of_maximum_pv_potential=0.5)  -> power 6593.33, share recorded 0.5
+   get_scaled_pv_system(rooftop_area_in_m2=100, share_of_maximum_pv_potential=1.0)  -> power 13186.67, share recorded 1.0
+   get_default_pv_system(power_in_watt=10000, share_of_maximum_pv_potential=0.5)    -> power 5000.0, share recorded 0.5
+   ```
+   The two factories therefore agree on what the field *means*: the share that was really applied, the power beside it being the result. A realized record **is** re‑executable for share ≠ 1 (EAC2/UC5), because a record is rebuilt from its fields and the block already carries the scaled power — pinned by `test_a_scaled_pv_record_re_executes_to_the_same_power`. What remains for B5 is only the *law form*: a law reading `Self("share_of_maximum_pv_potential")` over the rooftop maximum reproduces exactly what both factories now do, so the conversion is result‑neutral for every caller, not merely for the golden fleet. No caller was ever affected in practice either — the fleet's share is `1.0` (`system_config.py:181`) and RenoVisor emits only `0.0` or `1.0` (`hisim/renovisor/mapping.py:250`); the one caller that does pass `0.5` is the recorder's own `half_pv` probe. → **D‑12, done.**
 8. **Deletions.** `PVSystem.get_default_config` (`:441`, 0 call sites, diverging module/inverter/database — conflict 5). Both config‑class factories become the two presets. No SimRepository construction‑time keys (`:797` is inside `i_prepare_simulation`, `:649`).
 9. **Flags** (all A2 → `config:`): `integrate_inverter` (`True`), `load_module_data` (`False`, and `get_scaled_pv_system` overrides it *after* delegating, `:210`), `predictive` (`False`), `predictive_control` (`False`).
 10. **Hazards.**
@@ -962,7 +974,7 @@ What it *does* contribute, as dead-or-defective code the gate should sweep up:
 - **`MpcController`, `PIDController`, `Windturbine`, `PriceSignal` — 0 setup uses**, tests only.
 - **`configuration.WarmWaterStorageConfig`, `PVConfig`, `HydrogenStorageConfig`, `LoadConfig`, `ElectricityDemandConfig` — 0 call sites**, all five deletable in one commit.
 - **Not a D13 case but a latent defect:** `SimpleHotWaterStorage.i_simulate` would raise `UnboundLocalError` on `water_mass_flow_rate_from_secondary_heat_generator_in_kg_per_second` (assigned only at `:934`, read at `:971` and `:1091`) if `WATERMASSFLOWRATEOFHEATGENERATOR` ever had a writer again.
-- **Not a D13 case but a recording defect:** `PVSystemConfig.get_scaled_pv_system` records `share_of_maximum_pv_potential = 1.0` regardless of the share it applied (`:198`, `:202-211`; verified). See D‑12.
+- **Not a D13 case, and no longer a defect:** `PVSystemConfig.get_scaled_pv_system` recorded `share_of_maximum_pv_potential = 1.0` regardless of the share it applied (`:198`, `:202-211`; verified). Fixed in #638; it now stamps the real share (`:236`). See D‑12.
 - **No mutable defaults anywhere in group B** — every unconverted config has all fields mandatory (verified over all 21 classes). Group A's `Coordinates` hazard has no analogue here.
 
 ---
@@ -983,10 +995,10 @@ All 12 setups pass `my_building_information.max_thermal_building_demand_in_watt`
 *Consequence:* (a) makes all 13 heat‑distribution setups agree on one law, at the cost of an unwitnessed change in three of them (consider adding one of them to the golden fleet in the same commit); (b) preserves the diff and preserves the inconsistency.
 **Answered 2026-09-10: (a)** — convert and record the diff (16 → 18 °C for the three legacy-factory setups); no `fixed_threshold_16c` preset, and `basic_household_only_heating` is blessed in the same commit.
 
-**D‑12 — `share_of_maximum_pv_potential`: fix the recording or preserve it?**
-`get_scaled_pv_system(share=0.5)` halves the power and records `share = 1.0`; `get_default_pv_system(share=0.5)` halves the power and records `0.5`. Options: (a) **Fix** — the preset's law reads `Self("share_of_maximum_pv_potential")` and the field records the real share. Golden‑neutral (the fleet's share is 1.0, `system_config.py:181`) but changes results for every RenoVisor / building‑sizer payload with `share ≠ 1` that came through the *scaled* path. (b) **Preserve** — the law ignores the field and takes the share as a builder argument, i.e. the field stays a lie. (c) **Delete the field** and make the share a pure builder argument, recording only the resulting `power_in_watt`.
+**D‑12 — `share_of_maximum_pv_potential`: fix the recording or preserve it?** `[answered 2026-09-10]` **(a) fix — records must re‑execute.** As surveyed: `get_scaled_pv_system(share=0.5)` halved the power and recorded `share = 1.0`; `get_default_pv_system(share=0.5)` halved the power and recorded `0.5`. Options were: (a) **Fix** — the preset's law reads `Self("share_of_maximum_pv_potential")` and the field records the real share. Golden‑neutral (the fleet's share is 1.0, `system_config.py:181`) but changes results for every RenoVisor / building‑sizer payload with `share ≠ 1` that came through the *scaled* path. (b) **Preserve** — the law ignores the field and takes the share as a builder argument, i.e. the field stays a lie. (c) **Delete the field** and make the share a pure builder argument, recording only the resulting `power_in_watt`.
 *Consequence:* (a) is the only option under which a realized record re‑executes (EAC2/UC5) for a scaled PV with a share; (b) freezes a field that means two different things depending on which factory built it; (c) loses the provenance the epic exists to provide but is honest.
 **Answered 2026-09-10: (a)** — the law reads `Self("share_of_maximum_pv_potential")` and the field records the real share; golden-neutral, and RenoVisor payloads with a share below one change to what they meant, which the commit and the RenoVisor docs state.
+*Execution:* the physics half of (a) was already shipped inside #638 (`d50e85de`), which needed an honest share for its `half_pv` probe column: the scaled factory stamps the real share after delegating (`generic_pv_system.py:226-237`). No result moved — no caller in the repo passes a share below one outside that probe, the golden fleet is at `1.0`, and RenoVisor emits only `0.0` or `1.0`. Left for B5: the law form only, which is result‑neutral now that both factories agree.
 
 **D‑13 — Keep `rooftop_10kw`?**
 Conflict 3's rule ("rating suffix only for a real catalogue rating") says drop it — 10 kW is a round default. But four setups call `get_default_pv_system()` with no arguments and depend on it (`basic_household.py:86`, `basic_household_with_weather_data_request.py:119`, `default_connections.py:77`, `dynamic_components.py:101`), unlike group A's `air_water_8kw`, which had none. Options: (a) keep `rooftop_10kw` as a documented exception to conflict 3; (b) drop it and give the four setups a `power_in_watt: 10000` override.

--- a/roadmap/declarative_energy_systems/p4_class_survey.md
+++ b/roadmap/declarative_energy_systems/p4_class_survey.md
@@ -724,15 +724,18 @@ Added by inspection of `ls hisim/components`: `dual_circuit_system.py` (`SetTemp
 
 ### `PVSystemConfig` (`hisim/components/generic_pv_system.py:100`) → `PVSystem` (`:293`)
 
-*(The `file:line` references in the numbered items below are the ones the survey recorded and have
-drifted since; only the numbers quoted in item 2 and item 7 are against today's file.)*
+*(The numbered items' line references are as recorded and may have drifted; only items 2 and 7
+were re-verified against today's file.)*
 
 1. The pvlib rooftop array; 17 instantiations, the most‑used unconverted class in the fleet (`p3 §3b`).
 2. **status: to convert.** The recording defect it carried is fixed: D‑12 is answered (a) and
    executed in the code (`:236-237`, test `tests/test_generic_pv_system.py`). What is left for B5 is the
-   law form, not the physics.
+   law form, not the physics. After the #684 review the factory argument was renamed on 2026‑09‑11 —
+   `get_default_pv_system(maximum_power_in_watt=…)`, the field still `power_in_watt` — so the preset
+   and the law of that conversion must not reintroduce a *maximum* named `power_in_watt`; the field
+   is the result, and the share is now range‑checked in `PVSystemConfig.__post_init__`.
 3. **Factories.**
-   - `get_default_pv_system(name="PVSystem", power_in_watt=10e3, source_weight=0, share_of_maximum_pv_potential=1.0, location="Aachen", component_id=None, module_name="Trina Solar TSM-435NE09RC.05", module_database=CEC_MODULE_DATABASE, inverter_name="Enphase Energy Inc : IQ8P-3P-72-E-DOM-US [208V]", inverter_database=CEC_INVERTER_DATABASE)` — `:136`. setups **15**, tests **3** + 1 method reference (`test_config_enum_serialization.py:70`), hisim **1** (its own caller at `:202`). Four of the 15 call it with **no arguments at all** and thus depend on the 10 kW default: `basic_household.py:86`, `basic_household_with_weather_data_request.py:119`, `default_connections.py:77`, `dynamic_components.py:101`.
+   - `get_default_pv_system(name="PVSystem", maximum_power_in_watt=10e3, source_weight=0, share_of_maximum_pv_potential=1.0, location="Aachen", component_id=None, module_name="Trina Solar TSM-435NE09RC.05", module_database=CEC_MODULE_DATABASE, inverter_name="Enphase Energy Inc : IQ8P-3P-72-E-DOM-US [208V]", inverter_database=CEC_INVERTER_DATABASE)` — `:136`. setups **15**, tests **3** + 1 method reference (`test_config_enum_serialization.py:70`), hisim **1** (its own caller at `:202`). Four of the 15 call it with **no arguments at all** and thus depend on the 10 kW default: `basic_household.py:86`, `basic_household_with_weather_data_request.py:119`, `default_connections.py:77`, `dynamic_components.py:101`.
    - `get_scaled_pv_system(rooftop_area_in_m2, name="PVSystem", share_of_maximum_pv_potential=1.0, …)` — `:180`. setups **12**, tests **7** (`test_controller_l2_energy_management_system.py:125`, `test_heating_meter.py:92`, `test_gas_meter.py:91`, `test_fuel_meter.py:96`, `test_electricity_meter.py:60`, `test_time_resolution.py:376`, `test_sizing_energy_systems.py:147`), hisim **0**.
    - `PVSystem.get_default_config(power_in_watt=10e3, source_weight=1, share_of_maximum_pv_potential=1.0, component_id=None)` — `:441`, a **static method on the component class** returning `Any`, pinning `Hanwha HSL60P6-PA-4-250T [2013]` + Sandia databases against the config class's Trina/CEC. **0 call sites anywhere.**
 4. **Presets.** Supplement: `rooftop`, `rooftop_10kw`; conflict 5 resolves "delete the component‑class factory; canonical preset `rooftop` from `get_scaled_pv_system`". **Agreed on `rooftop` and on the deletion.** **Deviation flagged on `rooftop_10kw`, in the opposite direction from group A's D‑6:** 10 kW is a round default, not a catalogue rating, so conflict 3's rule says drop it — but unlike the hplib `_8kw` case, **four setups actually depend on that default** (list above), and dropping it turns four zero‑argument call sites into explicit `power_in_watt: 10000` overrides. Recommend **keeping** `rooftop_10kw` and recording the exception. → part of **D‑13**.

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -304,7 +304,7 @@ def setup_function(
         )
     else:
         my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-            power_in_watt=pv_power_in_watt,
+            maximum_power_in_watt=pv_power_in_watt,
             share_of_maximum_pv_potential=share_of_maximum_pv_potential,
             location=weather_location,
         )

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -262,7 +262,7 @@ def setup_function(
         )
     else:
         my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-            power_in_watt=pv_power_in_watt,
+            maximum_power_in_watt=pv_power_in_watt,
             share_of_maximum_pv_potential=share_of_maximum_pv_potential,
             location=weather_location,
         )

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -270,7 +270,7 @@ def setup_function(
         )
     else:
         my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-            power_in_watt=pv_power_in_watt,
+            maximum_power_in_watt=pv_power_in_watt,
             share_of_maximum_pv_potential=share_of_maximum_pv_potential,
             location=weather_location,
         )

--- a/system_setups/household_gas_solar_thermal_building_sizer.py
+++ b/system_setups/household_gas_solar_thermal_building_sizer.py
@@ -257,7 +257,7 @@ def setup_function(
         )
     else:
         my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-            power_in_watt=pv_power_in_watt,
+            maximum_power_in_watt=pv_power_in_watt,
             share_of_maximum_pv_potential=share_of_maximum_pv_potential,
             location=weather_location,
         )

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -266,7 +266,7 @@ def setup_function(
         )
     else:
         my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-            power_in_watt=pv_power_in_watt,
+            maximum_power_in_watt=pv_power_in_watt,
             share_of_maximum_pv_potential=share_of_maximum_pv_potential,
             location=weather_location,
         )

--- a/system_setups/household_heatpump_car_building_sizer.py
+++ b/system_setups/household_heatpump_car_building_sizer.py
@@ -270,7 +270,7 @@ def setup_function(
         )
     else:
         my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-            power_in_watt=pv_power_in_watt,
+            maximum_power_in_watt=pv_power_in_watt,
             share_of_maximum_pv_potential=share_of_maximum_pv_potential,
             location=weather_location,
         )

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.py
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.py
@@ -257,7 +257,7 @@ def setup_function(
         )
     else:
         my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-            power_in_watt=pv_power_in_watt,
+            maximum_power_in_watt=pv_power_in_watt,
             share_of_maximum_pv_potential=share_of_maximum_pv_potential,
             location=weather_location,
         )

--- a/system_setups/household_hydrogen_boiler_building_sizer.py
+++ b/system_setups/household_hydrogen_boiler_building_sizer.py
@@ -257,7 +257,7 @@ def setup_function(
         )
     else:
         my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-            power_in_watt=pv_power_in_watt,
+            maximum_power_in_watt=pv_power_in_watt,
             share_of_maximum_pv_potential=share_of_maximum_pv_potential,
             location=weather_location,
         )

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -295,7 +295,7 @@ def setup_function(
         )
     else:
         my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-            power_in_watt=pv_power_in_watt,
+            maximum_power_in_watt=pv_power_in_watt,
             share_of_maximum_pv_potential=share_of_maximum_pv_potential,
             location=weather_location,
         )

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -269,7 +269,7 @@ def setup_function(
         )
     else:
         my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-            power_in_watt=pv_power_in_watt,
+            maximum_power_in_watt=pv_power_in_watt,
             share_of_maximum_pv_potential=share_of_maximum_pv_potential,
             location=weather_location,
         )

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -268,7 +268,7 @@ def setup_function(
         )
     else:
         my_photovoltaic_system_config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-            power_in_watt=pv_power_in_watt,
+            maximum_power_in_watt=pv_power_in_watt,
             share_of_maximum_pv_potential=share_of_maximum_pv_potential,
             location=weather_location,
         )

--- a/tests/functions_for_testing.py
+++ b/tests/functions_for_testing.py
@@ -1,10 +1,42 @@
 """Helper functions for testing."""
 # clean
-from typing import ClassVar, Tuple
+from typing import Any, ClassVar, Tuple, Type
+
+import yaml
 
 from hisim.component import ComponentOutput
+from hisim.energy_system.codec import ConfigValueCodec
+from hisim.energy_system.path_resolver import PathResolver
+from hisim.energy_system.record import ConfigBlockWriter
 from hisim.postprocessingoptions import PostProcessingOptions
 from hisim.simulationparameters import SimulationParameters
+
+
+def round_trip_config_block(config: Any, config_class: Type, component_name: str) -> Any:
+    """Sends a configuration through the record's own writer, a YAML file and the reader.
+
+    This is line for line what ``EntryConfigurator._realize_origin``
+    (:mod:`hisim.energy_system.configure`) does for an entry configured by a complete ``config``
+    block: the block writer renders the configuration, the value codec turns the block back into a
+    deserializer payload, the entry's key is injected as the identity the block itself never
+    carries, and the class reads it. The YAML pass in the middle is what makes it a file somebody
+    runs rather than a dictionary handed straight back.
+
+    Args:
+        config: The configuration to write out.
+        config_class: The configuration's class, which reads the block back.
+        component_name: The entry key the component is recorded under; also its identity.
+
+    Returns:
+        The configuration as its own record rebuilds it.
+    """
+    block = ConfigBlockWriter(PathResolver.default()).block(component_name, config)
+    reloaded = yaml.safe_load(yaml.safe_dump(block))
+    payload = ConfigValueCodec(config_class).to_deserializer_payload(
+        reloaded, f"components.{component_name}.config", component_name
+    )
+    payload[ConfigBlockWriter.IDENTITY_FIELD] = {"name": component_name}
+    return config_class.from_dict(payload)
 
 
 class SetupTestParameters:

--- a/tests/test_energy_system_utsp.py
+++ b/tests/test_energy_system_utsp.py
@@ -28,7 +28,6 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 import pytest
-import yaml
 from utspclient.helpers.lpgdata import (
     ChargingStationSets,
     Households,
@@ -45,6 +44,7 @@ from hisim.energy_system.codec import ConfigValueCodec
 from hisim.energy_system.executor import SimulationParametersReader, build_energy_system
 from hisim.energy_system.record import ConfigBlockWriter, realize
 from hisim.energy_system.path_resolver import PathResolver
+from tests import functions_for_testing as fft
 
 
 class References:
@@ -122,13 +122,8 @@ def test_a_named_constructors_catalogue_references_survive_the_record_round_trip
     exception reports.
     """
     written = References.deliberately_unusual()
-    block = ConfigBlockWriter(PathResolver.default()).block(References.NAME, written)
 
-    reloaded = yaml.safe_load(yaml.safe_dump(block))
-    codec = ConfigValueCodec(UtspLpgConnectorConfig)
-    payload = codec.to_deserializer_payload(reloaded, "components.occupancy.config", References.NAME)
-    payload[ConfigBlockWriter.IDENTITY_FIELD] = written.component_id.to_dict()  # type: ignore[attr-defined]
-    read_back = UtspLpgConnectorConfig.from_dict(payload)
+    read_back = fft.round_trip_config_block(written, UtspLpgConnectorConfig, References.NAME)
 
     References.assert_same(written, read_back)
 

--- a/tests/test_generic_pv_system.py
+++ b/tests/test_generic_pv_system.py
@@ -3,12 +3,16 @@
 import os
 
 import pytest
+import yaml
 from tests import functions_for_testing as fft
 from hisim import sim_repository
 from hisim import component
 from hisim import utils
 from hisim.components import weather
 from hisim.components import generic_pv_system
+from hisim.energy_system.codec import ConfigValueCodec
+from hisim.energy_system.path_resolver import PathResolver
+from hisim.energy_system.record import ConfigBlockWriter
 from hisim import simulator as sim
 from hisim import log
 
@@ -240,3 +244,56 @@ def test_scaled_pv_system_records_the_share_it_applied() -> None:
     )
     assert half_config.power_in_watt == expected_power_in_watt
     assert half_config.power_in_watt == pytest.approx(full_config.power_in_watt / 2, abs=0.01)
+
+
+@pytest.mark.base
+def test_a_scaled_pv_record_re_executes_to_the_same_power() -> None:
+    """Catches a scaled array whose own record would rebuild a differently sized array.
+
+    This is the property the recorded field exists for (D-12 in
+    ``roadmap/declarative_energy_systems/p4_class_survey.md``): a share is only worth recording if
+    the record it lands in reproduces the run it describes. The round trip here is the record's
+    own - the writer that renders a configuration into a ``config`` block, one pass through YAML,
+    and the reader the executor uses to hand a complete block back to the class - so what it
+    proves holds for a file somebody runs, not only for a value that happens to be stored.
+
+    The share must survive because it is the provenance, and the power must survive *unscaled*,
+    because the block already carries the scaled number. A reader that applied the recorded share
+    to the recorded power a second time would halve a half-share array on every re-run.
+    """
+    scaled_config = generic_pv_system.PVSystemConfig.get_scaled_pv_system(
+        rooftop_area_in_m2=120.0,
+        share_of_maximum_pv_potential=0.5,
+    )
+
+    block = ConfigBlockWriter(PathResolver.default()).block("PVSystem", scaled_config)
+    reloaded = yaml.safe_load(yaml.safe_dump(block))
+    codec = ConfigValueCodec(generic_pv_system.PVSystemConfig)
+    payload = codec.to_deserializer_payload(reloaded, "components.PVSystem.config", "PVSystem")
+    payload[ConfigBlockWriter.IDENTITY_FIELD] = {"name": scaled_config.component_id.name}
+    re_executed = generic_pv_system.PVSystemConfig.from_dict(payload)
+
+    assert re_executed.share_of_maximum_pv_potential == 0.5
+    assert re_executed.power_in_watt == scaled_config.power_in_watt
+    assert re_executed == scaled_config
+
+
+@pytest.mark.base
+def test_the_default_pv_factory_reads_its_power_argument_as_the_unscaled_maximum() -> None:
+    """Pins the one factory whose power argument is a maximum rather than a result.
+
+    ``get_default_pv_system`` multiplies the power it is given by the share, so its argument is
+    the array's maximum and the field it writes is what the share left of it - the same meaning
+    ``get_scaled_pv_system`` records, arrived at from the other side. The contrast is worth a test
+    because it is also the trap: the pair ``(power_in_watt, share)`` a record carries is a result
+    and a provenance, so feeding a *recorded* pair back through this factory would apply the share
+    twice. Records are rebuilt from their fields, which is what the round-trip test above proves;
+    this test only fixes what the factory itself promises to a caller who states a maximum.
+    """
+    config = generic_pv_system.PVSystemConfig.get_default_pv_system(
+        power_in_watt=10e3,
+        share_of_maximum_pv_potential=0.5,
+    )
+
+    assert config.power_in_watt == 5000.0
+    assert config.share_of_maximum_pv_potential == 0.5

--- a/tests/test_generic_pv_system.py
+++ b/tests/test_generic_pv_system.py
@@ -3,16 +3,12 @@
 import os
 
 import pytest
-import yaml
 from tests import functions_for_testing as fft
 from hisim import sim_repository
 from hisim import component
 from hisim import utils
 from hisim.components import weather
 from hisim.components import generic_pv_system
-from hisim.energy_system.codec import ConfigValueCodec
-from hisim.energy_system.path_resolver import PathResolver
-from hisim.energy_system.record import ConfigBlockWriter
 from hisim import simulator as sim
 from hisim import log
 
@@ -250,15 +246,9 @@ def test_scaled_pv_system_records_the_share_it_applied() -> None:
 def test_a_scaled_pv_record_re_executes_to_the_same_power() -> None:
     """Catches a scaled array whose own record would rebuild a differently sized array.
 
-    This is the property the recorded field exists for (D-12 in
-    ``roadmap/declarative_energy_systems/p4_class_survey.md``): a share is only worth recording if
-    the record it lands in reproduces the run it describes. The round trip here is the record's
-    own - the writer that renders a configuration into a ``config`` block, one pass through YAML,
-    and the reader the executor uses to hand a complete block back to the class - so what it
-    proves holds for a file somebody runs, not only for a value that happens to be stored.
-
+    A share is only worth recording if the record it lands in reproduces the run it describes.
     The share must survive because it is the provenance, and the power must survive *unscaled*,
-    because the block already carries the scaled number. A reader that applied the recorded share
+    because the block already carries the scaled number: a reader that applied the recorded share
     to the recorded power a second time would halve a half-share array on every re-run.
     """
     scaled_config = generic_pv_system.PVSystemConfig.get_scaled_pv_system(
@@ -266,12 +256,9 @@ def test_a_scaled_pv_record_re_executes_to_the_same_power() -> None:
         share_of_maximum_pv_potential=0.5,
     )
 
-    block = ConfigBlockWriter(PathResolver.default()).block("PVSystem", scaled_config)
-    reloaded = yaml.safe_load(yaml.safe_dump(block))
-    codec = ConfigValueCodec(generic_pv_system.PVSystemConfig)
-    payload = codec.to_deserializer_payload(reloaded, "components.PVSystem.config", "PVSystem")
-    payload[ConfigBlockWriter.IDENTITY_FIELD] = {"name": scaled_config.component_id.name}
-    re_executed = generic_pv_system.PVSystemConfig.from_dict(payload)
+    re_executed = fft.round_trip_config_block(
+        scaled_config, generic_pv_system.PVSystemConfig, "PVSystem"
+    )
 
     assert re_executed.share_of_maximum_pv_potential == 0.5
     assert re_executed.power_in_watt == scaled_config.power_in_watt
@@ -282,18 +269,44 @@ def test_a_scaled_pv_record_re_executes_to_the_same_power() -> None:
 def test_the_default_pv_factory_reads_its_power_argument_as_the_unscaled_maximum() -> None:
     """Pins the one factory whose power argument is a maximum rather than a result.
 
-    ``get_default_pv_system`` multiplies the power it is given by the share, so its argument is
-    the array's maximum and the field it writes is what the share left of it - the same meaning
-    ``get_scaled_pv_system`` records, arrived at from the other side. The contrast is worth a test
-    because it is also the trap: the pair ``(power_in_watt, share)`` a record carries is a result
-    and a provenance, so feeding a *recorded* pair back through this factory would apply the share
-    twice. Records are rebuilt from their fields, which is what the round-trip test above proves;
-    this test only fixes what the factory itself promises to a caller who states a maximum.
+    ``get_default_pv_system`` multiplies the power it is given by the share, so the argument
+    states the array's maximum while the field it writes is what the share left of it -- a
+    distinction the argument's name carries and this test keeps honest.
     """
     config = generic_pv_system.PVSystemConfig.get_default_pv_system(
-        power_in_watt=10e3,
+        maximum_power_in_watt=10e3,
         share_of_maximum_pv_potential=0.5,
     )
 
     assert config.power_in_watt == 5000.0
     assert config.share_of_maximum_pv_potential == 0.5
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("impossible_share", [2.0, -0.5])
+def test_the_default_pv_factory_refuses_a_share_that_is_not_a_share(impossible_share: float) -> None:
+    """Catches a share outside [0, 1] sizing an array in silence instead of stopping.
+
+    The share is multiplied onto the maximum, so a percentage typed as a fraction or a negative
+    value produces a run that finishes and reports plausible numbers for an array nobody asked
+    for. The refusal has to name the value, because the number that is wrong is the only clue.
+    """
+    with pytest.raises(ValueError, match=str(impossible_share)):
+        generic_pv_system.PVSystemConfig.get_default_pv_system(
+            share_of_maximum_pv_potential=impossible_share
+        )
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("impossible_share", [2.0, -0.5])
+def test_the_scaled_pv_factory_refuses_a_share_that_is_not_a_share(impossible_share: float) -> None:
+    """Catches the same value slipping past on the rooftop path, where it is stamped afterwards.
+
+    The scaled factory applies the share in ``size_pv_system`` and writes it onto the finished
+    configuration, so it reaches the field by a second route; the check has to hold on both or it
+    holds on neither.
+    """
+    with pytest.raises(ValueError, match=str(impossible_share)):
+        generic_pv_system.PVSystemConfig.get_scaled_pv_system(
+            rooftop_area_in_m2=120.0, share_of_maximum_pv_potential=impossible_share
+        )


### PR DESCRIPTION
﻿P4 decision D-12, option (a): a scaled PV system records the share it was scaled by, so a realized record re-executes to the same power. The physics fix turned out to be on main already: #638 stamped the real share onto the scaled config because its half-PV probe column needed it, and the survey's entry had gone stale. This commit finishes the decision around that fix: a round-trip test through the record's own writer and codec (a half-share array comes back identical), a docstring stating that the default factory's power argument is the array's maximum and a recorded pair must never be fed back through it, the survey corrected to record (a) as executed, and one sentence in the RenoVisor spec. No number moves: every caller of the scaled factory forwards a share of 1.0, RenoVisor can only express 0 or 1, and the full fleet re-records byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
