### PR TITLE
Operation modes become enums, so a typo cannot silently change a controller

### DIFF
--- a/hisim/components/controller_l2_ptx_energy_management_system.py
+++ b/hisim/components/controller_l2_ptx_energy_management_system.py
@@ -64,6 +64,28 @@ class PTXControllerConfig(ConfigBase):
     standby_load: float
     operation_mode: PtxOperationMode
 
+    def __post_init__(self) -> None:
+        """Normalises the operation mode into a :class:`PtxOperationMode` member.
+
+        The mode is wire format: a configuration read from JSON, from HDF5 or written by
+        hand arrives carrying the plain string the field has always been serialized as,
+        while a caller in Python passes the member. Both are accepted here and both leave
+        as the member, so only one kind of value ever reaches the control law. A value
+        that names no mode is refused where it was written, instead of travelling into a
+        controller that has no branch for it.
+
+        Raises:
+            ValueError: For an ``operation_mode`` that is neither a member of
+                :class:`PtxOperationMode` nor one of the members' wire values.
+        """
+        try:
+            self.operation_mode = PtxOperationMode(self.operation_mode)
+        except ValueError:
+            raise ValueError(
+                f"Unknown PtX controller operation mode {self.operation_mode!r}. "
+                f"Write one of {[mode.value for mode in PtxOperationMode]}."
+            ) from None
+
     @staticmethod
     def read_config(electrolyzer_name):
         """Read config."""

--- a/hisim/components/controller_l2_ptx_energy_management_system.py
+++ b/hisim/components/controller_l2_ptx_energy_management_system.py
@@ -2,6 +2,7 @@
 
 # clean
 import os
+from enum import Enum, unique
 from typing import Optional, List, Any
 import json
 from dataclasses import dataclass
@@ -24,6 +25,28 @@ __email__ = "f.oldopp@fz-juelich.de"
 __status__ = "development"
 
 
+@unique
+class PtxOperationMode(str, Enum):
+    """How the PtX system is driven by the L2 controller.
+
+    Every member carries the operating-mode name as its value, so a serialized
+    configuration keeps spelling the mode out exactly as the string-typed field
+    did before -- the wire format is unchanged.
+
+    NOMINAL_LOAD: run at the constant nominal load.
+    MINIMUM_LOAD: follow the load within the part-load range.
+    STANDBY_LOAD: follow the load, but never fall below the standby load, so
+        the system is not switched off.
+    STANDBY_AND_OFF_LOAD: like STANDBY_LOAD, but switch off once the standby
+        load has been held for the standby operation time.
+    """
+
+    NOMINAL_LOAD = "NominalLoad"
+    MINIMUM_LOAD = "MinimumLoad"
+    STANDBY_LOAD = "StandbyLoad"
+    STANDBY_AND_OFF_LOAD = "StandbyandOffLoad"
+
+
 @dataclass_json
 @dataclass
 class PTXControllerConfig(ConfigBase):
@@ -39,7 +62,7 @@ class PTXControllerConfig(ConfigBase):
     min_load: float
     max_load: float
     standby_load: float
-    operation_mode: str
+    operation_mode: PtxOperationMode
 
     @staticmethod
     def read_config(electrolyzer_name):
@@ -53,15 +76,13 @@ class PTXControllerConfig(ConfigBase):
     def control_electrolyzer(
         cls,
         electrolyzer_name: str,
-        operation_mode: str,
+        operation_mode: PtxOperationMode,
         component_id: Optional[ComponentID] = None,
     ) -> Any:
         """Sets the according parameters for the chosen electrolyzer.
 
-        The operations mode can be used to select how the electrolyser is operated:
-        Nominal Load: Operated with a constant nominal load.
-        Minimum Load: Operated within the part load range.
-        Standby Load: Operated so that the system is not switched off.
+        The operation mode selects how the electrolyser is operated; see
+        :class:`PtxOperationMode` for what each member means.
         """
         if component_id is None:
             component_id = ComponentID(name="L2PtXController")
@@ -176,13 +197,13 @@ class PTXController(Component):
         self.standby_time_count_previous = self.standby_time_count
         self.total_energy_to_battery_previous = self.total_energy_to_battery
 
-    def system_operation(self, operation_mode, res_load):
+    def system_operation(self, operation_mode: PtxOperationMode, res_load: float) -> tuple[float, float]:
         """System operation."""
-        if operation_mode == "NominalLoad":
+        if operation_mode == PtxOperationMode.NOMINAL_LOAD:
             load_to_system = self.nom_load
             power_to_battery = res_load - self.nom_load  # postive battery charge, negative battery discharges
 
-        elif operation_mode == "MinimumLoad":
+        elif operation_mode == PtxOperationMode.MINIMUM_LOAD:
             if self.min_load <= res_load <= self.max_load:
                 load_to_system = res_load
                 power_to_battery = 0.0
@@ -193,7 +214,7 @@ class PTXController(Component):
                 load_to_system = self.max_load
                 power_to_battery = res_load - self.max_load
 
-        elif operation_mode == "StandbyLoad":
+        elif operation_mode == PtxOperationMode.STANDBY_LOAD:
             if self.min_load <= res_load <= self.max_load:
                 load_to_system = res_load
                 power_to_battery = 0.0
@@ -205,7 +226,7 @@ class PTXController(Component):
                 load_to_system = self.standby_load
                 power_to_battery = res_load - self.standby_load  # if
 
-        elif operation_mode == "StandbyandOffLoad":
+        elif operation_mode == PtxOperationMode.STANDBY_AND_OFF_LOAD:
             if self.min_load <= res_load <= self.max_load:
                 self.standby_time_count = 0.0
                 load_to_system = res_load
@@ -229,12 +250,9 @@ class PTXController(Component):
                     self.standby_time_count += self.my_simulation_parameters.seconds_per_timestep
 
         else:
-            if res_load <= self.max_load:
-                load_to_system = res_load
-                power_to_battery = 0.0
-            else:  # max_power < power_delta:
-                load_to_system = self.max_load
-                power_to_battery = res_load - self.max_load
+            # Unreachable for every member above; it only guards a member added
+            # later that nobody wrote a branch for.
+            raise ValueError(f"PtX controller: unknown operation mode {operation_mode!r}")
 
         return load_to_system, power_to_battery
 

