### PR TITLE
The freshness workflows ask for bash, like the parity summary

### DIFF
--- a/.github/workflows/energy-system-freshness.yml
+++ b/.github/workflows/energy-system-freshness.yml
@@ -85,21 +85,27 @@ jobs:
           mode: restore
           scope: ${{ github.workflow }}
       - name: Re-record every setup and compare with the committed twins
+        # bash by name: this step once fell back to sh in this container and died on the
+        # bash-only PIPESTATUS ("Bad substitution"), yet bash is installed here -- the
+        # resource-monitor steps of this same job ask for it and run. With the shell named,
+        # the recorder goes back into a pipeline: pipefail keeps the recorder's own exit
+        # code (1 on drift, a missing twin, a setup that cannot be recorded, or two
+        # parameter files describing one run), which `tee` would otherwise replace with 0.
+        shell: bash
         run: |
           # --check records into a throwaway directory inside the workspace and
           # never writes into energy_systems/, so the job cannot mask drift by
           # repairing it. It prints the diff of every twin that moved, names every
           # setup it could not record, and asserts that no two committed
           # simulation-parameters files describe the same run.
-          # No pipeline here: GitHub runs this step with 'sh' inside the test container,
-          # where the bash-only PIPESTATUS array expands to "Bad substitution".
-          # Redirect, then show the file, so the exit code is the recorder's own.
-          set +e
-          python scripts/record_all_setups.py --check > energy_system_drift.txt 2>&1
-          rc=$?
-          set -e
-          cat energy_system_drift.txt
-          if [ "${rc}" -ne 0 ]; then
+          #
+          # `tee` shows the report in the log and writes the file the failure artifact
+          # uploads; stderr is merged into the pipe so a recorder traceback reaches both.
+          # GitHub already invokes this shell as `bash -eo pipefail`, so the `set` line is
+          # belt and braces for a reader. The failure is caught by the `if` rather than by
+          # -e, because the step has to print its annotation before it exits.
+          set -o pipefail
+          if ! python scripts/record_all_setups.py --check 2>&1 | tee energy_system_drift.txt; then
             echo "::error title=Energy-system twins are stale or a setup cannot be recorded::Run 'python scripts/record_all_setups.py' locally, resolve any recorder errors, and commit what it writes."
             exit 1
           fi

--- a/.github/workflows/scenario-json-freshness.yml
+++ b/.github/workflows/scenario-json-freshness.yml
@@ -69,6 +69,11 @@ jobs:
           mode: restore
           scope: ${{ github.workflow }}
       - name: Regenerate all scenario JSONs
+        # bash by name, as in the energy-system gate and the parity summary: a plain `run:`
+        # step in this container was once observed to fall back to sh. Nothing below is
+        # bash-only today, but with the shell named the next pipe or array added here behaves
+        # as written.
+        shell: bash
         run: |
           # Auto-adapt parallelism to the runner: one worker per vCPU, capped so a
           # very large runner cannot oversubscribe memory with concurrent LPG builds.
@@ -85,12 +90,12 @@ jobs:
           # failure, but we do NOT abort here: we record the script's exit code and
           # let the check step below run too, so build failures AND drift are both
           # reported in a single run instead of the first one masking the rest.
-          set +e
+          # `|| rc=$?` is what records it -- the exit code survives, and the failure
+          # does not trip the -e that GitHub's bash invocation sets.
+          rc=0
           python scripts/regenerate_scenario_jsons.py \
             -j "${jobs}" \
-            --all-py
-          rc=$?
-          set -e
+            --all-py || rc=$?
           echo "REGEN_RC=${rc}" >> "$GITHUB_ENV"
           if [ "${rc}" -ne 0 ]; then
             echo "::error title=Setup failed to convert::One or more .py setups could not be built into a scenario JSON (see the summary above and the per-setup logs). Every setup must produce a valid JSON."


### PR DESCRIPTION
## The freshness workflows ask for bash, like the parity summary

#681 established that the test container has bash and that a plain `run:` step was observed to fall back to sh; its summary step now declares `shell: bash`. The two freshness workflows carried the same sh idiom (`set +e` / `rc=` / `set -e`) and one of them the same wrong rationale.

- `energy-system-freshness`: the recorder check runs under `shell: bash` with `set -o pipefail`, piped through `tee` into the drift file the failure artifact uploads; a failing recorder still prints its error annotation before the step exits, via `if !` rather than `-e`, which GitHub's bash invocation enables by default.
- `scenario-json-freshness`: the regeneration step also declares `shell: bash`; its deliberate record-and-continue semantics (export `REGEN_RC` so the drift check runs too) are unchanged, written as `|| rc=True`.
- Comments state the observed fallback, not a rule about GitHub.

Both bodies were exercised under `bash --noprofile --norc -eo pipefail`: the recorder step reports, writes the file, annotates and exits 1 on failure; the regeneration step records the exit code and continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)