### PR TITLE
The mypy profiles stop excusing packages nothing imports

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -32,8 +32,6 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-matplotlib.*]
 ignore_missing_imports = True
-[mypy-seaborn.*]
-ignore_missing_imports = True
 [mypy-reportlab.*]
 ignore_missing_imports = True
 [mypy-scipy.*]
@@ -60,17 +58,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-utspclient.*]
 ignore_missing_imports = True
-[mypy-control.*]
-ignore_missing_imports = True
 [mypy-dotenv.*]
-ignore_missing_imports = True
-[mypy-windpowerlib.*]
-ignore_missing_imports = True
-[mypy-wetterdienst.*]
-ignore_missing_imports = True
-[mypy-cdsapi.*]
-ignore_missing_imports = True
-[mypy-xarray.*]
 ignore_missing_imports = True
 [mypy-urllib.*]
 ignore_missing_imports = True

--- a/mypy_moderate.ini
+++ b/mypy_moderate.ini
@@ -16,15 +16,20 @@ disable_error_code = misc, no-untyped-call, no-untyped-def, type-arg, unused-ign
 # Sections were removed only when their override is truly redundant:
 #   - imported by neither run: pympler, networkx, setuptools; or
 #   - the package ships a py.typed marker, so mypy resolves its types natively:
-#     pydot, dotenv, xarray (presence of <pkg>/py.typed in site-packages was
+#     pydot, dotenv (presence of <pkg>/py.typed in site-packages was
 #     verified, and `mypy --config-file mypy_moderate.ini` was run against both
-#     system_setups/ and tests/ with zero import-not-found / import-untyped errors).
+#     system_setups/ and tests/ with zero import-not-found / import-untyped errors); or
+#   - nothing under hisim/, tests/, system_setups/ or scripts/ imports the package any
+#     more: seaborn, cdsapi, xarray, wetterdienst (its importer is gone; the name only
+#     survives as an OPTIONAL_DEPENDENCIES string and a docs autodoc mock), control and
+#     windpowerlib (imported solely by obsolete/, which no mypy job checks).
 # Sections for packages that are missing or ship no py.typed marker MUST remain even
 # though each is "unused" in one run: deleting it would surface import-not-found /
 # import-untyped errors in the other run that does import it (e.g. hpc_harness,
-# seaborn, cdsapi, wetterdienst). The residual unused-section notes are
-# inherent to a shared config and are preferable to breaking type-checking for the
-# importing run.
+# submit_system_setups, submit_json_setups, numpy_financial, pygfunction, jsonschema
+# and openpyxl, all of which only the tests/ run imports). The residual unused-section
+# notes are inherent to a shared config and are preferable to breaking type-checking
+# for the importing run.
 
 # The HPC harness lives under scripts/ (not an installed package); treat it like the
 # other non-installed dependencies below so tests importing it don't fail resolution.
@@ -53,8 +58,6 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-matplotlib.*]
 ignore_missing_imports = True
-[mypy-seaborn.*]
-ignore_missing_imports = True
 [mypy-reportlab.*]
 ignore_missing_imports = True
 [mypy-scipy.*]
@@ -76,14 +79,6 @@ ignore_missing_imports = True
 [mypy-psutil.*]
 ignore_missing_imports = True
 [mypy-utspclient.*]
-ignore_missing_imports = True
-[mypy-control.*]
-ignore_missing_imports = True
-[mypy-windpowerlib.*]
-ignore_missing_imports = True
-[mypy-wetterdienst.*]
-ignore_missing_imports = True
-[mypy-cdsapi.*]
 ignore_missing_imports = True
 [mypy-urllib.*]
 ignore_missing_imports = True


### PR DESCRIPTION
## The mypy profiles stop excusing packages nothing imports

Six `[mypy-*]` sections excused packages no live code imports any more: seaborn, cdsapi and xarray were never imported anywhere; wetterdienst's reader is gone and only its name survives in tests and docs; windpowerlib left with the wind turbine (#680) and control with the PID controller, both now only under `obsolete/`, which no mypy job checks. The sections go from both profiles, and the moderate profile's header names the seven sections that must stay because the tests-directory run imports those packages.

requirements.txt is untouched; whether to drop the dependencies is a separate decision. Lines with no importer in `hisim/`, `tests/`, `system_setups/` or `scripts/`: seaborn, control, windpowerlib, cdsapi, xarray (the five above), html2image, plotly, ordered_set, and, noticed on the way, graphviz and timezonefinder, which may still matter as runtime dependencies behind pydot and pvlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)