### PR TITLE
A skipped test says why in the test summary

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,11 +2,13 @@
 testpaths = tests
 filterwarnings =
     ignore::DeprecationWarning
-# -rfE emits the "=== short test summary info ===" block for failures and errors. CI
-# failure reporting parses that block rather than tracebacks (traceback formatting varies
-# with --tb, with xdist, and with whichever plugins are installed); without it a failing
-# CI job reports one opaque "job failed" instead of the individual tests.
-addopts = --strict-markers -rfE
+# -rfEs emits the "=== short test summary info ===" block: one line per failure, error and
+# skip, the skip line carrying the reason given to pytest.skip(), pytest.importorskip() or
+# skipif. CI does not parse that block - it only reads pytest's exit code - but the block is
+# what makes the job log readable: a failing test is named in the summary instead of having
+# to be found by scrolling the tracebacks, and a test that opted out (because an optional
+# dependency is missing, say) appears by name and reason rather than a bare count.
+addopts = --strict-markers -rfEs
 markers =
     base: base tests that have to run in any case
     extendedbase: extended base tests that take up to 10 minutes to run (deselect with '-m "not extendedBase"')


### PR DESCRIPTION
`pytest.ini`: `-rfE` becomes `-rfEs`, so a skipped test is named in the short test summary together with the reason given to `pytest.skip()`, `importorskip` or `skipif`, instead of being a bare count in the progress line. The comment above the option is corrected as well: CI does not parse that block, it only reads pytest's exit code; the block matters because it makes the job log readable.

Originally proposed in #549, carried forward from current main so the stale branch does not come with it.

Verified: a planted skip prints `SKIPPED [1] test_cli.py:240: <reason>`; `pytest --co` still parses the ini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)