### PR TITLE
D-26: an unknown electrolyzer name is refused, naming the ones that exist

### DIFF
--- a/hisim/components/controller_l1_electrolyzer_h2.py
+++ b/hisim/components/controller_l1_electrolyzer_h2.py
@@ -4,15 +4,13 @@ from __future__ import annotations
 
 # clean
 from typing import Any, ClassVar, Optional
-from pathlib import Path
-import json
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.component import Component, ComponentInput, ComponentOutput, SingleTimeStepValues
+from hisim.components.generic_electrolyzer_h2 import read_electrolyzer_variant
 
 from hisim import loadtypes as lt
-from hisim import utils
 from hisim.simulationparameters import SimulationParameters
 from hisim import log
 from hisim.economics.facts import CostRelevance
@@ -64,17 +62,40 @@ class ElectrolyzerControllerConfig(ConfigBase):
         )
         return config
 
+    #: the manufacturer-table fields this controller is built from, checked before any is read.
+    TABLE_FIELDS: ClassVar[tuple[str, ...]] = (
+        "nom_load",
+        "min_load",
+        "max_load",
+        "standby_load",
+        "warm_start_time",
+        "cold_start_time",
+    )
+
     @staticmethod
     def read_config(electrolyzer_name: str) -> dict[str, Any]:
-        """Opens the according JSON-file, based on the electrolyzer_name."""
+        """Returns the manufacturer table's row for that device, refusing a name it does not carry.
 
-        config_file = Path(utils.HISIMPATH["inputs"]) / "electrolyzer_manufacturer_config.json"
-        with config_file.open("r", encoding="utf-8") as json_file:
-            data = json.load(json_file)
-            config = data.get("Electrolyzer variants", {}).get(electrolyzer_name, {})
-            if isinstance(config, dict):
-                return config
-            return {}
+        The lookup is the electrolyzer module's own, so the controller and the machine it controls
+        accept and refuse exactly the same device names. It used to answer an unknown name with an
+        empty dictionary, out of which the zero fallbacks below built a controller whose loads were
+        all zero -- a mistyped name ran, and ran an electrolyzer that never left standby.
+
+        Args:
+            electrolyzer_name: the device name as written by the setup or the configuration file.
+
+        Returns:
+            The row of "Electrolyzer variants" belonging to that device, carrying every field in
+            :attr:`TABLE_FIELDS`.
+
+        Raises:
+            ValueError: if no device of that name is in the table, or its row lacks one of the
+                fields this controller reads.
+        """
+        return read_electrolyzer_variant(
+            electrolyzer_name,
+            required_fields=ElectrolyzerControllerConfig.TABLE_FIELDS,
+        )
 
     @classmethod
     def control_electrolyzer(
@@ -82,7 +103,19 @@ class ElectrolyzerControllerConfig(ConfigBase):
         electrolyzer_name: str,
         component_id: Optional[ComponentID] = None,
     ) -> "ElectrolyzerControllerConfig":
-        """Initializes the config variables based on the JSON-file."""
+        """Initializes the config variables based on the JSON-file.
+
+        Every field is read straight out of the row, which :meth:`read_config` has already
+        checked carries all of them: a table entry missing one is an error naming the field and
+        the device, not a load of zero.
+
+        Args:
+            electrolyzer_name: the device name to look up in the manufacturer table.
+            component_id: the identity to give the controller, defaulted when not supplied.
+
+        Returns:
+            The controller configuration of that device.
+        """
 
         if component_id is None:
             component_id = ComponentID(name="L1ElectrolyzerController")
