### PR TITLE
The Building stops writing six thermal-model values nobody reads

### DIFF
--- a/hisim/components/building/building.py
+++ b/hisim/components/building/building.py
@@ -913,33 +913,6 @@ class Building(cp.Component):
             self.thermal_conductance_by_ventilation_in_watt_per_kelvin,
         ) = self.get_conductances()
 
-        # send building parameters 5r1c to PID controller and to the MPC controller to generate an equivalent state space model
-        # state space represntation is used for tuning of the pid and as a prediction model in the model predictive controller
-        SingletonSimRepository().set_entry(
-            key=SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTGLAZING,
-            entry=self.transmission_heat_transfer_coeff_windows_and_door_in_watt_per_kelvin,
-        )
-        SingletonSimRepository().set_entry(
-            key=SingletonDictKeyEnum.THERMALTRANSMISSIONSURFACEINDOORAIR,
-            entry=self.heat_transfer_coeff_indoor_air_and_internal_surface_in_watt_per_kelvin,
-        )
-        SingletonSimRepository().set_entry(
-            key=SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTOPAQUEEM,
-            entry=self.external_part_of_transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin,
-        )
-        SingletonSimRepository().set_entry(
-            key=SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTOPAQUEMS,
-            entry=self.internal_part_of_transmission_heat_transfer_coeff_opaque_elements_in_watt_per_kelvin,
-        )
-        SingletonSimRepository().set_entry(
-            key=SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTVENTILLATION,
-            entry=self.thermal_conductance_by_ventilation_in_watt_per_kelvin,
-        )
-        SingletonSimRepository().set_entry(
-            key=SingletonDictKeyEnum.THERMALCAPACITYENVELOPE,
-            entry=self.my_building_information.thermal_capacity_of_building_thermal_mass_in_joule_per_kelvin,
-        )
-
         # Get windows
         self.windows, self.total_scaled_windows_area = self.get_windows()
 

--- a/hisim/sim_repository_singleton.py
+++ b/hisim/sim_repository_singleton.py
@@ -196,12 +196,12 @@ class SingletonDictKeyEnum(enum.Enum):
     # 6 was LOCATION, written by the Weather at construction time and read back as the
     # report region; postprocessing now reads the Weather component's own config instead.
     RESULT_SCENARIO_NAME = 7
-    THERMALTRANSMISSIONCOEFFICIENTGLAZING = 8
-    THERMALTRANSMISSIONSURFACEINDOORAIR = 9
-    THERMALTRANSMISSIONCOEFFICIENTOPAQUEEM = 10
-    THERMALTRANSMISSIONCOEFFICIENTOPAQUEMS = 11
-    THERMALTRANSMISSIONCOEFFICIENTVENTILLATION = 12
-    THERMALCAPACITYENVELOPE = 13
+    # 8 to 13 were the six 5R1C thermal-model values the Building wrote at build time --
+    # THERMALTRANSMISSIONCOEFFICIENTGLAZING, THERMALTRANSMISSIONSURFACEINDOORAIR,
+    # THERMALTRANSMISSIONCOEFFICIENTOPAQUEEM, THERMALTRANSMISSIONCOEFFICIENTOPAQUEMS,
+    # THERMALTRANSMISSIONCOEFFICIENTVENTILLATION and THERMALCAPACITYENVELOPE. Their only
+    # readers were the PID and MPC controllers, which moved to obsolete/; the Building
+    # keeps the values on itself.
     PREDICTIVE = 14
     PREDICTIONHORIZON = 15
     PVINCLUDED = 16

--- a/roadmap/declarative_energy_systems/p4_component_sweep_requirements.md
+++ b/roadmap/declarative_energy_systems/p4_component_sweep_requirements.md
@@ -383,6 +383,13 @@ row is struck from the table, which keeps the question and the option chosen nex
   component's `config.location` directly instead of `SingletonDictKeyEnum.LOCATION`; the six Building 5R1C keys go once
   this branch's D-16 move has put `controller_mpc` and `controller_pid` in `obsolete/`, after which they have no reader
   at all. The last construction-time globals leave the Weather and the Building.
