### PR TITLE
A constructor called from a file gets its arguments decoded

### DIFF
--- a/energy_systems/README.md
+++ b/energy_systems/README.md
@@ -66,7 +66,7 @@ provides, every fact somebody reads, and which provider each read resolved to.
 
 A constructor's arguments are written and decoded exactly like a `config` value: an enum by its
 member name or its value, a nested object as a mapping of its own fields, several of them as a
-list, and a wrong one refused by name with the spellings that would have worked.
+list, and a wrong one refused by name, listing the accepted members or types.
 
 Editors get the same knowledge from `hisim/energy_system_v3.schema.json`, which every file in this
 directory binds to with its first line. The schema is generated from the same declarations

--- a/energy_systems/README.md
+++ b/energy_systems/README.md
@@ -64,6 +64,10 @@ file and without running it, the file's knobs — a flag per group and a selecte
 which is everything a consumer of a checked-in system edits — and then every fact somebody
 provides, every fact somebody reads, and which provider each read resolved to.
 
+A constructor's arguments are written and decoded exactly like a `config` value: an enum by its
+member name or its value, a nested object as a mapping of its own fields, several of them as a
+list, and a wrong one refused by name with the spellings that would have worked.
+
 Editors get the same knowledge from `hisim/energy_system_v3.schema.json`, which every file in this
 directory binds to with its first line. The schema is generated from the same declarations
 `describe` reads — regenerate it with `hisim energy-system schema` whenever a component gains a

--- a/hisim/config/presets.py
+++ b/hisim/config/presets.py
@@ -57,10 +57,6 @@ from typing import Any, Callable, ClassVar, Dict, Iterable, Mapping, Optional, T
 #: ``attr-defined`` error and a wrong argument an ``arg-type`` error at the call site.
 BuilderT = TypeVar("BuilderT")
 
