### PR TITLE
A script draws how every golden KPI moved across the blesses

### DIFF
--- a/golden_ref_spec.md
+++ b/golden_ref_spec.md
@@ -61,6 +61,8 @@ scripts/
   golden_check.py           # REWRITE: config-driven, tolerance compare, --setup filter, report, exit codes
   golden_matrix.py          # NEW: emit GH Actions matrix JSON (per-horizon) from golden_config.json
   golden_validate.py        # NEW: vet the manually-listed setups (offline/KPI/deterministic)
+  golden_history.py         # local-only: draw how every golden KPI moved across the blesses (walks git history)
+  golden_kpi_renames.py     # the old-name → new-name table golden_history.py stitches renamed series with
   ci_all_green.sh           # NEW: gh-api helper — did quality+tests+golden-check all pass for a SHA?
   # [2026-09-12: ci_all_green.sh was never wired into any workflow — the gate polls with
   #  scripts/ci_wait_all.sh instead — and the unused helper was removed on that date.]

--- a/golden_references/README.md
+++ b/golden_references/README.md
@@ -72,3 +72,35 @@ locally produced goldens are not the canonical committed ones. A local run is
 sticky like the CI one — every value the gate would still accept stays exactly as
 committed, and nothing is dropped — so add `--force-rewrite` to see the fresh
 values verbatim.)
+
+## Seeing how the references moved
+
+The git history of this directory is a record of which KPI moved in which pull
+request. To draw it:
+
+```bash
+python scripts/golden_history.py                    # every pair, PNG + HTML
+python scripts/golden_history.py --pairs household_oil_building_sizer --since 2026-09-01
+```
+
+Output lands in `results/golden_history/` (gitignored): one figure per pair in both
+formats, an `index.html` linking them, a shared `plotly.min.js` the pages reference
+relatively, and one `moves.csv` — `commit, date, pr, pair, kpi, previous, value,
+relative_change` for every value that changed beyond the gate's tolerance, which is
+the greppable answer to "what moved when". Nothing is committed and no CI job runs it.
+
+A figure is one panel per KPI. The x axis is the commits that changed *this* pair's
+file, labelled with the date and the PR number; the y axis is the KPI's change
+against its first recorded value, in percent. A KPI whose first value is exactly `0`
+has no percentage, so its panel shows the absolute change and is marked `[abs]`.
+Non-numeric values (`null`, strings) are skipped and leave a gap. Panels are sorted
+with the largest total movement first — the three largest carry their rank — and a
+KPI that never moved is drawn in grey, so the eye lands on the movers.
+
+Renames are stitched back into one series through
+[`../scripts/golden_kpi_renames.py`](../scripts/golden_kpi_renames.py). To add one,
+find the commit that renamed the key (diff the key sets of two neighbouring golden
+commits), add the old and new spelling under the pair's stem with that commit and its
+PR, and run `pytest tests/test_golden_history.py` — it checks every old name against
+the real history and every new name against the files as they stand.
+

