### PR TITLE
The Python floor is 3.11 everywhere it is stated

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,13 +77,12 @@ Ready to contribute? Here's how to set up `hisim` for local development.
    Now you can make your changes locally.
 
 5. When you're done making changes, check that your changes pass flake8 and the
-   tests, including testing other Python versions with tox::
+   tests on Python 3.11::
 
     $ flake8 hisim tests
-    $ python setup.py test or pytest
-    $ tox
+    $ pytest
 
-   To get flake8 and tox, just pip install them into your virtualenv.
+   To get flake8, just pip install it into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub::
 
@@ -102,9 +101,9 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.5, 3.6, 3.7 and 3.8, and for PyPy. Check
-   https://travis-ci.com/FZJ-IEK3-VSA/hisim/pull_requests
-   and make sure that the tests pass for all supported Python versions.
+3. The pull request has to pass on Python 3.11, the version the GitHub Actions
+   checks run: the ``quality`` and ``tests`` workflows both use the ``py311`` test
+   image. Check the checks on your pull request and make sure they are green.
 
 
 Deploying
@@ -118,4 +117,4 @@ $ bump2version patch # possible: major / minor / patch
 $ git push
 $ git push --tags
 
-Travis will then deploy to PyPI if tests pass.
+The ``pypi-publish`` workflow will then deploy to PyPI if the tests pass.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ git clone https://github.com/FZJ-IEK3-VSA/HiSim.git
 
 Virtual Environment
 -----------------------
+`ETHOS.HiSim` needs Python 3.11 or newer.
 Before installing `ETHOS.Hisim`, it is recommended to set up a Python virtual environment. Let `hisimvenv` be the name of
 virtual environment to be created. For Windows users, setting the virtual environment in the path `\Hisim` is done with
 the command line:
@@ -56,7 +57,7 @@ virtual hisimvenv source hisimvenv/bin/activate
 Alternatively, Anaconda can be used to set up and activate the virtual environment:
 
 ```python 
-conda create -n hisimvenv python=3.10
+conda create -n hisimvenv python=3.11
 conda activate hisimvenv
 ```
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,6 +15,7 @@ To clone this repository, enter the following command to your terminal:
 
 Set Virtual Environment
 -----------------------
+`ETHOS.HiSim` needs Python 3.11 or newer.
 Before installing `ETHOS.Hisim`, it is recommended to set up a python virtual environment. Let `hisimvenv` be the name of virtual environment to be created. For Windows users, setting the virtual environment in the path `\Hisim` is done with the command line:
 
 
@@ -36,7 +37,7 @@ For Linux/Mac users, the virtual environment is set up and activated as follows:
 Alternatively, Anaconda can be used to set up and activate the virtual environment:
 
 
-``conda create -n hisimvenv python=3.10``
+``conda create -n hisimvenv python=3.11``
 ``conda activate hisimvenv``
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,15 +22,15 @@ test_requirements = [
 setup(
     author="Noah Pflugradt",
     author_email="n.pflugradt@fz-juelich.de",
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     description="ETHOS.HiSim is a house infrastructure simulator",
     entry_points={


### PR DESCRIPTION
## The Python floor is 3.11 everywhere it is stated

The requirement was stated four different ways: `setup.py` asked for >=3.10 and classified 3.10 and 3.11, README.md and `docs/installation.rst` told readers to create a 3.10 conda environment, and CONTRIBUTING.rst still demanded Python 3.5 to 3.8 plus PyPy, checked on Travis.

- `setup.py`: `python_requires=">=3.11"`; classifiers drop 3.10 and add 3.12 (the docs already build on 3.12).
- README.md and `docs/installation.rst`: one sentence stating Python 3.11 or newer, conda line at 3.11.
- CONTRIBUTING.rst: a pull request has to pass on 3.11 as the `quality` and `tests` workflows run it; the tox and Travis mentions are gone, deployment names the `pypi-publish` workflow.

Every tool pin (mypy, pylint), CI workflow, the test image and both Dockerfiles were already 3.11 and are untouched. `.readthedocs.yaml` stays on 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)