### PR TITLE
The example's magic literal becomes a law, and the template shows one

### DIFF
--- a/hisim/components/example_component.py
+++ b/hisim/components/example_component.py
@@ -10,7 +10,7 @@ from dataclasses_json import dataclass_json
 # Owned
 from hisim.simulationparameters import SimulationParameters
 from hisim.component import Component, SingleTimeStepValues, ComponentInput, ComponentOutput
-from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.config import AUTO, ConfigBase, ComponentID, DisplayConfig, Sizable, Size, concrete, sized_field
 from hisim import loadtypes as lt
 from hisim.economics.facts import CostRelevance
 
@@ -23,11 +23,28 @@ __maintainer__ = "Vitor Hugo Bellotto Zago"
 __email__ = "vitor.zago@rwth-aachen.de"
 __status__ = "development"
 
+#: Specific heat capacity of the fictitious thermal mass this component stands for, in
+#: joule per kelvin and square metre of conditioned floor area. It is the constant half of
+#: the ``capacity`` sizing law below; the other half is the floor area of the building the
+#: component sits in. The number, and the law it forms, are where the literal
+#: ``45 * 121.2`` that this config used to carry came from: 121.2 m² is the conditioned
+#: floor area of the default TABULA building (``BuildingConfig.preset_standard``,
+#: ``DE.N.SFH.05.Gen.ReEx.001.002``), so the law reproduces the old value exactly for that
+#: building and scales with any other one.
+SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2: float = 45.0
+
 
 @dataclass_json
 @dataclass
 class ExampleComponentConfig(ConfigBase):
-    """Configuration of the Example Component."""
+    """Configuration of the Example Component.
+
+    ``capacity`` is a *sizable* field: its value is not a number written here but a law
+    declared at the field, which the sizing kernel evaluates against the facts of the
+    surrounding system (see :mod:`hisim.config.sizing`). The factory below therefore says
+    :data:`~hisim.config.AUTO` instead of a number, and a caller resolves the config
+    against a :class:`~hisim.config.SizingContext` before handing it to the component.
+    """
 
     @classmethod
     def get_main_classname(cls) -> str:
@@ -39,8 +56,14 @@ class ExampleComponentConfig(ConfigBase):
     unit: lt.Units
     electricity: Optional[float]
     # heat: float = 0.0,
-    capacity: Optional[float]
     initial_temperature: Optional[float]
+    #: Thermal capacity of the modelled mass in J/K: the specific capacity above times the
+    #: conditioned floor area of the building. Declared last because a sizable field carries
+    #: a default (``AUTO``) and must follow the fields that do not.
+    capacity: Sizable[float] = sized_field(
+        rule=Size.CONDITIONED_FLOOR_AREA_IN_M2 * SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2,
+        note="45 J/K per m² of conditioned floor area",
+    )
 
     @classmethod
     def get_default_example_component(
@@ -56,7 +79,7 @@ class ExampleComponentConfig(ConfigBase):
             loadtype=lt.LoadTypes.HEATING,
             unit=lt.Units.WATT,
             # heat=0.0,
-            capacity=45 * 121.2,
+            capacity=AUTO,
             initial_temperature=25.0,
         )
 
@@ -122,7 +145,10 @@ class ExampleComponent(Component):
         self.build(
             electricity=config.electricity,
             # heat=config.heat,
-            capacity=config.capacity,
+            # The central check in Component.__init__ has already refused any config that
+            # still carries AUTO, so the sized field is a number by now; ``concrete`` is the
+            # read-side idiom that says so to the type checker as well.
+            capacity=concrete(config.capacity),
             initial_temperature=config.initial_temperature,
         )
 
@@ -161,7 +187,7 @@ class ExampleComponent(Component):
         self,
         electricity: Optional[float],
         # heat: float,
-        capacity: Optional[float],
+        capacity: float,
         initial_temperature: Optional[float],
     ) -> None:
         """Build load profile for entire simulation duration."""
@@ -173,10 +199,9 @@ class ExampleComponent(Component):
         else:
             self.electricity_output = -1e3 * electricity
 
-        if capacity is None:
-            self.capacity: float = 45 * 121.2
-        else:
-            self.capacity = capacity
+        # No None fallback: ``capacity`` is sized, and a config that still carried AUTO
+        # never reaches a component, so the value is always a real number here.
+        self.capacity: float = capacity
 
         if initial_temperature is None:
             self.temperature = 25.0

--- a/hisim/components/example_component.py
+++ b/hisim/components/example_component.py
@@ -62,7 +62,8 @@ class ExampleComponentConfig(ConfigBase):
     #: a default (``AUTO``) and must follow the fields that do not.
     capacity: Sizable[float] = sized_field(
         rule=Size.CONDITIONED_FLOOR_AREA_IN_M2 * SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2,
-        note="45 J/K per m² of conditioned floor area",
+        value_type=float,
+        note=f"{SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2} J/K per m² of conditioned floor area",
     )
 
     @classmethod

--- a/hisim/components/example_template.py
+++ b/hisim/components/example_template.py
@@ -16,10 +16,11 @@ Steps to build a component, in the order they appear below:
    provides (``hisim/config/context.py`` holds the whole vocabulary).
 3. Write the factory / preset. A sized field is spelled :data:`~hisim.config.AUTO` there:
    the factory says "this one is computed", not what it computes to.
-4. If the component is itself a *source* of facts — a weather file contributing its
-   identity, a building contributing its heating load, a boiler contributing its power
-   band — declare that in ``SIZING_CONTRIBUTIONS``; see the note above
-   :class:`ComponentName` and ``weather.py`` for a real one.
+4. Where a contribution is declared: if the component is itself a *source* of facts — a
+   weather file contributing its identity, a building contributing its heating load, a
+   boiler contributing its power band — that goes into ``SIZING_CONTRIBUTIONS``. Shown as
+   a comment block below, since the template models no real fact; ``weather.py`` holds a
+   real one.
 5. Write the component class: declare inputs and outputs, implement the four lifecycle
    methods. By the time a config reaches the constructor the sizing kernel has already
    turned every ``AUTO`` into a number (``Component.__init__`` refuses anything else), so