@@ -91,12 +124,12 @@ class ElectrolyzerControllerConfig(ConfigBase):
 
         config = ElectrolyzerControllerConfig(
             component_id=component_id,  # config_json.get("name", "")
-            nom_load=config_json.get("nom_load", 0.0),
-            min_load=config_json.get("min_load", 0.0),
-            max_load=config_json.get("max_load", 0.0),
-            standby_load=config_json.get("standby_load", 0.0),
-            warm_start_time=config_json.get("warm_start_time", 0.0),
-            cold_start_time=config_json.get("cold_start_time", 0.0),
+            nom_load=config_json["nom_load"],
+            min_load=config_json["min_load"],
+            max_load=config_json["max_load"],
+            standby_load=config_json["standby_load"],
+            warm_start_time=config_json["warm_start_time"],
+            cold_start_time=config_json["cold_start_time"],
         )
         return config
 

--- a/hisim/components/controller_l2_ptx_energy_management_system.py
+++ b/hisim/components/controller_l2_ptx_energy_management_system.py
@@ -1,17 +1,15 @@
 """ L2 Controller for PtX Buffer Battery operation. """
 
 # clean
-import os
 from enum import Enum, unique
-from typing import Optional, List, Any
-import json
+from typing import Any, ClassVar, Dict, List, Optional
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 from hisim.config import ConfigBase, ComponentID, DisplayConfig
 from hisim.component import Component, ComponentInput, ComponentOutput, SingleTimeStepValues
+from hisim.components.generic_electrolyzer_h2 import read_electrolyzer_variant
 
 from hisim import loadtypes as lt
-from hisim import utils
 from hisim.simulationparameters import SimulationParameters
 from hisim.economics.facts import CostRelevance
 
@@ -86,13 +84,30 @@ class PTXControllerConfig(ConfigBase):
                 f"Write one of {[mode.value for mode in PtxOperationMode]}."
             ) from None
 
+    #: the manufacturer-table fields this controller is built from, checked before any is read.
+    TABLE_FIELDS: ClassVar[tuple[str, ...]] = ("nom_load", "min_load", "max_load", "standby_load")
+
     @staticmethod
