### PR TITLE
Dependabot keeps the pins, the actions and the base image current

### DIFF
--- a/.github/ci-monitoring.md
+++ b/.github/ci-monitoring.md
@@ -124,3 +124,16 @@ job that goes red because GitHub was busy trains everyone to ignore it.
 - The index lives in an artifact with a 7-day retention — 24 of them are written a day, and a
   week outlasts a weekend of failed runs. Losing it costs a cold start, not the history: the
   API still holds the runs, and the following sweeps fill the window back in.
+
+## Dependency updates
+
+`.github/dependabot.yml` points Dependabot at three things: the requirements, the third-party
+actions the workflows call, and the `python` base image of `Dockerfile` and `Dockerfile.test`.
+On the Python side it can only raise a version that is written down, so it reaches the pinned
+lines of `requirements.txt` — pandas, hplib, bslib, utspclient, pyhumps, the `timezonefinder`
+ceiling — and says nothing about the unpinned majority, which already resolve to the newest
+release. The image is held at 3.11 by an `ignore` rule for major and minor updates, so the bot
+proposes patch tags and leaves the Python floor to the owner; the two local composite actions
+under `.github/actions/` are this repository's own and are not covered either. Everything is
+grouped per ecosystem and scheduled weekly on Monday, so the result is one batch of pull
+requests a week rather than a trickle of single bumps.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,76 @@
+# Dependabot watches three things: the pinned Python requirements, the third-party actions the
+# workflows call, and the Python base image of the two Dockerfiles. All three run weekly on the
+# same day, so the maintainers see one batch of pull requests a week rather than a trickle.
+version: 2
+updates:
+
+  # Python dependencies (requirements.txt).
+  #
+  # Most lines there are unpinned (numpy, matplotlib, pydantic, ...) and Dependabot will never
+  # propose anything for them: an unpinned requirement already resolves to the newest release, so
+  # there is no version in the file to raise. In practice this entry therefore covers the pinned
+  # handful only — pandas, hplib, bslib, utspclient, pyhumps and the timezonefinder<6.0 ceiling.
+  # The commented-out wetterdienst line is not seen at all; that upgrade waits on the API
+  # migration noted next to it.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      # One pull request for the lot. Five separate ones for five pinned packages is how a
+      # dependency bot stops being read.
+      python-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+
+  # GitHub Actions used by the workflows: actions/checkout, actions/setup-python,
+  # actions/upload-artifact, actions/download-artifact, astral-sh/setup-uv,
+  # docker/build-push-action, docker/login-action, docker/setup-buildx-action,
+  # ts-graphviz/setup-graphviz and pypa/gh-action-pypi-publish.
+  #
+  # The two local composite actions — .github/actions/hisim-cache and
+  # .github/actions/resource-monitor — are referenced by path and live in this repository, so
+  # Dependabot does not cover them. They change when this repository changes them.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+
+  # The base image of Dockerfile (python:3.11-slim) and Dockerfile.test
+  # (python:3.11-slim-bookworm).
+  #
+  # Patch tags only. The 3.11 floor is a decision about which Python this project supports, taken
+  # by the owner and stated in several places; a bot raising the image to 3.12 would quietly
+  # overrule it. Ignoring major and minor updates leaves Dependabot doing the part that is
+  # genuinely maintenance — picking up the security patches inside 3.11.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    ignore:
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
## Dependabot keeps the pins, the actions and the base image current

Adds `.github/dependabot.yml` with three weekly, grouped update entries and a short section in `.github/ci-monitoring.md` describing them.

- `pip`: the pinned lines of `requirements.txt` (pandas, hplib, bslib, utspclient, pyhumps, the timezonefinder ceiling), one grouped pull request per week. Unpinned lines already float to the newest release and are not touched.
- `github-actions`: every third-party action the workflows call, grouped. The two local composite actions are this repository's own and are not covered.
- `docker`: the `python` base image of `Dockerfile` and `Dockerfile.test`, patch tags only. Major and minor updates are ignored so the bot cannot move the image past the 3.11 floor.

Labels `dependencies`, at most three open pull requests per ecosystem, commit subjects prefixed `deps`. Nothing beyond merging this file is needed to activate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)