### PR TITLE
The hisim console script reads the .env file, as hisim_main always did

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ UTSP_API_KEY
 
 They are needed only when the occupancy is taken from the UTSP connector
 (`hisim/components/loadprofilegenerator_utsp_connector.py`) in its `USE_UTSP` data-acquisition mode; the
-`USE_PREDEFINED_PROFILE` and `USE_LOCAL_LPG` modes of the same component do without them. An `.env` file in the
-repository root is read automatically by `hisim/hisim_main.py`, which calls `load_dotenv()` on start-up; the `hisim`
-console script does not read the file, so with it the two variables have to be set in the environment.
+`USE_PREDEFINED_PROFILE` and `USE_LOCAL_LPG` modes of the same component do without them. Both the `hisim`
+console script and `hisim/hisim_main.py` call `load_dotenv()` on start-up, so either of them reads an `.env` file from
+the repository root without anything else being set.
 
 Executing a Building Simulation
 -----------------------

--- a/hisim/cli.py
+++ b/hisim/cli.py
@@ -34,6 +34,8 @@ import sys
 from pathlib import Path
 from typing import Optional, Sequence, TextIO
 
+from dotenv import load_dotenv
+
 from hisim.cli_exit import ExitCodes
 from hisim.cli_grouping import GroupingCommands, GroupingPaths
 from hisim.config.introspection import describe_config
@@ -297,6 +299,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         Zero on success, two when the command line itself was wrong, and one when a file was
         rejected — the message having gone to the standard error stream.
     """
+    # The two documented ways to run the same setup have to see the same configuration, so the
+    # console script reads the `.env` holding UTSP_URL and UTSP_API_KEY exactly as
+    # `hisim/hisim_main.py` does: python-dotenv walks up from the directory of the module that
+    # calls it, which is `hisim/` for both of them, so both find the same file. It is read here
+    # and not at import, because importing a library should not read files.
+    load_dotenv()
     parser = build_parser()
     try:
         arguments = parser.parse_args(list(argv) if argv is not None else None)

--- a/roadmap/p4_random_findings.md
+++ b/roadmap/p4_random_findings.md
@@ -118,7 +118,7 @@ summer timestep with `t_dhw` between the heating maximum and the DHW maximum and
 deactivating where it should stay on. No setup builds `L1CHPController`, so it is a physics change (R5) with
 no recorded result behind it; it can land before or after the conversion.
 
-### F-4 — the `hisim` console script ignores the repository's `.env` **[verified]**
+### F-4 — the `hisim` console script ignores the repository's `.env` **[verified, fixed]**
 
 `hisim/hisim_main.py` imports `load_dotenv` (`:12`) and calls it at import time (`:33`), so
 `python hisim/hisim_main.py …` picks up `UTSP_URL` and `UTSP_API_KEY` from the repository's `.env` — the file
@@ -133,7 +133,13 @@ than a message naming the missing variable.
 *Cost of not finding it: the documented environment file works for one of the two documented entry points, and
 the one it fails for is the one the install instructions produce.*
 
-**Where it stands.** Not fixed. One line in `cli.main`, matching `hisim_main.py`.
+**Where it stands.** Fixed. `cli.main` now calls `load_dotenv()` before it parses anything, matching
+`hisim_main.py`; the call sits in `main` rather than at import, because importing a library should not read files.
+`hisim_main.py`'s import-time call stays where it is: `scripts/hpc_harness/run_one.py`, `scripts/p3_parity_runs.py`
+and the economic-example setups import `initialize_from_json` / `initialize_from_python` without ever going through
+its `main`, so moving it would take the file away from them. Both calls resolve to the same file — python-dotenv
+walks up from the directory of the module that calls it, which is `hisim/` for both. A test in `tests/test_cli.py`
+plants a sentinel `.env` and asserts the console script has read it.
 
 ### F-5 — a component copied from `example_template.py` raises before its first timestep **[verified]**
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,11 +14,13 @@ file. And ``run`` has to leave a result directory holding the three artifacts ev
 
 # clean
 
+import os
 from pathlib import Path
 from typing import ClassVar
 
 import pytest
 
+from hisim import cli
 from hisim.cli import ExitCodes, main
 from hisim.energy_system.audit import AuditWriter
 from hisim.energy_system.comments import AnnotatedEmitter
@@ -185,3 +187,40 @@ def test_a_command_line_naming_no_verb_is_a_usage_error(capsys) -> None:
     assert main([]) == ExitCodes.USAGE
     assert main(["energy-system"]) == ExitCodes.USAGE
     capsys.readouterr()
+
+
+#: A variable no real environment holds, so the test can tell a file that was read from one that
+#: was not without touching the two variables a developer may legitimately have set.
+DOTENV_SENTINEL = "HISIM_TEST_DOTENV_SENTINEL"
+
+
+@pytest.mark.base
+def test_the_command_line_reads_the_environment_file_on_start_up(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Catches the console script running without the credentials the module entry point has.
+
+    ``hisim/hisim_main.py`` reads the ``.env`` that holds ``UTSP_URL`` and ``UTSP_API_KEY``, so a
+    run started the other documented way has to read the same file or the UTSP occupancy fails for
+    want of credentials rather than saying what is missing. python-dotenv resolves that file by
+    walking up from the directory of the module that calls it, and from the working directory
+    instead whenever a tracer is installed, so the sentinel is planted on both paths: what is
+    asserted is that the file was read, not which of the two python-dotenv happened to take.
+    """
+    beside_the_package = Path(cli.__file__).parent / ".env"
+    if beside_the_package.exists():  # a real one, which a test must never overwrite
+        pytest.skip(f"{beside_the_package} exists")
+    written = f"{DOTENV_SENTINEL}=read\n"
+    beside_the_package.write_text(written, encoding="utf-8")
+    (tmp_path / ".env").write_text(written, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(DOTENV_SENTINEL, raising=False)
+
+    try:
+        code = main(["energy-system", "schema", "--out", str(tmp_path / "exported.schema.json")])
+        loaded = os.environ.get(DOTENV_SENTINEL)
+    finally:
+        beside_the_package.unlink()
+        os.environ.pop(DOTENV_SENTINEL, None)
+    capsys.readouterr()
+
+    assert code == ExitCodes.OK
+    assert loaded == "read"


### PR DESCRIPTION
## The hisim console script reads the .env file, as hisim_main always did

`hisim/hisim_main.py` calls `load_dotenv()` at import, so a run through it picks up the repository's `.env` (UTSP_URL, UTSP_API_KEY). The `hisim` console script never did, so the same run through it ignored the file. Found while verifying the README rewrite (#690); recorded as F-4.

- `cli.main` now calls `load_dotenv()` first, not at import, since importing a library should not read files. python-dotenv resolves the file from the calling module's directory upward, which is `hisim/` for both entry points, so both find the same repository-root file regardless of the working directory.
- `hisim_main`'s import-time call stays: several entry paths (the HPC harness, the parity runs, the economic examples, a test) import the module without calling its `main` and rely on it.
- A CLI test plants a sentinel `.env`, clears the variable, runs a harmless verb and asserts the variable is set; it fails without the new call.
- README: the environment-variable paragraph says both entry points read the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)