+  **Part one executed 2026-09-11 (#686)**: `region_of(ppdt)` in `postprocessing_main` reads the run's own
+  Weather and `LOCATION` is gone from the enum, value 6 left as a comment. **Part two executed 2026-09-11**:
+  `Building.build()` stops writing the six 5R1C values and `SingletonDictKeyEnum` loses members 8-13, whose
+  numbers a comment holds in place of a renumbering; the stale comment naming the PID and MPC controllers goes
+  with the writes. Result-neutral -- nothing outside the retired controllers ever read them. The three
+  `HEATFLUX*NODEFORECAST` keys the Building writes in its predictive branch stay: the survey parks them with
+  the runtime forecast half, and dropping them would retire the whole `predictive` forecast path.
 - **D-25** `[answered 2026-09-11]` **(b) obsolete the RSOC trio and the fuel-cell table path.** `RsocConfig`,
   `RsocControllerConfig` and `RsocBatteryControllerConfig` move to `obsolete/` with their tests, together with the fuel
   cell's manufacturer-table builders — verified 2026-09-11 that `hisim/inputs/` still holds only

--- a/tests/test_singleton_sim_repository.py
+++ b/tests/test_singleton_sim_repository.py
@@ -30,6 +30,10 @@ def test_house(
 ) -> None:  # noqa: too-many-statements
     """Check that a normal simulation works with the singleton sim repository implementation.
 
+    What a Weather/occupancy/Building run still puts into the repository is the Weather's
+    yearly forecast series; the Weather's location and the Building's six 5R1C thermal
+    parameters used to live here too and are read off the components themselves now.
+
     The singleton identity property is verified separately in
     ``test_singleton_returns_same_instance``.
     """
@@ -152,17 +156,16 @@ def test_house(
     assert repo.my_dict is not None
     assert len(repo.my_dict) > 0
     # The Weather no longer registers its location here: the report region is read from the
-    # Weather component's own config, so the key is gone from the enum entirely.
-    # Building registers its 5R1C thermal parameters in the singleton during build().
-    assert SingletonDictKeyEnum.THERMALCAPACITYENVELOPE in repo.my_dict
-    assert SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTGLAZING in repo.my_dict
-    assert SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTVENTILLATION in repo.my_dict
-    # The thermal parameters must carry real, positive computed values -- not just
-    # be present -- to confirm the building genuinely pushed its 5R1C results
-    # through the singleton sim repository during the run.
-    assert repo.my_dict[SingletonDictKeyEnum.THERMALCAPACITYENVELOPE] > 0
-    assert repo.my_dict[SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTGLAZING] > 0
-    assert repo.my_dict[SingletonDictKeyEnum.THERMALTRANSMISSIONCOEFFICIENTVENTILLATION] > 0
+    # Weather component's own config, so the key is gone from the enum entirely. The Building
+    # no longer registers its six 5R1C thermal parameters either -- their only readers were
+    # the PID and MPC controllers, now in obsolete/ -- so what the run leaves behind are the
+    # Weather's yearly forecast series, which the PV system and predictive components read.
+    assert SingletonDictKeyEnum.WEATHERTEMPERATUREOUTSIDEYEARLYFORECAST in repo.my_dict
+    assert SingletonDictKeyEnum.WEATHERAZIMUTHYEARLYFORECAST in repo.my_dict
+    # The forecasts must carry real series -- not just be present -- to confirm the Weather
+    # genuinely pushed its computed values through the singleton sim repository during the run.
+    assert len(repo.my_dict[SingletonDictKeyEnum.WEATHERTEMPERATUREOUTSIDEYEARLYFORECAST]) > 0
+    assert len(repo.my_dict[SingletonDictKeyEnum.WEATHERAZIMUTHYEARLYFORECAST]) > 0
     assert len(repo.my_dict) >= 7
 
 

--- a/tests/test_singleton_sim_repository.py
+++ b/tests/test_singleton_sim_repository.py
@@ -31,8 +31,9 @@ def test_house(
     """Check that a normal simulation works with the singleton sim repository implementation.
 
     What a Weather/occupancy/Building run still puts into the repository is the Weather's
-    yearly forecast series; the Weather's location and the Building's six 5R1C thermal
-    parameters used to live here too and are read off the components themselves now.
+    yearly forecast series, which the Weather writes unconditionally; the Weather's location
+    and the Building's six 5R1C thermal parameters used to live here too and are read off the
+    components themselves now.
 
     The singleton identity property is verified separately in
     ``test_singleton_returns_same_instance``.
@@ -158,12 +159,11 @@ def test_house(
     # The Weather no longer registers its location here: the report region is read from the
     # Weather component's own config, so the key is gone from the enum entirely. The Building
     # no longer registers its six 5R1C thermal parameters either -- their only readers were
-    # the PID and MPC controllers, now in obsolete/ -- so what the run leaves behind are the
-    # Weather's yearly forecast series, which the PV system and predictive components read.
-    assert SingletonDictKeyEnum.WEATHERTEMPERATUREOUTSIDEYEARLYFORECAST in repo.my_dict
-    assert SingletonDictKeyEnum.WEATHERAZIMUTHYEARLYFORECAST in repo.my_dict
-    # The forecasts must carry real series -- not just be present -- to confirm the Weather
-    # genuinely pushed its computed values through the singleton sim repository during the run.
+    # the PID and MPC controllers, now in obsolete/. What the run leaves behind are the two
+    # yearly forecast series the Weather writes unconditionally, which the PV system and the
+    # predictive components read. Each is asserted once: indexing the key proves it is there,
+    # and a non-empty series proves the Weather genuinely pushed its computed values through
+    # the singleton sim repository during the run rather than registering an empty entry.
     assert len(repo.my_dict[SingletonDictKeyEnum.WEATHERTEMPERATUREOUTSIDEYEARLYFORECAST]) > 0
     assert len(repo.my_dict[SingletonDictKeyEnum.WEATHERAZIMUTHYEARLYFORECAST]) > 0
     assert len(repo.my_dict) >= 7


### PR DESCRIPTION
## D-32, part two: the Building stops writing six thermal-model values nobody reads

The Building wrote six 5R1C values (glazing, surface-to-air, opaque, ventilation transmission coefficients and the envelope capacity) into the process-wide singleton at build time. Their only readers were the PID and MPC controllers, which #680 moved to `obsolete/`; a tree-wide grep finds no live reader left.

- The six `set_entry` writes in `building.py` and the six enum members go; a comment holds the numbers 8 to 13, as #686 did for the LOCATION key, so nothing is renumbered.
- The comment describing the feed to the two controllers is corrected; the singleton test's presence-and-value check is repointed at the Weather's forecast series that a run still writes.
- Left in place: the three heat-flux forecast keys the Building writes only under `predictive`. They are reader-less too, but they are the tail of the whole-year forecast computation; removing them would retire that path, which this decision does not cover.

Result-neutral: the values were only written to the singleton and never reach a result series, so no golden or twin moves. Part one (the LOCATION key) is #686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)