@@ -92,19 +93,29 @@ class ComponentNameConfig(ConfigBase):
     #: * ``rule=`` is the **law**: an expression over ``Size.*`` terms. Each term is one
     #:   *fact* about the surrounding system; the complete vocabulary of facts, and the
     #:   ``SizingContext`` that carries them, live in ``hisim/config/context.py``. Laws
-    #:   can be scaled, clamped (``.at_least(...)``), rounded (``.rounded(2)``), read a
-    #:   sibling field (``Self("other_field")``) or be a plain function of the context —
-    #:   see ``generic_boiler.py`` and ``heat_distribution_system.py`` for real ones.
-    #: * ``note=`` records where the number comes from. The audit trail and
-    #:   ``hisim energy-system describe`` print it next to the computed value, so a
-    #:   hard-coded constant can cite its source.
+    #:   can be scaled, rounded (``.rounded(2)``), clamped (``.at_least(...)``), read a
+    #:   sibling field (``Self("other_field")``) or be a plain function of the context.
+    #:   Real ones: ``heat_distribution_system.py`` rounds a fact
+    #:   (``Size.WATER_MASS_FLOW_RATE_IN_KG_PER_SECOND.rounded(2)``) and ``generic_boiler.py``
+    #:   scales a sibling (``Self("maximal_thermal_power_in_watt") * (1 / 12)``); no component
+    #:   clamps today, so ``.at_least(...)`` is shown by ``tests/test_sizing.py`` only.
+    #: * ``value_type=`` names the concrete type the field's *wire* value is coerced into,
+    #:   so a ``"2.0"`` written in a JSON or YAML file arrives as a float instead of a string.
+    #: * ``note=`` records where the number comes from. ``hisim energy-system describe``
+    #:   prints it under the field, so a hard-coded constant can cite its source. (The
+    #:   audit written next to a run's results carries the law, the inputs and the value,
+    #:   but not the note.)
     #:
     #: The facts themselves are provided by the other components of the system (see the
     #: note on ``SIZING_CONTRIBUTIONS`` below) and the value is computed by the executor,
     #: before any component is constructed.
     rated_power_in_watt: Sizable[float] = sized_field(
         rule=Size.CONDITIONED_FLOOR_AREA_IN_M2 * SPECIFIC_RATED_POWER_IN_WATT_PER_M2,
-        note="2 W per m² of conditioned floor area (invented: the template models no real device)",
+        value_type=float,
+        note=(
+            f"{SPECIFIC_RATED_POWER_IN_WATT_PER_M2} W per m² of conditioned floor area"
+            " (invented: the template models no real device)"
+        ),
     )
 
     @classmethod
@@ -158,7 +169,8 @@ class ComponentName(Component):
     Attributes:
         InputFromOtherComponent: Name of the input field read from another component.
         OutputWithState: Name of the output field whose value is held in state.
-        OutputWithoutState: Name of the stateless output field.
+        OutputWithoutState: Name of the stateless output field, a power in watts capped
+            at the sized ``rated_power_in_watt``.
     """
 
     cost_relevance = CostRelevance.FREE_OF_COST
@@ -227,7 +239,7 @@ class ComponentName(Component):
             object_name=self.componentnameconfig.component_id.name,
             field_name=self.OutputWithoutState,
             load_type=loadtypes.LoadTypes.ELECTRICITY,
-            unit=loadtypes.Units.WATT_HOUR,
+            unit=loadtypes.Units.WATT,
             output_description="Output without State",
         )
 
@@ -252,8 +264,8 @@ class ComponentName(Component):
         """Compute outputs for the current timestep.
 
         Reads the external input and the previous in-state output, computes the
-        two outputs (one accumulated into state, one stateless) and writes them
-        back to ``stsv`` and to :py:attr:`state`.
+        two outputs (one accumulated into state, one stateless power capped at the
+        sized rated power) and writes them back to ``stsv`` and to :py:attr:`state`.
 
         Args:
             timestep: Current simulation timestep index.
@@ -265,18 +277,18 @@ class ComponentName(Component):
         input_2_in_wh = self.state.output_with_state_in_wh
 
         # do your calculations
-        # NOTE: arithmetic is dimensionally inconsistent with the declared output
-        # units: input_1_in_w * seconds_per_timestep is W·s (J), not Wh, and
-        # output_2_in_wh sums two powers (W) for a WATT_HOUR output. Suffixes
-        # follow the declared channel units; this is a known template limitation.
+        # NOTE: the stateful branch is dimensionally inconsistent with its declared unit:
+        # input_1_in_w * seconds_per_timestep is W·s (J), not Wh. Suffixes follow the
+        # declared channel units; this is a known template limitation.
         output_1_in_wh = input_2_in_wh + input_1_in_w * self.my_simulation_parameters.seconds_per_timestep
         # The sized field is used here like any other number: the device cannot deliver
-        # more than the power it was sized for.
-        output_2_in_wh = min(input_1_in_w + self.factor_in_w, self.rated_power_in_watt)
+        # more than the power it was sized for. Both sides of the min are watts, which is
+        # why ``OutputWithoutState`` is declared in WATT.
+        output_2_in_w = min(input_1_in_w + self.factor_in_w, self.rated_power_in_watt)
 
         # write values for output time series
         stsv.set_output_value(self.output_with_state, output_1_in_wh)
-        stsv.set_output_value(self.output_without_state, output_2_in_wh)
+        stsv.set_output_value(self.output_without_state, output_2_in_w)
 
         # write values to state
         self.state.output_with_state_in_wh = output_1_in_wh