-    def read_config(electrolyzer_name):
-        """Read config."""
-        config_file = os.path.join(utils.HISIMPATH["inputs"], "electrolyzer_manufacturer_config.json")
-        with open(config_file, "r", encoding="utf-8") as json_file:
-            config_data = json.load(json_file)
-            return config_data.get("Electrolyzer variants", {}).get(electrolyzer_name, {})
+    def read_config(electrolyzer_name: str) -> Dict[str, Any]:
+        """Returns the manufacturer table's row for that device, refusing a name it does not carry.
+
+        The lookup is the electrolyzer module's own, so this controller, the L1 controller and the
+        machine itself accept and refuse exactly the same device names. It used to answer an
+        unknown name with an empty dictionary, out of which the zero fallbacks below built a PtX
+        system whose four loads were all zero -- a mistyped name ran, and ran nothing.
+
+        Args:
+            electrolyzer_name: the device name as written by the setup or the configuration file.
+
+        Returns:
+            The row of "Electrolyzer variants" belonging to that device, carrying every field in
+            :attr:`TABLE_FIELDS`.
+
+        Raises:
+            ValueError: if no device of that name is in the table, or its row lacks one of the
+                fields this controller reads.
+        """
+        return read_electrolyzer_variant(electrolyzer_name, required_fields=PTXControllerConfig.TABLE_FIELDS)
 
     @classmethod
     def control_electrolyzer(
@@ -104,7 +119,17 @@ class PTXControllerConfig(ConfigBase):
         """Sets the according parameters for the chosen electrolyzer.
 
         The operation mode selects how the electrolyser is operated; see
-        :class:`PtxOperationMode` for what each member means.
+        :class:`PtxOperationMode` for what each member means. The four loads are read straight
+        out of the row, which :meth:`read_config` has already checked carries all of them: a
+        table entry missing one is an error naming the field and the device, not a load of zero.
+
+        Args:
+            electrolyzer_name: the device name to look up in the manufacturer table.
+            operation_mode: how the PtX system is to be driven.
+            component_id: the identity to give the controller, defaulted when not supplied.
+
+        Returns:
+            The PtX controller configuration of that device.
         """
         if component_id is None:
             component_id = ComponentID(name="L2PtXController")
@@ -112,10 +137,10 @@ class PTXControllerConfig(ConfigBase):
 
         config = PTXControllerConfig(
             component_id=component_id,  # config_json.get("name", "")
-            nom_load=config_json.get("nom_load", 0.0),
-            min_load=config_json.get("min_load", 0.0),
-            max_load=config_json.get("max_load", 0.0),
-            standby_load=config_json.get("standby_load", 0.0),
+            nom_load=config_json["nom_load"],
+            min_load=config_json["min_load"],
+            max_load=config_json["max_load"],
+            standby_load=config_json["standby_load"],
             operation_mode=operation_mode,
         )
         return config

--- a/hisim/components/generic_electrolyzer_h2.py
+++ b/hisim/components/generic_electrolyzer_h2.py
@@ -2,7 +2,8 @@
 
 # clean
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Optional, Tuple
+from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple
+import difflib
 import json
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
@@ -36,6 +37,74 @@ __license__ = "-"
 __version__ = "1.0"
 __maintainer__ = "Franz Oldopp"
 __status__ = "development"
+
+
+ELECTROLYZER_TABLE_FILE_NAME = "electrolyzer_manufacturer_config.json"
+ELECTROLYZER_VARIANTS_SECTION = "Electrolyzer variants"
+
+
+def electrolyzer_table_path() -> Path:
+    """Returns the path of the manufacturer table every electrolyzer reader looks a device up in."""
+    return Path(utils.HISIMPATH["inputs"]) / ELECTROLYZER_TABLE_FILE_NAME
+
+
+def read_electrolyzer_variant(
+    electrolyzer_name: str,
+    required_fields: Sequence[str] = (),
+) -> Dict[str, Any]:
+    """Returns one device's row of the manufacturer table, or refuses naming the rows that exist.
+
+    The three configurations built from that table -- the electrolyzer's own, its L1 controller's
+    and the L2 PtX controller's -- share this one lookup so that a device name is accepted or
+    refused identically wherever it is written. Two of them used to answer a name the table does
+    not carry with an empty dictionary, which the per-field ``.get(key, 0.0)`` fallbacks behind it
+    turned into a machine rated at zero kW: a mistyped name produced a plausible-looking run with
+    an idle electrolyzer instead of an error. Both the unknown name and a row missing a field a
+    caller asked for are refused here, with the message naming what is missing and what exists,
+    the way the energy-system error catalogue words its rejections.
+
+    A missing table file is not caught: the ``FileNotFoundError`` carries the path it looked for,
+    which is what a caller needs, and no substitute for the file exists. Only the presence of a
+    required field is checked, not its value: five of the nine rows write ``standby_load`` as
+    ``null``, which the readers have always passed through as it stands, and reading a written
+    ``null`` as an absent field would refuse machines that run today.
+
+    Args:
+        electrolyzer_name: the device name as written by the setup or the configuration file.
+        required_fields: the field names the caller is about to read out of the row. Each one is
+            checked here so that a row missing a field is refused by name rather than silently
+            read as a zero.
+
+    Returns:
+        The row of "Electrolyzer variants" belonging to that device.
+
+    Raises:
+        ValueError: if no device of that name is in the table, or if the device's row does not
+            carry one of ``required_fields``.
+    """
+    config_file = electrolyzer_table_path()
+    with config_file.open("r", encoding="utf-8") as json_file:
+        data = json.load(json_file)
+    electrolyzer_variants: Dict[str, Dict[str, Any]] = data[ELECTROLYZER_VARIANTS_SECTION]
+
+    if electrolyzer_name not in electrolyzer_variants:
+        available = sorted(electrolyzer_variants)
+        hint = difflib.get_close_matches(electrolyzer_name, available, n=3)
+        did_you_mean = f"Did you mean: {', '.join(hint)}? " if hint else ""
+        raise ValueError(
+            f"Electrolyzer {electrolyzer_name!r} is not in {config_file}. "
+            f"{did_you_mean}"
+            f"Available: {', '.join(available)}."
+        )
+
+    variant: Dict[str, Any] = electrolyzer_variants[electrolyzer_name]
+    missing = [field_name for field_name in required_fields if field_name not in variant]
+    if missing:
+        raise ValueError(
+            f"The entry for electrolyzer {electrolyzer_name!r} in {config_file} carries no "
+            f"{', '.join(missing)}. Present: {', '.join(sorted(variant))}."
+        )
+    return variant
 
 
 @dataclass_json
@@ -123,24 +192,25 @@ class ElectrolyzerConfig(ConfigBase):
         )
         return config
 