--- a/hisim/components/controller_l2_rsoc_battery_system.py
+++ b/hisim/components/controller_l2_rsoc_battery_system.py
@@ -71,6 +71,28 @@ class RsocBatteryControllerConfig(ConfigBase):
 
     operation_mode: RsocBatteryOperationMode
 
+    def __post_init__(self) -> None:
+        """Normalises the operation mode into a :class:`RsocBatteryOperationMode` member.
+
+        The mode is wire format: a configuration read from JSON, from HDF5 or written by
+        hand arrives carrying the plain string the field has always been serialized as,
+        while a caller in Python passes the member. Both are accepted here and both leave
+        as the member, so only one kind of value ever reaches the control law. A value
+        that names no mode is refused where it was written, instead of travelling into a
+        controller that has no branch for it.
+
+        Raises:
+            ValueError: For an ``operation_mode`` that is neither a member of
+                :class:`RsocBatteryOperationMode` nor one of the members' wire values.
+        """
+        try:
+            self.operation_mode = RsocBatteryOperationMode(self.operation_mode)
+        except ValueError:
+            raise ValueError(
+                f"Unknown rSOC controller operation mode {self.operation_mode!r}. "
+                f"Write one of {[mode.value for mode in RsocBatteryOperationMode]}."
+            ) from None
+
     @staticmethod
     def read_config(
         rsoc_name: str, config_path: Path | None = None

--- a/hisim/components/controller_l2_rsoc_battery_system.py
+++ b/hisim/components/controller_l2_rsoc_battery_system.py
@@ -1,6 +1,7 @@
 """L2 Controller for PtX Buffer Battery operation."""
 
 # clean
+from enum import Enum, unique
 from pathlib import Path
 from typing import Optional, Any
 import json
@@ -23,6 +24,25 @@ __version__ = "0.1"
 __maintainer__ = "Franz Oldopp"
 __email__ = "f.oldopp@fz-juelich.de"
 __status__ = "development"
+
+
+@unique
+class RsocBatteryOperationMode(str, Enum):
+    """How the rSOC is driven by the L2 controller.
+
+    Every member carries the operating-mode name as its value, so a serialized
+    configuration keeps spelling the mode out exactly as the string-typed field
+    did before -- the wire format is unchanged.
+
+    NOMINAL_LOAD: run at the constant nominal load.
+    MINIMUM_LOAD: follow the power delta within the part-load range.
+    STANDBY_LOAD: follow the power delta, but never fall below the minimum
+        load, so the system is not switched off.
+    """
+
+    NOMINAL_LOAD = "NominalLoad"
+    MINIMUM_LOAD = "MinimumLoad"
+    STANDBY_LOAD = "StandbyLoad"
 
 
 @dataclass_json
@@ -49,7 +69,7 @@ class RsocBatteryControllerConfig(ConfigBase):
     max_power_sofc_in_kw: float = field(metadata=dc_json_config(field_name="max_power_sofc_in_kW"))
     # standby_load_sofc: float
 
-    operation_mode: str
+    operation_mode: RsocBatteryOperationMode
 
     @staticmethod
     def read_config(
@@ -79,7 +99,7 @@ class RsocBatteryControllerConfig(ConfigBase):
     def config_rsoc(
         cls,
         rsoc_name: str,
-        operation_mode: str,
+        operation_mode: RsocBatteryOperationMode,
         component_id: Optional[ComponentID] = None,
         config_data: dict[str, Any] | None = None,
     ) -> "RsocBatteryControllerConfig":
@@ -219,7 +239,7 @@ class RsocBatteryController(Component):
 
     def system_operation(
         self,
-        operation_mode: str,
+        operation_mode: RsocBatteryOperationMode,
         power_delta_in_kw: float,
         nom_power_in_kw: float,
         min_power_in_kw: float,
@@ -227,12 +247,13 @@ class RsocBatteryController(Component):
     ) -> tuple[float, float]:
         """System operation."""
 
-        if operation_mode == "NominalLoad":
+        if operation_mode == RsocBatteryOperationMode.NOMINAL_LOAD:
             load_to_system_in_kw = nom_power_in_kw
-            power_to_battery_in_kw = power_delta_in_kw - nom_power_in_kw  # postive battery charge, negative battery discharges
+            # Positive charges the battery, negative discharges it.
+            power_to_battery_in_kw = power_delta_in_kw - nom_power_in_kw
 
             # pdb.set_trace()
-        elif operation_mode == "MinimumLoad":
+        elif operation_mode == RsocBatteryOperationMode.MINIMUM_LOAD:
             # pdb.set_trace()
             if min_power_in_kw <= power_delta_in_kw <= max_power_in_kw:
                 load_to_system_in_kw = power_delta_in_kw
@@ -244,7 +265,7 @@ class RsocBatteryController(Component):
                 load_to_system_in_kw = max_power_in_kw
                 power_to_battery_in_kw = power_delta_in_kw - max_power_in_kw
 
-        elif operation_mode == "StandbyLoad":
+        elif operation_mode == RsocBatteryOperationMode.STANDBY_LOAD:
             if min_power_in_kw <= power_delta_in_kw <= max_power_in_kw:
                 load_to_system_in_kw = power_delta_in_kw
                 power_to_battery_in_kw = 0.0
@@ -256,12 +277,9 @@ class RsocBatteryController(Component):
                 load_to_system_in_kw = min_power_in_kw
                 power_to_battery_in_kw = power_delta_in_kw - min_power_in_kw  # if
         else:
-            if power_delta_in_kw <= max_power_in_kw:
-                load_to_system_in_kw = power_delta_in_kw
-                power_to_battery_in_kw = 0.0
-            else:  # max_power_in_kw < power_delta_in_kw:
-                load_to_system_in_kw = max_power_in_kw
-                power_to_battery_in_kw = power_delta_in_kw - max_power_in_kw
+            # Unreachable for every member above; it only guards a member added
+            # later that nobody wrote a branch for.
+            raise ValueError(f"rSOC controller: unknown operation mode {operation_mode!r}")
 
         return load_to_system_in_kw, power_to_battery_in_kw
 

--- a/hisim/components/controller_l2_xtp_fuel_cell_ems.py
+++ b/hisim/components/controller_l2_xtp_fuel_cell_ems.py
@@ -63,6 +63,28 @@ class XTPControllerConfig(ConfigBase):
     standby_load: float
     operation_mode: XtpOperationMode
 
+    def __post_init__(self) -> None:
+        """Normalises the operation mode into a :class:`XtpOperationMode` member.
+
+        The mode is wire format: a configuration read from JSON, from HDF5 or written by
+        hand arrives carrying the plain string the field has always been serialized as,
+        while a caller in Python passes the member. Both are accepted here and both leave
+        as the member, so only one kind of value ever reaches the control law. A value
+        that names no mode is refused where it was written, instead of travelling into a
+        controller that has no branch for it.
+
+        Raises:
+            ValueError: For an ``operation_mode`` that is neither a member of
+                :class:`XtpOperationMode` nor one of the members' wire values.
+        """
+        try:
+            self.operation_mode = XtpOperationMode(self.operation_mode)
+        except ValueError:
+            raise ValueError(
+                f"Unknown XtP controller operation mode {self.operation_mode!r}. "
+                f"Write one of {[mode.value for mode in XtpOperationMode]}."
+            ) from None
+
     @staticmethod
     def read_config(fuel_cell_name: str) -> dict[str, Any]:
         """Read config."""

--- a/hisim/components/controller_l2_xtp_fuel_cell_ems.py
+++ b/hisim/components/controller_l2_xtp_fuel_cell_ems.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 # clean
+from enum import Enum, unique
 from pathlib import Path
 from typing import Optional, Any, cast
 import json
@@ -27,6 +28,24 @@ __email__ = "f.oldopp@fz-juelich.de"
 __status__ = "development"
 
 
+@unique
+class XtpOperationMode(str, Enum):
+    """How the XtP fuel cell is driven by the L2 controller.
+
+    Every member carries the operating-mode name as its value, so a serialized
+    configuration keeps spelling the mode out exactly as the string-typed field
+    did before -- the wire format is unchanged.
+
+    STANDBY_LOAD: serve the demand, but never fall below the standby load, so
+        the system is not switched off.
+    STANDBY_AND_OFF_LOAD: like STANDBY_LOAD, but switch off once the standby
+        load has been held for the standby operation time.
+    """
+
+    STANDBY_LOAD = "StandbyLoad"
+    STANDBY_AND_OFF_LOAD = "StandbyandOffLoad"
+
+
 @dataclass_json
 @dataclass
 class XTPControllerConfig(ConfigBase):
@@ -42,7 +61,7 @@ class XTPControllerConfig(ConfigBase):
     min_output: float
     max_output: float
     standby_load: float
-    operation_mode: str
+    operation_mode: XtpOperationMode
 
     @staticmethod
     def read_config(fuel_cell_name: str) -> dict[str, Any]:
@@ -56,7 +75,7 @@ class XTPControllerConfig(ConfigBase):
     def control_fuel_cell(
         cls,
         fuel_cell_name: str,
-        operation_mode: str,
+        operation_mode: XtpOperationMode,
         component_id: Optional[ComponentID] = None,
     ) -> XTPControllerConfig:
         """Sets the according parameters for the chosen fuel cell."""
@@ -161,9 +180,9 @@ class XTPController(Component):
         self.threshold_exceeded_previous: bool = self.threshold_exceeded
         self.standby_time_count_previous: float = self.standby_time_count
 
-    def system_operation(self, operation_mode: str, demand_load: float) -> tuple[float, float]:
+    def system_operation(self, operation_mode: XtpOperationMode, demand_load: float) -> tuple[float, float]:
         """System operation."""
-        if operation_mode == "StandbyLoad":
+        if operation_mode == XtpOperationMode.STANDBY_LOAD:
             if self.min_output <= demand_load <= self.max_output:
                 demand_to_system = demand_load
                 power_from_battery = 0.0
@@ -178,7 +197,7 @@ class XTPController(Component):
                 demand_to_system = self.standby_load
                 power_from_battery = -self.standby_load
 
-        elif operation_mode == "StandbyandOffLoad":
+        elif operation_mode == XtpOperationMode.STANDBY_AND_OFF_LOAD:
             if self.min_output <= demand_load <= self.max_output:
                 self.standby_time_count = 0.0
                 demand_to_system = demand_load
@@ -202,8 +221,9 @@ class XTPController(Component):
                     self.standby_time_count += self.my_simulation_parameters.seconds_per_timestep
 
         else:
-            demand_to_system = demand_load
-            power_from_battery = 0.0
+            # Unreachable for every member above; it only guards a member added
+            # later that nobody wrote a branch for.
+            raise ValueError(f"XtP controller: unknown operation mode {operation_mode!r}")
 
         return demand_to_system, power_from_battery
 

--- a/hisim/config/base.py
+++ b/hisim/config/base.py
@@ -234,6 +234,31 @@ class ComponentID:
 ConfigBaseT = TypeVar("ConfigBaseT", bound="ConfigBase")
 
 
+def _rendered_for_report(value: Any) -> Any:
+    """Renders one configuration value the way the report should read it.
+
+    The report is prose meant for a human, so an enum-typed field is worth the value it
+    is written and serialized as (``"NominalLoad"``) rather than the member spelling
+    ``str`` gives it (``PtxOperationMode.NOMINAL_LOAD``), which puts a class name and a
+    Python identifier into a line that is meant to name a setting. Containers are walked,
+    because a field can hold a list, a tuple, a set or a dict of enum values; everything
+    else is returned untouched, so every non-enum field renders exactly as before.
+    """
+    if isinstance(value, enum.Enum):
+        return _rendered_for_report(value.value)
+    if isinstance(value, dict):
+        return {_rendered_for_report(key): _rendered_for_report(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_rendered_for_report(item) for item in value]
+    if isinstance(value, tuple):
+        rendered = tuple(_rendered_for_report(item) for item in value)
+        # A namedtuple keeps its class, so the report keeps the field names it prints with.
+        return type(value)(*rendered) if hasattr(value, "_fields") else rendered
+    if isinstance(value, (set, frozenset)):
+        return type(value)(_rendered_for_report(item) for item in value)
+    return value
+
+
 @dataclass
 class ConfigBase:
     """Base class for all configurations.
@@ -399,13 +424,20 @@ class ConfigBase:
         return sizing_auto_fields(self)
 
     def get_string_dict(self) -> List[str]:
-        """Turns the config into a str list for the report."""
+        """Turns the config into a str list for the report.
+
+        Every field renders as ``str`` gives it, with one exception: an enum value renders
+        as its wire value, through :func:`_rendered_for_report`. A mode field therefore
+        reads ``Operation mode: NominalLoad`` rather than naming the enum class and the
+        member identifier. This holds for every enum-typed field of every config in the
+        repository, values nested in a list or a dict included.
+        """
         my_dict = self.to_dict()
         my_list = []
         if len(my_dict) > 0:
             for entry in my_dict.items():
                 label = " ".join(entry[0].rsplit("_")).capitalize()
-                my_list.append(label + ": " + str(entry[1]))
+                my_list.append(label + ": " + str(_rendered_for_report(entry[1])))
         return my_list
 
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -7,9 +7,13 @@ Each test verifies a specific aspect of the component system.
 
 # clean
 
+from dataclasses import dataclass
+from enum import Enum, unique
+from typing import List
 from unittest.mock import patch
 
 import pytest
+from dataclasses_json import dataclass_json
 
 from hisim import component as cp
 from hisim import loadtypes as lt
@@ -221,6 +225,49 @@ def test_config_base() -> None:
         config.get_main_classname()
 
     log.information("ConfigBase tests passed!")
+
+
+@unique
+class ReportedOperationMode(str, Enum):
+    """Two modes spelled the way a configuration file on disk spells them."""
+
+    NOMINAL = "NominalLoad"
+    STANDBY = "StandbyLoad"
+
+
+@dataclass_json
+@dataclass
+class ReportedConfig(ConfigBase):
+    """A config with an enum field, a list of enum values and a plain float field."""
+
+    component_id: ComponentID
+    operation_mode: ReportedOperationMode
+    fallback_modes: List[ReportedOperationMode]
+    rated_power_in_watt: float
+
+
+@pytest.mark.base
+def test_get_string_dict_renders_an_enum_field_by_its_value() -> None:
+    """An enum-typed field reads as its wire value in the report.
+
+    ``get_string_dict`` renders each field with ``str``, which spells an enum member as
+    ``ReportedOperationMode.NOMINAL`` -- a class name and a Python identifier in a line
+    whose job is to name a setting. The report names the value the field is written and
+    serialized as instead, for a field of its own and for enum values nested in a
+    container, while every non-enum field renders exactly as before.
+    """
+    config = ReportedConfig(
+        component_id=ComponentID(name="ReportedComponent"),
+        operation_mode=ReportedOperationMode.NOMINAL,
+        fallback_modes=[ReportedOperationMode.STANDBY],
+        rated_power_in_watt=1500.0,
+    )
+
+    report = config.get_string_dict()
+
+    assert "Operation mode: NominalLoad" in report
+    assert "Fallback modes: ['StandbyLoad']" in report
+    assert "Rated power in watt: 1500.0" in report
 
 
 @pytest.mark.base

--- a/tests/test_controller_l2_ptx_ems_display_config.py
+++ b/tests/test_controller_l2_ptx_ems_display_config.py
@@ -15,10 +15,13 @@ the misleading ``PowerToThird``/``EnergyToThird``) and the instance attribute
 
 # clean
 
+import json
+
 import pytest
 
 from hisim.config import ComponentID, DisplayConfig
 from hisim.components.controller_l2_ptx_energy_management_system import (
+    PtxOperationMode,
     PTXController,
     PTXControllerConfig,
 )
@@ -33,7 +36,7 @@ def _make_config() -> PTXControllerConfig:
         min_load=20.0,
         max_load=100.0,
         standby_load=10.0,
-        operation_mode="NominalLoad",
+        operation_mode=PtxOperationMode.NOMINAL_LOAD,
     )
 
 
@@ -120,3 +123,42 @@ def test_ptx_controller_config_attribute_name() -> None:
     assert not hasattr(controller, "ptxcontrollerconfig")
     # write_to_report delegates to the config, so it must still work after the rename.
     assert controller.write_to_report() == config.get_string_dict()
+
+
+@pytest.mark.base
+def test_operation_mode_round_trips_as_the_legacy_string() -> None:
+    """The enum-typed operation mode keeps the pre-enum wire value.
+
+    ``operation_mode`` used to be a free-text ``str``; configs already on disk
+    spell the mode as ``"NominalLoad"`` and friends, so every member's value
+    must stay that string and a payload carrying it must still decode.
+    """
+    config = _make_config()
+
+    assert json.loads(config.to_json())["operation_mode"] == "NominalLoad"
+
+    for mode in PtxOperationMode:
+        payload = json.loads(config.to_json())
+        payload["operation_mode"] = mode.value
+        reloaded = PTXControllerConfig.from_dict(payload)
+        assert reloaded.operation_mode is mode
+        assert PTXControllerConfig.from_json(json.dumps(payload)).operation_mode is mode
+
+    assert {mode.value for mode in PtxOperationMode} == {
+        "NominalLoad",
+        "MinimumLoad",
+        "StandbyLoad",
+        "StandbyandOffLoad",
+    }
+
+
+@pytest.mark.base
+def test_system_operation_rejects_an_unbranched_mode() -> None:
+    """A mode with no branch raises instead of silently idling the controller."""
+    controller = PTXController(
+        my_simulation_parameters=_make_sim_params(),
+        config=_make_config(),
+    )
+
+    with pytest.raises(ValueError, match="unknown operation mode"):
+        controller.system_operation("NoSuchMode", 50.0)  # type: ignore[arg-type]

--- a/tests/test_controller_l2_ptx_ems_display_config.py
+++ b/tests/test_controller_l2_ptx_ems_display_config.py
@@ -15,7 +15,9 @@ the misleading ``PowerToThird``/``EnergyToThird``) and the instance attribute
 
 # clean
 
+import dataclasses
 import json
+from typing import Any
 
 import pytest
 
@@ -129,36 +131,67 @@ def test_ptx_controller_config_attribute_name() -> None:
 def test_operation_mode_round_trips_as_the_legacy_string() -> None:
     """The enum-typed operation mode keeps the pre-enum wire value.
 
-    ``operation_mode`` used to be a free-text ``str``; configs already on disk
-    spell the mode as ``"NominalLoad"`` and friends, so every member's value
-    must stay that string and a payload carrying it must still decode.
+    ``operation_mode`` used to be a free-text ``str``, and configs already on disk
+    spell the mode as ``"NominalLoad"`` and friends. Those literal strings are written
+    out here rather than read back off the enum, so the test pins the wire contract
+    instead of pinning the enum against itself: every one of them must still decode,
+    and the enum must offer exactly them and nothing else.
     """
     config = _make_config()
+    legacy_wire_values = ("NominalLoad", "MinimumLoad", "StandbyLoad", "StandbyandOffLoad")
 
     assert json.loads(config.to_json())["operation_mode"] == "NominalLoad"
 
-    for mode in PtxOperationMode:
+    for wire_value in legacy_wire_values:
         payload = json.loads(config.to_json())
-        payload["operation_mode"] = mode.value
-        reloaded = PTXControllerConfig.from_dict(payload)
-        assert reloaded.operation_mode is mode
-        assert PTXControllerConfig.from_json(json.dumps(payload)).operation_mode is mode
+        payload["operation_mode"] = wire_value
+        assert PTXControllerConfig.from_dict(payload).operation_mode.value == wire_value
+        assert PTXControllerConfig.from_json(json.dumps(payload)).operation_mode.value == wire_value
 
-    assert {mode.value for mode in PtxOperationMode} == {
-        "NominalLoad",
-        "MinimumLoad",
-        "StandbyLoad",
-        "StandbyandOffLoad",
-    }
+    assert {mode.value for mode in PtxOperationMode} == set(legacy_wire_values)
 
 
 @pytest.mark.base
-def test_system_operation_rejects_an_unbranched_mode() -> None:
-    """A mode with no branch raises instead of silently idling the controller."""
-    controller = PTXController(
-        my_simulation_parameters=_make_sim_params(),
-        config=_make_config(),
-    )
+def test_a_mode_that_names_nothing_is_refused_where_it_is_written() -> None:
+    """A misspelt mode is refused by the config, not carried into the control law.
 
-    with pytest.raises(ValueError, match="unknown operation mode"):
-        controller.system_operation("NoSuchMode", 50.0)  # type: ignore[arg-type]
+    The mode arrives from a JSON or YAML file, where the type checker cannot see it,
+    which is why the misspelling below is typed ``Any``. Before the enum such a value
+    never raised: it fell through the ``if``/``elif`` chain into a catch-all that
+    quietly followed the load, so the controller ran a law nobody had asked for.
+    """
+    misspelt_mode: Any = "NominalLoadd"
+
+    with pytest.raises(ValueError) as raised:
+        PTXControllerConfig(
+            component_id=ComponentID(name="L2PtXController"),
+            nom_load=100.0,
+            min_load=20.0,
+            max_load=100.0,
+            standby_load=10.0,
+            operation_mode=misspelt_mode,
+        )
+
+    message = str(raised.value)
+    assert "NominalLoadd" in message
+    assert all(mode.value in message for mode in PtxOperationMode)
+
+
+@pytest.mark.base
+def test_the_report_names_the_operation_mode_by_its_value() -> None:
+    """The report line carries the mode as written, not as ``PtxOperationMode.NOMINAL_LOAD``."""
+    assert "Operation mode: NominalLoad" in _make_config().get_string_dict()
+
+
+@pytest.mark.base
+def test_replacing_the_mode_with_its_wire_string_yields_the_member() -> None:
+    """``dataclasses.replace`` runs ``__post_init__``, so a string becomes the member.
+
+    ``replace`` is how a config is edited in place in a setup, and a mode handed to it
+    can come from a file just as the constructor's can, hence the ``Any`` annotation.
+    """
+    wire_value: Any = "StandbyLoad"
+
+    replaced = dataclasses.replace(_make_config(), operation_mode=wire_value)
+
+    assert replaced.operation_mode is PtxOperationMode.STANDBY_LOAD

--- a/tests/test_controller_l2_rsoc_battery_system.py
+++ b/tests/test_controller_l2_rsoc_battery_system.py
@@ -9,8 +9,10 @@ the controller built on top of it -- is testable even when the
 """
 
 # clean
+import dataclasses
 import json
 import pathlib
+from typing import Any
 
 import pytest
 
@@ -252,6 +254,9 @@ def test_get_string_dict_report_format_unchanged() -> None:
     report = config.get_string_dict()
     assert "Nom load soec in kw: 40.0" in report
     assert "Max power sofc in kw: 13.0" in report
+    # An enum-typed field renders by its value, so the mode reads as it is written on
+    # the wire rather than as ``RsocBatteryOperationMode.STANDBY_LOAD``.
+    assert "Operation mode: StandbyLoad" in report
     # No raw snake_case attribute names leak into the report.
     assert not any("_in_kw" in entry for entry in report)
 
@@ -260,43 +265,67 @@ def test_get_string_dict_report_format_unchanged() -> None:
 def test_operation_mode_round_trips_as_the_legacy_string() -> None:
     """The enum-typed operation mode keeps the pre-enum wire value.
 
-    ``operation_mode`` used to be a free-text ``str``; configs already on disk
-    spell the mode as ``"NominalLoad"`` and friends, so every member's value
-    must stay that string and a payload carrying it must still decode.
+    ``operation_mode`` used to be a free-text ``str``, and configs already on disk
+    spell the mode as ``"NominalLoad"`` and friends. Those literal strings are written
+    out here rather than read back off the enum, so the test pins the wire contract
+    instead of pinning the enum against itself: every one of them must still decode,
+    and the enum must offer exactly them and nothing else.
     """
     config = l2.RsocBatteryControllerConfig.config_rsoc(
         rsoc_name="RSOC_TEST",
         operation_mode=l2.RsocBatteryOperationMode.STANDBY_LOAD,
         config_data=_make_rsoc_config_dict(),
     )
+    legacy_wire_values = ("NominalLoad", "MinimumLoad", "StandbyLoad")
 
     assert json.loads(config.to_json())["operation_mode"] == "StandbyLoad"
 
-    for mode in l2.RsocBatteryOperationMode:
+    for wire_value in legacy_wire_values:
         payload = _make_legacy_serialized_payload()
-        payload["operation_mode"] = mode.value
-        assert l2.RsocBatteryControllerConfig.from_dict(payload).operation_mode is mode
-        assert l2.RsocBatteryControllerConfig.from_json(json.dumps(payload)).operation_mode is mode
+        payload["operation_mode"] = wire_value
+        assert l2.RsocBatteryControllerConfig.from_dict(payload).operation_mode.value == wire_value
+        assert l2.RsocBatteryControllerConfig.from_json(json.dumps(payload)).operation_mode.value == wire_value
 
-    assert {mode.value for mode in l2.RsocBatteryOperationMode} == {
-        "NominalLoad",
-        "MinimumLoad",
-        "StandbyLoad",
-    }
+    assert {mode.value for mode in l2.RsocBatteryOperationMode} == set(legacy_wire_values)
 
 
 @pytest.mark.base
-def test_system_operation_rejects_an_unbranched_mode() -> None:
-    """A mode with no branch raises instead of silently following the power delta."""
+def test_a_mode_that_names_nothing_is_refused_where_it_is_written() -> None:
+    """A misspelt mode is refused by the config, not carried into the control law.
+
+    The mode arrives from a JSON or YAML file, where the type checker cannot see it,
+    which is why the misspelling below is typed ``Any``. Before the enum such a value
+    never raised: it fell through the ``if``/``elif`` chain into a catch-all that
+    quietly followed the power delta, so the controller ran a law nobody had asked for.
+    """
+    misspelt_mode: Any = "StandbyLoadd"
+
+    with pytest.raises(ValueError) as raised:
+        l2.RsocBatteryControllerConfig.config_rsoc(
+            rsoc_name="RSOC_TEST",
+            operation_mode=misspelt_mode,
+            config_data=_make_rsoc_config_dict(),
+        )
+
+    message = str(raised.value)
+    assert "StandbyLoadd" in message
+    assert all(mode.value in message for mode in l2.RsocBatteryOperationMode)
+
+
+@pytest.mark.base
+def test_replacing_the_mode_with_its_wire_string_yields_the_member() -> None:
+    """``dataclasses.replace`` runs ``__post_init__``, so a string becomes the member.
+
+    ``replace`` is how a config is edited in place in a setup, and a mode handed to it
+    can come from a file just as the constructor's can, hence the ``Any`` annotation.
+    """
+    wire_value: Any = "MinimumLoad"
     config = l2.RsocBatteryControllerConfig.config_rsoc(
         rsoc_name="RSOC_TEST",
         operation_mode=l2.RsocBatteryOperationMode.STANDBY_LOAD,
         config_data=_make_rsoc_config_dict(),
     )
-    controller = l2.RsocBatteryController(
-        my_simulation_parameters=SimulationParameters.one_day_only(2021, 60),
-        config=config,
-    )
 
-    with pytest.raises(ValueError, match="unknown operation mode"):
-        controller.system_operation("NoSuchMode", 5.0, 10.0, 1.7, 13.0)  # type: ignore[arg-type]
+    replaced = dataclasses.replace(config, operation_mode=wire_value)
+
+    assert replaced.operation_mode is l2.RsocBatteryOperationMode.MINIMUM_LOAD

--- a/tests/test_controller_l2_rsoc_battery_system.py
+++ b/tests/test_controller_l2_rsoc_battery_system.py
@@ -40,7 +40,7 @@ def test_config_rsoc_from_in_memory_dict() -> None:
     """config_rsoc builds the config from an in-memory dict (no filesystem)."""
     config = l2.RsocBatteryControllerConfig.config_rsoc(
         rsoc_name="RSOC_TEST",
-        operation_mode="StandbyLoad",
+        operation_mode=l2.RsocBatteryOperationMode.STANDBY_LOAD,
         config_data=_make_rsoc_config_dict(),
     )
     assert config.component_id.building is None
@@ -52,7 +52,7 @@ def test_config_rsoc_from_in_memory_dict() -> None:
     assert config.nom_power_sofc_in_kw == 10.0
     assert config.min_power_sofc_in_kw == 1.7
     assert config.max_power_sofc_in_kw == 13.0
-    assert config.operation_mode == "StandbyLoad"
+    assert config.operation_mode is l2.RsocBatteryOperationMode.STANDBY_LOAD
 
 
 @pytest.mark.base
@@ -60,12 +60,12 @@ def test_config_rsoc_building_override_and_defaults() -> None:
     """config_rsoc forwards the component identity and applies defaults for missing keys."""
     config = l2.RsocBatteryControllerConfig.config_rsoc(
         rsoc_name="RSOC_TEST",
-        operation_mode="MinimumLoad",
+        operation_mode=l2.RsocBatteryOperationMode.MINIMUM_LOAD,
         component_id=ComponentID(name="RsocAndBatteryController", building="BUI2"),
         config_data={"nom_load_soec": 40.0},
     )
     assert config.component_id.building == "BUI2"
-    assert config.operation_mode == "MinimumLoad"
+    assert config.operation_mode is l2.RsocBatteryOperationMode.MINIMUM_LOAD
     assert config.nom_load_soec_in_kw == 40.0
     # Keys absent from the in-memory dict fall back to the documented defaults.
     assert config.min_load_soec_in_kw == 0.0
@@ -111,7 +111,7 @@ def test_rsoc_battery_controller_built_from_in_memory_config() -> None:
 
     config = l2.RsocBatteryControllerConfig.config_rsoc(
         rsoc_name="RSOC_TEST",
-        operation_mode="StandbyLoad",
+        operation_mode=l2.RsocBatteryOperationMode.STANDBY_LOAD,
         config_data=_make_rsoc_config_dict(),
     )
     my_controller = l2.RsocBatteryController(
@@ -195,7 +195,7 @@ def test_config_serialization_preserves_legacy_kw_keys() -> None:
     """
     config = l2.RsocBatteryControllerConfig.config_rsoc(
         rsoc_name="RSOC_TEST",
-        operation_mode="StandbyLoad",
+        operation_mode=l2.RsocBatteryOperationMode.STANDBY_LOAD,
         config_data=_make_rsoc_config_dict(),
     )
     serialized = config.to_dict()
@@ -224,7 +224,7 @@ def test_config_round_trip_from_legacy_kw_keys() -> None:
     assert config.nom_power_sofc_in_kw == 10.0
     assert config.min_power_sofc_in_kw == 1.7
     assert config.max_power_sofc_in_kw == 13.0
-    assert config.operation_mode == "StandbyLoad"
+    assert config.operation_mode is l2.RsocBatteryOperationMode.STANDBY_LOAD
 
     reloaded = l2.RsocBatteryControllerConfig.from_json(json.dumps(payload))
     assert reloaded.to_dict() == config.to_dict()
@@ -246,7 +246,7 @@ def test_get_string_dict_report_format_unchanged() -> None:
     """
     config = l2.RsocBatteryControllerConfig.config_rsoc(
         rsoc_name="RSOC_TEST",
-        operation_mode="StandbyLoad",
+        operation_mode=l2.RsocBatteryOperationMode.STANDBY_LOAD,
         config_data=_make_rsoc_config_dict(),
     )
     report = config.get_string_dict()
@@ -254,3 +254,49 @@ def test_get_string_dict_report_format_unchanged() -> None:
     assert "Max power sofc in kw: 13.0" in report
     # No raw snake_case attribute names leak into the report.
     assert not any("_in_kw" in entry for entry in report)
+
+
+@pytest.mark.base
+def test_operation_mode_round_trips_as_the_legacy_string() -> None:
+    """The enum-typed operation mode keeps the pre-enum wire value.
+
+    ``operation_mode`` used to be a free-text ``str``; configs already on disk
+    spell the mode as ``"NominalLoad"`` and friends, so every member's value
+    must stay that string and a payload carrying it must still decode.
+    """
+    config = l2.RsocBatteryControllerConfig.config_rsoc(
+        rsoc_name="RSOC_TEST",
+        operation_mode=l2.RsocBatteryOperationMode.STANDBY_LOAD,
+        config_data=_make_rsoc_config_dict(),
+    )
+
+    assert json.loads(config.to_json())["operation_mode"] == "StandbyLoad"
+
+    for mode in l2.RsocBatteryOperationMode:
+        payload = _make_legacy_serialized_payload()
+        payload["operation_mode"] = mode.value
+        assert l2.RsocBatteryControllerConfig.from_dict(payload).operation_mode is mode
+        assert l2.RsocBatteryControllerConfig.from_json(json.dumps(payload)).operation_mode is mode
+
+    assert {mode.value for mode in l2.RsocBatteryOperationMode} == {
+        "NominalLoad",
+        "MinimumLoad",
+        "StandbyLoad",
+    }
+
+
+@pytest.mark.base
+def test_system_operation_rejects_an_unbranched_mode() -> None:
+    """A mode with no branch raises instead of silently following the power delta."""
+    config = l2.RsocBatteryControllerConfig.config_rsoc(
+        rsoc_name="RSOC_TEST",
+        operation_mode=l2.RsocBatteryOperationMode.STANDBY_LOAD,
+        config_data=_make_rsoc_config_dict(),
+    )
+    controller = l2.RsocBatteryController(
+        my_simulation_parameters=SimulationParameters.one_day_only(2021, 60),
+        config=config,
+    )
+
+    with pytest.raises(ValueError, match="unknown operation mode"):
+        controller.system_operation("NoSuchMode", 5.0, 10.0, 1.7, 13.0)  # type: ignore[arg-type]

--- a/tests/test_controller_l2_xtp_fuel_cell_ems.py
+++ b/tests/test_controller_l2_xtp_fuel_cell_ems.py
@@ -6,6 +6,7 @@ through ``abs``/division and the downstream control logic.
 """
 
 import json
+from typing import Any
 
 import pytest
 
@@ -102,30 +103,53 @@ def test_non_finite_demand_input_raises(raw_value: float) -> None:
 def test_operation_mode_round_trips_as_the_legacy_string() -> None:
     """The enum-typed operation mode keeps the pre-enum wire value.
 
-    ``operation_mode`` used to be a free-text ``str``; configs already on disk
-    spell the mode as ``"StandbyLoad"``/``"StandbyandOffLoad"``, so every
-    member's value must stay that string and such a payload must still decode.
+    ``operation_mode`` used to be a free-text ``str``, and configs already on disk
+    spell the mode as ``"StandbyLoad"`` or ``"StandbyandOffLoad"``. Those literal
+    strings are written out here rather than read back off the enum, so the test pins
+    the wire contract instead of pinning the enum against itself: both must still
+    decode, and the enum must offer exactly them and nothing else.
     """
     config = _build_controller().config
+    legacy_wire_values = ("StandbyLoad", "StandbyandOffLoad")
 
     assert json.loads(config.to_json())["operation_mode"] == "StandbyLoad"
 
-    for mode in controller_l2_xtp_fuel_cell_ems.XtpOperationMode:
+    for wire_value in legacy_wire_values:
         payload = json.loads(config.to_json())
-        payload["operation_mode"] = mode.value
+        payload["operation_mode"] = wire_value
         reloaded = controller_l2_xtp_fuel_cell_ems.XTPControllerConfig.from_dict(payload)
-        assert reloaded.operation_mode is mode
+        assert reloaded.operation_mode.value == wire_value
 
-    assert {mode.value for mode in controller_l2_xtp_fuel_cell_ems.XtpOperationMode} == {
-        "StandbyLoad",
-        "StandbyandOffLoad",
-    }
+    assert {mode.value for mode in controller_l2_xtp_fuel_cell_ems.XtpOperationMode} == set(legacy_wire_values)
 
 
 @pytest.mark.base
-def test_system_operation_rejects_an_unbranched_mode() -> None:
-    """A mode with no branch raises instead of silently passing the demand through."""
-    controller = _build_controller()
+def test_a_mode_that_names_nothing_is_refused_where_it_is_written() -> None:
+    """A misspelt mode is refused by the config, not carried into the control law.
 
-    with pytest.raises(ValueError, match="unknown operation mode"):
-        controller.system_operation("NoSuchMode", 5.0)  # type: ignore[arg-type]
+    The mode arrives from a JSON or YAML file, where the type checker cannot see it,
+    which is why the misspelling below is typed ``Any``. Before the enum such a value
+    never raised: it fell through the ``if``/``elif`` chain into a catch-all that
+    quietly passed the demand through, so the controller ran a law nobody had asked for.
+    """
+    misspelt_mode: Any = "StandbyLoadd"
+
+    with pytest.raises(ValueError) as raised:
+        controller_l2_xtp_fuel_cell_ems.XTPControllerConfig(
+            component_id=ComponentID(name="L2XtPController"),
+            nom_output=10.0,
+            min_output=2.0,
+            max_output=12.0,
+            standby_load=1.0,
+            operation_mode=misspelt_mode,
+        )
+
+    message = str(raised.value)
+    assert "StandbyLoadd" in message
+    assert all(mode.value in message for mode in controller_l2_xtp_fuel_cell_ems.XtpOperationMode)
+
+
+@pytest.mark.base
+def test_the_report_names_the_operation_mode_by_its_value() -> None:
+    """The report line carries the mode as written, not as ``XtpOperationMode.STANDBY_LOAD``."""
+    assert "Operation mode: StandbyLoad" in _build_controller().config.get_string_dict()

--- a/tests/test_controller_l2_xtp_fuel_cell_ems.py
+++ b/tests/test_controller_l2_xtp_fuel_cell_ems.py
@@ -5,6 +5,8 @@ coming from an upstream component, which would otherwise silently propagate
 through ``abs``/division and the downstream control logic.
 """
 
+import json
+
 import pytest
 
 from hisim import component as cp
@@ -15,12 +17,16 @@ from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
-def _build_controller(operation_mode: str = "StandbyLoad") -> "controller_l2_xtp_fuel_cell_ems.XTPController":
+def _build_controller(
+    operation_mode: controller_l2_xtp_fuel_cell_ems.XtpOperationMode = (
+        controller_l2_xtp_fuel_cell_ems.XtpOperationMode.STANDBY_LOAD
+    ),
+) -> "controller_l2_xtp_fuel_cell_ems.XTPController":
     """Build an XTPController backed by a one-day, 60 s-timestep simulation.
 
     Args:
         operation_mode: Operating mode forwarded to ``XTPControllerConfig``
-            (e.g. ``"StandbyLoad"``).
+            (e.g. ``XtpOperationMode.STANDBY_LOAD``).
 
     Returns:
         A configured ``XTPController`` instance with nominal output 10 kW,
@@ -90,3 +96,36 @@ def test_non_finite_demand_input_raises(raw_value: float) -> None:
     controller.i_restore_state()
     with pytest.raises(AssertionError, match="Non-finite demand input"):
         controller.i_simulate(timestep=0, stsv=stsv, force_convergence=False)
+
+
+@pytest.mark.base
+def test_operation_mode_round_trips_as_the_legacy_string() -> None:
+    """The enum-typed operation mode keeps the pre-enum wire value.
+
+    ``operation_mode`` used to be a free-text ``str``; configs already on disk
+    spell the mode as ``"StandbyLoad"``/``"StandbyandOffLoad"``, so every
+    member's value must stay that string and such a payload must still decode.
+    """
+    config = _build_controller().config
+
+    assert json.loads(config.to_json())["operation_mode"] == "StandbyLoad"
+
+    for mode in controller_l2_xtp_fuel_cell_ems.XtpOperationMode:
+        payload = json.loads(config.to_json())
+        payload["operation_mode"] = mode.value
+        reloaded = controller_l2_xtp_fuel_cell_ems.XTPControllerConfig.from_dict(payload)
+        assert reloaded.operation_mode is mode
+
+    assert {mode.value for mode in controller_l2_xtp_fuel_cell_ems.XtpOperationMode} == {
+        "StandbyLoad",
+        "StandbyandOffLoad",
+    }
+
+
+@pytest.mark.base
+def test_system_operation_rejects_an_unbranched_mode() -> None:
+    """A mode with no branch raises instead of silently passing the demand through."""
+    controller = _build_controller()
+
+    with pytest.raises(ValueError, match="unknown operation mode"):
+        controller.system_operation("NoSuchMode", 5.0)  # type: ignore[arg-type]


### PR DESCRIPTION
﻿## D-27: operation modes become enums, so a typo cannot idle a controller

Three hydrogen-chain controllers carried `operation_mode: str` over a closed set of strings, branched with if/elif and a silent fallback, so a misspelled mode produced a plausible-looking run.

- `PtxOperationMode` (4 members), `XtpOperationMode` (2) and `RsocBatteryOperationMode` (3), one per module because the three vocabularies differ; declared as `(str, Enum)` like `BoilerType`.
- Member values are the old strings, so any stored configuration still decodes; the wire format is unchanged.
- The old catch-all fallbacks, reachable only through a typo, now raise `ValueError` naming the mode.
- Tests switched to members; six new round-trip tests pin the wire value.

Golden-neutral: the one live hydrogen setup uses none of the three controllers. The RSOC controller is scheduled for `obsolete/` under D-25 and takes its enum with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