--- a/hisim/components/example_template.py
+++ b/hisim/components/example_template.py
@@ -4,6 +4,32 @@ It serves as a template for creating new component modules.
 It shows with a simplified example which steps are necessary to create a new component.
 Additionally it contains examples for doc strings according to the sphinx format.
 
+Steps to build a component, in the order they appear below:
+
+1. Write the configuration dataclass (:class:`ComponentNameConfig`). Every parameter of
+   the device is a field of it.
+2. For every parameter whose value is *not* the author's choice but follows from the
+   surrounding system — the size of the building, the load it has to cover, the power of
+   the device next to it — declare a **sizing law** at the field instead of writing a
+   number: ``sized_field(rule=...)``, see ``rated_power_in_watt`` below. The law is an
+   expression over ``Size.*`` terms, which are the *facts* the surrounding system
+   provides (``hisim/config/context.py`` holds the whole vocabulary).
+3. Write the factory / preset. A sized field is spelled :data:`~hisim.config.AUTO` there:
+   the factory says "this one is computed", not what it computes to.
+4. If the component is itself a *source* of facts — a weather file contributing its
+   identity, a building contributing its heating load, a boiler contributing its power
+   band — declare that in ``SIZING_CONTRIBUTIONS``; see the note above
+   :class:`ComponentName` and ``weather.py`` for a real one.
+5. Write the component class: declare inputs and outputs, implement the four lifecycle
+   methods. By the time a config reaches the constructor the sizing kernel has already
+   turned every ``AUTO`` into a number (``Component.__init__`` refuses anything else), so
+   the component reads a sized field like any other value — through
+   :func:`~hisim.config.concrete`, which says exactly that to the type checker.
+
+Who runs the sizing: the energy-system executor resolves every config of a system against
+the facts the system provides, before any component is constructed. A hand-written setup
+or a test does the same explicitly with ``config.resolve(SizingContext(...))``.
+
 """
 
 # clean
@@ -16,7 +42,7 @@ from dataclasses_json import dataclass_json
 
 # Import modules from HiSim
 from hisim.component import Component, ComponentInput, ComponentOutput, SingleTimeStepValues
-from hisim.config import ConfigBase, ComponentID, DisplayConfig
+from hisim.config import AUTO, ConfigBase, ComponentID, DisplayConfig, Sizable, Size, concrete, sized_field
 from hisim import loadtypes
 from hisim.simulationparameters import SimulationParameters
 from hisim.economics.facts import CostRelevance
@@ -30,11 +56,26 @@ __maintainer__ = "Vitor Hugo Bellotto Zago"
 __email__ = "vitor.zago@rwth-aachen.de"
 __status__ = "development"
 
+#: Rated electrical power of this fictitious device per square metre of conditioned floor
+#: area, in W/m². It is the constant half of the ``rated_power_in_watt`` sizing law below;
+#: the other half is a fact about the surrounding system. A real component cites a source
+#: for such a constant (a standard, a datasheet) in the field's ``note``; this one is
+#: invented, because the template models no real device.
+SPECIFIC_RATED_POWER_IN_WATT_PER_M2: float = 2.0
+
 
 @dataclass_json
 @dataclass
 class ComponentNameConfig(ConfigBase):
-    """Configuration of the ComponentName."""
+    """Configuration of the ComponentName.
+
+    A configuration holds two kinds of parameter, and the difference is the point of this
+    class: ``loadtype`` and ``unit`` are the *author's* choices and are written as plain
+    fields with plain values, while ``rated_power_in_watt`` *follows from the system the
+    component is placed in* and is therefore declared with :func:`~hisim.config.sized_field`
+    — a law at the field, evaluated once by the sizing kernel, instead of a number repeated
+    in every setup that uses the component.
+    """
 
     @classmethod
     def get_main_classname(cls) -> str:
@@ -44,6 +85,27 @@ class ComponentNameConfig(ConfigBase):
     component_id: ComponentID
     loadtype: loadtypes.LoadTypes
     unit: loadtypes.Units
+    #: How the sizing mechanism is declared, in one field:
+    #:
+    #: * ``Sizable[float]`` is the field's type — a float, or, until it is resolved, the
+    #:   ``AUTO`` sentinel (or a per-preset law overriding the one declared here).
+    #: * ``rule=`` is the **law**: an expression over ``Size.*`` terms. Each term is one
+    #:   *fact* about the surrounding system; the complete vocabulary of facts, and the
+    #:   ``SizingContext`` that carries them, live in ``hisim/config/context.py``. Laws
+    #:   can be scaled, clamped (``.at_least(...)``), rounded (``.rounded(2)``), read a
+    #:   sibling field (``Self("other_field")``) or be a plain function of the context —
+    #:   see ``generic_boiler.py`` and ``heat_distribution_system.py`` for real ones.
+    #: * ``note=`` records where the number comes from. The audit trail and
+    #:   ``hisim energy-system describe`` print it next to the computed value, so a
+    #:   hard-coded constant can cite its source.
+    #:
+    #: The facts themselves are provided by the other components of the system (see the
+    #: note on ``SIZING_CONTRIBUTIONS`` below) and the value is computed by the executor,
+    #: before any component is constructed.
+    rated_power_in_watt: Sizable[float] = sized_field(
+        rule=Size.CONDITIONED_FLOOR_AREA_IN_M2 * SPECIFIC_RATED_POWER_IN_WATT_PER_M2,
+        note="2 W per m² of conditioned floor area (invented: the template models no real device)",
+    )
 
     @classmethod
     def get_default_template_component(
@@ -57,7 +119,33 @@ class ComponentNameConfig(ConfigBase):
             component_id=component_id,
             loadtype=loadtypes.LoadTypes.ELECTRICITY,
             unit=loadtypes.Units.WATT,
+            # A sized field is spelled AUTO in a factory or a preset: the value is the
+            # law's to compute, so the factory only says that it is not pinned here.
+            # (It is also the field's declared default, so it could be omitted entirely;
+            # it is written out once here because this file is read as a tutorial.)
+            rated_power_in_watt=AUTO,
         )
+
+
+# Step 4 -- contributing facts, the other half of the sizing mechanism.
+#
+# A component that is a *source* of facts declares that next to its config class:
+#
+#     ComponentNameConfig.SIZING_CONTRIBUTIONS = (
+#         FactContribution(facts=("<fact name>",), compute=ComponentNameConfig.<method>),
+#     )
+#
+# ``compute`` receives the (by then resolved) config and the context, and returns exactly
+# the declared facts; the engine then hands them to whichever sibling config declares a law
+# reading them. ``weather.py`` and ``loadprofilegenerator_utsp_connector.py`` hold the two
+# smallest real examples, ``building/information.py`` the largest.
+#
+# The template declares no contribution of its own, because a contributed fact name must
+# today be a field of ``SizingContext`` (``FactContribution.__post_init__`` refuses any
+# other name) and inventing a template-only fact in that shared vocabulary would put a
+# fact nothing reads into every energy system. A real component either contributes one of
+# the existing facts or adds its fact to ``hisim/config/context.py`` together with its
+# ``Size`` term.
 
 
 class ComponentName(Component):
@@ -114,6 +202,10 @@ class ComponentName(Component):
         self.previous_state: "ComponentNameState" = deepcopy(self.state)
         # Initialized variables
         self.factor_in_w: float = 1.0
+        # A sized field is read like any other config value: by the time a config reaches
+        # a component, ``Component.__init__`` has already refused every config that still
+        # carried AUTO, so this is a number. ``concrete`` states that for the type checker.
+        self.rated_power_in_watt: float = concrete(config.rated_power_in_watt)
 
         self.input_from_other_component: ComponentInput = self.add_input(
             object_name=self.componentnameconfig.component_id.name,
@@ -178,7 +270,9 @@ class ComponentName(Component):
         # output_2_in_wh sums two powers (W) for a WATT_HOUR output. Suffixes
         # follow the declared channel units; this is a known template limitation.
         output_1_in_wh = input_2_in_wh + input_1_in_w * self.my_simulation_parameters.seconds_per_timestep
-        output_2_in_wh = input_1_in_w + self.factor_in_w
+        # The sized field is used here like any other number: the device cannot deliver
+        # more than the power it was sized for.
+        output_2_in_wh = min(input_1_in_w + self.factor_in_w, self.rated_power_in_watt)
 
         # write values for output time series
         stsv.set_output_value(self.output_with_state, output_1_in_wh)

--- a/tests/functions_for_testing.py
+++ b/tests/functions_for_testing.py
@@ -1,15 +1,56 @@
 """Helper functions for testing."""
 # clean
-from typing import Any, ClassVar, Tuple, Type
+from typing import Any, ClassVar, Optional, Tuple, Type
 
 import yaml
 
 from hisim.component import ComponentOutput
+from hisim.components.example_component import ExampleComponentConfig
+from hisim.config import ComponentID, SizingContext
 from hisim.energy_system.codec import ConfigValueCodec
 from hisim.energy_system.path_resolver import PathResolver
 from hisim.energy_system.record import ConfigBlockWriter
 from hisim.postprocessingoptions import PostProcessingOptions
 from hisim.simulationparameters import SimulationParameters
+
+#: Conditioned floor area of the default TABULA building (``BuildingConfig.preset_standard``,
+#: building code ``DE.N.SFH.05.Gen.ReEx.001.002``) in m². The two example components size
+#: fields from this fact, and the tests below resolve their configs against exactly this
+#: value, which is what keeps their numbers identical to the literals the modules used to
+#: carry (45 J/K/m² x 121.2 m² = 5454.0 J/K for the example component's capacity).
+DEFAULT_CONDITIONED_FLOOR_AREA_IN_M2: float = 121.2
+
+
+def default_building_sizing_context() -> SizingContext:
+    """The sizing context of a default-building scenario, for tests that size one component.
+
+    A real run gets its context from the building via ``SizingContext.for_building``, which
+    reads the TABULA catalogue; a unit test that only needs one fact states that fact instead,
+    so it stays fast and its numbers are visible in the test.
+
+    Returns:
+        SizingContext: a context carrying the default building's conditioned floor area.
+    """
+    return SizingContext(conditioned_floor_area_in_m2=DEFAULT_CONDITIONED_FLOOR_AREA_IN_M2)
+
+
+def sized_example_component_config(component_id: Optional[ComponentID] = None) -> ExampleComponentConfig:
+    """The default example component configuration, resolved so a component may be built from it.
+
+    ``ExampleComponentConfig.capacity`` is a sizable field, so the factory hands back a config
+    carrying ``AUTO`` and ``Component.__init__`` refuses it. Every test that constructs an
+    ``ExampleComponent`` therefore resolves first, and does it through this one helper rather
+    than repeating the context.
+
+    Args:
+        component_id: the identity to build the configuration for; the factory default if None.
+
+    Returns:
+        ExampleComponentConfig: the resolved configuration, with ``capacity`` a real number.
+    """
+    return ExampleComponentConfig.get_default_example_component(component_id=component_id).resolve(
+        default_building_sizing_context()
+    )
 
 
 def round_trip_config_block(config: Any, config_class: Type, component_name: str) -> Any:

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -289,7 +289,10 @@ def test_example_component_with_config() -> None:
         loadtype=lt.LoadTypes.ELECTRICITY,
         unit=lt.Units.WATT,
         electricity=-1e3,
-        capacity=example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2 * 121.2,
+        capacity=(
+            example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2
+            * fft.DEFAULT_CONDITIONED_FLOOR_AREA_IN_M2
+        ),
         initial_temperature=25.0,
     )
 
@@ -342,7 +345,10 @@ def test_component_connections() -> None:
         loadtype=lt.LoadTypes.HEATING,
         unit=lt.Units.WATT,
         electricity=-1e3,
-        capacity=example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2 * 121.2,
+        capacity=(
+            example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2
+            * fft.DEFAULT_CONDITIONED_FLOOR_AREA_IN_M2
+        ),
         initial_temperature=25.0,
     )
 
@@ -422,7 +428,10 @@ def test_add_default_connections_empty_raises() -> None:
         loadtype=lt.LoadTypes.HEATING,
         unit=lt.Units.WATT,
         electricity=-1e3,
-        capacity=example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2 * 121.2,
+        capacity=(
+            example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2
+            * fft.DEFAULT_CONDITIONED_FLOOR_AREA_IN_M2
+        ),
         initial_temperature=25.0,
     )
     component = example_component.ExampleComponent(config=config, my_simulation_parameters=sim_params)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -289,7 +289,7 @@ def test_example_component_with_config() -> None:
         loadtype=lt.LoadTypes.ELECTRICITY,
         unit=lt.Units.WATT,
         electricity=-1e3,
-        capacity=45 * 121.2,
+        capacity=example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2 * 121.2,
         initial_temperature=25.0,
     )
 
@@ -342,7 +342,7 @@ def test_component_connections() -> None:
         loadtype=lt.LoadTypes.HEATING,
         unit=lt.Units.WATT,
         electricity=-1e3,
-        capacity=45 * 121.2,
+        capacity=example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2 * 121.2,
         initial_temperature=25.0,
     )
 
@@ -422,7 +422,7 @@ def test_add_default_connections_empty_raises() -> None:
         loadtype=lt.LoadTypes.HEATING,
         unit=lt.Units.WATT,
         electricity=-1e3,
-        capacity=45 * 121.2,
+        capacity=example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2 * 121.2,
         initial_temperature=25.0,
     )
     component = example_component.ExampleComponent(config=config, my_simulation_parameters=sim_params)
@@ -540,7 +540,7 @@ def test_example_component_simulation() -> None:
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
 
     # Create component with default config
-    config = example_component.ExampleComponentConfig.get_default_example_component()
+    config = fft.sized_example_component_config()
     component = example_component.ExampleComponent(config=config, my_simulation_parameters=sim_params)
 
     # Create outputs
@@ -770,7 +770,7 @@ def test_connect_inputs_raises_for_unconnected_mandatory() -> None:
     from hisim.component_wrapper import ComponentWrapper
 
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    config = example_component.ExampleComponentConfig.get_default_example_component()
+    config = fft.sized_example_component_config()
     component = example_component.ExampleComponent(config=config, my_simulation_parameters=sim_params)
 
     mandatory_input = cp.ComponentInput(
@@ -795,7 +795,7 @@ def test_connect_inputs_warns_for_allow_unconnected_mandatory() -> None:
     from hisim.component_wrapper import ComponentWrapper
 
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    config = example_component.ExampleComponentConfig.get_default_example_component()
+    config = fft.sized_example_component_config()
     component = example_component.ExampleComponent(config=config, my_simulation_parameters=sim_params)
 
     optional_mandatory_input = cp.ComponentInput(

--- a/tests/test_component_id.py
+++ b/tests/test_component_id.py
@@ -27,6 +27,7 @@ from hisim.components import example_component
 from hisim.energy_system.errors import EnergySystemFormatError
 from hisim.energy_system.model import NameRules
 from hisim.simulationparameters import SimulationParameters
+from tests import functions_for_testing as fft
 
 
 @dataclass_json
@@ -214,7 +215,7 @@ def test_default_factories_produce_building_less_identities() -> None:
     default configuration used to carry was suppressed by ``multiple_buildings=False`` anyway,
     so dropping it leaves every runtime name and therefore every result column unchanged.
     """