-#: Stands for "this parameter's annotation could not be evaluated", which is not the same
-#: answer as "it evaluated to something undecodable" and must not be refused as if it were.
-_UNRESOLVED = object()
-
 
 class BuilderKind(enum.Enum):
     """Whether a decorated classmethod is a named default or a named constructor.
@@ -123,6 +119,13 @@ class ConfigBuilder:
     build: Callable[..., Any]
     function: Callable[..., Any]
 
+    #: The resolved type of every parameter, by parameter name, computed once when the
+    #: builder was declared. The loader decodes an argument against it and the schema
+    #: exporter states it as the parameter's type; both read it here rather than resolving
+    #: the signature again, which is what keeps the file format's idea of a parameter's type
+    #: single.
+    parameter_types: Mapping[str, Any]
+
 
 @dataclass(frozen=True)
 class _BuilderMarker:
@@ -137,6 +140,7 @@ class _BuilderMarker:
     name: str
     note: Optional[str]
     function: Callable[..., Any]
+    parameter_types: Mapping[str, Any]
 
 
 def _wire_name(kind: BuilderKind, method_name: str) -> str:
@@ -192,17 +196,21 @@ def resolved_parameter_types(function: Callable[..., Any]) -> Dict[str, Any]:
     module's globals. The return annotation is deliberately left out: it names the config
     class, which does not exist yet while the decorator runs.
 
-    An annotation that cannot be resolved at all is *omitted* rather than reported. That is
-    the same concession the value codec makes for a field whose annotation it cannot resolve
-    — the value is passed on for the builder itself to reject — and it keeps a forward
-    reference from turning into an import-time failure of the whole module.
+    An annotation that cannot be resolved at all is *reported*, not skipped. A parameter of a
+    named constructor is part of the file format — the schema states its type and the loader
+    decodes a written value into it — so an annotation naming nothing is a declaration that
+    cannot be honoured, and a silent omission would leave the parameter permissive in the
+    schema and undecoded at the call, which is the failure this whole check exists to end.
 
     Args:
         function: The undecorated function underneath a builder's classmethod.
 
     Returns:
-        A mapping from parameter name to resolved type, holding only the parameters whose
-        annotation could be evaluated.
+        A mapping from parameter name to resolved type, holding every annotated parameter.
+
+    Raises:
+        TypeError: If an annotation cannot be evaluated, naming the parameter and the
+            annotation as it was written.
     """
     written = {
         name: annotation
@@ -214,28 +222,47 @@ def resolved_parameter_types(function: Callable[..., Any]) -> Dict[str, Any]:
     namespace = getattr(function, "__globals__", {})
     try:
         return dict(typing.get_type_hints(_AnnotationCarrier(written), globalns=namespace))
-    except Exception:  # pylint: disable=broad-except
-        resolved: Dict[str, Any] = {}
+    except Exception as error:  # pylint: disable=broad-except
+        # The batch failure names the first offender only in its own words; resolving one at
+        # a time is what lets the message say which parameter is the unusable one.
         for name, annotation in written.items():
             try:
-                resolved.update(
-                    typing.get_type_hints(_AnnotationCarrier({name: annotation}), globalns=namespace)
-                )
-            except Exception:  # pylint: disable=broad-except
-                continue
-        return resolved
+                typing.get_type_hints(_AnnotationCarrier({name: annotation}), globalns=namespace)
+            except Exception as single:  # pylint: disable=broad-except
+                raise TypeError(
+                    f"parameter '{name}' is annotated {_render_annotation(annotation)}, which "
+                    f"names nothing resolvable where the builder is declared: {single}"
+                ) from single
+        raise TypeError(f"the parameter annotations could not be resolved: {error}") from error
 
 
 def is_decodable_annotation(annotation: Any) -> bool:
     """Whether a value written in a file can be decoded into the type this annotation names.
 
     A named constructor is callable from an energy-system file, where its arguments arrive as
-    plain YAML — a string, a number, a boolean, a mapping, a list. The decoding of those into
-    the types a constructor asks for knows five shapes and no more: the four scalars, an enum
-    (by member name or by member value), a dataclass that can rebuild itself from a mapping,
-    and ``Optional``/``Union``/``List`` over those. This predicate is the closed statement of
-    that set, kept here in the bottom layer so the decorator can refuse an unusable parameter
-    at import time and the decoder can agree with it without either importing the other.
+    plain YAML — a string, a number, a boolean, a mapping, a list. This predicate is the
+    closed statement of what such a value can be decoded into, and it is the *only* one: the
+    decorator consults it to refuse an unusable parameter while the class body is still
+    executing, and :mod:`hisim.energy_system.codec` imports it and consults it before
+    decoding anything, so the gate and the decoder cannot come to disagree. It lives here in
+    the bottom layer because that is the direction the import may run.
+
+    Decodable, exactly:
+
+    * ``None`` (that is, ``NoneType``), which a written ``null`` becomes;
+    * ``bool``, ``int``, ``float`` and ``str``, which YAML writes directly;
+    * any :class:`enum.Enum`, written as a member name or as a member value;
+    * any dataclass, written as a mapping of its fields and rebuilt by its own ``from_dict``
+      or, where it has none, by its constructor;
+    * ``List[X]`` over a decodable ``X``, written as a list and decoded item by item;
+    * ``Optional[X]`` and any other ``Union`` whose members are all decodable and which holds
+      **at most one** dataclass member and **at most one** list member — ``Union[Reference,
+      List[Reference]]`` and ``Optional[Enum]`` pass, while ``Union[A, B]`` of two dataclasses
+      and ``Union[List[A], List[B]]`` do not, because nothing in a written mapping or list
+      would tell the decoder which of the two to build.
+
+    Everything else is refused: ``Any``, a bare ``list`` or ``dict``, a ``Dict``, a tuple, a
+    callable, and a plain class that is no dataclass and no enum.
 
     Args:
         annotation: A resolved type annotation.
@@ -251,23 +278,32 @@ def is_decodable_annotation(annotation: Any) -> bool:
         return isinstance(annotation, type) and (
             annotation in (bool, int, float, str)
             or issubclass(annotation, enum.Enum)
-            or (
-                dataclasses.is_dataclass(annotation)
-                and callable(getattr(annotation, "from_dict", None))
-            )
+            or dataclasses.is_dataclass(annotation)
         )
     if origin is typing.Union or origin is types.UnionType:
-        return bool(arguments) and all(is_decodable_annotation(argument) for argument in arguments)
+        if not arguments or not all(is_decodable_annotation(argument) for argument in arguments):
+            return False
+        nested = sum(
+            1
+            for argument in arguments
+            if isinstance(argument, type) and dataclasses.is_dataclass(argument)
+        )
+        listed = sum(1 for argument in arguments if typing.get_origin(argument) is list)
+        return nested <= 1 and listed <= 1
     return origin is list and len(arguments) == 1 and is_decodable_annotation(arguments[0])
 
 
 def _render_annotation(annotation: Any) -> str:
-    """Renders a resolved annotation the way an error message should print it."""
+    """Renders an annotation — resolved or still written as text — as a message prints it."""
+    if isinstance(annotation, str):
+        return annotation
     name = getattr(annotation, "__name__", None)
     return name if isinstance(name, str) else str(annotation)
 
 
-def _check_signature(kind: BuilderKind, method_name: str, function: Callable[..., Any]) -> None:
+def _check_signature(
+    kind: BuilderKind, method_name: str, function: Callable[..., Any]
+) -> Dict[str, Any]:
     """Checks that a builder takes the instance name first and nothing unusable after it.
 
     A preset takes exactly ``(cls, name)``: anything a preset would need beyond the name
@@ -282,11 +318,19 @@ def _check_signature(kind: BuilderKind, method_name: str, function: Callable[...
     object — is a constructor only Python can call, and that is a mistake worth reporting
     while the class body is still executing rather than at the first file that tries.
 
+    The resolved annotations are handed back rather than thrown away: they are what the
+    loader decodes an argument against and what the schema exporter states as a parameter's
+    type, and resolving them once here is what keeps those two from resolving them again,
+    differently.
+
+    Returns:
+        The resolved type of every annotated parameter, by parameter name.
+
     Raises:
         ValueError: If the first parameter after ``cls`` is not ``name``, if a preset
             declares further parameters, if a constructor parameter is variadic,
-            positional-only or unannotated, or if its annotation cannot be decoded from a
-            written value.
+            positional-only or unannotated, if an annotation names nothing resolvable, or if
+            it cannot be decoded from a written value.
     """
     parameters = list(inspect.signature(function).parameters.values())[1:]
     if not parameters or parameters[0].name != "name":
@@ -314,18 +358,26 @@ def _check_signature(kind: BuilderKind, method_name: str, function: Callable[...
                 "type annotation; the description surface reports the type of every "
                 "parameter, so an unannotated one cannot be offered to a caller."
             )
-    annotations = resolved_parameter_types(function)
+    try:
+        annotations = resolved_parameter_types(function)
+    except TypeError as error:
+        raise ValueError(
+            f"{kind.explain()} '{method_name}': {error}. A parameter's type is part of the "
+            "file format — the schema states it and the loader decodes a written value into "
+            "it — so an annotation naming nothing cannot be declared."
+        ) from error
     for parameter in parameters:
-        annotation = annotations.get(parameter.name, _UNRESOLVED)
-        if annotation is _UNRESOLVED or is_decodable_annotation(annotation):
+        annotation = annotations[parameter.name]
+        if is_decodable_annotation(annotation):
             continue
         raise ValueError(
             f"{kind.explain()} '{method_name}': parameter '{parameter.name}' is annotated "
             f"{_render_annotation(annotation)}, which no value written in a file can be "
             "decoded into; a parameter must be a bool, int, float or str, an Enum, a "
-            "dataclass with a 'from_dict', or an Optional, Union or List over those, "
-            "because a file passes its arguments as plain YAML."
+            "dataclass, or an Optional, Union or List over those, because a file passes its "
+            "arguments as plain YAML."
         )
+    return annotations
 
 
 def _declare(kind: BuilderKind, decorated: Any, note: Optional[str]) -> Any:
@@ -353,7 +405,7 @@ def _declare(kind: BuilderKind, decorated: Any, note: Optional[str]) -> Any:
     function = decorated.__func__
     method_name = function.__name__
     name = _wire_name(kind, method_name)
-    _check_signature(kind, method_name, function)
+    parameter_types = _check_signature(kind, method_name, function)
 
     @functools.wraps(function)
     def wrapper(cls: Any, *args: Any, **kwargs: Any) -> Any:
@@ -363,7 +415,11 @@ def _declare(kind: BuilderKind, decorated: Any, note: Optional[str]) -> Any:
             setattr(instance, ConfigBuilder.PROVENANCE_ATTRIBUTE, name)
         return instance
 
-    setattr(wrapper, ConfigBuilder.MARKER_ATTRIBUTE, _BuilderMarker(kind, name, note, function))
+    setattr(
+        wrapper,
+        ConfigBuilder.MARKER_ATTRIBUTE,
+        _BuilderMarker(kind, name, note, function, parameter_types),
+    )
     return classmethod(wrapper)
 
 
@@ -481,6 +537,7 @@ def _builders_of(config_class: type, kind: BuilderKind) -> Mapping[str, ConfigBu
             note=marker.note,
             build=getattr(config_class, method_name),
             function=marker.function,
+            parameter_types=marker.parameter_types,
         )
     return registry
 

--- a/hisim/config/presets.py
+++ b/hisim/config/presets.py
@@ -41,10 +41,14 @@ the sizing machinery — which is why every builder spells the ``ComponentID`` o
 
 from __future__ import annotations
 
+import dataclasses
 import enum
 import functools
 import inspect
+import types
+import typing
 from dataclasses import dataclass
+from types import NoneType
 from typing import Any, Callable, ClassVar, Dict, Iterable, Mapping, Optional, Tuple, TypeVar, overload
 
 #: Type variable of the two decorators. It is deliberately unbounded and used as an
@@ -52,6 +56,10 @@ from typing import Any, Callable, ClassVar, Dict, Iterable, Mapping, Optional, T
 #: classmethod stay a fully typed classmethod for mypy, so a typo in its name is an
 #: ``attr-defined`` error and a wrong argument an ``arg-type`` error at the call site.
 BuilderT = TypeVar("BuilderT")
+
+#: Stands for "this parameter's annotation could not be evaluated", which is not the same
+#: answer as "it evaluated to something undecodable" and must not be refused as if it were.
+_UNRESOLVED = object()
 
 
 class BuilderKind(enum.Enum):
@@ -161,6 +169,104 @@ def _wire_name(kind: BuilderKind, method_name: str) -> str:
     return method_name
 
 
+class _AnnotationCarrier:
+    """A throwaway object holding just the annotations :func:`resolved_parameter_types` resolves.
+
+    ``typing.get_type_hints`` on a function resolves its *return* annotation too, and a
+    builder's return annotation names the very class whose body is still executing when the
+    decorator runs. Handing the resolver an object that carries only the parameter
+    annotations is what lets the same helper serve the import-time check and the run-time
+    decoding, instead of one spelling that works before the class exists and another after.
+    """
+
+    def __init__(self, annotations: Dict[str, Any]) -> None:
+        """Stores the annotations to resolve, keyed by parameter name."""
+        self.__annotations__ = annotations
+
+
+def resolved_parameter_types(function: Callable[..., Any]) -> Dict[str, Any]:
+    """Resolves the annotations of a builder's parameters into the types they name.
+
+    Under ``from __future__ import annotations`` every annotation is a string, so a caller
+    that wants the type rather than its spelling has to evaluate it against the defining
+    module's globals. The return annotation is deliberately left out: it names the config
+    class, which does not exist yet while the decorator runs.
+
+    An annotation that cannot be resolved at all is *omitted* rather than reported. That is
+    the same concession the value codec makes for a field whose annotation it cannot resolve
+    — the value is passed on for the builder itself to reject — and it keeps a forward
+    reference from turning into an import-time failure of the whole module.
+
+    Args:
+        function: The undecorated function underneath a builder's classmethod.
+
+    Returns:
+        A mapping from parameter name to resolved type, holding only the parameters whose
+        annotation could be evaluated.
+    """
+    written = {
+        name: annotation
+        for name, annotation in getattr(function, "__annotations__", {}).items()
+        if name != "return"
+    }
+    if not written:
+        return {}
+    namespace = getattr(function, "__globals__", {})
+    try:
+        return dict(typing.get_type_hints(_AnnotationCarrier(written), globalns=namespace))
+    except Exception:  # pylint: disable=broad-except
+        resolved: Dict[str, Any] = {}
+        for name, annotation in written.items():
+            try:
+                resolved.update(
+                    typing.get_type_hints(_AnnotationCarrier({name: annotation}), globalns=namespace)
+                )
+            except Exception:  # pylint: disable=broad-except
+                continue
+        return resolved
+
+
+def is_decodable_annotation(annotation: Any) -> bool:
+    """Whether a value written in a file can be decoded into the type this annotation names.
+
+    A named constructor is callable from an energy-system file, where its arguments arrive as
+    plain YAML — a string, a number, a boolean, a mapping, a list. The decoding of those into
+    the types a constructor asks for knows five shapes and no more: the four scalars, an enum
+    (by member name or by member value), a dataclass that can rebuild itself from a mapping,
+    and ``Optional``/``Union``/``List`` over those. This predicate is the closed statement of
+    that set, kept here in the bottom layer so the decorator can refuse an unusable parameter
+    at import time and the decoder can agree with it without either importing the other.
+
+    Args:
+        annotation: A resolved type annotation.
+
+    Returns:
+        ``True`` when a written value can be decoded into it.
+    """
+    if annotation is NoneType or annotation is None:
+        return True
+    origin = typing.get_origin(annotation)
+    arguments = typing.get_args(annotation)
+    if origin is None:
+        return isinstance(annotation, type) and (
+            annotation in (bool, int, float, str)
+            or issubclass(annotation, enum.Enum)
+            or (
+                dataclasses.is_dataclass(annotation)
+                and callable(getattr(annotation, "from_dict", None))
+            )
+        )
+    if origin is typing.Union or origin is types.UnionType:
+        return bool(arguments) and all(is_decodable_annotation(argument) for argument in arguments)
+    return origin is list and len(arguments) == 1 and is_decodable_annotation(arguments[0])
+
+
+def _render_annotation(annotation: Any) -> str:
+    """Renders a resolved annotation the way an error message should print it."""
+    name = getattr(annotation, "__name__", None)
+    return name if isinstance(name, str) else str(annotation)
+
+
 def _check_signature(kind: BuilderKind, method_name: str, function: Callable[..., Any]) -> None:
     """Checks that a builder takes the instance name first and nothing unusable after it.
 
@@ -170,10 +276,17 @@ def _check_signature(kind: BuilderKind, method_name: str, function: Callable[...
     what lets a scenario file spell the call as a mapping and the introspection describe
     it without reading the source.
 
+    The annotation itself must additionally be one a written value can be decoded into (see
+    :func:`is_decodable_annotation`). A file calling this constructor passes plain YAML, so a
+    parameter asking for something no YAML value can become — a callable, an arbitrary
+    object — is a constructor only Python can call, and that is a mistake worth reporting
+    while the class body is still executing rather than at the first file that tries.
+
     Raises:
         ValueError: If the first parameter after ``cls`` is not ``name``, if a preset
-            declares further parameters, or if a constructor parameter is variadic,
-            positional-only or unannotated.
+            declares further parameters, if a constructor parameter is variadic,
+            positional-only or unannotated, or if its annotation cannot be decoded from a
+            written value.
     """
     parameters = list(inspect.signature(function).parameters.values())[1:]
     if not parameters or parameters[0].name != "name":
@@ -201,6 +314,18 @@ def _check_signature(kind: BuilderKind, method_name: str, function: Callable[...
                 "type annotation; the description surface reports the type of every "
                 "parameter, so an unannotated one cannot be offered to a caller."
             )
+    annotations = resolved_parameter_types(function)
+    for parameter in parameters:
+        annotation = annotations.get(parameter.name, _UNRESOLVED)
+        if annotation is _UNRESOLVED or is_decodable_annotation(annotation):
+            continue
+        raise ValueError(
+            f"{kind.explain()} '{method_name}': parameter '{parameter.name}' is annotated "
+            f"{_render_annotation(annotation)}, which no value written in a file can be "
+            "decoded into; a parameter must be a bool, int, float or str, an Enum, a "
+            "dataclass with a 'from_dict', or an Optional, Union or List over those, "
+            "because a file passes its arguments as plain YAML."
+        )
 
 
 def _declare(kind: BuilderKind, decorated: Any, note: Optional[str]) -> Any:

--- a/hisim/energy_system/codec.py
+++ b/hisim/energy_system/codec.py
@@ -15,6 +15,12 @@ second rule is ``AUTO``: the bare word re-opens a field that a preset pinned, wh
 author asks for a value to be sized rather than fixed, and it is legal only on a field that
 has a law to close it again.
 
+The same decoding serves the arguments of a named constructor, which a file writes as a
+mapping under ``constructor:`` and which reach a Python classmethod expecting the same enum
+members and nested objects a field holds. :meth:`ConfigValueCodec.decode_argument` is that one
+implementation, and the field path is a call into it, so the two cannot come to mean different
+things by the same written word.
+
 Everything the codec cannot decode is a hard error naming the entry, the field, the value and
 the type expected — never a silent pass-through of a wrong type, because a wrong number in a
 configuration surfaces as a wrong simulation result rather than as a crash.
@@ -26,6 +32,7 @@ from __future__ import annotations
 
 import dataclasses
 import enum
+import types
 import typing
 from types import NoneType
 from typing import Any, Dict, Mapping, Optional, Tuple, Type
@@ -238,6 +245,11 @@ class ConfigValueCodec:
     def _decode_by_annotation(self, field_name: str, value: Any, location: str, name: str) -> Any:
         """Decodes a value against the field's resolved type annotation.
 
+        A thin call into :meth:`decode_argument`, which is the whole of the annotation-driven
+        decoding and is shared with the arguments of a named constructor. Keeping one
+        implementation is what makes ``location: AACHEN`` mean the same thing whether it is
+        written as a ``config`` override or passed to ``for_location``.
+
         Args:
             field_name: The field being overridden.
             value: The written value.
@@ -251,9 +263,42 @@ class ConfigValueCodec:
         Raises:
             EnergySystemBindingError: ``EF-1A`` when the value contradicts the annotation.
         """
-        annotation = self.hints.get(field_name)
+        return self.decode_argument(self.hints.get(field_name), value, location, name, field_name)
+
+    def decode_argument(
+        self, annotation: Any, value: Any, location: str, name: str, field_name: str
+    ) -> Any:
+        """Decodes one written value against a type annotation, whatever declared it.
+
+        The annotation-driven half of the codec, factored out of the field path so that the
+        arguments of a named constructor get exactly the treatment a ``config`` block's values
+        get: an enum arrives as the member and not as the string that spells it, a mapping on
+        a dataclass-typed parameter is rebuilt by that class, a list is decoded item by item,
+        and a plain scalar is checked against the types the annotation admits.
+
+        Args:
+            annotation: The resolved annotation to decode against; ``None`` when there is
+                none, in which case the value is passed on untouched.
+            value: The written value.
+            location: The dotted key path of the value, for the message.
+            name: The component's name, for the message.
+            field_name: What the value is being written to — a field name or a parameter
+                name — as the message spells it.
+
+        Returns:
+            The decoded value.
+
+        Raises:
+            EnergySystemBindingError: ``EF-1A`` when the value contradicts the annotation.
+        """
         if annotation is None:
             return value
+        item_annotation = self._list_item_annotation(annotation)
+        if item_annotation is not None and isinstance(value, list):
+            return [
+                self.decode_argument(item_annotation, item, f"{location}[{index}]", name, field_name)
+                for index, item in enumerate(value)
+            ]
         candidates = self._candidate_types(annotation)
         for candidate in candidates:
             if isinstance(candidate, type) and issubclass(candidate, enum.Enum):
@@ -264,6 +309,33 @@ class ConfigValueCodec:
         if rebuilt is not None:
             return rebuilt
         return self._decode_scalar(candidates, value, location, name, field_name)
+
+    @classmethod
+    def _list_item_annotation(cls, annotation: Any) -> Optional[Any]:
+        """Returns the item type of a list-admitting annotation, or ``None`` for any other.
+
+        Both spellings that occur in HiSim are read: a plain ``List[X]`` and the
+        ``Union[X, List[X]]`` of a parameter that takes either one thing or several — the LPG
+        occupancy's household, where a list means one reference per apartment. Reading the
+        item type *before* the union is flattened is what keeps a list from being mistaken for
+        a single value of its own item type.
+
+        Args:
+            annotation: The resolved annotation.
+
+        Returns:
+            The type each item is decoded against, or ``None`` when no list is admitted.
+        """
+        origin = typing.get_origin(annotation)
+        if origin is list:
+            arguments = typing.get_args(annotation)
+            return arguments[0] if len(arguments) == 1 else None
+        if origin is typing.Union or origin is types.UnionType:
+            for member in typing.get_args(annotation):
+                item = cls._list_item_annotation(member)
+                if item is not None:
+                    return item
+        return None
 
     @classmethod
     def _rebuild_nested_dataclass(

--- a/hisim/energy_system/codec.py
+++ b/hisim/energy_system/codec.py
@@ -18,8 +18,22 @@ has a law to close it again.
 The same decoding serves the arguments of a named constructor, which a file writes as a
 mapping under ``constructor:`` and which reach a Python classmethod expecting the same enum
 members and nested objects a field holds. :meth:`ConfigValueCodec.decode_argument` is that one
-implementation, and the field path is a call into it, so the two cannot come to mean different
-things by the same written word.
+implementation, and the two paths that go through it — the *sparse override*, which writes a
+value onto one field of an already-built configuration, and the constructor argument — cannot
+come to mean different things by the same written word. A *complete* ``config`` block is the
+third path and goes elsewhere: the configuration class deserializes it whole through its own
+``from_dict``, because only the class knows how to rebuild every nested object at once, and
+this module's part in that is :meth:`ConfigValueCodec.to_deserializer_payload`, which only
+rewrites the enum spellings the two formats disagree on.
+
+What a written value may be decoded into at all is not stated here either: it is
+:func:`hisim.config.presets.is_decodable_annotation`, in the bottom layer, which the
+``@constructor`` decorator consults to refuse an undecodable parameter at import time and which
+this module consults before decoding, so that the gate and the decoder cannot disagree. An
+annotation the predicate refuses is passed through untouched on the field path, leaving the
+last word to the configuration class itself; on the constructor path the decoded value is
+additionally checked against the shape its parameter asks for, because a constructor argument
+has no class behind it to catch what the codec let through.
 
 Everything the codec cannot decode is a hard error naming the entry, the field, the value and
 the type expected — never a silent pass-through of a wrong type, because a wrong number in a
@@ -37,6 +51,7 @@ import typing
 from types import NoneType
 from typing import Any, Dict, Mapping, Optional, Tuple, Type
 
+from hisim.config.presets import is_decodable_annotation
 from hisim.config.sizing import AUTO, SizedFieldMetadata, _AutoSize
 from hisim.energy_system.errors import EnergySystemBindingError, EnergySystemErrorId
 
@@ -99,7 +114,7 @@ class ConfigValueCodec:
                 raise
             except Exception as error:  # pylint: disable=broad-except
                 raise self._decoder_failure(field_name, value, location, name, error) from error
-        return self._decode_by_annotation(field_name, value, location, name)
+        return self.decode_argument(self.hints.get(field_name), value, location, name, field_name)
 
     def to_deserializer_payload(
         self, block: Mapping[str, Any], location: str, name: str
@@ -242,29 +257,6 @@ class ConfigValueCodec:
             decoder = metadata.get("decoder")
         return decoder
 
-    def _decode_by_annotation(self, field_name: str, value: Any, location: str, name: str) -> Any:
-        """Decodes a value against the field's resolved type annotation.
-
-        A thin call into :meth:`decode_argument`, which is the whole of the annotation-driven
-        decoding and is shared with the arguments of a named constructor. Keeping one
-        implementation is what makes ``location: AACHEN`` mean the same thing whether it is
-        written as a ``config`` override or passed to ``for_location``.
-
-        Args:
-            field_name: The field being overridden.
-            value: The written value.
-            location: The dotted key path, for the message.
-            name: The component's name, for the message.
-
-        Returns:
-            The decoded value; the value unchanged when the annotation gives the codec
-            nothing to go on, which leaves the final say to the configuration class itself.
-
-        Raises:
-            EnergySystemBindingError: ``EF-1A`` when the value contradicts the annotation.
-        """
-        return self.decode_argument(self.hints.get(field_name), value, location, name, field_name)
-
     def decode_argument(
         self, annotation: Any, value: Any, location: str, name: str, field_name: str
     ) -> Any:
@@ -275,6 +267,12 @@ class ConfigValueCodec:
         get: an enum arrives as the member and not as the string that spells it, a mapping on
         a dataclass-typed parameter is rebuilt by that class, a list is decoded item by item,
         and a plain scalar is checked against the types the annotation admits.
+
+        An annotation :func:`~hisim.config.presets.is_decodable_annotation` refuses gives the
+        codec nothing to work with — ``Any``, a tuple, a plain class — and the value is passed
+        on as written, which is the field path's standing concession to a class that
+        deserializes such a field itself. A constructor parameter never has an annotation like
+        that: the decorator refused it at import time, from the same predicate.
 
         Args:
             annotation: The resolved annotation to decode against; ``None`` when there is
@@ -291,7 +289,7 @@ class ConfigValueCodec:
         Raises:
             EnergySystemBindingError: ``EF-1A`` when the value contradicts the annotation.
         """
-        if annotation is None:
+        if annotation is None or not is_decodable_annotation(annotation):
             return value
         item_annotation = self._list_item_annotation(annotation)
         if item_annotation is not None and isinstance(value, list):
@@ -299,16 +297,203 @@ class ConfigValueCodec:
                 self.decode_argument(item_annotation, item, f"{location}[{index}]", name, field_name)
                 for index, item in enumerate(value)
             ]
-        candidates = self._candidate_types(annotation)
-        for candidate in candidates:
-            if isinstance(candidate, type) and issubclass(candidate, enum.Enum):
-                return self._decode_enum(candidate, value, location, name, field_name)
         if value is None:
-            return None
+            # Asked before the enum lookup, which would otherwise refuse the very null an
+            # Optional exists to admit, and asked at all, because a null on a field that
+            # admits none used to be written through as None.
+            if self._admits_none(annotation):
+                return None
+            raise EnergySystemBindingError(
+                EnergySystemErrorId.UNDECODABLE_VALUE,
+                location,
+                f"'{name}' sets '{field_name}' to null, but it holds "
+                f"{self._render_annotation(annotation)} and must not be null.",
+            )
+        candidates = self._candidate_types(annotation)
+        member = self._decode_admitted_enum(candidates, value, location, name, field_name)
+        if member is not None:
+            return member
         rebuilt = self._rebuild_nested_dataclass(candidates, value, location, name, field_name)
         if rebuilt is not None:
             return rebuilt
         return self._decode_scalar(candidates, value, location, name, field_name)
+
+    @classmethod
+    def _decode_admitted_enum(
+        cls, candidates: Tuple[Any, ...], value: Any, location: str, name: str, field_name: str
+    ) -> Optional[Any]:
+        """Decodes the value as an enum member where the annotation admits an enum.
+
+        Where the enum is the only thing admitted, a value naming no member is refused here
+        with the members listed. Where a plain ``str`` is admitted beside it — the shape of a
+        parameter that takes either a catalogue key or a free name — a string that names no
+        member is not a mistake but the other half of the union, so it is handed back for the
+        scalar path to accept.
+
+        Args:
+            candidates: The types the annotation admits.
+            value: The written value.
+            location: The dotted key path, for the message.
+            name: The component's name, for the message.
+            field_name: The field or parameter being written, for the message.
+
+        Returns:
+            The member, or ``None`` when no enum is admitted or a free string was written.
+
+        Raises:
+            EnergySystemBindingError: ``EF-1A`` naming the value and listing the members.
+        """
+        for candidate in candidates:
+            if not (isinstance(candidate, type) and issubclass(candidate, enum.Enum)):
+                continue
+            if str in candidates and isinstance(value, str):
+                return cls._enum_member(candidate, value)
+            return cls._decode_enum(candidate, value, location, name, field_name)
+        return None
+
+    def check_argument_shape(
+        self, annotation: Any, value: Any, location: str, name: str, parameter: str
+    ) -> None:
+        """Refuses a decoded constructor argument whose shape its parameter cannot hold.
+
+        The field path may pass a value it could not type-check on to the configuration class,
+        which validates itself and would refuse it. A constructor argument has no such second
+        reader: it goes straight into a Python call, where a mapping that stayed a mapping or a
+        list where one object belongs fails deep inside the builder, or worse, does not fail at
+        all. So the shape the annotation asks for is checked once here, after the decoding,
+        which is the only point at which "still a mapping" means "nothing rebuilt it".
+
+        Args:
+            annotation: The parameter's resolved annotation.
+            value: The value as the decoding left it.
+            location: The dotted key path of the argument, for the message.
+            name: The component's name, for the message.
+            parameter: The parameter's name, for the message.
+
+        Raises:
+            EnergySystemBindingError: ``EF-1A`` naming the parameter, the written value's type
+                and the shape the parameter asks for.
+        """
+        clause = self._unmet_shape(annotation, value)
+        if clause is None:
+            return
+        raise EnergySystemBindingError(
+            EnergySystemErrorId.UNDECODABLE_VALUE,
+            location,
+            f"'{name}' sets '{parameter}' to {value!r} ({type(value).__name__}), which must "
+            f"{clause}; the parameter is annotated {self._render_annotation(annotation)}.",
+        )
+
+    @classmethod
+    def _unmet_shape(cls, annotation: Any, value: Any) -> Optional[str]:
+        """Names the shape an annotation asks for, when the decoded value is not of it.
+
+        The four shapes a decoded value can still be wrong in, each of which reaches the
+        builder as a Python error naming nothing the author wrote: a null where the parameter
+        admits none, a list where no list is admitted, a single value where only a list is,
+        and a mapping or a scalar where the parameter wants an object of its own class. An
+        annotation the decodability predicate refuses states no shape and is not policed.
+
+        Args:
+            annotation: The parameter's resolved annotation.
+            value: The value as the decoding left it.
+
+        Returns:
+            The clause an error message completes with ``which must …``, or ``None`` when the
+            value fits.
+        """
+        if annotation is None or not is_decodable_annotation(annotation):
+            return None
+        if value is None:
+            return None if cls._admits_none(annotation) else "not be null"
+        unmet = cls._unmet_list_shape(annotation, value)
+        if unmet is not None or isinstance(value, list):
+            return unmet
+        return cls._unmet_object_shape(annotation, value)
+
+    @classmethod
+    def _unmet_list_shape(cls, annotation: Any, value: Any) -> Optional[str]:
+        """Names the list shape an annotation asks for, when the value is not of it.
+
+        The two mistakes a list makes: several values written where the parameter admits only
+        one, and one written where it admits only several. The second is the reason this is
+        asked of a *decoded* value at all — a mapping that rebuilt itself into the item class
+        is a perfectly good item and still not the list its parameter iterates over.
+
+        Args:
+            annotation: The parameter's resolved annotation.
+            value: The value as the decoding left it.
+
+        Returns:
+            The clause, or ``None`` when nothing about the list shape is wrong.
+        """
+        item_annotation = cls._list_item_annotation(annotation)
+        if isinstance(value, list):
+            return None if item_annotation is not None else "not be a list"
+        if item_annotation is not None and all(
+            member is NoneType or typing.get_origin(member) is list
+            for member in cls._union_members(annotation)
+        ):
+            return f"be a list of {cls._render_annotation(item_annotation)}"
+        return None
+
+    @classmethod
+    def _unmet_object_shape(cls, annotation: Any, value: Any) -> Optional[str]:
+        """Names the object an annotation asks for, when the value is not one.
+
+        Reached for a value that is neither ``None`` nor a list, so the question left is
+        whether it is one of the types the annotation admits. A mapping that is still a
+        mapping was rebuilt by nothing, and a scalar where only an object belongs is the
+        shorthand — a catalogue name, say — that the format does not have.
+
+        Args:
+            annotation: The parameter's resolved annotation.
+            value: The value as the decoding left it.
+
+        Returns:
+            The clause, or ``None`` when the value is of an admitted type or the annotation
+            names no object to compare it against.
+        """
+        candidates = cls._candidate_types(annotation)
+        concrete = tuple(candidate for candidate in candidates if isinstance(candidate, type))
+        if concrete and isinstance(value, concrete):
+            return None
+        if isinstance(value, Mapping):
+            return "not be a mapping"
+        nested = [candidate for candidate in concrete if dataclasses.is_dataclass(candidate)]
+        return f"be a mapping of {nested[0].__name__}'s own fields" if nested else None
+
+    @classmethod
+    def _union_members(cls, annotation: Any) -> Tuple[Any, ...]:
+        """Returns a union's members as written, ``NoneType`` included, or the annotation itself.
+
+        The counterpart of :meth:`_candidate_types`, which drops ``NoneType`` because a value
+        has to match one of the *other* members. Whether ``None`` is admitted at all is exactly
+        what this one is asked.
+
+        Args:
+            annotation: The resolved annotation.
+
+        Returns:
+            The union's members, or a single-element tuple for anything else.
+        """
+        origin = typing.get_origin(annotation)
+        if origin is typing.Union or origin is types.UnionType:
+            return typing.get_args(annotation)
+        return (annotation,)
+
+    @classmethod
+    def _admits_none(cls, annotation: Any) -> bool:
+        """Whether a written ``null`` is a legal value of this annotation."""
+        return any(member is NoneType for member in cls._union_members(annotation))
+
+    @classmethod
+    def _render_annotation(cls, annotation: Any) -> str:
+        """Renders an annotation the way an error message prints it, without the ``typing.``."""
+        name = getattr(annotation, "__name__", None)
+        if isinstance(name, str) and typing.get_origin(annotation) is None:
+            return name
+        return str(annotation).replace("typing.", "")
 
     @classmethod
     def _list_item_annotation(cls, annotation: Any) -> Optional[Any]:
@@ -431,16 +616,9 @@ class ConfigValueCodec:
         Raises:
             EnergySystemBindingError: ``EF-1A`` naming the value and listing the members.
         """
-        if isinstance(value, enum_class):
-            return value
-        if isinstance(value, str):
-            member = enum_class.__members__.get(value)
-            if member is not None:
-                return member
-            try:
-                return enum_class(value)
-            except ValueError:
-                pass
+        member = cls._enum_member(enum_class, value)
+        if member is not None:
+            return member
         raise EnergySystemBindingError(
             EnergySystemErrorId.UNDECODABLE_VALUE,
             location,
@@ -450,6 +628,32 @@ class ConfigValueCodec:
             alternatives_label=f"members of {enum_class.__name__}",
             offending_value=value if isinstance(value, str) else None,
         )
+
+    @classmethod
+    def _enum_member(cls, enum_class: Type[enum.Enum], value: Any) -> Optional[Any]:
+        """Looks a written value up among an enum's members, by name and then by value.
+
+        The lookup alone, without the refusal: a caller that admits something else beside the
+        enum needs to know that the value names no member without being told it is an error.
+
+        Args:
+            enum_class: The enum to look the value up in.
+            value: The written value.
+
+        Returns:
+            The member, or ``None`` when the value names none.
+        """
+        if isinstance(value, enum_class):
+            return value
+        if isinstance(value, str):
+            member = enum_class.__members__.get(value)
+            if member is not None:
+                return member
+            try:
+                return enum_class(value)
+            except ValueError:
+                return None
+        return None
 
     @classmethod
     def _decode_scalar(

--- a/hisim/energy_system/configure.py
+++ b/hisim/energy_system/configure.py
@@ -37,9 +37,9 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Any, ClassVar, List, Mapping, Optional, Tuple
+from typing import Any, ClassVar, Dict, List, Mapping, Optional, Tuple
 
-from hisim.config.presets import ConfigBuilder, resolved_parameter_types
+from hisim.config.presets import ConfigBuilder
 from hisim.config.report import ResolutionReport
 from hisim.energy_system.bindings import ClassBinding, ClassBindings
 from hisim.energy_system.classes import validate_classes
@@ -294,9 +294,18 @@ class EntryConfigurator:
         Each argument goes through the same codec a ``config`` value does, against the
         parameter's own resolved annotation rather than against a field's, so the two forms
         accept the same spellings and refuse the same mistakes with the same sentence. The
-        argument names are already known to be parameters — the class-bound validator checked
-        that, with the parameter list in its message — so the only question left here is
-        whether each value fits.
+        annotations are the ones the ``@constructor`` decorator resolved when the class was
+        declared, read off the builder rather than resolved again here: a parameter's type is
+        part of the file format, and resolving it twice is how two readings of it start.
+
+        The decoded value is then checked against the shape its parameter asks for, which the
+        field path leaves to the configuration class. A constructor argument has no such
+        second reader — it goes straight into a Python call — so a mapping nothing rebuilt or
+        a list where one object belongs is refused here, at the argument's own key.
+
+        The argument names are already known to be parameters — the class-bound validator
+        checked that, with the parameter list in its message — so the only question left here
+        is whether each value fits.
 
         Args:
             builder: The declared builder the entry selected.
@@ -312,14 +321,18 @@ class EntryConfigurator:
         if not arguments:
             return {}
         entry = self.binding.entry
-        annotations = resolved_parameter_types(builder.function)
         location = f"components.{entry.name}.{builder.kind.value}.{builder.name}"
-        return {
-            key: self.codec.decode_argument(
-                annotations.get(key), value, f"{location}.{key}", entry.name, key
+        decoded: Dict[str, Any] = {}
+        for key, value in arguments.items():
+            annotation = builder.parameter_types.get(key)
+            argument_location = f"{location}.{key}"
+            decoded[key] = self.codec.decode_argument(
+                annotation, value, argument_location, entry.name, key
             )
-            for key, value in arguments.items()
-        }
+            self.codec.check_argument_shape(
+                annotation, decoded[key], argument_location, entry.name, key
+            )
+        return decoded
 
     def _apply_overrides(self, config: Any) -> Any:
         """Writes the entry's sparse ``config`` block onto the configuration it built.

--- a/hisim/energy_system/configure.py
+++ b/hisim/energy_system/configure.py
@@ -8,7 +8,8 @@ lets a file be rejected for a sizing contradiction without anything having been 
 is what lets a run write down what it would have built even when it is not going to run.
 
 Three things happen per entry, in a fixed order. The configuration's *origin* is realized:
-the named preset is called, or the named constructor is called with the entry's arguments, or
+the named preset is called, or the named constructor is called with the entry's arguments —
+each decoded into the type its parameter asks for, exactly as a ``config`` value is — or
 the entry's own complete block is deserialized. The *overrides* are applied on top, each value
 decoded into the type its field holds, with the bare word ``AUTO`` re-opening a field that the
 preset had pinned. Then the *paths* are expanded, turning the portable ``${inputs}/…``
@@ -38,7 +39,7 @@ import dataclasses
 from dataclasses import dataclass
 from typing import Any, ClassVar, List, Mapping, Optional, Tuple
 
-from hisim.config.presets import ConfigBuilder
+from hisim.config.presets import ConfigBuilder, resolved_parameter_types
 from hisim.config.report import ResolutionReport
 from hisim.energy_system.bindings import ClassBinding, ClassBindings
 from hisim.energy_system.classes import validate_classes
@@ -254,6 +255,13 @@ class EntryConfigurator:
     def _call_builder(self, builder: ConfigBuilder, arguments: Mapping[str, Any]) -> Any:
         """Calls one preset or named constructor with the entry's key as the instance name.
 
+        The arguments are decoded before the call, not handed over as the file wrote them: a
+        constructor is an ordinary Python classmethod asking for an enum member or a nested
+        object, and a file can only write a string, a number or a mapping. Passing those
+        through unconverted made the builder fail somewhere inside itself — ``'str' object has
+        no attribute 'value'`` for a weather location — which named neither the argument nor
+        the spellings that would have worked.
+
         Args:
             builder: The declared builder the entry selected.
             arguments: The arguments the entry passes; empty for a preset.
@@ -262,12 +270,14 @@ class EntryConfigurator:
             The configuration the builder produced.
 
         Raises:
-            EnergySystemBindingError: ``EF-1A`` when the builder raises, naming the builder
-                and keeping its own message.
+            EnergySystemBindingError: ``EF-1A`` for an argument that does not fit its
+                parameter, or when the builder itself raises, naming the builder and keeping
+                its own message.
         """
         entry = self.binding.entry
+        decoded = self._decode_arguments(builder, arguments)
         try:
-            return builder.build(entry.name, **arguments)
+            return builder.build(entry.name, **decoded)
         except Exception as error:  # pylint: disable=broad-except
             raise EnergySystemBindingError(
                 EnergySystemErrorId.UNDECODABLE_VALUE,
@@ -275,6 +285,41 @@ class EntryConfigurator:
                 f"the {builder.kind.explain()} '{builder.name}' of '{entry.name}' failed: "
                 f"{error}.",
             ) from error
+
+    def _decode_arguments(
+        self, builder: ConfigBuilder, arguments: Mapping[str, Any]
+    ) -> Mapping[str, Any]:
+        """Decodes a builder's written arguments into the types its parameters ask for.
+
+        Each argument goes through the same codec a ``config`` value does, against the
+        parameter's own resolved annotation rather than against a field's, so the two forms
+        accept the same spellings and refuse the same mistakes with the same sentence. The
+        argument names are already known to be parameters — the class-bound validator checked
+        that, with the parameter list in its message — so the only question left here is
+        whether each value fits.
+
+        Args:
+            builder: The declared builder the entry selected.
+            arguments: The arguments the entry passes.
+
+        Returns:
+            The arguments, each decoded into the type its parameter holds.
+
+        Raises:
+            EnergySystemBindingError: ``EF-1A`` for an argument that does not fit its
+                parameter, located at the parameter that refused it.
+        """
+        if not arguments:
+            return {}
+        entry = self.binding.entry
+        annotations = resolved_parameter_types(builder.function)
+        location = f"components.{entry.name}.{builder.kind.value}.{builder.name}"
+        return {
+            key: self.codec.decode_argument(
+                annotations.get(key), value, f"{location}.{key}", entry.name, key
+            )
+            for key, value in arguments.items()
+        }
 
     def _apply_overrides(self, config: Any) -> Any:
         """Writes the entry's sparse ``config`` block onto the configuration it built.

--- a/hisim/energy_system/schema_export.py
+++ b/hisim/energy_system/schema_export.py
@@ -365,8 +365,10 @@ class SchemaBuilder:
         The description carries an annotation as the string it was written as, which is enough
         for a human reading a ``describe`` output but not enough to build a schema from: an
         enumeration only becomes a closed list of member names once the annotation is resolved to
-        the class. So the builders are inspected once more here, and a constructor whose
-        annotations do not resolve simply contributes nothing, leaving its parameters permissive.
+        the class. The resolution is not done here: the ``@constructor`` decorator did it when the
+        class was declared, refusing anything it could not resolve, and the builder carries the
+        result. Reading it off the builder is what keeps the type the schema states and the type
+        the loader decodes against the same type.
 
         Args:
             config_class: The configuration dataclass.
@@ -374,13 +376,10 @@ class SchemaBuilder:
         Returns:
             Constructor name to parameter name to resolved annotation.
         """
-        resolved: Dict[str, Dict[str, Any]] = {}
-        for name, builder in constructors_of(config_class).items():
-            try:
-                resolved[name] = dict(typing.get_type_hints(builder.function))
-            except Exception:  # pylint: disable=broad-except  # an unresolvable annotation stays open
-                resolved[name] = {}
-        return resolved
+        return {
+            name: dict(builder.parameter_types)
+            for name, builder in constructors_of(config_class).items()
+        }
 
     @classmethod
     def _config(cls, config_class: type, description: ConfigDescription) -> Dict[str, Any]:

--- a/tests/test_energy_system_codec_shapes.py
+++ b/tests/test_energy_system_codec_shapes.py
@@ -1,0 +1,238 @@
+"""Tests that the decodability gate and the value decoder state the same set of shapes.
+
+A named constructor is refused at import time when one of its parameters asks for something
+no written value can become, and a written value is decoded against the annotation of the
+field or parameter it lands on. Those are two readings of one question, and they used to be
+two implementations of it: ``is_decodable_annotation`` admitted a dataclass only if it had a
+``from_dict`` while the decoder happily rebuilt one through its constructor, it admitted
+``Union[A, B]`` of two dataclasses that the decoder then refused to disambiguate, and it said
+nothing at all about ``None`` although the decoder had a rule for it.
+
+So the predicate is now the single statement, the codec imports and consults it, and this
+file is the matrix that keeps the two honest: every shape the predicate names is decoded here
+and its result inspected — by type, not only by value, because HiSim's enums derive from
+``str`` and an undecoded member compares equal to the string that spells it — and every shape
+it refuses is listed with the reason it cannot be written.
+
+Two decoder bugs the matrix pins by construction: a ``null`` written for an ``Optional`` enum
+used to be handed to the enum lookup, which refused the very absence the ``Optional`` exists
+to admit, and a ``Union[str, Enum]`` refused every string that was not a member instead of
+letting the free-string half of the union have it.
+"""
+
+# clean
+
+import enum
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import pytest
+from dataclasses_json import dataclass_json
+
+from hisim.components.air_conditioner import AirConditionerConfig
+from hisim.config.presets import is_decodable_annotation
+from hisim.energy_system.codec import ConfigValueCodec
+from hisim.energy_system.errors import EnergySystemBindingError
+
+
+class Fuel(str, enum.Enum):
+    """An enum whose member values differ from its member names, as HiSim's often do.
+
+    The difference is the whole point: a decoder that passes the written string through
+    produces a value that compares equal to the member and is not the member, which is the
+    failure the codec exists to prevent and the one a test comparing with ``==`` misses.
+    """
+
+    DIESEL = "Diesel"
+    PETROL = "Petrol"
+
+
+@dataclass_json
+@dataclass
+class Station:
+    """A nested object that can rebuild itself from a mapping, through ``from_dict``."""
+
+    code: str
+    altitude_in_m: float = 0.0
+
+
+@dataclass
+class Plain:
+    """A nested object with no ``from_dict``, rebuilt through its own constructor.
+
+    The predicate used to refuse this shape while the decoder rebuilt it anyway, which is one
+    half of the divergence this file pins.
+    """
+
+    size: int
+
+
+class NotADataclass:
+    """A plain class: no fields to write, nothing to rebuild it from."""
+
+
+#: Every shape the predicate admits, as ``(annotation, written value, decoded value)``. The
+#: decoded value is compared by value *and* by type, which is what distinguishes an enum
+#: member from the string that spells it and a float from the integer that was written.
+DECODABLE: Tuple[Tuple[str, Any, Any, Any], ...] = (
+    ("bool", bool, True, True),
+    ("int", int, 5, 5),
+    ("float from an int", float, 5, 5.0),
+    ("str", str, "profile", "profile"),
+    ("enum by member name", Fuel, "DIESEL", Fuel.DIESEL),
+    ("enum by member value", Fuel, "Diesel", Fuel.DIESEL),
+    ("dataclass with from_dict", Station, {"code": "DE.01", "altitude_in_m": 202.0},
+     Station(code="DE.01", altitude_in_m=202.0)),
+    ("dataclass without from_dict", Plain, {"size": 2}, Plain(size=2)),
+    ("list of floats", List[float], [1, 2.5], [1.0, 2.5]),
+    ("list of dataclasses", List[Plain], [{"size": 1}, {"size": 2}], [Plain(size=1), Plain(size=2)]),
+    ("optional enum, written", Optional[Fuel], "PETROL", Fuel.PETROL),
+    ("optional enum, written null", Optional[Fuel], None, None),
+    ("one or several, one", Union[Plain, List[Plain]], {"size": 3}, Plain(size=3)),
+    ("one or several, several", Union[Plain, List[Plain]], [{"size": 3}], [Plain(size=3)]),
+    ("enum or free string, a member", Union[str, Fuel], "DIESEL", Fuel.DIESEL),
+    ("enum or free string, a string", Union[str, Fuel], "anything else", "anything else"),
+)
+
+#: Every shape the predicate refuses, with what makes it unwritable. A file carries scalars,
+#: mappings and lists; these are the annotations none of those three can become without the
+#: decoder guessing.
+REFUSED: Tuple[Tuple[str, Any], ...] = (
+    ("anything at all", Any),
+    ("two dataclasses to choose between", Union[Plain, Station]),
+    ("two lists to choose between", Union[List[Plain], List[Station]]),
+    ("a callable", Callable[[], None]),
+    ("a plain class", NotADataclass),
+    ("a mapping of its own", Dict[str, float]),
+    ("a tuple", Tuple[float, float]),
+    ("a list of anything", list),
+)
+
+
+def kinds_of(value: Any) -> Any:
+    """Returns the type of a value, or the types of a list's items.
+
+    Args:
+        value: A decoded value.
+
+    Returns:
+        The type, or the list of item types, which is what an equality comparison hides.
+    """
+    if isinstance(value, list):
+        return [type(item) for item in value]
+    return type(value)
+
+
+def codec() -> ConfigValueCodec:
+    """Builds a codec on a real configuration class.
+
+    The class matters only for the field path; ``decode_argument`` is asked about an
+    annotation the caller hands it, so any real class serves — and this one carries the
+    ``List[float]`` fields the override test below needs.
+
+    Returns:
+        A codec over :class:`AirConditionerConfig`.
+    """
+    return ConfigValueCodec(AirConditionerConfig)
+
+
+@pytest.mark.base
+@pytest.mark.parametrize(
+    "annotation, written, expected", [case[1:] for case in DECODABLE], ids=[case[0] for case in DECODABLE]
+)
+def test_every_shape_the_gate_admits_is_one_the_decoder_produces(
+    annotation: Any, written: Any, expected: Any
+) -> None:
+    """Catches the gate and the decoder disagreeing about one written shape.
+
+    Failure mode caught: a constructor parameter accepted at import time whose value no file
+    can actually supply, or refused at import time although the decoder would have read it —
+    both of which were true before the predicate became the only statement of the set.
+    """
+    assert is_decodable_annotation(annotation), f"the gate refuses {annotation}"
+
+    decoded = codec().decode_argument(annotation, written, "components.Probe.x", "Probe", "x")
+
+    assert decoded == expected
+    assert kinds_of(decoded) == kinds_of(expected)
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("annotation", [case[1] for case in REFUSED], ids=[case[0] for case in REFUSED])
+def test_a_shape_no_written_value_can_become_is_refused_by_the_gate(annotation: Any) -> None:
+    """Catches the gate widening to a shape the decoder could only guess at.
+
+    Failure mode caught: a parameter typed ``Any`` or ``Union[A, B]`` over two dataclasses
+    passing the declaration check, which would leave the schema permissive and the decoder
+    picking one of two classes at random.
+    """
+    assert not is_decodable_annotation(annotation)
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("annotation", [case[1] for case in REFUSED], ids=[case[0] for case in REFUSED])
+def test_a_shape_the_gate_refuses_is_passed_through_untouched(annotation: Any) -> None:
+    """Catches the decoder inventing a reading for a shape it has no rule for.
+
+    A field may be annotated in a way the codec cannot act on — the class deserializes it
+    itself — and the standing concession is that such a value is handed on as written. It has
+    to be a *pass-through*, though, not a half-decoding: the value that comes back is the
+    value that went in.
+    """
+    written = {"whatever": [1, 2]}
+
+    assert codec().decode_argument(annotation, written, "components.Probe.x", "Probe", "x") is written
+
+
+@pytest.mark.base
+def test_a_null_on_a_parameter_that_admits_none_is_not_looked_up_in_the_enum() -> None:
+    """Catches ``null`` being refused as a misspelled enum member.
+
+    The defect this pins: the enum lookup ran before the ``None`` check, so a written ``null``
+    on an ``Optional`` enum was reported as naming no member — the one value an ``Optional``
+    exists to accept.
+    """
+    assert codec().decode_argument(Optional[Fuel], None, "components.Probe.x", "Probe", "x") is None
+
+
+@pytest.mark.base
+def test_a_null_where_none_is_not_admitted_is_refused_rather_than_written_through() -> None:
+    """Catches a written ``null`` silently becoming the value of a field that cannot hold it.
+
+    The defect this pins: ``None`` was returned unchecked, so a mandatory float ended up
+    holding ``None`` and failed much later, in arithmetic, with nothing left to name the line
+    that wrote it.
+    """
+    with pytest.raises(EnergySystemBindingError) as raised:
+        codec().decode_argument(float, None, "components.Probe.x", "Probe", "x")
+
+    assert "must not be null" in str(raised.value)
+
+
+@pytest.mark.base
+def test_a_string_that_names_no_member_is_refused_when_only_the_enum_is_admitted() -> None:
+    """Catches the free-string fallback leaking into a parameter that admits only the enum.
+
+    The fallback belongs to ``Union[str, Enum]`` alone. Where the enum is the only thing
+    admitted, a string naming no member is still the mistake it always was, and the message
+    still has to list the members.
+    """
+    with pytest.raises(EnergySystemBindingError) as raised:
+        codec().decode_argument(Fuel, "Kerosene", "components.Probe.x", "Probe", "x")
+
+    assert "no member of Fuel" in str(raised.value)
+    assert "DIESEL" in str(raised.value)
+
+
+@pytest.mark.base
+def test_a_list_written_over_a_list_field_is_decoded_item_by_item() -> None:
+    """Catches a list override of a ``List[float]`` field being refused as a single number.
+
+    The field path reduced ``List[float]`` to its item type and then complained that the list
+    was not a float, so a real configuration's reference curve could not be overridden at all.
+    Reading the list case first fixes that, and the integers in it arrive as floats.
+    """
+    decoded = codec().decode("eer_ref", [3, 3.5], "components.AC.config.eer_ref", "AC")
+
+    assert decoded == [3.0, 3.5]
+    assert kinds_of(decoded) == [float, float]

--- a/tests/test_energy_system_constructor_arguments.py
+++ b/tests/test_energy_system_constructor_arguments.py
@@ -15,19 +15,34 @@ constructor worked at all, by accident of taking nothing but strings and numbers
 So the four constructors HiSim ships are each called from a file here, with the four kinds of
 value the decoder knows — an enum by member name, an enum by member value, a mapping onto a
 nested dataclass and a list of them — and the configurations they produce are compared with
-the ones the same call produces in Python. Two more tests pin the messages a wrong value now
-gets, and the last one pins the import-time rule that keeps the two halves honest: a
-constructor may only ask for something a written value can become.
+the ones the same call produces in Python.
+
+Decoding a value is only half of getting an argument right; the other half is its *shape*. A
+field that receives something the codec cannot type-check is still read by the configuration
+class, which validates itself and refuses what does not fit. A constructor argument has no
+such second reader — it goes straight into a Python call — so the shape a parameter asks for
+is checked after the decoding, and a scalar where an object belongs, a list where one value
+belongs, a single value where a list belongs and a ``null`` where nothing may be absent are
+each refused at the argument's own key rather than inside the builder.
+
+The last two tests pin the import-time rules that keep all of this honest: a constructor may
+only ask for something a written value can become, and only for something its own module can
+resolve, since an unresolved parameter type is one the schema cannot state and the loader
+cannot decode against.
 """
 
 # clean
 
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List
+
+from dataclasses_json import dataclass_json
 
 import pytest
 from utspclient.helpers.lpgdata import Households
 
 from hisim import loadtypes as lt
+from hisim.component import Component, SingleTimeStepValues
 from hisim.components.building.config import BuildingConfig
 from hisim.components.generic_car import CarConfig
 from hisim.components.loadprofilegenerator_utsp_connector import (
@@ -35,11 +50,12 @@ from hisim.components.loadprofilegenerator_utsp_connector import (
     UtspLpgConnectorConfig,
 )
 from hisim.components.weather import LocationEnum, WeatherConfig, WeatherDataSourceEnum
-from hisim.config import ComponentID, ConfigBase, constructor
+from hisim.config import ComponentID, ConfigBase, DisplayConfig, constructor
 from hisim.energy_system import EnergySystemBindingError, EnergySystemErrorId, expand_groups
 from hisim.energy_system.configure import configure_energy_system
 from hisim.energy_system.document import RawDocument
 from hisim.energy_system.loader import EnergySystemReader
+from hisim.simulationparameters import SimulationParameters
 
 #: The one household reference every LPG fixture below uses. A file spells it as a mapping of
 #: the field names ``JsonReference`` and ``StrGuid`` declare; Python spells it as this
@@ -110,6 +126,99 @@ CAR_ENTRY = """  Car:
 """
 
 
+@dataclass_json
+@dataclass
+class Station:
+    """One entry of the station list the probe constructor below takes."""
+
+    code: str
+
+
+@dataclass_json
+@dataclass
+class StationProbeConfig(ConfigBase):
+    """The configuration of the probe component, whose constructor takes a list and only a list.
+
+    No constructor HiSim ships has a parameter annotated ``List[X]`` on its own: the LPG
+    household takes either one reference or several, which is a union, and every other list a
+    configuration holds is a field rather than an argument. The shape "a list is required" is
+    real all the same — it is what the next such constructor will be — so it is declared here
+    rather than left untested.
+    """
+
+    component_id: ComponentID
+    stations: List[Station]
+
+    @classmethod
+    def get_main_classname(cls) -> str:
+        """Returns the full class name of the component this configuration belongs to."""
+        return StationProbe.get_full_classname()
+
+    @constructor
+    @classmethod
+    def for_stations(cls, name: str, stations: List[Station]) -> "StationProbeConfig":
+        """Builds the probe from one station per entry of the list.
+
+        Args:
+            name: The instance name, which becomes the component's identity.
+            stations: The stations, one per list entry.
+
+        Returns:
+            The configuration.
+        """
+        return cls(component_id=ComponentID(name=name), stations=list(stations))
+
+
+class StationProbe(Component):
+    """A component that exists only so its configuration can be named by a file.
+
+    The class-bound stage resolves the dotted name under ``class:`` and pairs it with the
+    dataclass its constructor annotates, so a configuration cannot appear in a file without a
+    component to carry it. Nothing here ever runs a timestep.
+    """
+
+    def __init__(
+        self, my_simulation_parameters: SimulationParameters, config: StationProbeConfig
+    ) -> None:
+        """Builds the probe with no inputs and no outputs.
+
+        Args:
+            my_simulation_parameters: The run's simulation parameters.
+            config: The probe's configuration.
+        """
+        super().__init__(
+            name=config.component_id.key,
+            my_simulation_parameters=my_simulation_parameters,
+            my_config=config,
+            my_display_config=DisplayConfig(),
+        )
+
+    def i_simulate(self, timestep: int, stsv: SingleTimeStepValues, force_convergence: bool) -> None:
+        """No-op: the probe has nothing to simulate."""
+
+    def i_prepare_simulation(self) -> None:
+        """No-op: the probe needs no preparation."""
+
+    def i_save_state(self) -> None:
+        """No-op: the probe is stateless."""
+
+    def i_restore_state(self) -> None:
+        """No-op: the probe is stateless."""
+
+    def i_doublecheck(self, timestep: int, stsv: SingleTimeStepValues) -> None:
+        """No-op: there is nothing to double-check."""
+
+
+#: The probe called with a single mapping where its parameter takes a list of them.
+STATIONS_ENTRY = """  Stations:
+    class: tests.test_energy_system_constructor_arguments.StationProbe
+    constructor:
+      for_stations:
+        stations:
+          code: DE.01
+"""
+
+
 def origins_of(entries: str) -> Dict[str, Any]:
     """Configures one inline file and returns each entry's configuration by name.
 
@@ -142,6 +251,10 @@ def test_an_enum_argument_reaches_the_constructor_as_the_member() -> None:
     assert origins["Weather"] == WeatherConfig.for_location(
         "Weather", location=LocationEnum.AACHEN, data_source=WeatherDataSourceEnum.DWD_TRY
     )
+    # Hand-derived, so that the constructor is not the only oracle in the test: the station's
+    # own spelling of itself, and the member the optional reader names.
+    assert origins["Weather"].location == "Aachen"
+    assert origins["Weather"].data_source is WeatherDataSourceEnum.DWD_TRY
 
 
 @pytest.mark.base
@@ -158,6 +271,9 @@ def test_an_enum_argument_may_be_written_as_the_members_value() -> None:
     assert origins["Car"] == CarConfig.for_household(
         "Car", household_name="CHR01", car_name="Car1", fuel=lt.LoadTypes.DIESEL, source_weight=2
     )
+    # By identity, not by equality: HiSim's load types derive from ``str``, so the undecoded
+    # string 'Diesel' compares equal to the member and would pass the comparison above.
+    assert origins["Car"].fuel is lt.LoadTypes.DIESEL
 
 
 @pytest.mark.base
@@ -242,6 +358,110 @@ def test_an_argument_of_the_wrong_scalar_type_is_refused_naming_the_type() -> No
         "absolute_conditioned_floor_area_in_m2" in message
     )
     assert "'large'" in message and "float" in message
+
+
+@pytest.mark.base
+def test_a_scalar_where_a_nested_object_belongs_is_refused_naming_the_shape() -> None:
+    """Catches a household reference written as a bare name reaching the builder as a string.
+
+    Nothing in the decoding refuses it — a string is a perfectly good string — and the
+    configuration would be built holding it, so the failure would surface inside the profile
+    lookup with the written word nowhere in sight.
+    """
+    with pytest.raises(EnergySystemBindingError) as raised:
+        origins_of(
+            """  Occupancy:
+    class: hisim.components.loadprofilegenerator_utsp_connector.UtspLpgConnector
+    constructor:
+      for_household:
+        household: CHR01 Couple both at Work
+"""
+        )
+
+    message = str(raised.value)
+    assert raised.value.error_id is EnergySystemErrorId.UNDECODABLE_VALUE
+    assert "components.Occupancy.constructor.for_household.household" in message
+    assert "mapping of JsonReference's own fields" in message
+
+
+@pytest.mark.base
+def test_a_list_where_one_object_belongs_is_refused() -> None:
+    """Catches several values written for a parameter that takes one.
+
+    ``travel_route_set`` is a single optional reference, not a list of them. A list written
+    there is not decoded item by item — the parameter admits no list — and would otherwise be
+    handed to the builder as the list it is.
+    """
+    with pytest.raises(EnergySystemBindingError) as raised:
+        origins_of(
+            OCCUPANCY_ENTRY
+            + """        travel_route_set:
+          - Name: Travel Route Set for 10km Commuting Distance
+            Guid:
+              StrVal: e5b2e4e2-0b0f-4c6b-8c6f-000000000000
+"""
+        )
+
+    message = str(raised.value)
+    assert raised.value.error_id is EnergySystemErrorId.UNDECODABLE_VALUE
+    assert "components.Occupancy.constructor.for_household.travel_route_set" in message
+    assert "must not be a list" in message
+
+
+@pytest.mark.base
+def test_a_single_object_where_a_list_belongs_is_refused() -> None:
+    """Catches one mapping written for a parameter that takes a list of them.
+
+    The mapping is decoded — it rebuilds into the item class perfectly well — and only its
+    shape is wrong, which is exactly the mistake the decoding alone cannot see: the builder
+    would receive one object where it iterates over several.
+    """
+    with pytest.raises(EnergySystemBindingError) as raised:
+        origins_of(STATIONS_ENTRY)
+
+    message = str(raised.value)
+    assert raised.value.error_id is EnergySystemErrorId.UNDECODABLE_VALUE
+    assert "components.Stations.constructor.for_stations.stations" in message
+    assert "must be a list of Station" in message
+
+
+@pytest.mark.base
+def test_a_null_for_a_parameter_that_admits_no_absence_is_refused() -> None:
+    """Catches a written ``null`` becoming the value of a mandatory argument.
+
+    A TABULA code is a string and nothing else. Written as ``null`` it used to pass the
+    decoding untouched and reach the builder as ``None``, which fails on the first lookup that
+    slices it — far from the line that wrote it.
+    """
+    with pytest.raises(EnergySystemBindingError) as raised:
+        origins_of(WEATHER_ENTRY + BUILDING_ENTRY.replace("DE.N.SFH.05.Gen.ReEx.001.002", "null"))
+
+    message = str(raised.value)
+    assert raised.value.error_id is EnergySystemErrorId.UNDECODABLE_VALUE
+    assert "components.Building.constructor.for_tabula_code.building_code" in message
+    assert "must not be null" in message
+
+
+@pytest.mark.base
+def test_a_constructor_whose_parameter_type_names_nothing_is_refused_at_declaration() -> None:
+    """Catches a parameter annotation that resolves to nothing being quietly skipped.
+
+    An annotation naming a type that is not in scope used to be passed over: the parameter
+    then had no type at all, which left it permissive in the generated schema and undecoded at
+    the call — the two failures this whole check exists to prevent, arrived at by silence
+    rather than by declaration.
+    """
+    with pytest.raises(ValueError, match="Mystery"):
+
+        class _TakesAMystery(ConfigBase):
+            """A constructor asking for a type no module in scope defines."""
+
+            @constructor
+            @classmethod
+            def for_mystery(cls, name: str, x: "Mystery") -> "_TakesAMystery":  # type: ignore[name-defined]  # noqa: F821,E501
+                """A constructor whose parameter type is under test, not its body."""
+                del x
+                return cls(component_id=ComponentID(name=name))
 
 
 @pytest.mark.base

--- a/tests/test_energy_system_constructor_arguments.py
+++ b/tests/test_energy_system_constructor_arguments.py
@@ -1,0 +1,282 @@
+"""Tests that a named constructor called from a file gets decoded arguments.
+
+An energy-system file may configure a component through a named constructor, writing the
+call as a mapping under ``constructor:``. Everything in that mapping arrives as plain YAML —
+a string, a number, a mapping, a list — while the classmethod underneath expects an enum
+member, a nested dataclass or a typed scalar, exactly as a configuration field does.
+
+The defect these tests pin is that the arguments used to be forwarded verbatim. A weather
+location written as ``AACHEN`` reached ``WeatherConfig.for_location`` as the string, which
+did ``location.value`` on it and failed with ``'str' object has no attribute 'value'`` — a
+message naming neither the argument nor the spellings that would have worked. The LPG
+occupancy failed the same way on its household references, and only the all-scalar TABULA
+constructor worked at all, by accident of taking nothing but strings and numbers.
+
+So the four constructors HiSim ships are each called from a file here, with the four kinds of
+value the decoder knows — an enum by member name, an enum by member value, a mapping onto a
+nested dataclass and a list of them — and the configurations they produce are compared with
+the ones the same call produces in Python. Two more tests pin the messages a wrong value now
+gets, and the last one pins the import-time rule that keeps the two halves honest: a
+constructor may only ask for something a written value can become.
+"""
+
+# clean
+
+from typing import Any, Callable, Dict, List
+
+import pytest
+from utspclient.helpers.lpgdata import Households
+
+from hisim import loadtypes as lt
+from hisim.components.building.config import BuildingConfig
+from hisim.components.generic_car import CarConfig
+from hisim.components.loadprofilegenerator_utsp_connector import (
+    LpgDataAcquisitionMode,
+    UtspLpgConnectorConfig,
+)
+from hisim.components.weather import LocationEnum, WeatherConfig, WeatherDataSourceEnum
+from hisim.config import ComponentID, ConfigBase, constructor
+from hisim.energy_system import EnergySystemBindingError, EnergySystemErrorId, expand_groups
+from hisim.energy_system.configure import configure_energy_system
+from hisim.energy_system.document import RawDocument
+from hisim.energy_system.loader import EnergySystemReader
+
+#: The one household reference every LPG fixture below uses. A file spells it as a mapping of
+#: the field names ``JsonReference`` and ``StrGuid`` declare; Python spells it as this
+#: catalogue member, and the two have to produce the same configuration.
+HOUSEHOLD = Households.CHR01_Couple_both_at_Work
+
+#: A weather built from a catalogue station named by its member name, with the optional
+#: reader named the same way. ``LocationEnum`` spells its values as tuples, so the member
+#: name is the only spelling a file has for it.
+WEATHER_ENTRY = """  Weather:
+    class: hisim.components.weather.Weather
+    constructor:
+      for_location:
+        location: AACHEN
+        data_source: DWD_TRY
+"""
+
+#: A building from a TABULA code: the all-scalar constructor, which worked before this change
+#: and has to keep working after it.
+BUILDING_ENTRY = """  Building:
+    class: hisim.components.building.Building
+    constructor:
+      for_tabula_code:
+        building_code: DE.N.SFH.05.Gen.ReEx.001.002
+        absolute_conditioned_floor_area_in_m2: 121.2
+"""
+
+#: One LPG household as a mapping onto ``JsonReference``, in the predefined mode that reads
+#: the profile from disk.
+OCCUPANCY_ENTRY = """  Occupancy:
+    class: hisim.components.loadprofilegenerator_utsp_connector.UtspLpgConnector
+    constructor:
+      for_household:
+        household:
+          Name: CHR01 Couple both at Work
+          Guid:
+            StrVal: 516a33ab-79e1-4221-853b-967fc11cc85a
+"""
+
+#: Two apartments as a list of the same mapping. The predefined mode reads one profile from
+#: disk and refuses a list, so a multi-apartment household is only meaningful in a computing
+#: mode — which is what makes this the fixture for the list case.
+MULTI_APARTMENT_ENTRY = """  Occupancy:
+    class: hisim.components.loadprofilegenerator_utsp_connector.UtspLpgConnector
+    constructor:
+      for_household:
+        data_acquisition_mode: USE_UTSP
+        household:
+          - Name: CHR01 Couple both at Work
+            Guid:
+              StrVal: 516a33ab-79e1-4221-853b-967fc11cc85a
+          - Name: CHR01 Couple both at Work
+            Guid:
+              StrVal: 516a33ab-79e1-4221-853b-967fc11cc85a
+"""
+
+#: A car of that occupancy, whose fuel is written as the enum's *value* (``Diesel``) rather
+#: than as its member name (``DIESEL``). Both spellings are legal and they differ here, which
+#: is what makes this the fixture for the by-value case.
+CAR_ENTRY = """  Car:
+    class: hisim.components.generic_car.Car
+    constructor:
+      for_household:
+        household_name: CHR01
+        car_name: Car1
+        fuel: Diesel
+        source_weight: 2
+"""
+
+
+def origins_of(entries: str) -> Dict[str, Any]:
+    """Configures one inline file and returns each entry's configuration by name.
+
+    The origins rather than the finished configurations, because an origin is precisely what
+    the builder produced: the value a Python call to the same constructor has to match, before
+    any override or any sized field enters into it.
+
+    Args:
+        entries: The body of the ``components`` block, indented by two spaces.
+
+    Returns:
+        A mapping from component name to the configuration its builder produced.
+    """
+    text = f"schema_version: 3\nname: constructor arguments\ncomponents:\n{entries}"
+    model = EnergySystemReader.build(RawDocument.parse_text(text, "inline"), "inline")
+    expanded, _ = expand_groups(model)
+    return dict(configure_energy_system(expanded).origins)
+
+
+@pytest.mark.base
+def test_an_enum_argument_reaches_the_constructor_as_the_member() -> None:
+    """Catches the weather location arriving as the string that spells it.
+
+    The defect this pins: ``location: AACHEN`` was forwarded verbatim, so ``for_location``
+    did ``location.value`` on a ``str`` and the author was told about an attribute rather than
+    about the station they had named.
+    """
+    origins = origins_of(WEATHER_ENTRY)
+
+    assert origins["Weather"] == WeatherConfig.for_location(
+        "Weather", location=LocationEnum.AACHEN, data_source=WeatherDataSourceEnum.DWD_TRY
+    )
+
+
+@pytest.mark.base
+def test_an_enum_argument_may_be_written_as_the_members_value() -> None:
+    """Catches the by-value spelling of an enum being refused for a constructor argument.
+
+    A ``config`` block accepts both the member name and the member value, because HiSim's
+    enums spell the two alike often enough that an author cannot know which one applies. A
+    constructor argument has to accept both for the same reason: ``fuel: Diesel`` is the value
+    of ``LoadTypes.DIESEL`` and reads more naturally than the shouted member name.
+    """
+    origins = origins_of(OCCUPANCY_ENTRY + CAR_ENTRY)
+
+    assert origins["Car"] == CarConfig.for_household(
+        "Car", household_name="CHR01", car_name="Car1", fuel=lt.LoadTypes.DIESEL, source_weight=2
+    )
+
+
+@pytest.mark.base
+def test_a_mapping_argument_is_rebuilt_by_the_class_it_is_written_onto() -> None:
+    """Catches an LPG household reference staying a plain ``dict``.
+
+    ``for_household`` takes a ``JsonReference``, which the LoadProfileGenerator's own code
+    reads attribute by attribute. A mapping forwarded as written would reach the occupancy as
+    a ``dict`` and fail inside the profile lookup, far from the line that wrote it.
+    """
+    origins = origins_of(OCCUPANCY_ENTRY)
+
+    assert origins["Occupancy"] == UtspLpgConnectorConfig.for_household(
+        "Occupancy", household=HOUSEHOLD
+    )
+
+
+@pytest.mark.base
+def test_a_list_argument_is_decoded_item_by_item() -> None:
+    """Catches a multi-apartment household, the one argument that is a list of objects.
+
+    One reference per apartment is how the format states a multi-apartment building, so the
+    decoder has to walk a list against the ``List[X]`` half of the parameter's union instead
+    of treating the whole list as one value.
+    """
+    origins = origins_of(MULTI_APARTMENT_ENTRY)
+
+    assert origins["Occupancy"] == UtspLpgConnectorConfig.for_household(
+        "Occupancy",
+        household=[HOUSEHOLD, HOUSEHOLD],
+        data_acquisition_mode=LpgDataAcquisitionMode.USE_UTSP,
+    )
+
+
+@pytest.mark.base
+def test_a_scalar_argument_reaches_an_all_scalar_constructor_unharmed() -> None:
+    """Catches a regression in the one constructor that worked before arguments were decoded.
+
+    ``for_tabula_code`` takes nothing but strings and numbers, which is why it was the only
+    one a file could call at all. Decoding must leave it exactly where it was.
+    """
+    origins = origins_of(WEATHER_ENTRY + BUILDING_ENTRY)
+
+    assert origins["Building"] == BuildingConfig.for_tabula_code(
+        "Building",
+        building_code="DE.N.SFH.05.Gen.ReEx.001.002",
+        absolute_conditioned_floor_area_in_m2=121.2,
+    )
+
+
+@pytest.mark.base
+def test_a_misspelled_enum_member_is_refused_with_the_members_and_a_suggestion() -> None:
+    """Catches a mistyped station name reported as a missing Python attribute.
+
+    The message a constructor argument gets is the message a ``config`` value gets: it names
+    the argument, prints the members of the enum and suggests the one the author meant.
+    """
+    with pytest.raises(EnergySystemBindingError) as raised:
+        origins_of(WEATHER_ENTRY.replace("AACHEN", "AACHN"))
+
+    message = str(raised.value)
+    assert raised.value.error_id is EnergySystemErrorId.UNDECODABLE_VALUE
+    assert "components.Weather.constructor.for_location.location" in message
+    assert "Did you mean: AACHEN?" in message
+    assert "POTSDAM" in message and "LocationEnum" in message
+
+
+@pytest.mark.base
+def test_an_argument_of_the_wrong_scalar_type_is_refused_naming_the_type() -> None:
+    """Catches a word written where a number belongs, which no builder would report clearly.
+
+    A floor area of ``"large"`` would reach ``for_tabula_code``, be stored, and surface as a
+    wrong building rather than as a refused file.
+    """
+    with pytest.raises(EnergySystemBindingError) as raised:
+        origins_of(WEATHER_ENTRY + BUILDING_ENTRY.replace("121.2", "large"))
+
+    message = str(raised.value)
+    assert raised.value.error_id is EnergySystemErrorId.UNDECODABLE_VALUE
+    assert (
+        "components.Building.constructor.for_tabula_code."
+        "absolute_conditioned_floor_area_in_m2" in message
+    )
+    assert "'large'" in message and "float" in message
+
+
+@pytest.mark.base
+def test_a_constructor_asking_for_something_undecodable_is_refused_at_declaration() -> None:
+    """Catches a constructor no file could ever call, declared without anyone noticing.
+
+    A named constructor is part of the file format, so every parameter of one must be
+    something a written value can become. A callable or a plain object cannot be, and saying
+    so while the class body runs points at the offending method instead of at the first file
+    that tries to call it.
+    """
+
+    class _Callback:
+        """A plain class with no ``from_dict``, so no mapping can be decoded into it."""
+
+    with pytest.raises(ValueError, match="decoded into"):
+
+        class _TakesACallable(ConfigBase):
+            """A constructor asking for a callable, which no YAML value can be."""
+
+            @constructor
+            @classmethod
+            def for_callback(cls, name: str, callback: Callable[[], None]) -> "_TakesACallable":
+                """A constructor whose parameter type is under test, not its body."""
+                del callback
+                return cls(component_id=ComponentID(name=name))
+
+    with pytest.raises(ValueError, match="decoded into"):
+
+        class _TakesAPlainObject(ConfigBase):
+            """A constructor asking for a class that cannot rebuild itself from a mapping."""
+
+            @constructor
+            @classmethod
+            def for_callback(cls, name: str, callback: List[_Callback]) -> "_TakesAPlainObject":
+                """A constructor whose parameter type is under test, not its body."""
+                del callback
+                return cls(component_id=ComponentID(name=name))


### PR DESCRIPTION
﻿## D-19: a constructor called from a file gets its arguments decoded

A named constructor under `constructor:` had its YAML arguments forwarded verbatim, so `location: AACHEN` reached `WeatherConfig.for_location` as a string and the author was told `'str' object has no attribute 'value'`. Only the all-scalar TABULA constructor worked from a file.

- `codec.py`: the annotation-driven decoding becomes `decode_argument`, shared by `config` blocks and constructor calls, with a list case for `List[X]` / `Union[X, List[X]]`.
- `configure.py`: `_call_builder` decodes each argument against the parameter's resolved annotation; a bad value is EF-1A at `components.<name>.constructor.<constructor>.<parameter>` with the members and a did-you-mean.
- `presets.py`: `@constructor` refuses at decoration time a parameter whose type no written value can become (allowed: scalars, enums, dataclasses with `from_dict`, and Optional/Union/List over those).
- New `tests/test_energy_system_constructor_arguments.py` calls all four existing constructors from YAML.

Golden-neutral: no recorded twin uses `constructor:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
