### PR TITLE
The region test resolves the example component it builds

### DIFF
--- a/tests/test_postprocessing_region.py
+++ b/tests/test_postprocessing_region.py
@@ -16,10 +16,11 @@ import pytest
 
 from hisim.component import Component
 from hisim.component_wrapper import ComponentWrapper
-from hisim.components.example_component import ExampleComponent, ExampleComponentConfig
+from hisim.components.example_component import ExampleComponent
 from hisim.components.weather import LocationEnum, Weather, WeatherConfig
 from hisim.postprocessing.postprocessing_datatransfer import PostProcessingDataTransfer
 from hisim.postprocessing.postprocessing_main import region_of
+from tests import functions_for_testing as fft
 from tests.postprocessing_option_test_framework import (
     PreparedPostProcessingCase,
     SETUP_MODULE_NAME,
@@ -69,7 +70,7 @@ def _non_weather(case: PreparedPostProcessingCase) -> ExampleComponent:
     """Build a component that is not a Weather, so the search cannot simply take the first one."""
     return ExampleComponent(
         my_simulation_parameters=case.ppdt.simulation_parameters,
-        config=ExampleComponentConfig.get_default_example_component(),
+        config=fft.sized_example_component_config(),
     )
 
 


### PR DESCRIPTION
## The region test resolves the example component it builds

#686 and #688 were merged in the same hour without CI on the combined main: #686's region test built an `ExampleComponent` from its default factory, and #688 made that factory's `capacity` a sized field returning `AUTO`, so the two tests failed on main with a `ConfigSizingError`. The test now builds the component through the shared `sized_example_component_config` helper that #688 added for this purpose. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)