-    config = example_component.ExampleComponentConfig.get_default_example_component()
+    config = fft.sized_example_component_config()
     assert config.component_id.building is None
     assert config.component_id.key == "ExampleComponent"
 
@@ -228,7 +229,7 @@ def test_default_factories_produce_building_less_identities() -> None:
 def test_outputs_carry_the_identity_of_their_component() -> None:
     """Every output records the identity of the component that produced it."""
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    config = example_component.ExampleComponentConfig.get_default_example_component(
+    config = fft.sized_example_component_config(
         component_id=ComponentID(name="ExampleComponent", building="BUI2")
     )
     component = example_component.ExampleComponent(config=config, my_simulation_parameters=sim_params)
@@ -279,7 +280,7 @@ def test_district_style_setup_groups_by_building() -> None:
     ]
     components = [
         example_component.ExampleComponent(
-            config=example_component.ExampleComponentConfig.get_default_example_component(component_id=identity),
+            config=fft.sized_example_component_config(component_id=identity),
             my_simulation_parameters=sim_params,
         )
         for identity in identities
@@ -336,7 +337,7 @@ def test_a_component_refuses_a_runtime_name_that_is_not_an_identifier() -> None:
     the two from diverging silently.
     """
     sim_params = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
-    config = example_component.ExampleComponentConfig.get_default_example_component()
+    config = fft.sized_example_component_config()
     with pytest.raises(ValueError) as rejection:
         cp.Component(
             name="Bad Name",

--- a/tests/test_example_component.py
+++ b/tests/test_example_component.py
@@ -8,7 +8,7 @@ from hisim import loadtypes as lt
 from hisim import log
 from hisim.components import example_component
 from hisim.simulationparameters import SimulationParameters
-from hisim.config import AUTO, ComponentID, describe_config
+from hisim.config import AUTO, ComponentID, SizableFieldKind, describe_config
 from tests import functions_for_testing as fft
 
 
@@ -32,7 +32,12 @@ def test_example_component() -> None:
     assert example_component.ExampleComponentConfig.get_default_example_component().capacity is AUTO
     my_example_component_config = fft.sized_example_component_config()
     # The law reproduces the literal the module used to carry, exactly: 45 J/K/m2 x 121.2 m2.
-    assert my_example_component_config.capacity == 45 * 121.2 == 5454.0
+    assert (
+        my_example_component_config.capacity
+        == example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2
+        * fft.DEFAULT_CONDITIONED_FLOOR_AREA_IN_M2
+        == 5454.0
+    )
     log.information(f"default example component config {my_example_component_config}\n")
     my_example_component = example_component.ExampleComponent(
         config=my_example_component_config, my_simulation_parameters=mysim
@@ -109,15 +114,56 @@ def test_display_config_isolation() -> None:
 
 
 @pytest.mark.base
+def test_the_default_capacity_resolves_to_the_literal_it_replaced() -> None:
+    """The default config, resolved against the default building, still yields 5454.0 J/K.
+
+    The capacity used to be written as ``45 * 121.2``. That product is now a law over one
+    fact, so this is the assertion that keeps the change neutral for the default building --
+    and it is a base test, because a claim about a number should not need a system setup to
+    be checked.
+    """
+    config = fft.sized_example_component_config()
+    assert config.capacity == 5454.0
+    assert (
+        config.capacity
+        == example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2
+        * fft.DEFAULT_CONDITIONED_FLOOR_AREA_IN_M2
+    )
+
+
+@pytest.mark.base
+def test_a_capacity_written_as_a_string_is_coerced_to_a_float() -> None:
+    """``value_type=float`` types the wire value, so a JSON string never reaches arithmetic.
+
+    Without it the field's own AUTO-aware decoder passes whatever the file said straight
+    through, and ``concrete()`` would hand the component the string ``"5454.0"``.
+    """
+    written = {
+        "component_id": {"name": "FromAFile"},
+        "loadtype": "Heating",
+        "unit": "W",
+        "electricity": -1e3,
+        "initial_temperature": 25.0,
+        "capacity": "5454.0",
+    }
+    assert example_component.ExampleComponentConfig.from_dict(written).capacity == 5454.0
+    with pytest.raises(ValueError, match="could not convert string to float"):
+        example_component.ExampleComponentConfig.from_dict({**written, "capacity": "big"})
+
+
+@pytest.mark.base
 def test_capacity_is_described_as_a_sized_field() -> None:
-    """The capacity field describes itself as derived, with its law, its fact and its note.
+    """The capacity field describes itself as derived, with its fact and its note.
 
     This is what a reader of ``hisim energy-system describe`` sees, and what the template
     claims a component's sizing looks like: the value is not a literal in the module but a
-    law naming the fact it reads.
+    law naming the fact it reads. The description is asserted structurally rather than by its
+    rendered text -- the one place the rendering itself is pinned is the template's test.
     """
     description = describe_config(example_component.ExampleComponentConfig)
     capacity = next(field for field in description.sizable_fields if field.name == "capacity")
-    assert capacity.law == "45.0 * Size.CONDITIONED_FLOOR_AREA_IN_M2"
     assert capacity.facts_read == (("conditioned_floor_area_in_m2", "ONE"),)
-    assert capacity.note is not None and "45 J/K" in capacity.note
+    assert capacity.fields_read == ()
+    assert capacity.kind is SizableFieldKind.LAW
+    assert capacity.note is not None
+    assert str(example_component.SPECIFIC_HEAT_CAPACITY_IN_JOULE_PER_KELVIN_PER_M2) in capacity.note

--- a/tests/test_example_component.py
+++ b/tests/test_example_component.py
@@ -8,7 +8,7 @@ from hisim import loadtypes as lt
 from hisim import log
 from hisim.components import example_component
 from hisim.simulationparameters import SimulationParameters
-from hisim.config import ComponentID
+from hisim.config import AUTO, ComponentID, describe_config
 from tests import functions_for_testing as fft
 
 
@@ -26,7 +26,13 @@ def test_example_component() -> None:
 
     mysim: SimulationParameters = SimulationParameters.full_year(year=2021, seconds_per_timestep=60)
 
-    my_example_component_config = example_component.ExampleComponentConfig.get_default_example_component()
+    # ``capacity`` is a sizable field, so the factory hands back AUTO and the config has to be
+    # resolved against the facts of the surrounding system before a component may be built from
+    # it. The helper carries the one fact this law reads: the building's conditioned floor area.
+    assert example_component.ExampleComponentConfig.get_default_example_component().capacity is AUTO
+    my_example_component_config = fft.sized_example_component_config()
+    # The law reproduces the literal the module used to carry, exactly: 45 J/K/m2 x 121.2 m2.
+    assert my_example_component_config.capacity == 45 * 121.2 == 5454.0
     log.information(f"default example component config {my_example_component_config}\n")
     my_example_component = example_component.ExampleComponent(
         config=my_example_component_config, my_simulation_parameters=mysim
@@ -91,7 +97,7 @@ def test_display_config_isolation() -> None:
     DisplayConfig instance, not a shared one.
     """
     mysim: SimulationParameters = SimulationParameters.full_year(year=2021, seconds_per_timestep=60)
-    config = example_component.ExampleComponentConfig.get_default_example_component()
+    config = fft.sized_example_component_config()
 
     comp_a = example_component.ExampleComponent(my_simulation_parameters=mysim, config=config)
     comp_b = example_component.ExampleComponent(my_simulation_parameters=mysim, config=config)
@@ -100,3 +106,18 @@ def test_display_config_isolation() -> None:
     assert (
         comp_a.my_display_config is not comp_b.my_display_config
     ), "my_display_config must not be shared across instances"
+
+
+@pytest.mark.base
+def test_capacity_is_described_as_a_sized_field() -> None:
+    """The capacity field describes itself as derived, with its law, its fact and its note.
+
+    This is what a reader of ``hisim energy-system describe`` sees, and what the template
+    claims a component's sizing looks like: the value is not a literal in the module but a
+    law naming the fact it reads.
+    """
+    description = describe_config(example_component.ExampleComponentConfig)
+    capacity = next(field for field in description.sizable_fields if field.name == "capacity")
+    assert capacity.law == "45.0 * Size.CONDITIONED_FLOOR_AREA_IN_M2"
+    assert capacity.facts_read == (("conditioned_floor_area_in_m2", "ONE"),)
+    assert capacity.note is not None and "45 J/K" in capacity.note

--- a/tests/test_example_template.py
+++ b/tests/test_example_template.py
@@ -7,7 +7,7 @@ from hisim.components import example_template
 from hisim.simulationparameters import SimulationParameters
 from hisim import loadtypes as lt
 from hisim import log
-from hisim.config import AUTO, ComponentID, ConfigSizingError, SizableFieldKind, describe_config
+from hisim.config import AUTO, ComponentID, ConfigSizingError, SizableFieldKind, SizingContext, describe_config
 from tests import functions_for_testing as fft
 
 
@@ -28,7 +28,10 @@ def test_example_template() -> None:
     my_example_template_config = example_template.ComponentNameConfig.get_default_template_component().resolve(
         fft.default_building_sizing_context()
     )
-    assert my_example_template_config.rated_power_in_watt == 2.0 * 121.2
+    assert (
+        my_example_template_config.rated_power_in_watt
+        == example_template.SPECIFIC_RATED_POWER_IN_WATT_PER_M2 * fft.DEFAULT_CONDITIONED_FLOOR_AREA_IN_M2
+    )
     print("\n")
     log.information(f"default componentname config {my_example_template_config}\n")
     my_example_template = example_template.ComponentName(
@@ -143,6 +146,10 @@ def test_the_template_describes_its_sizing_mechanism() -> None:
     ``hisim energy-system describe hisim.components.example_template.ComponentName``: the
     field is derived from a named fact of the surrounding system, not from a literal in the
     module, and the law says so in its own words.
+
+    This is also the one place where the law's *rendered* text is pinned: every other
+    assertion about a description reads its structure, but the template is the file whose
+    whole point is what ``describe`` prints, so the formatter is worth one exact string.
     """
     description = describe_config(example_template.ComponentNameConfig)
     assert [field.name for field in description.sizable_fields] == ["rated_power_in_watt"]
@@ -150,10 +157,83 @@ def test_the_template_describes_its_sizing_mechanism() -> None:
     assert rated_power.law == "2.0 * Size.CONDITIONED_FLOOR_AREA_IN_M2"
     assert rated_power.facts_read == (("conditioned_floor_area_in_m2", "ONE"),)
     assert rated_power.kind is SizableFieldKind.LAW
-    assert rated_power.note is not None and "W per m" in rated_power.note
+    assert rated_power.fields_read == ()
+    assert rated_power.note is not None
+    assert str(example_template.SPECIFIC_RATED_POWER_IN_WATT_PER_M2) in rated_power.note
     assert [field.name for field in description.fields if field.sizable] == ["rated_power_in_watt"]
     # The template contributes no fact of its own; see the note in the module about why.
     assert not description.facts_provided
+
+
+def _stateless_output_of_one_step(conditioned_floor_area_in_m2: float, input_in_w: float) -> float:
+    """Runs one timestep of the template component sized for one building, and returns its output.
+
+    The stateless channel is the one the rated power caps, so this helper exists to let a test
+    choose the building -- and with it the rated power -- and read back what the cap did.
+
+    Args:
+        conditioned_floor_area_in_m2: the one fact the component's law reads.
+        input_in_w: the power offered at the component's input.
+
+    Returns:
+        float: the value written to ``OutputWithoutState``, in watts.
+    """
+    mysim = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    config = example_template.ComponentNameConfig.get_default_template_component().resolve(
+        SizingContext(conditioned_floor_area_in_m2=conditioned_floor_area_in_m2)
+    )
+    component = example_template.ComponentName(config=config, my_simulation_parameters=mysim)
+    source = cp.ComponentOutput(
+        object_name="source",
+        field_name="input_from_another_component",
+        load_type=lt.LoadTypes.ELECTRICITY,
+        unit=lt.Units.WATT,
+        component_id=ComponentID("source"),
+    )
+    component.input_from_other_component.source_output = source
+    stsv = cp.SingleTimeStepValues(fft.get_number_of_outputs([component, source]))
+    fft.add_global_index_of_components([component, source])
+    stsv.values[source.global_index] = input_in_w
+    component.i_simulate(0, stsv, False)
+    return stsv.values[component.output_without_state.global_index]
+
+
+@pytest.mark.base
+def test_the_stateless_output_is_capped_at_the_sized_rated_power() -> None:
+    """A building small enough to size the device below its input gets the rated power out.
+
+    This is what makes ``rated_power_in_watt`` more than decoration in the template: 20 m2 of
+    floor area size the device at 40 W, the input offers 50 W, and the output is the 40 W the
+    device was sized for -- both sides of the ``min`` being watts, which is why
+    ``OutputWithoutState`` is declared in WATT.
+    """
+    rated_power_in_watt = example_template.SPECIFIC_RATED_POWER_IN_WATT_PER_M2 * 20.0
+    assert rated_power_in_watt == 40.0
+    assert _stateless_output_of_one_step(conditioned_floor_area_in_m2=20.0, input_in_w=50.0) == rated_power_in_watt
+
+
+@pytest.mark.base
+def test_the_stateless_output_passes_the_input_through_when_the_cap_does_not_bind() -> None:
+    """The default building sizes the device at 242.4 W, well above the 51 W it is offered."""
+    rated_power_in_watt = (
+        example_template.SPECIFIC_RATED_POWER_IN_WATT_PER_M2 * fft.DEFAULT_CONDITIONED_FLOOR_AREA_IN_M2
+    )
+    output_in_w = _stateless_output_of_one_step(
+        conditioned_floor_area_in_m2=fft.DEFAULT_CONDITIONED_FLOOR_AREA_IN_M2, input_in_w=50.0
+    )
+    assert output_in_w == 51.0 < rated_power_in_watt
+
+
+@pytest.mark.base
+def test_a_rated_power_written_as_a_string_is_coerced_to_a_float() -> None:
+    """``value_type=float`` types the wire value: a file may write ``"242.4"`` and get a float."""
+    written = {
+        "component_id": {"name": "FromAFile"},
+        "loadtype": "Electricity",
+        "unit": "W",
+        "rated_power_in_watt": "242.4",
+    }
+    assert example_template.ComponentNameConfig.from_dict(written).rated_power_in_watt == 242.4
 
 
 @pytest.mark.base

--- a/tests/test_example_template.py
+++ b/tests/test_example_template.py
@@ -7,7 +7,7 @@ from hisim.components import example_template
 from hisim.simulationparameters import SimulationParameters
 from hisim import loadtypes as lt
 from hisim import log
-from hisim.config import ComponentID
+from hisim.config import AUTO, ComponentID, ConfigSizingError, SizableFieldKind, describe_config
 from tests import functions_for_testing as fft
 
 
@@ -23,7 +23,12 @@ def test_example_template() -> None:
 
     mysim: SimulationParameters = SimulationParameters.full_year(year=2021, seconds_per_timestep=60)
 
-    my_example_template_config = example_template.ComponentNameConfig.get_default_template_component()
+    # ``rated_power_in_watt`` is sized, so the factory's config carries AUTO and has to be
+    # resolved against the facts of the surrounding system before a component is built from it.
+    my_example_template_config = example_template.ComponentNameConfig.get_default_template_component().resolve(
+        fft.default_building_sizing_context()
+    )
+    assert my_example_template_config.rated_power_in_watt == 2.0 * 121.2
     print("\n")
     log.information(f"default componentname config {my_example_template_config}\n")
     my_example_template = example_template.ComponentName(
@@ -89,6 +94,8 @@ def test_get_default_template_component_no_args() -> None:
     assert config.component_id.name == "ComponentNameDefault"
     assert config.loadtype == lt.LoadTypes.ELECTRICITY
     assert config.unit == lt.Units.WATT
+    # The sized field is not a default *value*: the factory leaves it to the law.
+    assert config.rated_power_in_watt is AUTO
 
 
 @pytest.mark.base
@@ -101,6 +108,7 @@ def test_get_default_template_component_custom_building() -> None:
     assert config.component_id.name == "ComponentNameDefault"
     assert config.loadtype == lt.LoadTypes.ELECTRICITY
     assert config.unit == lt.Units.WATT
+    assert config.rated_power_in_watt is AUTO
 
 
 @pytest.mark.base
@@ -125,3 +133,35 @@ def test_get_main_classname() -> None:
     classname = example_template.ComponentNameConfig.get_main_classname()
     assert classname == example_template.ComponentName.get_full_classname()
     assert classname == "hisim.components.example_template.ComponentName"
+
+
+@pytest.mark.base
+def test_the_template_describes_its_sizing_mechanism() -> None:
+    """``describe_config`` shows the template's sized field with its law, fact and note.
+
+    This is what the template exists to demonstrate and what a reader gets from
+    ``hisim energy-system describe hisim.components.example_template.ComponentName``: the
+    field is derived from a named fact of the surrounding system, not from a literal in the
+    module, and the law says so in its own words.
+    """
+    description = describe_config(example_template.ComponentNameConfig)
+    assert [field.name for field in description.sizable_fields] == ["rated_power_in_watt"]
+    rated_power = description.sizable_fields[0]
+    assert rated_power.law == "2.0 * Size.CONDITIONED_FLOOR_AREA_IN_M2"
+    assert rated_power.facts_read == (("conditioned_floor_area_in_m2", "ONE"),)
+    assert rated_power.kind is SizableFieldKind.LAW
+    assert rated_power.note is not None and "W per m" in rated_power.note
+    assert [field.name for field in description.fields if field.sizable] == ["rated_power_in_watt"]
+    # The template contributes no fact of its own; see the note in the module about why.
+    assert not description.facts_provided
+
+
+@pytest.mark.base
+def test_an_unresolved_template_config_is_refused_by_the_component() -> None:
+    """A config that still says AUTO never reaches the component, and the error names the law."""
+    mysim = SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60)
+    config = example_template.ComponentNameConfig.get_default_template_component()
+    with pytest.raises(ConfigSizingError) as refusal:
+        example_template.ComponentName(config=config, my_simulation_parameters=mysim)
+    assert "rated_power_in_watt" in str(refusal.value)
+    assert "Size.CONDITIONED_FLOOR_AREA_IN_M2" in str(refusal.value)


### PR DESCRIPTION
﻿## D-31: the example's magic literal becomes a law, and the template shows one

`example_template.py` is the file every new component author copies, and it demonstrated none of the sizing mechanism. `example_component.py` hid a law in a literal: `capacity = 45 * 121.2` is 45 J/K per m² times the conditioned floor area of the default TABULA building.

- `example_component`: `capacity` is a `sized_field` over `Size.CONDITIONED_FLOOR_AREA_IN_M2`; the factory says `AUTO`; the duplicate literal in `build()` is gone. Resolved against the default building the value is 5454.0, exactly as before, asserted in the test.
- `example_template`: one sized field with its law and note, an `AUTO` factory, a numbered walk-through of the five steps, and a comment block with the exact `SIZING_CONTRIBUTIONS` shape pointing at the real providers. No contribution entry: the kernel only accepts facts that are `SizingContext` fields, and a template-only fact in the shared vocabulary was rejected in favour of the documented block.
- Tests resolve against a stated `SizingContext(conditioned_floor_area_in_m2=121.2)` through a shared helper; `describe` shows the sizable field with its law text.

Golden-neutral: neither class is in any setup or energy system. Schema unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