--- a/scripts/golden_history.py
+++ b/scripts/golden_history.py
@@ -1,0 +1,983 @@
+#!/usr/bin/env python3
+"""Draw how every golden KPI moved across the blesses.
+
+``golden_references/*.json`` records what the gated fleet produced at the moment of the
+last bless: one flat ``{"BUI1.<component>.<kpi>": number}`` file per ``(setup,
+parameter_set)`` pair. The files are re-blessed whenever an intended change moves a number,
+and since #682 a bless is sticky -- a value the gate would have accepted keeps its stored
+number -- so the git history of that directory is a fairly clean record of which KPI moved
+in which pull request.
+
+This script reads that record and draws it. It walks the commits that touched
+``golden_references/`` on the current branch, loads every golden file at every commit where
+it existed, stitches renamed keys back into one series through
+:mod:`scripts.golden_kpi_renames`, and writes, per pair, a grid of small multiples -- one
+panel per KPI, one marker per commit that touched the pair's file, the y axis being the
+KPI's change against its first recorded value. It also writes one ``moves.csv`` covering
+every pair, which is the greppable answer to "what moved when".
+
+Conventions
+-----------
+* **y axis.** Percent change against the KPI's first recorded value in the plotted window.
+  If that first value is exactly ``0`` the percentage is undefined, so the panel plots the
+  **absolute** change instead (which equals the value) and its title is marked ``[abs]``.
+  ``moves.csv`` leaves ``relative_change`` empty for a move out of a zero.
+* **Non-numeric values** (``null``, strings) are skipped: the commit gets no marker in that
+  panel. A KPI that is non-numeric throughout still gets a panel, labelled "no numeric
+  values", so that "one panel per KPI" stays literally true.
+* **Panel order.** Largest total movement first. Total movement is the path length of the
+  series -- the sum of ``|v(i) - v(i-1)|`` over consecutive recorded values -- divided by the
+  first non-zero value, so it is defined for a series that starts at zero as well, and it
+  counts a KPI that moved five times above one that moved once as far. The three largest
+  movers are annotated with their rank. Panels that never moved are drawn in grey, so the
+  eye lands on the movers.
+* **x axis.** The commits that changed this pair's file, oldest first, labelled with the
+  date and the PR number parsed from the commit subject (``... (#NNN)``), or the short sha
+  when the subject carries no PR.
+
+Output lands in ``results/golden_history/`` by default (gitignored): ``<pair>.png``,
+``<pair>.html``, one shared ``plotly.min.js`` the pages reference relatively, an
+``index.html`` linking them, and ``moves.csv``.
+
+Usage::
+
+    python scripts/golden_history.py
+    python scripts/golden_history.py --pairs household_oil_building_sizer --since 2026-09-01
+    python scripts/golden_history.py --formats png --out /tmp/gh --max-commits 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import json
+import math
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import matplotlib
+
+matplotlib.use("Agg")  # no display anywhere this runs -- must precede the pyplot import
+
+# pylint: disable=wrong-import-position
+from matplotlib import pyplot as plt  # noqa: E402
+import plotly.graph_objects as go  # type: ignore[import-untyped]  # noqa: E402
+from plotly.offline import get_plotlyjs  # type: ignore[import-untyped]  # noqa: E402
+from plotly.subplots import make_subplots  # type: ignore[import-untyped]  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+try:  # run as a script from scripts/ ...
+    from golden_check import golden_filename  # type: ignore[import-not-found]
+    from golden_kpi_renames import canonical_pair, kpi_renames_for  # type: ignore[import-not-found]
+    from golden_kpis import ABS_TOL, REL_TOL  # type: ignore[import-not-found]
+    from runner import load_config, select_pairs  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # ... or imported as scripts.golden_history (tests)
+    from scripts.golden_check import golden_filename
+    from scripts.golden_kpi_renames import canonical_pair, kpi_renames_for
+    from scripts.golden_kpis import ABS_TOL, REL_TOL
+    from scripts.runner import load_config, select_pairs
+
+GOLDEN_DIR_NAME = "golden_references"
+#: Files in the golden directory that are not a pair's references.
+NON_PAIR_FILES = frozenset({"manifest.json", "README.md"})
+DEFAULT_CONFIG_PATH = Path(__file__).parent / "golden_config.json"
+DEFAULT_OUT_DIR = _REPO_ROOT / "results" / "golden_history"
+#: Trailing ``(#1234)`` of a squash-merge subject.
+PR_IN_SUBJECT = re.compile(r"\(#(\d+)\)\s*$")
+#: How many of the largest movers get their rank written into the panel title.
+ANNOTATED_MOVERS = 3
+PANEL_COLUMNS = 5
+
+MOVER_COLOUR = "#1f4e79"
+TOP_MOVER_COLOUR = "#c2410c"
+QUIET_COLOUR = "#b0b0b0"
+
+#: Panel modes: percent change, absolute change (first value was zero), nothing to plot.
+MODE_PERCENT = "percent"
+MODE_ABSOLUTE = "absolute"
+MODE_EMPTY = "empty"
+
+
+# ---------------------------------------------------------------------------
+# Pure model
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class Commit:
+    """One commit that touched ``golden_references/``.
+
+    Attributes:
+        sha: The full commit sha.
+        date: The author date as ``YYYY-MM-DD``.
+        subject: The commit subject line.
+    """
+
+    sha: str
+    date: str
+    subject: str
+
+    @property
+    def short(self) -> str:
+        """The eight-character sha, as the labels and ``moves.csv`` spell it."""
+        return self.sha[:8]
+
+    @property
+    def pr(self) -> Optional[int]:
+        """The pull request number in the subject, or ``None`` if it carries none."""
+        return parse_pr_number(self.subject)
+
+    @property
+    def label(self) -> str:
+        """The x-axis tick: the date plus the PR number, or the short sha."""
+        return f"{self.date} #{self.pr}" if self.pr is not None else f"{self.date} {self.short}"
+
+
+@dataclass(frozen=True)
+class Panel:
+    """One KPI's history within one pair, ready to draw.
+
+    Attributes:
+        kpi: The KPI key, in its current spelling.
+        values: The recorded value per plotted commit; ``None`` where the pair's file did
+            not carry the KPI, or carried a non-numeric value.
+        plotted: What the panel's y axis shows, aligned with ``values``.
+        mode: ``"percent"``, ``"absolute"`` (the first value was zero) or ``"empty"``.
+        baseline: The first recorded numeric value, or ``None`` if there is none.
+        score: Total movement -- the series' path length relative to its first non-zero
+            value. Zero for a KPI that never moved.
+        moved: Whether any consecutive recorded pair differs beyond the gate's tolerance.
+    """
+
+    kpi: str
+    values: Tuple[Optional[float], ...]
+    plotted: Tuple[Optional[float], ...]
+    mode: str
+    baseline: Optional[float]
+    score: float
+    moved: bool
+
+
+@dataclass(frozen=True)
+class PairHistory:
+    """Everything one pair contributes: its commits and one panel per KPI.
+
+    Attributes:
+        stem: The golden filename stem, e.g. ``household_oil_building_sizer__one_week_60s``.
+        commits: The commits that changed this pair's file, oldest first.
+        panels: One panel per KPI, largest total movement first.
+    """
+
+    stem: str
+    commits: Tuple[Commit, ...]
+    panels: Tuple[Panel, ...]
+
+
+@dataclass(frozen=True)
+class Move:
+    """One KPI value that changed at one commit.
+
+    Attributes:
+        commit: The commit at which the new value was recorded.
+        pair: The golden filename stem.
+        kpi: The KPI key, in its current spelling.
+        previous: The last value recorded before this commit.
+        value: The value recorded at this commit.
+        relative_change: The change against ``previous`` in percent, or ``None`` when
+            ``previous`` is exactly zero.
+    """
+
+    commit: Commit
+    pair: str
+    kpi: str
+    previous: float
+    value: float
+    relative_change: Optional[float]
+
+
+def parse_pr_number(subject: str) -> Optional[int]:
+    """Return the pull request number a commit subject ends with.
+
+    Args:
+        subject: A commit subject line, e.g. ``"Maintenance is a yearly cost (#657)"``.
+
+    Returns:
+        The number, or ``None`` when the subject carries no trailing ``(#NNN)``.
+    """
+    match = PR_IN_SUBJECT.search(subject)
+    return int(match.group(1)) if match else None
+
+
+def is_number(value: Any) -> bool:
+    """True for a real number; ``bool`` is not one for our purposes.
+
+    Args:
+        value: Any value read out of a golden file.
+
+    Returns:
+        Whether it can be plotted as a number.
+    """
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def apply_kpi_renames(mapping: Mapping[str, Any], renames: Mapping[str, str]) -> Dict[str, Any]:
+    """Rewrite a snapshot's keys through the declared renames.
+
+    A rename applies only where the old key is present and the new key is not: a snapshot
+    carrying both is one where the two names are two measurements, not two spellings of one,
+    and rewriting it would silently merge them.
+
+    Args:
+        mapping: One golden file's contents.
+        renames: ``old key -> new key``, from :func:`~scripts.golden_kpi_renames.kpi_renames_for`.
+
+    Returns:
+        A new mapping with the renames applied.
+    """
+    out = dict(mapping)
+    for old, new in renames.items():
+        if old in out and new not in out:
+            out[new] = out.pop(old)
+    return out
+
+
+def moved_beyond_tolerance(previous: float, value: float) -> bool:
+    """Whether two values differ by more than the golden gate would have accepted.
+
+    Args:
+        previous: The earlier value.
+        value: The later value.
+
+    Returns:
+        True when the gate would have reported the difference.
+    """
+    return not math.isclose(value, previous, rel_tol=REL_TOL, abs_tol=ABS_TOL)
+
+
+def relative_change(previous: float, value: float) -> Optional[float]:
+    """The change from ``previous`` to ``value`` in percent.
+
+    Args:
+        previous: The reference value.
+        value: The new value.
+
+    Returns:
+        ``(value - previous) / |previous| * 100``, or ``None`` when ``previous`` is zero.
+    """
+    if previous == 0:
+        return None
+    return (value - previous) / abs(previous) * 100.0
+
+
+def movement_score(values: Sequence[Optional[float]]) -> float:
+    """Total movement of a series: its path length relative to its first non-zero value.
+
+    Summing every step rather than taking the extreme means a KPI that drifted at five
+    blesses outranks one that jumped once and stayed. Dividing by the first non-zero value
+    keeps the number comparable between a KPI measured in euros and one in kilowatt-hours,
+    and leaves a series that starts at zero rankable, which a percentage against the first
+    value would not.
+
+    Args:
+        values: The recorded values, ``None`` where nothing was recorded.
+
+    Returns:
+        The score; ``0.0`` for a series that never moved or has fewer than two values.
+    """
+    recorded = [value for value in values if value is not None]
+    if len(recorded) < 2:
+        return 0.0
+    scale = next((abs(value) for value in recorded if value != 0), 0.0) or 1.0
+    return sum(abs(b - a) for a, b in zip(recorded, recorded[1:])) / scale
+
+
+def build_panel(kpi: str, values: Sequence[Optional[float]]) -> Panel:
+    """Turn one KPI's recorded values into a drawable panel.
+
+    Args:
+        kpi: The KPI key.
+        values: One entry per plotted commit, ``None`` where nothing numeric was recorded.
+
+    Returns:
+        The panel, carrying what to plot and how far the KPI moved.
+    """
+    recorded = [value for value in values if value is not None]
+    if not recorded:
+        return Panel(kpi, tuple(values), tuple(values), MODE_EMPTY, None, 0.0, False)
+
+    baseline = recorded[0]
+    if baseline == 0:
+        mode = MODE_ABSOLUTE
+        plotted: List[Optional[float]] = [None if v is None else v - baseline for v in values]
+    else:
+        mode = MODE_PERCENT
+        plotted = [None if v is None else (v - baseline) / abs(baseline) * 100.0 for v in values]
+
+    moved = any(moved_beyond_tolerance(a, b) for a, b in zip(recorded, recorded[1:]))
+    return Panel(kpi, tuple(values), tuple(plotted), mode, baseline, movement_score(values), moved)
+
+
+def build_pair_history(
+    stem: str, snapshots: Sequence[Tuple[Commit, Optional[Mapping[str, Any]]]]
+) -> PairHistory:
+    """Assemble one pair's history from its snapshot at every commit.
+
+    Commits before the file first appeared are dropped, as are commits at which the file is
+    absent (it has never been deleted, but a deletion would be a gap, not a zero) and
+    commits at which the renamed contents are identical to the previous kept snapshot --
+    those did not touch this pair even though they touched the directory.
+
+    Args:
+        stem: The golden filename stem, in its current spelling.
+        snapshots: ``(commit, contents or None)`` for every walked commit, oldest first.
+
+    Returns:
+        The pair's history, panels sorted by total movement, largest first.
+    """
+    renames = kpi_renames_for(stem)
+    kept: List[Tuple[Commit, Dict[str, Any]]] = []
+    for commit, contents in snapshots:
+        if contents is None:
+            continue
+        renamed = apply_kpi_renames(contents, renames)
+        if kept and renamed == kept[-1][1]:
+            continue
+        kept.append((commit, renamed))
+
+    keys: List[str] = []
+    seen = set()
+    for _, contents_at in kept:
+        for key in contents_at:
+            if key not in seen:
+                seen.add(key)
+                keys.append(key)
+
+    panels = [
+        build_panel(
+            key,
+            [
+                contents_at[key] if is_number(contents_at.get(key)) else None
+                for _, contents_at in kept
+            ],
+        )
+        for key in keys
+    ]
+    panels.sort(key=lambda panel: (-panel.score, panel.kpi))
+    return PairHistory(stem, tuple(commit for commit, _ in kept), tuple(panels))
+
+
+def collect_moves(history: PairHistory) -> List[Move]:
+    """Every value in one pair that changed beyond tolerance, in commit order.
+
+    The first value a KPI ever records is not a move -- there is nothing it moved from -- and
+    a KPI that reappears after a gap is compared against the last value actually recorded.
+
+    Args:
+        history: The pair's assembled history.
+
+    Returns:
+        The moves, ordered by commit and then by KPI name.
+    """
+    moves: List[Move] = []
+    by_name = sorted(history.panels, key=lambda panel: panel.kpi)
+    for index, commit in enumerate(history.commits):
+        for panel in by_name:
+            value = panel.values[index]
+            if value is None:
+                continue
+            previous = next(
+                (v for v in reversed(panel.values[:index]) if v is not None), None
+            )
+            if previous is None or not moved_beyond_tolerance(previous, value):
+                continue
+            moves.append(
+                Move(commit, history.stem, panel.kpi, previous, value, relative_change(previous, value))
+            )
+    return moves
+
+
+# ---------------------------------------------------------------------------
+# Git layer
+# ---------------------------------------------------------------------------
+def run_git(repo: Path, *args: str) -> str:
+    """Run a git command in ``repo`` and return its stdout.
+
+    Args:
+        repo: The repository (or worktree) root.
+        *args: The git arguments.
+
+    Returns:
+        Standard output, decoded as UTF-8.
+
+    Raises:
+        subprocess.CalledProcessError: If git exits non-zero.
+    """
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True
+    ).stdout
+
+
+def golden_commits(repo: Path, since: Optional[str] = None, max_commits: Optional[int] = None) -> List[Commit]:
+    """The commits that touched ``golden_references/``, oldest first.
+
+    Args:
+        repo: The repository root.
+        since: A commit-ish that itself touched the directory (the walk starts there,
+            inclusive), or anything git understands as a date (the walk keeps commits at or
+            after it). ``None`` walks everything.
+        max_commits: Keep at most this many of the most recent commits.
+
+    Returns:
+        The commits, oldest first.
+
+    Raises:
+        ValueError: If ``since`` resolves to a commit that does not touch the directory --
+            there is no snapshot to start from, and silently walking everything instead
+            would answer a question nobody asked.
+    """
+    args = ["log", "--reverse", "--format=%H%x1f%ad%x1f%s", "--date=short"]
+    start_sha: Optional[str] = None
+    if since is not None:
+        try:
+            start_sha = run_git(repo, "rev-parse", "--verify", "--quiet", f"{since}^{{commit}}").strip()
+        except subprocess.CalledProcessError:
+            args.append(f"--since={since}")
+    args += ["--", f"{GOLDEN_DIR_NAME}/"]
+
+    commits: List[Commit] = []
+    for line in run_git(repo, *args).splitlines():
+        sha, date, subject = line.split("\x1f", 2)
+        commits.append(Commit(sha=sha, date=date, subject=subject))
+
+    if start_sha:
+        shas = [commit.sha for commit in commits]
+        if start_sha not in shas:
+            raise ValueError(
+                f"--since {since!r} resolves to {start_sha[:8]}, which does not touch "
+                f"{GOLDEN_DIR_NAME}/. Pass a date, or one of the commits that do."
+            )
+        commits = commits[shas.index(start_sha):]
+    if max_commits is not None:
+        commits = commits[-max_commits:]
+    return commits
+
+
+def golden_files_at(repo: Path, commit: Commit) -> Dict[str, Dict[str, Any]]:
+    """Read every golden reference file as it stood at one commit.
+
+    Two git calls: one tree listing, one batched blob read. Keys are the filename stems as
+    *that commit* spelled them, before any renaming is applied.
+
+    Args:
+        repo: The repository root.
+        commit: The commit to read.
+
+    Returns:
+        ``stem -> contents`` for every pair file the commit's tree carries.
+    """
+    oids: Dict[str, str] = {}
+    listing = run_git(repo, "ls-tree", "-r", commit.sha, "--", f"{GOLDEN_DIR_NAME}/")
+    for line in listing.splitlines():
+        meta, _, path = line.partition("\t")
+        name = path.rsplit("/", 1)[-1]
+        if name in NON_PAIR_FILES or not name.endswith(".json"):
+            continue
+        oids[name[: -len(".json")]] = meta.split()[2]
+    if not oids:
+        return {}
+
+    raw = subprocess.run(
+        ["git", "-C", str(repo), "cat-file", "--batch"],
+        input="\n".join(oids.values()).encode(),
+        capture_output=True,
+        check=True,
+    ).stdout
+    contents: Dict[str, Dict[str, Any]] = {}
+    position = 0
+    for stem in oids:
+        header_end = raw.index(b"\n", position)
+        size = int(raw[position:header_end].split()[2])
+        body = raw[header_end + 1: header_end + 1 + size]
+        position = header_end + 1 + size + 1  # the blob is followed by a newline
+        parsed = json.loads(body.decode("utf-8"))
+        if isinstance(parsed, dict):
+            contents[stem] = parsed
+    return contents
+
+
+def snapshot_at(repo: Path, commit: Commit, stems: Sequence[str]) -> Dict[str, Optional[Dict[str, Any]]]:
+    """Read the wanted pairs as they stood at one commit, under their current names.
+
+    A stem the commit's tree does not carry maps to ``None`` -- the pair simply had no
+    reference yet, which is not an error.
+
+    Args:
+        repo: The repository root.
+        commit: The commit to read.
+        stems: The golden filename stems wanted, in their current spelling.
+
+    Returns:
+        ``stem -> contents`` (or ``None``), one entry per requested stem.
+    """
+    by_current_name = {
+        canonical_pair(stem): contents for stem, contents in golden_files_at(repo, commit).items()
+    }
+    return {stem: by_current_name.get(stem) for stem in stems}
+
+
+def walk_history(repo: Path, stems: Sequence[str], commits: Sequence[Commit]) -> List[PairHistory]:
+    """Load every pair at every commit and assemble the histories.
+
+    Args:
+        repo: The repository root.
+        stems: The golden filename stems to cover.
+        commits: The commits to read, oldest first.
+
+    Returns:
+        One :class:`PairHistory` per stem, in the order the stems were given; a stem with no
+        snapshot anywhere in the window yields a history with no commits.
+    """
+    per_stem: Dict[str, List[Tuple[Commit, Optional[Dict[str, Any]]]]] = {stem: [] for stem in stems}
+    for commit in commits:
+        snapshot = snapshot_at(repo, commit, stems)
+        for stem in stems:
+            per_stem[stem].append((commit, snapshot[stem]))
+    return [build_pair_history(stem, per_stem[stem]) for stem in stems]
+
+
+def configured_pairs(config_path: Path, golden_dir: Path) -> List[str]:
+    """The golden filename stems the gate configures and a reference exists for today.
+
+    Args:
+        config_path: Path to ``golden_config.json``.
+        golden_dir: Path to ``golden_references/``.
+
+    Returns:
+        The stems, in config order.
+    """
+    config = load_config(config_path)
+    stems = [golden_filename(setup.id, param.id)[: -len(".json")] for setup, param in select_pairs(config)]
+    return [stem for stem in stems if (golden_dir / f"{stem}.json").exists()]
+
+
+def resolve_pairs(requested: Sequence[str], available: Sequence[str]) -> List[str]:
+    """Expand what ``--pairs`` asked for into golden filename stems.
+
+    An argument may be a full stem (``household_oil_building_sizer__one_week_60s``) or a
+    setup id (``household_oil_building_sizer``), which selects every parameter set of it.
+
+    Args:
+        requested: The ``--pairs`` arguments; empty means all of ``available``.
+        available: Every stem that has a golden file today.
+
+    Returns:
+        The selected stems, in the order ``available`` lists them.
+
+    Raises:
+        ValueError: If an argument matches no stem.
+    """
+    if not requested:
+        return list(available)
+    selected: List[str] = []
+    for name in requested:
+        matched = [stem for stem in available if stem == name or stem.startswith(f"{name}__")]
+        if not matched:
+            raise ValueError(f"No golden reference matches {name!r}. Known pairs: {', '.join(available)}")
+        selected.extend(stem for stem in matched if stem not in selected)
+    return [stem for stem in available if stem in selected]
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+def write_moves_csv(moves: Sequence[Move], path: Path) -> int:
+    """Write one row per KPI value that changed, across every pair.
+
+    Args:
+        moves: The moves to write, in the order they should appear.
+        path: The file to write.
+
+    Returns:
+        The number of rows written.
+    """
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["commit", "date", "pr", "pair", "kpi", "previous", "value", "relative_change"])
+        for move in moves:
+            writer.writerow(
+                [
+                    move.commit.short,
+                    move.commit.date,
+                    "" if move.commit.pr is None else move.commit.pr,
+                    move.pair,
+                    move.kpi,
+                    repr(move.previous),
+                    repr(move.value),
+                    "" if move.relative_change is None else f"{move.relative_change:.6g}",
+                ]
+            )
+    return len(moves)
+
+
+def panel_title(panel: Panel, rank: int) -> str:
+    """The short label above one panel.
+
+    Args:
+        panel: The panel.
+        rank: Its position in the movement order, counting from one.
+
+    Returns:
+        The KPI without its building prefix, marked ``[abs]`` when the panel shows an
+        absolute change, and carrying its rank when it is among the largest movers.
+    """
+    name = panel.kpi[len("BUI1."):] if panel.kpi.startswith("BUI1.") else panel.kpi
+    if panel.mode == MODE_ABSOLUTE:
+        name = f"[abs] {name}"
+    if panel.moved and rank <= ANNOTATED_MOVERS:
+        name = f"#{rank} {name}"
+    return name
+
+
+def _wrap(text: str, width: int, lines: int) -> str:
+    """Break a label into at most ``lines`` lines of about ``width`` characters.
+
+    Args:
+        text: The label.
+        width: The target line width.
+        lines: The maximum number of lines; the last one is ellipsised if more are needed.
+
+    Returns:
+        The wrapped label.
+    """
+    words, out, current = text.split(), [], ""
+    for word in words:
+        if current and len(current) + 1 + len(word) > width:
+            out.append(current)
+            current = word
+        else:
+            current = f"{current} {word}".strip()
+    out.append(current)
+    if len(out) > lines:
+        out = out[:lines]
+        out[-1] = out[-1][: max(0, width - 1)] + "…"
+    return "\n".join(out)
+
+
+def _panel_colour(panel: Panel, rank: int) -> str:
+    """The colour a panel is drawn in: loud for a mover, grey for a KPI that never moved.
+
+    Args:
+        panel: The panel.
+        rank: Its position in the movement order, counting from one.
+
+    Returns:
+        A matplotlib colour string.
+    """
+    if not panel.moved:
+        return QUIET_COLOUR
+    return TOP_MOVER_COLOUR if rank <= ANNOTATED_MOVERS else MOVER_COLOUR
+
+
+def _grid_shape(count: int) -> Tuple[int, int]:
+    """Rows and columns for ``count`` panels.
+
+    Args:
+        count: The number of panels.
+
+    Returns:
+        ``(rows, columns)``, never smaller than one by one -- an empty golden file would
+        otherwise ask for a figure with no axes at all.
+    """
+    columns = min(PANEL_COLUMNS, max(1, count))
+    return (max(1, math.ceil(count / columns)), columns)
+
+
+def _y_label(panel: Panel) -> str:
+    """The y-axis meaning of one panel.
+
+    Args:
+        panel: The panel.
+
+    Returns:
+        A short description of the plotted quantity.
+    """
+    if panel.mode == MODE_ABSOLUTE:
+        return "abs. change"
+    return "% vs first"
+
+
+def render_png(history: PairHistory, path: Path) -> None:
+    """Draw one pair's small multiples into a PNG.
+
+    Args:
+        history: The pair's assembled history.
+        path: The file to write.
+    """
+    rows, columns = _grid_shape(len(history.panels))
+    figure, axes = plt.subplots(
+        rows, columns, figsize=(columns * 3.0, rows * 1.75), squeeze=False, constrained_layout=True
+    )
+    x_values = list(range(len(history.commits)))
+    labels = [commit.label for commit in history.commits]
+    movers = sum(1 for panel in history.panels if panel.moved)
+    figure.suptitle(
+        f"{history.stem}  —  {len(history.panels)} KPIs, {movers} of them moved "
+        f"across {len(history.commits)} blesses ({labels[0]} … {labels[-1]})",
+        fontsize=11,
+    )
+
+    for index in range(rows * columns):
+        axis = axes[index // columns][index % columns]
+        if index >= len(history.panels):
+            axis.axis("off")
+            continue
+        panel = history.panels[index]
+        colour = _panel_colour(panel, index + 1)
+        axis.set_title(_wrap(panel_title(panel, index + 1), 34, 2), fontsize=6, color=colour)
+        axis.tick_params(labelsize=5)
+        axis.set_ylabel(_y_label(panel), fontsize=5)
+        if panel.mode == MODE_EMPTY:
+            axis.text(0.5, 0.5, "no numeric values", fontsize=6, color=QUIET_COLOUR,
+                      ha="center", va="center", transform=axis.transAxes)
+            axis.set_yticks([])
+        else:
+            y_values = [math.nan if value is None else value for value in panel.plotted]
+            axis.plot(x_values, y_values, marker="o", markersize=3, linewidth=1.0, color=colour)
+            axis.axhline(0.0, color="#dddddd", linewidth=0.6, zorder=0)
+        axis.set_xlim(-0.5, len(history.commits) - 0.5)
+        axis.set_xticks(x_values)
+        bottom_of_column = index + columns >= len(history.panels)
+        axis.set_xticklabels(
+            labels if bottom_of_column else [""] * len(labels), rotation=90, fontsize=4.5
+        )
+
+    figure.savefig(path, dpi=110)
+    plt.close(figure)
+
+
+def render_html(history: PairHistory, path: Path, plotly_src: str) -> None:
+    """Draw one pair's small multiples into an interactive page.
+
+    Args:
+        history: The pair's assembled history.
+        path: The file to write.
+        plotly_src: The relative path the page's script tag references.
+    """
+    rows, columns = _grid_shape(len(history.panels))
+    figure = make_subplots(
+        rows=rows,
+        cols=columns,
+        subplot_titles=[panel_title(panel, i + 1) for i, panel in enumerate(history.panels)],
+        vertical_spacing=min(0.06, 0.9 / max(rows, 1)),
+        horizontal_spacing=0.04,
+    )
+    labels = [commit.label for commit in history.commits]
+    subjects = [commit.subject for commit in history.commits]
+
+    for index, panel in enumerate(history.panels):
+        if panel.mode == MODE_EMPTY:
+            continue
+        figure.add_trace(
+            go.Scatter(
+                x=labels,
+                y=[None if value is None else value for value in panel.plotted],
+                customdata=[
+                    [subject, "n/a" if raw is None else repr(raw)]
+                    for subject, raw in zip(subjects, panel.values)
+                ],
+                mode="lines+markers",
+                name=panel.kpi,
+                line={"color": _panel_colour(panel, index + 1), "width": 1.4},
+                marker={"size": 5},
+                hovertemplate=(
+                    f"<b>{html.escape(panel.kpi)}</b><br>%{{x}}<br>"
+                    f"{_y_label(panel)}: %{{y:.6g}}<br>value: %{{customdata[1]}}"
+                    "<br>%{customdata[0]}<extra></extra>"
+                ),
+                showlegend=False,
+            ),
+            row=index // columns + 1,
+            col=index % columns + 1,
+        )
+
+    movers = sum(1 for panel in history.panels if panel.moved)
+    figure.update_layout(
+        title=(
+            f"{history.stem} — {len(history.panels)} KPIs, {movers} moved, "
+            f"{len(history.commits)} blesses"
+        ),
+        height=max(400, rows * 210 + 120),
+        margin={"l": 50, "r": 20, "t": 90, "b": 40},
+        template="plotly_white",
+        font={"size": 10},
+    )
+    figure.update_annotations(font_size=8)
+    figure.update_xaxes(tickangle=-90, tickfont={"size": 7}, showticklabels=True)
+    figure.update_yaxes(tickfont={"size": 7})
+    figure.write_html(str(path), include_plotlyjs=plotly_src, full_html=True, auto_open=False)
+
+
+def render_index(histories: Sequence[PairHistory], formats: Sequence[str], move_counts: Mapping[str, int],
+                 path: Path) -> None:
+    """Write the page that links every pair's figures.
+
+    Args:
+        histories: The assembled histories, in output order.
+        formats: The formats that were written (``"png"``, ``"html"``).
+        move_counts: How many moves each pair contributed to ``moves.csv``.
+        path: The file to write.
+    """
+    rows = []
+    for history in histories:
+        links = " ".join(
+            f'<a href="{html.escape(history.stem)}.{fmt}">{fmt}</a>' for fmt in formats
+        )
+        top = ", ".join(
+            html.escape(panel.kpi[len("BUI1."):]) for panel in history.panels[:ANNOTATED_MOVERS] if panel.moved
+        )
+        rows.append(
+            "<tr>"
+            f"<td>{html.escape(history.stem)}</td>"
+            f"<td class=n>{len(history.commits)}</td>"
+            f"<td class=n>{len(history.panels)}</td>"
+            f"<td class=n>{sum(1 for panel in history.panels if panel.moved)}</td>"
+            f"<td class=n>{move_counts.get(history.stem, 0)}</td>"
+            f"<td>{top or '<span class=q>nothing moved</span>'}</td>"
+            f"<td>{links}</td></tr>"
+        )
+    path.write_text(
+        "<!DOCTYPE html>\n<html lang=\"en\"><head><meta charset=\"utf-8\">"
+        "<title>Golden reference history</title><style>"
+        "body{font:14px system-ui,sans-serif;margin:2rem;max-width:70rem}"
+        "table{border-collapse:collapse;width:100%}"
+        "th,td{border-bottom:1px solid #ddd;padding:.35rem .5rem;text-align:left;vertical-align:top}"
+        "td.n{text-align:right}.q{color:#999}a{margin-right:.5rem}"
+        "</style></head><body><h1>Golden reference history</h1>"
+        "<p>How every golden KPI moved across the blesses. Percent against each KPI's first "
+        "recorded value; panels marked <code>[abs]</code> start at zero and show the absolute "
+        "change instead. Every move is also a row in <a href=\"moves.csv\">moves.csv</a>.</p>"
+        "<table><thead><tr><th>pair</th><th>blesses</th><th>KPIs</th><th>movers</th><th>moves</th>"
+        "<th>largest movers</th><th>figures</th></tr></thead><tbody>"
+        + "\n".join(rows)
+        + "</tbody></table></body></html>\n",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser.
+
+    Returns:
+        The parser.
+    """
+    parser = argparse.ArgumentParser(
+        prog="golden_history.py",
+        description="Draw how every golden KPI moved across the blesses.",
+    )
+    parser.add_argument(
+        "--pairs", nargs="+", default=[], metavar="STEM",
+        help="Golden filename stems or setup ids to draw (default: every configured pair "
+             "that has a golden file today).",
+    )
+    parser.add_argument(
+        "--since", default=None, metavar="DATE_OR_SHA",
+        help="Start the walk at this commit (inclusive), or keep commits at or after this date.",
+    )
+    parser.add_argument(
+        "--out", type=Path, default=DEFAULT_OUT_DIR, metavar="DIR",
+        help=f"Output directory (default: {DEFAULT_OUT_DIR}).",
+    )
+    parser.add_argument(
+        "--formats", default="png,html",
+        help="Comma-separated output formats: png, html (default: both).",
+    )
+    parser.add_argument(
+        "--max-commits", type=int, default=None, metavar="N",
+        help="Keep only the N most recent commits of the walk.",
+    )
+    parser.add_argument(
+        "--repo", type=Path, default=_REPO_ROOT, metavar="DIR",
+        help="Repository to read the history from (default: this checkout).",
+    )
+    return parser
+
+
+def parse_formats(raw: str) -> List[str]:
+    """Validate the ``--formats`` argument.
+
+    Args:
+        raw: The comma-separated argument.
+
+    Returns:
+        The formats, in a stable order.
+
+    Raises:
+        ValueError: On an unknown or empty format list.
+    """
+    wanted = [part.strip().lower() for part in raw.split(",") if part.strip()]
+    unknown = [fmt for fmt in wanted if fmt not in ("png", "html")]
+    if unknown or not wanted:
+        raise ValueError(f"--formats must name png and/or html, got {raw!r}")
+    return [fmt for fmt in ("png", "html") if fmt in wanted]
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Walk the history, draw the figures and write ``moves.csv``.
+
+    Args:
+        argv: Command-line arguments; ``None`` reads ``sys.argv``.
+
+    Returns:
+        ``0`` on success, ``2`` on a bad argument.
+    """
+    args = build_parser().parse_args(argv)
+    try:
+        formats = parse_formats(args.formats)
+        available = configured_pairs(DEFAULT_CONFIG_PATH, args.repo / GOLDEN_DIR_NAME)
+        stems = resolve_pairs(args.pairs, available)
+        commits = golden_commits(args.repo, args.since, args.max_commits)
+    except ValueError as error:
+        print(f"golden_history: {error}", file=sys.stderr)
+        return 2
+
+    if not commits:
+        print("golden_history: no commit touches golden_references/ in that window.", file=sys.stderr)
+        return 2
+
+    histories = [history for history in walk_history(args.repo, stems, commits) if history.commits]
+    out_dir: Path = args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    moves_by_pair = {history.stem: collect_moves(history) for history in histories}
+    rows = write_moves_csv([move for moves in moves_by_pair.values() for move in moves], out_dir / "moves.csv")
+    move_counts = {stem: len(moves) for stem, moves in moves_by_pair.items()}
+
+    if "html" in formats:
+        # One shared bundle rather than 4.3 MB embedded in each page: the pages reference it
+        # relatively, so the directory as a whole opens without a network.
+        (out_dir / "plotly.min.js").write_text(get_plotlyjs(), encoding="utf-8")
+    for history in histories:
+        if "png" in formats:
+            render_png(history, out_dir / f"{history.stem}.png")
+        if "html" in formats:
+            render_html(history, out_dir / f"{history.stem}.html", "plotly.min.js")
+    render_index(histories, formats, move_counts, out_dir / "index.html")
+
+    print(
+        f"golden_history: {len(commits)} commits walked, {len(histories)} pairs drawn, "
+        f"{rows} moves -> {out_dir}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/golden_kpi_renames.py
+++ b/scripts/golden_kpi_renames.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""The declared translation between the golden references' old and new names.
+
+A golden reference is a flat ``{"BUI1.<component>.<kpi>": number}`` map, one file per
+``(setup, parameter_set)`` pair, and both halves of a key have been renamed in the past: a
+whole file when a setup was renamed, an individual key when the KPI collection changed how
+it spells a component. A history walker that reads every commit literally sees such a
+rename as one series ending and another beginning — two half-length panels where there is
+one KPI. This module is the table that stitches them back together, and
+``scripts/golden_history.py`` is its only consumer.
+
+Every entry is a **claim someone made**: that this old name and this new name are two
+spellings of one measurement, renamed by this commit. The claims here were derived
+empirically, not guessed — the key sets of consecutive golden commits were diffed for every
+file, and a pair was written down only where the diff showed one name leaving and one name
+arriving in the same commit with the same value. ``tests/test_golden_history.py`` checks
+the table back against the real history: every old name must occur in some historical
+golden, every new name in the golden files as they stand today.
+
+Why the KPI table is keyed per pair and not fleet-wide
+------------------------------------------------------
+The one real renaming so far (#653, "Two components of one name stay two components")
+appended the component's class name to every KPI of a component whose *name* collided with
+another component's in the same setup: ``BUI1.Fuel Meter.OPEX - CO2 Footprint`` became
+``BUI1.Fuel Meter.OPEX - CO2 Footprint (FuelMeter)``. The suffix arrived only where a
+collision actually existed, so the very same KPI name is renamed in one pair and untouched
+in another: ``household_oil_building_sizer__full_year_60s`` carries
+``BUI1.Fuel Meter.OPEX - CO2 Footprint (FuelMeter)`` and a plain, still-unsuffixed
+``BUI1.Fuel Meter.OPEX - Energy costs`` side by side to this day. A fleet-wide rule for that
+name would therefore merge two different series in the pairs that never renamed it. The
+``"*"`` key below is supported for a rename that really is fleet-wide, and is empty today.
+
+How to add a rename
+-------------------
+1. Find the commit that renamed it: ``git log --format='%H %s' -- golden_references/`` and
+   diff the key sets of the two neighbouring commits.
+2. Add the pair under the stem it applies to (or under ``"*"``), with the commit that did it
+   and the PR number, and a note whenever the choice was not forced by the data.
+3. Run ``pytest tests/test_golden_history.py`` — the consistency test fails on a name that
+   never existed or a new name nothing carries today.
+
+A renaming is applied only when the old name is present and the new name is absent in the
+same snapshot; a snapshot carrying both keeps them apart, because there the two names are
+two measurements rather than two spellings of one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Tuple
+
+#: Marker for the pair-independent section of :data:`KPI_RENAMES`.
+FLEET_WIDE = "*"
+
+#: The commit that gave every colliding component's KPIs a ``(ClassName)`` suffix, and its PR.
+#: Two components of one name used to collapse into one entry of the KPI collection; the fix
+#: kept them apart by spelling the class into the key.
+_COMPONENT_SPLIT = "dbde2c569faef264f6b3f4d038b1efa34dc07314"
+_COMPONENT_SPLIT_PR = 653
+
+
+@dataclass(frozen=True)
+class KpiRename:
+    """One claim that ``old`` and ``new`` are the same KPI under two names.
+
+    Attributes:
+        old: The key as the golden files spelled it before ``commit``.
+        new: The key as they spell it from ``commit`` onwards.
+        commit: The full sha of the commit that performed the rename.
+        pr: The pull request that carried that commit.
+        note: Why the pairing is what it is, whenever the data left a choice.
+    """
+
+    old: str
+    new: str
+    commit: str
+    pr: int
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class PairRename:
+    """One claim that a golden file's stem changed while the pair stayed the same.
+
+    Attributes:
+        old: The golden filename stem (no ``.json``) used before ``commit``.
+        new: The stem used from ``commit`` onwards.
+        commit: The full sha of the commit that renamed the file.
+        pr: The pull request that carried that commit.
+        note: Why the pairing is what it is.
+    """
+
+    old: str
+    new: str
+    commit: str
+    pr: int
+    note: str = ""
+
+
+def _suffixed(component_class: str, commit: str, pr: int, *kpi_names: str) -> Tuple[KpiRename, ...]:
+    """Build the ``old -> old + " (<class>)"`` claims of one component-name collision.
+
+    Only the mechanical half of the entry is computed; which keys were renamed, in which
+    pair, and to which class name stays written out at the call site, because that is the
+    part a reviewer has to check.
+
+    Args:
+        component_class: The class name the rename appended, e.g. ``"FuelMeter"``.
+        commit: The full sha of the commit that renamed the keys.
+        pr: The pull request that carried that commit.
+        *kpi_names: The keys as they were spelled before the rename.
+
+    Returns:
+        One :class:`KpiRename` per name, in the order given.
+    """
+    return tuple(
+        KpiRename(old=name, new=f"{name} ({component_class})", commit=commit, pr=pr)
+        for name in kpi_names
+    )
+
+
+#: Golden filename stems that were renamed, old stem -> the claim. Empty: no golden file has
+#: been renamed yet — the 30 files that exist were each added under the name they still
+#: carry (verified by diffing the file sets of every consecutive pair of golden commits). The
+#: schema is fixed here so the first setup rename is a table entry rather than a code change.
+#:
+#: An entry looks like::
+#:
+#:     "household_gas_building_sizer__one_week_60s": PairRename(
+#:         old="household_gas_building_sizer__one_week_60s",
+#:         new="household_gas_boiler_building_sizer__one_week_60s",
+#:         commit="<full sha>",
+#:         pr=1234,
+#:         note="the setup was renamed; the pair it gates is unchanged",
+#:     ),
+PAIR_RENAMES: Mapping[str, PairRename] = {}
+
+
+#: KPI renames, keyed by the golden filename stem they apply to, or by :data:`FLEET_WIDE`
+#: for a rename that happened in every pair at once. Within a pair the stem's own entries
+#: win over the fleet-wide ones.
+KPI_RENAMES: Mapping[str, Tuple[KpiRename, ...]] = {
+    # No KPI has been renamed across the whole fleet at once. See the module docstring for
+    # why #653 is emphatically not such a case.
+    FLEET_WIDE: (),
+    "dynamic_components__one_week_60s": (
+        # This setup runs two CHPs, and before #653 both wrote into one ``BUI1.CHP.*`` entry
+        # — the very collision the fix was about. The old series therefore has no single
+        # honest successor; it is continued into the first machine's, and CHP2's keys start
+        # as new series in #653. Both CHPs sit at 0.0 over the whole recorded history, so the
+        # choice moves no line on any panel; it is written down because it is a choice.
+        *_suffixed(
+            "CHP1",
+            _COMPONENT_SPLIT, _COMPONENT_SPLIT_PR,
+            "BUI1.CHP.Electrical energy produced",
+            "BUI1.CHP.Fuel consumed",
+            "BUI1.CHP.Number of activation cycles",
+            "BUI1.CHP.Thermal energy produced",
+        ),
+    ),
+    # The district-heating pairs gained a District Heating component of their own in #653;
+    # what the fuel meter measures kept its value and only took the suffix.
+    "household_district_heating_building_sizer__full_year_60s": (
+        *_suffixed(
+            "FuelMeter",
+            _COMPONENT_SPLIT, _COMPONENT_SPLIT_PR,
+            "BUI1.Fuel Meter.OPEX - CO2 Footprint",
+            "BUI1.Fuel Meter.OPEX - Energy costs",
+            "BUI1.Fuel Meter.OPEX - Maintenance costs",
+            "BUI1.Fuel Meter.Total energy consumption",
+        ),
+    ),
+    "household_district_heating_building_sizer__one_week_60s": (
+        *_suffixed(
+            "FuelMeter",
+            _COMPONENT_SPLIT, _COMPONENT_SPLIT_PR,
+            "BUI1.Fuel Meter.OPEX - CO2 Footprint",
+            "BUI1.Fuel Meter.OPEX - Energy costs",
+            "BUI1.Fuel Meter.OPEX - Maintenance costs",
+            "BUI1.Fuel Meter.Total energy consumption",
+        ),
+    ),
+    # In the two solar-thermal-plus-gas pairs the collector's KPIs had been covering the gas
+    # boiler's as well; the collector kept its numbers under the suffixed name and the boiler
+    # appeared beside it.
+    "household_gas_solar_thermal__one_week_60s": (
+        *_suffixed(
+            "SolarThermalSystem",
+            _COMPONENT_SPLIT, _COMPONENT_SPLIT_PR,
+            "BUI1.Solar Thermal.CAPEX - CO2 Footprint",
+            "BUI1.Solar Thermal.CAPEX - Investment cost",
+            "BUI1.Solar Thermal.OPEX - CO2 Footprint",
+            "BUI1.Solar Thermal.OPEX - Fuel costs",
+            "BUI1.Solar Thermal.OPEX - Maintenance costs",
+            "BUI1.Solar Thermal.Thermal energy delivered for domestic hot water",
+            "BUI1.Solar Thermal.Total CO2 Footprint (CAPEX for simulated period + OPEX)",
+            "BUI1.Solar Thermal.Total Costs (CAPEX for simulated period + OPEX fuel and maintenance)",
+            "BUI1.Solar Thermal.Total thermal energy delivered",
+        ),
+    ),
+    "household_gas_solar_thermal_building_sizer__one_week_60s": (
+        *_suffixed(
+            "SolarThermalSystem",
+            _COMPONENT_SPLIT, _COMPONENT_SPLIT_PR,
+            "BUI1.Solar Thermal.CAPEX - CO2 Footprint",
+            "BUI1.Solar Thermal.CAPEX - Investment cost",
+            "BUI1.Solar Thermal.OPEX - CO2 Footprint",
+            "BUI1.Solar Thermal.OPEX - Fuel costs",
+            "BUI1.Solar Thermal.OPEX - Maintenance costs",
+            "BUI1.Solar Thermal.Thermal energy delivered for domestic hot water",
+            "BUI1.Solar Thermal.Total CO2 Footprint (CAPEX for simulated period + OPEX)",
+            "BUI1.Solar Thermal.Total Costs (CAPEX for simulated period + OPEX fuel and maintenance)",
+            "BUI1.Solar Thermal.Total thermal energy delivered",
+        ),
+    ),
+    # The four fuel-boiler pairs: only the two KPIs the boiler also reports were ambiguous,
+    # so only those two took the suffix. The meter's other keys are unsuffixed to this day,
+    # which is why none of this can be stated fleet-wide.
+    "household_oil_building_sizer__full_year_60s": (
+        *_suffixed(
+            "FuelMeter",
+            _COMPONENT_SPLIT, _COMPONENT_SPLIT_PR,
+            "BUI1.Fuel Meter.OPEX - CO2 Footprint",
+            "BUI1.Fuel Meter.OPEX - Maintenance costs",
+        ),
+    ),
+    "household_oil_building_sizer__one_week_60s": (
+        *_suffixed(
+            "FuelMeter",
+            _COMPONENT_SPLIT, _COMPONENT_SPLIT_PR,
+            "BUI1.Fuel Meter.OPEX - CO2 Footprint",
+            "BUI1.Fuel Meter.OPEX - Maintenance costs",
+        ),
+    ),
+    "household_pellets_building_sizer__full_year_60s": (
+        *_suffixed(
+            "FuelMeter",
+            _COMPONENT_SPLIT, _COMPONENT_SPLIT_PR,
+            "BUI1.Fuel Meter.OPEX - CO2 Footprint",
+            "BUI1.Fuel Meter.OPEX - Maintenance costs",
+        ),
+    ),
+    "household_pellets_building_sizer__one_week_60s": (
+        *_suffixed(
+            "FuelMeter",
+            _COMPONENT_SPLIT, _COMPONENT_SPLIT_PR,
+            "BUI1.Fuel Meter.OPEX - CO2 Footprint",
+            "BUI1.Fuel Meter.OPEX - Maintenance costs",
+        ),
+    ),
+    "household_wood_chips_building_sizer__full_year_60s": (
+        *_suffixed(
+            "FuelMeter",
+            _COMPONENT_SPLIT, _COMPONENT_SPLIT_PR,
+            "BUI1.Fuel Meter.OPEX - CO2 Footprint",
+            "BUI1.Fuel Meter.OPEX - Maintenance costs",
+        ),
+    ),
+    "household_wood_chips_building_sizer__one_week_60s": (
+        *_suffixed(
+            "FuelMeter",
+            _COMPONENT_SPLIT, _COMPONENT_SPLIT_PR,
+            "BUI1.Fuel Meter.OPEX - CO2 Footprint",
+            "BUI1.Fuel Meter.OPEX - Maintenance costs",
+        ),
+    ),
+}
+
+
+def canonical_pair(stem: str) -> str:
+    """Return the stem a golden file is known by today.
+
+    Args:
+        stem: A golden filename stem as some commit spelled it.
+
+    Returns:
+        The current stem, following the chain of :data:`PAIR_RENAMES` to its end.
+
+    Raises:
+        ValueError: If the renames form a cycle, which would mean two entries disagree.
+    """
+    seen = [stem]
+    current = stem
+    while current in PAIR_RENAMES:
+        current = PAIR_RENAMES[current].new
+        if current in seen:
+            raise ValueError(f"PAIR_RENAMES forms a cycle: {' -> '.join(seen + [current])}")
+        seen.append(current)
+    return current
+
+
+def kpi_renames_for(stem: str) -> Dict[str, str]:
+    """Return the ``old key -> new key`` map that applies to one pair.
+
+    Args:
+        stem: The golden filename stem, in its current spelling.
+
+    Returns:
+        The fleet-wide claims merged with the pair's own, the pair's winning on a clash.
+
+    Raises:
+        ValueError: If one pair declares the same old key twice with two different new keys.
+    """
+    merged: Dict[str, str] = {}
+    for entry in KPI_RENAMES.get(FLEET_WIDE, ()):
+        merged[entry.old] = entry.new
+    own: Dict[str, str] = {}
+    for entry in KPI_RENAMES.get(stem, ()):
+        if entry.old in own and own[entry.old] != entry.new:
+            raise ValueError(
+                f"'{stem}' declares '{entry.old}' to mean both '{own[entry.old]}' and '{entry.new}'."
+            )
+        own[entry.old] = entry.new
+    merged.update(own)
+    return merged
+
+
+def all_kpi_renames() -> Tuple[KpiRename, ...]:
+    """Return every KPI rename claim in the table, fleet-wide ones first.
+
+    Returns:
+        The claims, flattened, in the table's own order.
+    """
+    flattened: list[KpiRename] = list(KPI_RENAMES.get(FLEET_WIDE, ()))
+    for stem, entries in KPI_RENAMES.items():
+        if stem != FLEET_WIDE:
+            flattened.extend(entries)
+    return tuple(flattened)

--- a/tests/test_golden_history.py
+++ b/tests/test_golden_history.py
@@ -1,0 +1,540 @@
+"""Tests for the golden-reference history visualiser.
+
+Two halves, as the rig itself has two: the pure functions of
+``scripts/golden_history.py`` are pinned against synthetic in-memory histories, and the
+translation table of ``scripts/golden_kpi_renames.py`` is checked back against reality --
+every old name it declares must occur in some historical golden, every new name in the
+golden files as they stand today.
+
+The reality half needs the git history of ``golden_references/``, which a shallow CI
+checkout does not have; those tests skip themselves when fewer than two commits touch the
+directory. Nothing here writes outside ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import csv
+import html.parser
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from scripts.golden_history import (
+    MODE_ABSOLUTE,
+    MODE_EMPTY,
+    MODE_PERCENT,
+    Commit,
+    apply_kpi_renames,
+    build_pair_history,
+    build_panel,
+    collect_moves,
+    golden_commits,
+    golden_files_at,
+    movement_score,
+    parse_formats,
+    parse_pr_number,
+    relative_change,
+    render_html,
+    render_index,
+    render_png,
+    resolve_pairs,
+    write_moves_csv,
+)
+from scripts.golden_kpi_renames import (
+    FLEET_WIDE,
+    KPI_RENAMES,
+    PAIR_RENAMES,
+    KpiRename,
+    canonical_pair,
+    kpi_renames_for,
+)
+
+pytestmark = pytest.mark.base
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GOLDEN_DIR = REPO_ROOT / "golden_references"
+
+
+def _commit(index: int, subject: str = "a bless (#100)") -> Commit:
+    """Build a throwaway commit for a synthetic history.
+
+    Args:
+        index: Distinguishes the commits; it becomes the sha and the day of month.
+        subject: The commit subject.
+
+    Returns:
+        The commit.
+    """
+    return Commit(sha=f"{index:040d}", date=f"2026-01-{index + 1:02d}", subject=subject)
+
+
+def _history(values_per_commit: List[Dict[str, Any]], stem: str = "pair__one_week_60s") -> Any:
+    """Assemble a synthetic pair history from one mapping per commit.
+
+    Args:
+        values_per_commit: The golden file's contents at each commit, oldest first.
+        stem: The pair stem to build under.
+
+    Returns:
+        The assembled :class:`~scripts.golden_history.PairHistory`.
+    """
+    snapshots: List[Tuple[Commit, Optional[Dict[str, Any]]]] = [
+        (_commit(index), contents) for index, contents in enumerate(values_per_commit)
+    ]
+    return build_pair_history(stem, snapshots)
+
+
+# --------------------------------------------------------------------------- #
+# PR numbers and labels
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "subject, expected",
+    [
+        ("Maintenance is a yearly cost, not a depreciating one (#657)", 657),
+        ("Golden gate full fleet: all 22 setups gated (merges last) (#642)", 642),
+        ("bless golden references: intentional simulation-output change", None),
+        ("fix hp golden ref test one week", None),
+        ("reverts (#12) and lands (#34)", 34),
+        ("mentions #99 without parentheses", None),
+        ("trailing whitespace is fine (#1) ", 1),
+    ],
+)
+def test_parse_pr_number(subject: str, expected: Optional[int]) -> None:
+    """A PR number is the trailing ``(#NNN)`` of a squash-merge subject and nothing else."""
+    assert parse_pr_number(subject) == expected
+
+
+def test_commit_label_prefers_the_pr_over_the_sha() -> None:
+    """A tick reads as date plus PR, and falls back to the short sha when there is none."""
+    assert Commit("abcdef1234", "2026-09-09", "a change (#657)").label == "2026-09-09 #657"
+    assert Commit("abcdef1234", "2026-07-10", "a bless").label == "2026-07-10 abcdef12"
+
+
+# --------------------------------------------------------------------------- #
+# Renaming
+# --------------------------------------------------------------------------- #
+def test_apply_kpi_renames_moves_the_value_to_the_new_key() -> None:
+    """A declared rename carries the value over and leaves the rest alone."""
+    out = apply_kpi_renames({"old": 1.0, "other": 2.0}, {"old": "new"})
+    assert out == {"new": 1.0, "other": 2.0}
+
+
+def test_apply_kpi_renames_leaves_a_snapshot_that_carries_both_names_alone() -> None:
+    """Where both names are present they are two measurements, so neither is merged away."""
+    out = apply_kpi_renames({"old": 1.0, "new": 2.0}, {"old": "new"})
+    assert out == {"old": 1.0, "new": 2.0}
+
+
+def test_apply_kpi_renames_is_a_no_op_when_the_old_key_is_absent() -> None:
+    """A rename for a key this pair never had changes nothing."""
+    assert apply_kpi_renames({"new": 3.0}, {"old": "new"}) == {"new": 3.0}
+
+
+def test_a_renamed_kpi_becomes_one_series(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stitching turns an ending and a beginning into one panel spanning every commit."""
+    monkeypatch.setattr("scripts.golden_history.kpi_renames_for", lambda stem: {"a.old": "a.new"})
+    history = _history([{"a.old": 10.0}, {"a.old": 12.0}, {"a.new": 15.0}])
+    assert [panel.kpi for panel in history.panels] == ["a.new"]
+    assert history.panels[0].values == (10.0, 12.0, 15.0)
+
+
+def test_without_the_table_a_rename_would_be_two_half_length_series(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stitching is what the table buys: without it the same history is two panels."""
+    monkeypatch.setattr("scripts.golden_history.kpi_renames_for", lambda stem: {})
+    history = _history([{"a.old": 10.0}, {"a.old": 12.0}, {"a.new": 15.0}])
+    assert sorted(panel.kpi for panel in history.panels) == ["a.new", "a.old"]
+
+
+# --------------------------------------------------------------------------- #
+# Panels: relative change, the zero baseline, non-numeric values
+# --------------------------------------------------------------------------- #
+def test_relative_change_is_percent_against_the_previous_value() -> None:
+    """A half is minus fifty percent, and a doubling is a hundred."""
+    assert relative_change(2.0, 1.0) == pytest.approx(-50.0)
+    assert relative_change(2.0, 4.0) == pytest.approx(100.0)
+    assert relative_change(-2.0, -3.0) == pytest.approx(-50.0)
+    assert relative_change(0.0, 5.0) is None
+
+
+def test_panel_plots_percent_against_the_first_recorded_value() -> None:
+    """The y axis is the change against the series' first value, in percent."""
+    panel = build_panel("kpi", [50.0, 75.0, 25.0])
+    assert panel.mode == MODE_PERCENT
+    assert panel.baseline == 50.0
+    assert panel.plotted == pytest.approx((0.0, 50.0, -50.0))
+    assert panel.moved is True
+
+
+def test_a_first_value_of_zero_switches_the_panel_to_absolute_change() -> None:
+    """A percentage against zero is undefined, so the panel shows the absolute change."""
+    panel = build_panel("kpi", [0.0, 4.0, 6.0])
+    assert panel.mode == MODE_ABSOLUTE
+    assert panel.plotted == pytest.approx((0.0, 4.0, 6.0))
+
+
+def test_non_numeric_values_are_skipped_and_leave_a_gap() -> None:
+    """``null`` and strings are not plotted; the surrounding series is unaffected."""
+    history = _history([{"k": 4.0}, {"k": None}, {"k": "Home"}, {"k": 8.0}])
+    panel = history.panels[0]
+    assert panel.values == (4.0, None, None, 8.0)
+    assert panel.plotted[1] is None
+    assert panel.plotted[3] == pytest.approx(100.0)
+
+
+def test_a_kpi_that_is_never_numeric_still_gets_a_panel() -> None:
+    """One panel per KPI stays literally true; the panel simply says there is nothing."""
+    panel = build_panel("kpi", [None, None])
+    assert panel.mode == MODE_EMPTY
+    assert panel.baseline is None
+    assert panel.moved is False
+    assert panel.score == 0.0
+
+
+def test_a_flat_series_never_moved() -> None:
+    """A KPI reproduced to the last bit across every bless is quiet."""
+    panel = build_panel("kpi", [3.5, 3.5, 3.5])
+    assert panel.moved is False
+    assert panel.score == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Ordering
+# --------------------------------------------------------------------------- #
+def test_movement_score_is_the_path_length_not_the_extreme() -> None:
+    """A KPI that drifted at every bless outranks one that jumped once and came back."""
+    assert movement_score([10.0, 11.0, 12.0, 13.0]) == pytest.approx(0.3)
+    assert movement_score([10.0, 20.0, 10.0]) == pytest.approx(2.0)
+    assert movement_score([10.0]) == 0.0
+    assert movement_score([None, None]) == 0.0
+
+
+def test_movement_score_of_a_series_that_starts_at_zero_uses_its_first_non_zero_value() -> None:
+    """A zero baseline would make every relative score infinite, so the scale moves on."""
+    assert movement_score([0.0, 4.0, 4.0]) == pytest.approx(1.0)
+    assert movement_score([0.0, 0.0]) == 0.0
+
+
+def test_panels_are_sorted_with_the_largest_mover_first() -> None:
+    """The eye should land on the movers, so they come first and the quiet ones last."""
+    history = _history(
+        [
+            {"quiet": 5.0, "small": 100.0, "large": 10.0},
+            {"quiet": 5.0, "small": 101.0, "large": 20.0},
+        ]
+    )
+    assert [panel.kpi for panel in history.panels] == ["large", "small", "quiet"]
+    assert history.panels[-1].moved is False
+
+
+# --------------------------------------------------------------------------- #
+# The commits a pair is drawn against
+# --------------------------------------------------------------------------- #
+def test_commits_before_the_file_existed_are_not_drawn() -> None:
+    """A pair added late starts at the commit that added it, which is not an error."""
+    history = _history([None, None, {"k": 1.0}, {"k": 2.0}])  # type: ignore[list-item]
+    assert len(history.commits) == 2
+    assert history.commits[0].date == "2026-01-03"
+
+
+def test_a_commit_that_did_not_change_this_pair_is_not_drawn() -> None:
+    """The x axis is the commits that touched *this* file, not the whole directory."""
+    history = _history([{"k": 1.0}, {"k": 1.0}, {"k": 2.0}])
+    assert [commit.date for commit in history.commits] == ["2026-01-01", "2026-01-03"]
+
+
+# --------------------------------------------------------------------------- #
+# moves.csv
+# --------------------------------------------------------------------------- #
+def test_a_first_appearance_is_not_a_move() -> None:
+    """There is nothing a KPI's first recorded value moved from."""
+    history = _history([{"k": 1.0}, {"k": 1.0, "fresh": 9.0}])
+    assert [move.kpi for move in collect_moves(history)] == []
+
+
+def test_a_move_is_reported_against_the_last_value_actually_recorded() -> None:
+    """A gap is a gap: the comparison reaches back past it rather than restarting."""
+    history = _history([{"k": 4.0}, {"k": None}, {"k": 5.0}])
+    moves = collect_moves(history)
+    assert len(moves) == 1
+    assert (moves[0].previous, moves[0].value) == (4.0, 5.0)
+    assert moves[0].relative_change == pytest.approx(25.0)
+
+
+def test_a_change_within_the_gate_tolerance_is_not_a_move() -> None:
+    """What the golden gate would have accepted does not count as movement."""
+    history = _history([{"k": 1.0}, {"k": 1.0 + 1e-15}])
+    assert collect_moves(history) == []
+
+
+def test_a_move_out_of_zero_has_no_relative_change() -> None:
+    """Percent against zero is undefined and the column stays empty rather than lying."""
+    history = _history([{"k": 0.0}, {"k": 3.0}])
+    moves = collect_moves(history)
+    assert len(moves) == 1
+    assert moves[0].relative_change is None
+
+
+def test_write_moves_csv_writes_one_row_per_move(tmp_path: Path) -> None:
+    """The CSV is the greppable answer to 'what moved when'."""
+    history = _history([{"a": 1.0, "b": 0.0}, {"a": 2.0, "b": 4.0}], stem="demo__one_week_60s")
+    path = tmp_path / "moves.csv"
+    assert write_moves_csv(collect_moves(history), path) == 2
+
+    rows = list(csv.DictReader(path.read_text(encoding="utf-8").splitlines()))
+    assert [row["kpi"] for row in rows] == ["a", "b"]
+    assert rows[0] == {
+        "commit": "0" * 8,
+        "date": "2026-01-02",
+        "pr": "100",
+        "pair": "demo__one_week_60s",
+        "kpi": "a",
+        "previous": "1.0",
+        "value": "2.0",
+        "relative_change": "100",
+    }
+    assert rows[1]["relative_change"] == ""
+
+
+def test_moves_csv_leaves_the_pr_column_empty_when_the_subject_has_none(tmp_path: Path) -> None:
+    """Not every bless came through a pull request; the column says so by being empty."""
+    snapshots = [(_commit(0, "a bless"), {"k": 1.0}), (_commit(1, "another bless"), {"k": 2.0})]
+    path = tmp_path / "moves.csv"
+    write_moves_csv(collect_moves(build_pair_history("demo__one_week_60s", snapshots)), path)
+    assert list(csv.DictReader(path.read_text(encoding="utf-8").splitlines()))[0]["pr"] == ""
+
+
+# --------------------------------------------------------------------------- #
+# CLI argument handling
+# --------------------------------------------------------------------------- #
+def test_resolve_pairs_expands_a_setup_id_into_its_parameter_sets() -> None:
+    """``--pairs household_oil_building_sizer`` means both of its horizons."""
+    available = ["a__one_week_60s", "a__full_year_60s", "b__one_week_60s"]
+    assert resolve_pairs(["a"], available) == ["a__one_week_60s", "a__full_year_60s"]
+    assert resolve_pairs(["b__one_week_60s"], available) == ["b__one_week_60s"]
+    assert resolve_pairs([], available) == available
+
+
+def test_resolve_pairs_refuses_a_name_nothing_matches() -> None:
+    """A typo is an error, not an empty run."""
+    with pytest.raises(ValueError, match="No golden reference matches"):
+        resolve_pairs(["nope"], ["a__one_week_60s"])
+
+
+def test_parse_formats() -> None:
+    """Formats are png, html or both, in a stable order."""
+    assert parse_formats("html,png") == ["png", "html"]
+    assert parse_formats("PNG") == ["png"]
+    for bad in ("", "pdf", "png,svg"):
+        with pytest.raises(ValueError):
+            parse_formats(bad)
+
+
+# --------------------------------------------------------------------------- #
+# Rendering (into tmp_path only)
+# --------------------------------------------------------------------------- #
+def test_rendering_writes_a_png_an_html_page_and_an_index(tmp_path: Path) -> None:
+    """The three outputs are produced without a display and the page parses as HTML."""
+    history = _history([{"a": 1.0, "b": 0.0, "c": None}, {"a": 2.0, "b": 0.0, "c": None}])
+    png, page, index = tmp_path / "p.png", tmp_path / "p.html", tmp_path / "index.html"
+    render_png(history, png)
+    render_html(history, page, "plotly.min.js")
+    render_index([history], ["png", "html"], {history.stem: 1}, index)
+
+    assert png.stat().st_size > 1000
+    for path in (page, index):
+        text = path.read_text(encoding="utf-8")
+        assert text.lstrip().lower().startswith("<!doctype html>")
+        html.parser.HTMLParser().feed(text)
+    assert 'src="plotly.min.js"' in page.read_text(encoding="utf-8")
+    assert "cdn" not in page.read_text(encoding="utf-8").split("<body")[0]
+
+
+# --------------------------------------------------------------------------- #
+# The rename table against the real history
+# --------------------------------------------------------------------------- #
+def _golden_commit_count() -> int:
+    """How many commits of this checkout touch ``golden_references/``.
+
+    Returns:
+        The count; ``0`` when git cannot answer at all.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "rev-list", "--count", "HEAD", "--", "golden_references/"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, OSError):  # pragma: no cover - no git, no history
+        return 0
+    return int(out.strip() or 0)
+
+
+requires_history = pytest.mark.skipif(
+    _golden_commit_count() < 2,
+    reason="needs the git history of golden_references/, which a shallow CI checkout lacks",
+)
+
+
+@pytest.fixture(scope="module")
+def historical_keys() -> Dict[str, set]:
+    """Every KPI key each golden file ever carried, keyed by the stem of that moment.
+
+    Returns:
+        ``stem -> set of keys``, over every commit that touched the directory.
+    """
+    keys: Dict[str, set] = {}
+    for commit in golden_commits(REPO_ROOT):
+        for stem, contents in golden_files_at(REPO_ROOT, commit).items():
+            keys.setdefault(stem, set()).update(contents)
+    return keys
+
+
+@pytest.fixture(scope="module")
+def current_keys() -> Dict[str, set]:
+    """Every KPI key the golden files carry today.
+
+    Returns:
+        ``stem -> set of keys``.
+    """
+    return {
+        path.stem: set(json.loads(path.read_text(encoding="utf-8")))
+        for path in sorted(GOLDEN_DIR.glob("*.json"))
+        if path.name != "manifest.json"
+    }
+
+
+@requires_history
+def test_every_declared_old_kpi_name_really_existed(historical_keys: Dict[str, set]) -> None:
+    """A rename claims a name the goldens once carried; a typo in it would go unnoticed."""
+    for stem, entries in KPI_RENAMES.items():
+        for entry in entries:
+            if stem == FLEET_WIDE:
+                assert any(entry.old in keys for keys in historical_keys.values()), (
+                    f"no golden ever carried {entry.old!r}"
+                )
+            else:
+                assert stem in historical_keys, f"no golden file was ever named {stem!r}"
+                assert entry.old in historical_keys[stem], (
+                    f"{stem!r} never carried {entry.old!r}"
+                )
+
+
+def test_every_declared_new_kpi_name_is_carried_today(current_keys: Dict[str, set]) -> None:
+    """The other end of the claim: the new name must be in the files as they stand."""
+    for stem, entries in KPI_RENAMES.items():
+        for entry in entries:
+            if stem == FLEET_WIDE:
+                assert any(entry.new in keys for keys in current_keys.values()), (
+                    f"no golden carries {entry.new!r} today"
+                )
+            else:
+                assert stem in current_keys, f"there is no golden file {stem!r} today"
+                assert entry.new in current_keys[stem], f"{stem!r} does not carry {entry.new!r}"
+
+
+def test_no_declared_rename_is_still_in_effect_under_its_old_name(current_keys: Dict[str, set]) -> None:
+    """A pair that still carries the old name today was not renamed and must not be listed."""
+    for stem, entries in KPI_RENAMES.items():
+        if stem == FLEET_WIDE:
+            continue
+        for entry in entries:
+            assert entry.old not in current_keys.get(stem, set()), (
+                f"{stem!r} still carries {entry.old!r}; that is not a rename"
+            )
+
+
+@requires_history
+def test_every_rename_names_a_commit_that_touched_the_goldens() -> None:
+    """The commit column is the evidence; it has to be a golden commit of this branch."""
+    shas = {commit.sha for commit in golden_commits(REPO_ROOT)}
+    claims: List[KpiRename] = [entry for entries in KPI_RENAMES.values() for entry in entries]
+    for entry in claims:
+        assert entry.commit in shas, f"{entry.commit} does not touch golden_references/"
+    for rename in PAIR_RENAMES.values():
+        assert rename.commit in shas, f"{rename.commit} does not touch golden_references/"
+
+
+@requires_history
+def test_pair_renames_name_a_file_that_existed_and_one_that_exists(
+    historical_keys: Dict[str, set], current_keys: Dict[str, set]
+) -> None:
+    """Both ends of a file rename must be real; today the table is empty and that is fine."""
+    for old, rename in PAIR_RENAMES.items():
+        assert old == rename.old, f"PAIR_RENAMES is keyed by the old stem; {old!r} is not {rename.old!r}"
+        assert old in historical_keys, f"no golden file was ever named {old!r}"
+        assert canonical_pair(old) in current_keys, f"{old!r} resolves to a stem nothing carries"
+
+
+def test_the_table_is_keyed_by_pairs_that_exist_today(current_keys: Dict[str, set]) -> None:
+    """A KPI table keyed by a pair nobody gates any more would never be applied."""
+    for stem in KPI_RENAMES:
+        if stem != FLEET_WIDE:
+            assert stem in current_keys, f"KPI_RENAMES names {stem!r}, which has no golden file"
+
+
+def test_kpi_renames_for_merges_the_fleet_wide_claims_with_the_pairs_own() -> None:
+    """A pair's own claim wins over a fleet-wide one for the same key."""
+    stem = "household_oil_building_sizer__one_week_60s"
+    merged = kpi_renames_for(stem)
+    assert merged["BUI1.Fuel Meter.OPEX - CO2 Footprint"] == (
+        "BUI1.Fuel Meter.OPEX - CO2 Footprint (FuelMeter)"
+    )
+    assert kpi_renames_for("a pair nobody has") == dict(
+        (entry.old, entry.new) for entry in KPI_RENAMES.get(FLEET_WIDE, ())
+    )
+
+
+def test_canonical_pair_is_the_identity_while_no_file_has_been_renamed() -> None:
+    """With an empty PAIR_RENAMES a stem is its own current name."""
+    assert canonical_pair("household_oil_building_sizer__one_week_60s") == (
+        "household_oil_building_sizer__one_week_60s"
+    )
+
+
+@requires_history
+def test_since_a_golden_commit_starts_the_walk_there() -> None:
+    """``--since <sha>`` means "from this bless onwards", inclusive."""
+    commits = golden_commits(REPO_ROOT)
+    truncated = golden_commits(REPO_ROOT, since=commits[-2].sha)
+    assert [commit.sha for commit in truncated] == [commits[-2].sha, commits[-1].sha]
+
+
+@requires_history
+def test_since_a_date_keeps_the_commits_at_or_after_it() -> None:
+    """A date that git understands is handed to ``git log --since``."""
+    assert golden_commits(REPO_ROOT, since="2099-01-01") == []
+    assert golden_commits(REPO_ROOT, since="1999-01-01") == golden_commits(REPO_ROOT)
+
+
+@requires_history
+def test_since_a_commit_that_never_touched_the_goldens_is_refused() -> None:
+    """There is no snapshot to start from, and walking everything would answer another question."""
+    golden = {commit.sha for commit in golden_commits(REPO_ROOT)}
+    everything = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-list", "-n", "80", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.split()
+    outsider = next((sha for sha in everything if sha not in golden), None)
+    if outsider is None:  # pragma: no cover - every recent commit blessed a golden
+        pytest.skip("every commit in reach touches golden_references/")
+    with pytest.raises(ValueError, match="does not touch"):
+        golden_commits(REPO_ROOT, since=outsider)
+
+
+@requires_history
+def test_max_commits_keeps_the_most_recent_ones() -> None:
+    """``--max-commits`` trims the old end, because the recent blesses are the interesting ones."""
+    commits = golden_commits(REPO_ROOT)
+    assert golden_commits(REPO_ROOT, max_commits=3) == commits[-3:]
+
+
+def test_an_empty_golden_file_still_renders(tmp_path: Path) -> None:
+    """A pair whose file carries no KPI at all must not crash the figure machinery."""
+    history = _history([{}, {"k": 1.0}])
+    render_png(history, tmp_path / "p.png")
+    render_html(history, tmp_path / "p.html", "plotly.min.js")
+    assert (tmp_path / "p.png").exists()

--- a/tests/test_golden_history.py
+++ b/tests/test_golden_history.py
@@ -268,7 +268,7 @@ def test_a_move_is_reported_against_the_last_value_actually_recorded() -> None:
 def test_a_change_within_the_gate_tolerance_is_not_a_move() -> None:
     """What the golden gate would have accepted does not count as movement."""
     history = _history([{"k": 1.0}, {"k": 1.0 + 1e-15}])
-    assert collect_moves(history) == []
+    assert not collect_moves(history)
 
 
 def test_a_move_out_of_zero_has_no_relative_change() -> None:
@@ -408,7 +408,9 @@ def current_keys() -> Dict[str, set]:
 
 
 @requires_history
-def test_every_declared_old_kpi_name_really_existed(historical_keys: Dict[str, set]) -> None:
+def test_every_declared_old_kpi_name_really_existed(  # pylint: disable=redefined-outer-name
+    historical_keys: Dict[str, set],
+) -> None:
     """A rename claims a name the goldens once carried; a typo in it would go unnoticed."""
     for stem, entries in KPI_RENAMES.items():
         for entry in entries:
@@ -423,7 +425,9 @@ def test_every_declared_old_kpi_name_really_existed(historical_keys: Dict[str, s
                 )
 
 
-def test_every_declared_new_kpi_name_is_carried_today(current_keys: Dict[str, set]) -> None:
+def test_every_declared_new_kpi_name_is_carried_today(  # pylint: disable=redefined-outer-name
+    current_keys: Dict[str, set],
+) -> None:
     """The other end of the claim: the new name must be in the files as they stand."""
     for stem, entries in KPI_RENAMES.items():
         for entry in entries:
@@ -436,7 +440,9 @@ def test_every_declared_new_kpi_name_is_carried_today(current_keys: Dict[str, se
                 assert entry.new in current_keys[stem], f"{stem!r} does not carry {entry.new!r}"
 
 
-def test_no_declared_rename_is_still_in_effect_under_its_old_name(current_keys: Dict[str, set]) -> None:
+def test_no_declared_rename_is_still_in_effect_under_its_old_name(  # pylint: disable=redefined-outer-name
+    current_keys: Dict[str, set],
+) -> None:
     """A pair that still carries the old name today was not renamed and must not be listed."""
     for stem, entries in KPI_RENAMES.items():
         if stem == FLEET_WIDE:
@@ -459,8 +465,9 @@ def test_every_rename_names_a_commit_that_touched_the_goldens() -> None:
 
 
 @requires_history
-def test_pair_renames_name_a_file_that_existed_and_one_that_exists(
-    historical_keys: Dict[str, set], current_keys: Dict[str, set]
+def test_pair_renames_name_a_file_that_existed_and_one_that_exists(  # pylint: disable=redefined-outer-name
+    historical_keys: Dict[str, set],
+    current_keys: Dict[str, set],
 ) -> None:
     """Both ends of a file rename must be real; today the table is empty and that is fine."""
     for old, rename in PAIR_RENAMES.items():
@@ -469,7 +476,9 @@ def test_pair_renames_name_a_file_that_existed_and_one_that_exists(
         assert canonical_pair(old) in current_keys, f"{old!r} resolves to a stem nothing carries"
 
 
-def test_the_table_is_keyed_by_pairs_that_exist_today(current_keys: Dict[str, set]) -> None:
+def test_the_table_is_keyed_by_pairs_that_exist_today(  # pylint: disable=redefined-outer-name
+    current_keys: Dict[str, set],
+) -> None:
     """A KPI table keyed by a pair nobody gates any more would never be applied."""
     for stem in KPI_RENAMES:
         if stem != FLEET_WIDE:


### PR DESCRIPTION
`scripts/golden_history.py` walks the git history of `golden_references/` and draws, per setup pair, one panel per KPI: every commit that touched the file as a marker, y as percent change against the first recorded value, the largest movers first and in colour, never-moved KPIs in grey. Output under `results/golden_history/` (gitignored): one PNG and one self-contained HTML per pair, an index page, and `moves.csv` with one row per commit, pair and KPI that moved beyond the gate's tolerance.

`scripts/golden_kpi_renames.py` is the translation table so a renamed KPI stays one series; it is per pair, because the one real rename so far (#653, `(ClassName)` suffixes on 42 keys across 11 pairs) applied only where names collided. No golden file has ever been renamed; that table is empty with its schema fixed. A base test checks every table entry against the history and today's files.

Full history today: 19 commits, 30 pairs, 1882 moves, 2m40s (mostly matplotlib); `--pairs` and `--since` narrow it. plotly.min.js is written once next to the pages rather than embedded 30 times. Zero-first-value KPIs show absolute change and are labelled so.

Checks: 47 new tests, flake8, prospector, mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)