+    #: the manufacturer-table fields this configuration reads without a fallback, checked first.
+    TABLE_FIELDS: ClassVar[Tuple[str, ...]] = ("electrolyzer_type", "nom_load", "max_load")
+
     @staticmethod
-    def read_config(electrolyzer_name):
-        """Opens the according JSON-file, based on the electrolyzer_name."""
+    def read_config(electrolyzer_name: str) -> Dict[str, Any]:
+        """Returns the manufacturer table's row for that device; see :func:`read_electrolyzer_variant`.
 
-        config_file = Path(utils.HISIMPATH["inputs"]) / "electrolyzer_manufacturer_config.json"
-        with config_file.open("r", encoding="utf-8") as json_file:
-            data = json.load(json_file)
-            electrolyzer_variants = data["Electrolyzer variants"]
-            if electrolyzer_name not in electrolyzer_variants:
-                raise KeyError(
-                    f"The electrolyzer {electrolyzer_name} could not be found in the input data. Please check the input data for electrolyzer names."
-                )
+        Args:
+            electrolyzer_name: the device name as written by the setup or the configuration file.
 
-            for key, values in electrolyzer_variants.items():
-                if key == electrolyzer_name:
-                    data_for_specific_electrolyzer = values
+        Returns:
+            The row of "Electrolyzer variants" belonging to that device, carrying every field in
+            :attr:`TABLE_FIELDS`.
 
-            return data_for_specific_electrolyzer
+        Raises:
+            ValueError: if no device of that name is in the table, or its row lacks the type or
+                one of the two ratings, which are read without a fallback.
+        """
+        return read_electrolyzer_variant(electrolyzer_name, required_fields=ElectrolyzerConfig.TABLE_FIELDS)
 
     @classmethod
     def config_electrolyzer(
@@ -156,10 +226,11 @@ class ElectrolyzerConfig(ConfigBase):
 
         config = ElectrolyzerConfig(
             component_id=component_id,  # config_json.get("name", "")
-            electrolyzer_type=config_json.get("electrolyzer_type"),
-            # The two ratings are read without a fallback: a variant that carries neither is a
-            # broken input file, and defaulting them to zero would silently produce a machine
+            # The type and the two ratings are read without a fallback: a variant that carries
+            # neither is a broken input file, and defaulting them would silently produce a machine
             # that is refused above -- or, worse, costed as free -- instead of naming the key.
+            # read_config has already checked all three are there, naming the device if not.
+            electrolyzer_type=config_json["electrolyzer_type"],
             nom_load=config_json["nom_load"],
             max_load=config_json["max_load"],
             nom_h2_flow_rate=config_json.get("nom_h2_flow_rate", 0.0),

--- a/roadmap/declarative_energy_systems/p4_component_sweep_requirements.md
+++ b/roadmap/declarative_energy_systems/p4_component_sweep_requirements.md
@@ -377,9 +377,28 @@ row is struck from the table, which keeps the question and the option chosen nex
   against a fresh preset and omits every field equal to the default — so the golden fleet's twins do not carry the ten
   `null` envelope opt-ins the survey warned the option would otherwise produce.
 - **D-26** `[answered 2026-09-11]` **(a) raise, listing the devices.** All nine hydrogen-chain `read_config` readers
+  `[count as written 2026-09-11; D-25 moved six of the nine to obsolete/ the same day, leaving three]`
   raise on an unknown device name and name the available ones, so the eight that zero-fill today stop building a
   plausible-looking config of zeros. A file that names a device which does not exist fails at build time, as
   everything else in P2's error catalogue does.
+
+  **Executed 2026-09-12**: the three readers left after D-25 -- `ElectrolyzerConfig.read_config`,
+  `ElectrolyzerControllerConfig.read_config` and `PTXControllerConfig.read_config`, all reading
+  `hisim/inputs/electrolyzer_manufacturer_config.json` -- raise through one shared lookup,
+  `generic_electrolyzer_h2.read_electrolyzer_variant`, which the two controller modules import. An unknown name
+  raises `ValueError` naming the name, the file, a `difflib` "Did you mean" near match and the nine device names
+  in sorted order, worded as `EnergySystemCatalogueError` words its alternatives (the readers are plain Python
+  factories, not the codec, so the exception is plain). The two controllers' per-field `.get(key, 0.0)` zero-fill
+  is gone: each declares the fields it reads as `TABLE_FIELDS`, the lookup checks them before returning, and the
+  factories index the row directly, so a row missing a field is an error naming the field and the device rather
+  than a load of zero. The electrolyzer's own reader requires the three fields it already read without a fallback
+  (`electrolyzer_type`, `nom_load`, `max_load`). A missing table file is not caught; the `FileNotFoundError`
+  carries the path. **Field check**: all nine variants carry all six fields the two controllers read, so nothing
+  had to be invented; five of them (`KumaTecPEM40100`, `McPhy - McLyzer 3200`, `NEL - MC250`, `NEL - MC500`,
+  `SunfireHYLINKSOEC`) write `standby_load` as `null`, which the readers passed through before and still do --
+  only presence is checked, because `.get` never defaulted a written `null` either. Result-neutral: the live
+  setup `electrolyzer_with_renewables` builds `HTecME450` through two of the readers and its recorded twin is
+  unchanged. Tested in `tests/test_electrolyzer_manufacturer_table.py`.
 - **D-32** `[answered 2026-09-11]` **(a) both key groups go, one commit each.** Postprocessing reads the Weather
   component's `config.location` directly instead of `SingletonDictKeyEnum.LOCATION`; the six Building 5R1C keys go once
   this branch's D-16 move has put `controller_mpc` and `controller_pid` in `obsolete/`, after which they have no reader
@@ -503,7 +522,7 @@ The 32 questions below are owner decisions surfaced by the survey, and **all 32 
 | D-19 | ~~Constructor arguments undecoded — executor fix, widen signatures, or leave constructors Python-only?~~ | `[answered 2026-09-11]` **(a)** `codec.decode_argument` shared by `config:` and `constructor:`, decoded in `_call_builder`, EF-1A at the argument's key path, and `@constructor` refuses undecodable parameter types at import | R2.3, B1 |
 | D-20 | ~~`for_household` ignores its argument in the predefined-profile mode~~ | `[answered 2026-08-27, review of #592]` **(a)** implemented in P2: `data_acquisition_mode` parameter, profile derived from the household, refusal listing the shipped households and the computing modes | B1 UTSP |
 | D-22 | ~~Building's 20-field post-construction mutation: `config:` overrides, wider constructor, or `for_measured_envelope`?~~ | `[answered 2026-09-11]` **(a)** the 14 non-parameters become sparse `config:` overrides; the recorder diffs against a fresh preset, so no twin carries ten nulls | R3 Building, P3 recorder |
-| D-26 | ~~Five `read_config` readers zero-fill on unknown device: raise everywhere?~~ — after D-25 only three are left (`generic_electrolyzer_h2`, `controller_l1_electrolyzer_h2`, `controller_l2_ptx_energy_management_system`, all reading `electrolyzer_manufacturer_config.json`) | `[answered 2026-09-11]` **(a)** all nine readers raise, listing the available device names | R3 H₂ |
+| D-26 | ~~Five `read_config` readers zero-fill on unknown device: raise everywhere?~~ — after D-25 only three are left (`generic_electrolyzer_h2`, `controller_l1_electrolyzer_h2`, `controller_l2_ptx_energy_management_system`, all reading `electrolyzer_manufacturer_config.json`) | `[answered 2026-09-11]` **(a)** all nine readers raise, listing the available device names — **executed 2026-09-12** for the three survivors, through one shared lookup | R3 H₂ |
 | D-32 | ~~Delete the `LOCATION` key and the six 5R1C keys?~~ | `[answered 2026-09-11]` **(a)** both, one commit each: postprocessing reads the Weather's `config.location`; the six 5R1C keys follow D-16's MPC/PID move, after which they have no reader | R2.4 |
 
 ## 12. Glossary

--- a/tests/test_electrolyzer_manufacturer_table.py
+++ b/tests/test_electrolyzer_manufacturer_table.py
@@ -1,0 +1,223 @@
+"""Tests for the one lookup behind the three readers of the electrolyzer manufacturer table.
+
+``electrolyzer_manufacturer_config.json`` is read by three configurations: the electrolyzer's
+own (``generic_electrolyzer_h2``), its L1 controller's (``controller_l1_electrolyzer_h2``) and
+the L2 PtX controller's (``controller_l2_ptx_energy_management_system``). The electrolyzer's
+reader has always refused a device name the table does not carry; the two controllers' readers
+answered the same name with an empty dictionary, which their per-field ``.get(key, 0.0)``
+fallbacks turned into a controller whose loads were all zero. A mistyped device name therefore
+did not fail -- it produced a plausible-looking run with an idle electrolyzer, and the two
+readers of one file disagreed about the same name.
+
+These tests pin the decision (P4 D-26): all three readers refuse an unknown name through one
+shared lookup, the message names the devices that do exist, a row missing a field a reader needs
+is refused by the name of the field, and the one device the live setup uses still builds exactly
+the values the table carries for it.
+"""
+
+# clean
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from hisim.components import controller_l1_electrolyzer_h2 as l1
+from hisim.components import controller_l2_ptx_energy_management_system as l2
+from hisim.components import generic_electrolyzer_h2 as electrolyzer
+from hisim.config import ComponentID
+
+#: the device the live setup ``electrolyzer_with_renewables`` builds, through two of the readers.
+KNOWN_DEVICE = "HTecME450"
+
+#: a name close enough to the known one to be a plausible typo, and absent from the table.
+UNKNOWN_DEVICE = "HTecME451"
+
+
+def _table() -> Dict[str, Any]:
+    """Returns the "Electrolyzer variants" section of the shipped manufacturer table."""
+    path = electrolyzer.electrolyzer_table_path()
+    variants: Dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))["Electrolyzer variants"]
+    return variants
+
+
+def _read_through_each_reader(device: str) -> Dict[str, Any]:
+    """Calls all three readers on one device name, returning what each returned."""
+    return {
+        "electrolyzer": electrolyzer.ElectrolyzerConfig.read_config(device),
+        "l1": l1.ElectrolyzerControllerConfig.read_config(device),
+        "l2": l2.PTXControllerConfig.read_config(device),
+    }
+
+
+@pytest.mark.base
+def test_every_reader_refuses_an_unknown_device_naming_the_ones_that_exist() -> None:
+    """All three readers raise on a name the table does not carry, and list the names it does.
+
+    The two controllers' readers used to return ``{}`` here, so this is the case where they
+    disagreed with the electrolyzer's own. The assertion is on the three ingredients of a repair
+    instruction: the name written, the near match, and the full list.
+    """
+    available = sorted(_table())
+
+    for reader_name, read in (
+        ("electrolyzer", electrolyzer.ElectrolyzerConfig.read_config),
+        ("l1", l1.ElectrolyzerControllerConfig.read_config),
+        ("l2", l2.PTXControllerConfig.read_config),
+    ):
+        with pytest.raises(ValueError) as raised:
+            read(UNKNOWN_DEVICE)
+
+        message = str(raised.value)
+        assert UNKNOWN_DEVICE in message, reader_name
+        assert KNOWN_DEVICE in message, reader_name
+        assert all(device in message for device in available), reader_name
+        assert "electrolyzer_manufacturer_config.json" in message, reader_name
+
+
+@pytest.mark.base
+def test_the_three_factories_refuse_an_unknown_device_too() -> None:
+    """The refusal reaches the config builders, not only the readers under them.
+
+    A setup calls ``config_electrolyzer`` and the two ``control_electrolyzer`` classmethods; the
+    zero-filled config was built there, so that is where the failure has to arrive.
+    """
+    with pytest.raises(ValueError, match=UNKNOWN_DEVICE):
+        electrolyzer.ElectrolyzerConfig.config_electrolyzer(UNKNOWN_DEVICE)
+
+    with pytest.raises(ValueError, match=UNKNOWN_DEVICE):
+        l1.ElectrolyzerControllerConfig.control_electrolyzer(UNKNOWN_DEVICE)
+
+    with pytest.raises(ValueError, match=UNKNOWN_DEVICE):
+        l2.PTXControllerConfig.control_electrolyzer(UNKNOWN_DEVICE, l2.PtxOperationMode.NOMINAL_LOAD)
+
+
+@pytest.mark.base
+def test_all_three_readers_return_the_same_row_for_a_known_device() -> None:
+    """One device name, one row: the readers no longer differ in what they see."""
+    rows = _read_through_each_reader(KNOWN_DEVICE)
+
+    assert rows["electrolyzer"] == rows["l1"] == rows["l2"] == _table()[KNOWN_DEVICE]
+
+
+@pytest.mark.base
+def test_the_known_device_still_builds_the_values_the_table_carries() -> None:
+    """``HTecME450`` builds what it built before, pinned against the table's literals.
+
+    The figures are written out rather than read back off the JSON, so that an edit to the table
+    or to a reader has to be intentional to pass. They are the ones the live setup runs on.
+    """
+    machine = electrolyzer.ElectrolyzerConfig.config_electrolyzer(
+        KNOWN_DEVICE, component_id=ComponentID(name=KNOWN_DEVICE)
+    )
+    assert machine.electrolyzer_type == "PEM"
+    assert machine.nom_load == 987.0
+    assert machine.max_load == 1028.225
+    assert machine.nom_h2_flow_rate == 18.875
+    assert machine.faraday_eff == 0.999
+
+    controller = l1.ElectrolyzerControllerConfig.control_electrolyzer(KNOWN_DEVICE)
+    assert controller.nom_load == 987.0
+    assert controller.min_load == 205.462
+    assert controller.max_load == 1028.225
+    assert controller.standby_load == 41.225
+    assert controller.warm_start_time == 30.0
+    assert controller.cold_start_time == 600.0
+
+    ptx = l2.PTXControllerConfig.control_electrolyzer(KNOWN_DEVICE, l2.PtxOperationMode.NOMINAL_LOAD)
+    assert ptx.nom_load == 987.0
+    assert ptx.min_load == 205.462
+    assert ptx.max_load == 1028.225
+    assert ptx.standby_load == 41.225
+    assert ptx.operation_mode is l2.PtxOperationMode.NOMINAL_LOAD
+
+
+@pytest.mark.base
+def test_every_shipped_variant_carries_the_fields_the_two_controllers_read() -> None:
+    """No shipped row leans on a fallback: every one carries all six controller fields.
+
+    This is what makes dropping the ``.get(key, 0.0)`` fallbacks result-neutral for the table as
+    it stands, and it fails the day a row is added without them -- which is the point.
+    """
+    needed = set(l1.ElectrolyzerControllerConfig.TABLE_FIELDS) | set(l2.PTXControllerConfig.TABLE_FIELDS)
+
+    for device, row in _table().items():
+        assert needed <= set(row), f"{device} is missing {sorted(needed - set(row))}"
+
+
+@pytest.mark.base
+def test_a_row_missing_a_field_is_refused_by_the_name_of_the_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A field a reader needs and a row does not carry is an error, not a zero.
+
+    The table is replaced with one whose single row lacks ``standby_load`` and ``cold_start_time``.
+    Before the change these read as ``0.0``, giving a controller that never went to standby and
+    restarted instantly.
+    """
+    broken = tmp_path / "electrolyzer_manufacturer_config.json"
+    broken.write_text(
+        json.dumps({"Electrolyzer variants": {"OnlyDevice": {"nom_load": 10.0, "min_load": 1.0, "max_load": 11.0}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(electrolyzer, "electrolyzer_table_path", lambda: broken)
+
+    with pytest.raises(ValueError) as raised:
+        l1.ElectrolyzerControllerConfig.control_electrolyzer("OnlyDevice")
+    message = str(raised.value)
+    assert "OnlyDevice" in message
+    assert "standby_load" in message and "cold_start_time" in message
+
+    with pytest.raises(ValueError, match="standby_load"):
+        l2.PTXControllerConfig.control_electrolyzer("OnlyDevice", l2.PtxOperationMode.NOMINAL_LOAD)
+
+    # The name lookup keeps working against the substituted table, so the two failures are told
+    # apart: an unknown name lists the one device this table does carry.
+    with pytest.raises(ValueError, match="OnlyDevice"):
+        l1.ElectrolyzerControllerConfig.read_config("NoSuchDevice")
+
+
+@pytest.mark.base
+def test_a_field_written_as_null_is_passed_through_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A field present as ``null`` is not treated as missing.
+
+    Five of the nine shipped rows write ``standby_load`` as ``null``, and both controllers have
+    always passed that value through -- ``.get`` defaults on an absent key, not on a written
+    ``null``. Refusing it would retire devices that run today, so presence is what is checked.
+    """
+    with_null = tmp_path / "electrolyzer_manufacturer_config.json"
+    with_null.write_text(
+        json.dumps(
+            {
+                "Electrolyzer variants": {
+                    "NullStandby": {
+                        "nom_load": 10.0,
+                        "min_load": 1.0,
+                        "max_load": 11.0,
+                        "standby_load": None,
+                        "warm_start_time": 30.0,
+                        "cold_start_time": 600.0,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(electrolyzer, "electrolyzer_table_path", lambda: with_null)
+
+    assert l1.ElectrolyzerControllerConfig.control_electrolyzer("NullStandby").standby_load is None
+
+
+@pytest.mark.base
+def test_a_missing_table_file_propagates_with_its_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A table that is not there raises ``FileNotFoundError`` naming the path it looked for."""
+    absent = tmp_path / "not_here" / "electrolyzer_manufacturer_config.json"
+    monkeypatch.setattr(electrolyzer, "electrolyzer_table_path", lambda: absent)
+
+    with pytest.raises(FileNotFoundError) as raised:
+        electrolyzer.ElectrolyzerConfig.read_config(KNOWN_DEVICE)
+
+    assert str(absent) in str(raised.value)


### PR DESCRIPTION
D-26 (a): the three electrolyzer readers left after D-25 raise on an unknown device name instead of zero-filling.

- generic_electrolyzer_h2.read_electrolyzer_variant is the one lookup all three ead_config methods use. An unknown name raises ValueError naming the name, the table file, a near match and the nine available devices, worded like the energy-system catalogue errors.
- The L1 and PtX controllers drop their .get(key, 0.0) fallbacks. Each declares its TABLE_FIELDS, the lookup checks presence, the factories index the row. A row missing a field is an error naming field and device, not a load of zero.
- Result-neutral: all nine table rows carry every field read; electrolyzer_with_renewables re-records unchanged. Five rows write standby_load as null and are passed through as before (presence is checked, not value).
- New 	ests/test_electrolyzer_manufacturer_table.py (8 tests); §11 D-26 marked executed.

Checks: 30 electrolyzer tests, the electrolyzer setup test, twin freshness, flake8, prospector, mypy (both profiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)