### PR TITLE
The electricity meter's legacy factory goes; every caller uses the preset

### DIFF
--- a/energy_systems/air_conditioned_house.energy_system.yaml
+++ b/energy_systems/air_conditioned_house.energy_system.yaml
@@ -152,12 +152,7 @@ components:
       - Building
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: AirConditioner.ElectricalPowerConsumption
         tags:

--- a/energy_systems/automatic_default_connections.energy_system.yaml
+++ b/energy_systems/automatic_default_connections.energy_system.yaml
@@ -184,12 +184,7 @@ components:
       - MoreAdvancedHeatPumpHPLib
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: MoreAdvancedHeatPumpHPLib.ElectricalInputPowerDHW
         component_type: HEAT_PUMP_DHW

--- a/energy_systems/basic_household.energy_system.yaml
+++ b/energy_systems/basic_household.energy_system.yaml
@@ -69,12 +69,7 @@ components:
       - Weather
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: HeatPump.ElectricityOutput
         component_type: HEAT_PUMP

--- a/energy_systems/basic_household_only_heating.energy_system.yaml
+++ b/energy_systems/basic_household_only_heating.energy_system.yaml
@@ -113,12 +113,7 @@ components:
       cars: null
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: UTSPConnector.ElectricalPowerConsumption
         tags:

--- a/energy_systems/default_connections.energy_system.yaml
+++ b/energy_systems/default_connections.energy_system.yaml
@@ -99,12 +99,7 @@ components:
       - Weather
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: HeatPump.ElectricityOutput
         component_type: HEAT_PUMP

--- a/energy_systems/household_district_heating_building_sizer.energy_system.yaml
+++ b/energy_systems/household_district_heating_building_sizer.energy_system.yaml
@@ -160,12 +160,7 @@ components:
         weight: 999
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
         tags:

--- a/energy_systems/household_district_heating_building_sizer.grouped.energy_system.yaml
+++ b/energy_systems/household_district_heating_building_sizer.grouped.energy_system.yaml
@@ -167,12 +167,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
                 tags:
@@ -219,12 +214,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: PVSystem.ElectricityOutput
                 component_type: PV

--- a/energy_systems/household_electric_heating_building_sizer.energy_system.yaml
+++ b/energy_systems/household_electric_heating_building_sizer.energy_system.yaml
@@ -120,12 +120,7 @@ components:
       - ElectricHeating
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
         tags:

--- a/energy_systems/household_electric_heating_building_sizer.grouped.energy_system.yaml
+++ b/energy_systems/household_electric_heating_building_sizer.grouped.energy_system.yaml
@@ -127,12 +127,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
                 tags:
@@ -191,12 +186,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: ElectricHeating.ElectricOutputDhwPower
                 component_type: ELECTRIC_HEATING_DHW

--- a/energy_systems/household_gas_building_sizer.energy_system.yaml
+++ b/energy_systems/household_gas_building_sizer.energy_system.yaml
@@ -180,12 +180,7 @@ components:
         weight: 999
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
         tags:

--- a/energy_systems/household_gas_building_sizer.grouped.energy_system.yaml
+++ b/energy_systems/household_gas_building_sizer.grouped.energy_system.yaml
@@ -187,12 +187,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
                 tags:
@@ -239,12 +234,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: PVSystem.ElectricityOutput
                 component_type: PV

--- a/energy_systems/household_gas_solar_thermal.energy_system.yaml
+++ b/energy_systems/household_gas_solar_thermal.energy_system.yaml
@@ -107,12 +107,7 @@ components:
       - CondensingGasBoiler
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: SolarThermalSystem.ElectricityConsumptionOutput
         component_type: SOLAR_THERMAL_SYSTEM

--- a/energy_systems/household_gas_solar_thermal.grouped.energy_system.yaml
+++ b/energy_systems/household_gas_solar_thermal.grouped.energy_system.yaml
@@ -108,12 +108,7 @@ components:
       - CondensingGasBoiler
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: SolarThermalSystem.ElectricityConsumptionOutput
         component_type: SOLAR_THERMAL_SYSTEM

--- a/energy_systems/household_gas_solar_thermal_building_sizer.energy_system.yaml
+++ b/energy_systems/household_gas_solar_thermal_building_sizer.energy_system.yaml
@@ -215,12 +215,7 @@ components:
         weight: 999
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
         tags:

--- a/energy_systems/household_gas_solar_thermal_building_sizer.grouped.energy_system.yaml
+++ b/energy_systems/household_gas_solar_thermal_building_sizer.grouped.energy_system.yaml
@@ -222,12 +222,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
                 tags:
@@ -280,12 +275,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: PVSystem.ElectricityOutput
                 component_type: PV

--- a/energy_systems/household_heatpump_building_sizer.energy_system.yaml
+++ b/energy_systems/household_heatpump_building_sizer.energy_system.yaml
@@ -190,12 +190,7 @@ components:
       - SimpleHotWaterStorage
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
         tags:

--- a/energy_systems/household_heatpump_building_sizer.grouped.energy_system.yaml
+++ b/energy_systems/household_heatpump_building_sizer.grouped.energy_system.yaml
@@ -197,12 +197,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
                 tags:
@@ -261,12 +256,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: MoreAdvancedHeatPumpHPLib.ElectricalInputPowerDHW
                 component_type: HEAT_PUMP_DHW

--- a/energy_systems/household_heatpump_car_building_sizer.energy_system.yaml
+++ b/energy_systems/household_heatpump_car_building_sizer.energy_system.yaml
@@ -233,12 +233,7 @@ components:
       - Car_2_22kW_Charging_Power_avg_Speed_30_kmh_0
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
         tags:

--- a/energy_systems/household_heatpump_car_building_sizer.grouped.energy_system.yaml
+++ b/energy_systems/household_heatpump_car_building_sizer.grouped.energy_system.yaml
@@ -240,12 +240,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
                 tags:
@@ -311,12 +306,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L1EVChargeControl_1.BatteryChargingPowerToEMS
                 component_type: CAR_BATTERY

--- a/energy_systems/household_heatpump_solar_thermal_building_sizer.energy_system.yaml
+++ b/energy_systems/household_heatpump_solar_thermal_building_sizer.energy_system.yaml
@@ -201,12 +201,7 @@ components:
         from: MoreAdvancedHeatPumpHPLib.TemperatureOutputDHW
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
         tags:

--- a/energy_systems/household_heatpump_solar_thermal_building_sizer.grouped.energy_system.yaml
+++ b/energy_systems/household_heatpump_solar_thermal_building_sizer.grouped.energy_system.yaml
@@ -230,12 +230,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
                 tags:
@@ -300,12 +295,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: MoreAdvancedHeatPumpHPLib.ElectricalInputPowerDHW
                 component_type: HEAT_PUMP_DHW

--- a/energy_systems/household_hydrogen_boiler_building_sizer.energy_system.yaml
+++ b/energy_systems/household_hydrogen_boiler_building_sizer.energy_system.yaml
@@ -180,12 +180,7 @@ components:
         weight: 999
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
         tags:

--- a/energy_systems/household_hydrogen_boiler_building_sizer.grouped.energy_system.yaml
+++ b/energy_systems/household_hydrogen_boiler_building_sizer.grouped.energy_system.yaml
@@ -187,12 +187,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
                 tags:
@@ -239,12 +234,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: PVSystem.ElectricityOutput
                 component_type: PV

--- a/energy_systems/household_oil_building_sizer.energy_system.yaml
+++ b/energy_systems/household_oil_building_sizer.energy_system.yaml
@@ -176,12 +176,7 @@ components:
         weight: 999
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
         tags:

--- a/energy_systems/household_oil_building_sizer.grouped.energy_system.yaml
+++ b/energy_systems/household_oil_building_sizer.grouped.energy_system.yaml
@@ -183,12 +183,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
                 tags:
@@ -235,12 +230,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: PVSystem.ElectricityOutput
                 component_type: PV

--- a/energy_systems/household_pellets_building_sizer.energy_system.yaml
+++ b/energy_systems/household_pellets_building_sizer.energy_system.yaml
@@ -176,12 +176,7 @@ components:
         weight: 999
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
         tags:

--- a/energy_systems/household_pellets_building_sizer.grouped.energy_system.yaml
+++ b/energy_systems/household_pellets_building_sizer.grouped.energy_system.yaml
@@ -183,12 +183,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
                 tags:
@@ -235,12 +230,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: PVSystem.ElectricityOutput
                 component_type: PV

--- a/energy_systems/household_wood_chips_building_sizer.energy_system.yaml
+++ b/energy_systems/household_wood_chips_building_sizer.energy_system.yaml
@@ -176,12 +176,7 @@ components:
         weight: 999
   ElectricityMeter:
     class: hisim.components.electricity_meter.ElectricityMeter
-    config:
-      device_co2_footprint_in_kg: null
-      investment_costs_in_euro: null
-      lifetime_in_years: null
-      maintenance_costs_in_euro_per_year: null
-      subsidy_as_percentage_of_investment_costs: null
+    preset: standard
     inputs:
       - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
         tags:

--- a/energy_systems/household_wood_chips_building_sizer.grouped.energy_system.yaml
+++ b/energy_systems/household_wood_chips_building_sizer.grouped.energy_system.yaml
@@ -183,12 +183,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: L2EMSElectricityController.TotalElectricityToOrFromGrid
                 tags:
@@ -235,12 +230,7 @@ variants:
         components:
           ElectricityMeter:
             class: hisim.components.electricity_meter.ElectricityMeter
-            config:
-              device_co2_footprint_in_kg: null
-              investment_costs_in_euro: null
-              lifetime_in_years: null
-              maintenance_costs_in_euro_per_year: null
-              subsidy_as_percentage_of_investment_costs: null
+            preset: standard
             inputs:
               - from: PVSystem.ElectricityOutput
                 component_type: PV

--- a/hisim/components/electricity_meter.py
+++ b/hisim/components/electricity_meter.py
@@ -54,25 +54,6 @@ class ElectricityMeterConfig(ConfigBase):
     # subsidies as percentage of investment costs
     subsidy_as_percentage_of_investment_costs: Optional[float]
 
-    @classmethod
-    def get_electricity_meter_default_config(
-        cls,
-        name: str = "ElectricityMeter",
-        component_id: Optional[ComponentID] = None,
-    ) -> "ElectricityMeterConfig":
-        """Gets a default ElectricityMeter."""
-        if component_id is None:
-            component_id = ComponentID(name=name)
-        return ElectricityMeterConfig(
-            component_id=component_id,
-            # capex and device emissions are calculated in get_cost_capex function by default
-            device_co2_footprint_in_kg=None,
-            investment_costs_in_euro=None,
-            lifetime_in_years=None,
-            maintenance_costs_in_euro_per_year=None,
-            subsidy_as_percentage_of_investment_costs=None,
-        )
-
     @preset
     @classmethod
     def preset_standard(cls, name: str) -> "ElectricityMeterConfig":

--- a/roadmap/declarative_energy_systems/p4_component_sweep_requirements.md
+++ b/roadmap/declarative_energy_systems/p4_component_sweep_requirements.md
@@ -123,7 +123,7 @@ Legend: **conv** convert · **del** retired — moved to `obsolete/` under D-16'
 | `BatteryConfig` | conv | `standard` | capacity ← pv_peak_power × 1e-3; inverter ← pv_peak_power × 0.5 (**not** `Self(capacity)` — rounding trap) | — | N | D-14 |
 | `WindturbineConfig` | del | | `generic_windturbine.py` → `obsolete/` with its test (D-16); the KPI vocabulary keys on `ComponentType.WINDTURBINE`, so no result moves | | | D-16 |
 | `PriceSignalConfig` | del | | `generic_price_signal.py` → `obsolete/` with its test (D-16); superseded by `tariff_provider.py` | | | D-16 |
-| `ElectricityMeterConfig` | done | `standard` | delete legacy factory (25 sites) | | N | |
+| `ElectricityMeterConfig` | done | `standard` | legacy factory **deleted 2026-09-12** (B1), 29 sites moved to `preset_standard(name)`: 17 setups, 12 calls in 10 test files | | N | |
 | `GasMeterConfig` | conv | `gas`, `hydrogen` | `gas_loadtype` ← generator carrier (copy, D-15 (b); the `energy_carrier` fact **landed 2026-09-11**, the `LoadTypes` codec has not) | — | N | D-15 |
 | `FuelMeterConfig` | conv | `oil`, `pellets`, `wood_chips`, `district_heating` | `fuel_loadtype`, `heating_value_of_fuel_in_kwh_per_liter`, `fuel_density_in_kg_per_m3` ← generator (copy, D-15 (b); `None` for district heating) — all three facts **landed 2026-09-11** | — | N | D-15 |
 | `HeatingMeterConfig` | conv | `standard` | — | — | N | |

--- a/roadmap/declarative_energy_systems/preset_naming_supplement.md
+++ b/roadmap/declarative_energy_systems/preset_naming_supplement.md
@@ -81,7 +81,7 @@ Proposed amendment, concretely worded: **(A1)** *A rating-suffixed preset does n
 | Config class (module) | Proposed presets (canonical first) | Replaces factory | AUTO fields | Rule flags / notes |
 |---|---|---|---|---|
 | `EMSConfig` (`controller_l2_energy_management_system.py`) | `optimize_own_consumption` | `get_default_config_ems` | — | Already converted; `strategy` field is commented "more or less obsolete" — the preset name and the field duplicate each other |
-| `ElectricityMeterConfig` (`electricity_meter.py`) | `standard` | `get_electricity_meter_default_config` | — | rule 5 clean; spelling `get_<x>_default_config` |
+| `ElectricityMeterConfig` (`electricity_meter.py`) | `standard` | *(factory deleted 2026-09-12, B1, #728 — only `preset_standard` remains)* | — | rule 5 clean; the deleted factory used the spelling `get_<x>_default_config` |
 | `GasMeterConfig` (`gas_meter.py`) | `gas` | `get_gas_meter_default_config` | — | Parameterised by `gas_loadtype: lt.LoadTypes = GAS`; a second carrier would give `biogas` |
 | `FuelMeterConfig` (`fuel_meter.py`) | `oil`, `pellets`, `wood_chips` | `get_fuel_meter_default_config` | — | One factory, three real carriers via `fuel_loadtype` + heating value; presets replace the parameter (rule 4 gives `oil` singular, `pellets` plural) |
 | `HeatingMeterConfig` (`heating_meter.py`) | `standard` | `get_heating_meter_default_config` | — | rule 5 clean |
@@ -192,7 +192,7 @@ Lookup-shaped classes: an identifier keys an external table (enum, JSON, CSV, li
 | `get_default_config_<variant>` | 14 | `get_default_config_chp`, `get_default_config_fuelcell`, `get_default_config_const_power`, `get_default_config_heat_source_controller_dhw` |
 | `get_scaled_<x>` | 12 | `get_scaled_battery`, `get_scaled_pv_system`, `get_scaled_advanced_hp_lib`, `get_scaled_conventional_pellet_boiler_config` |
 | `get_default_<x>` (no `_config`) | 10 | `get_default_pv_system`, `get_default_thermal_storage`, `get_default_transformer`, `get_default_german_single_family_home` |
-| `get_<x>_default_config` | 5 | `get_electricity_meter_default_config`, `get_gas_meter_default_config`, `get_sumbuilder_default_config` |
+| `get_<x>_default_config` | 4 | `get_gas_meter_default_config`, `get_fuel_meter_default_config`, `get_sumbuilder_default_config` |
 | `config_<x>` | 4 | `config_rsoc` (×2), `config_electrolyzer`, `config_fuel_cell` |
 | `control_<x>` | 2 | `control_electrolyzer`, `control_fuel_cell` |
 | `get_config_<x>` | 1 | `get_config_based_on_building_efficiency` |

--- a/system_setups/air_conditioned_house.py
+++ b/system_setups/air_conditioned_house.py
@@ -222,7 +222,7 @@ def setup_function(
     # Every electricity-balance KPI is derived from a meter: without one, the grid exchange is unknown
     # and the self-sufficiency chain in kpi_preparation.py has nothing to work from.
     my_electricity_meter = electricity_meter.ElectricityMeter(
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
         my_simulation_parameters=my_simulation_parameters,
     )
     my_electricity_meter.add_component_input_and_connect(

--- a/system_setups/automatic_default_connections.py
+++ b/system_setups/automatic_default_connections.py
@@ -202,7 +202,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # =================================================================================================================================

--- a/system_setups/basic_household.py
+++ b/system_setups/basic_household.py
@@ -99,7 +99,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # Build Heat Pump Controller

--- a/system_setups/basic_household_only_heating.py
+++ b/system_setups/basic_household_only_heating.py
@@ -165,7 +165,7 @@ def setup_function(my_sim: Any, my_simulation_parameters: Optional[SimulationPar
     # nothing to work from, and the run dies in post-processing.
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
     my_gas_meter = gas_meter.GasMeter(
         my_simulation_parameters=my_simulation_parameters,

--- a/system_setups/default_connections.py
+++ b/system_setups/default_connections.py
@@ -91,7 +91,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     my_heat_pump_controller = generic_heat_pump.GenericHeatPumpController(

--- a/system_setups/household_district_heating_building_sizer.py
+++ b/system_setups/household_district_heating_building_sizer.py
@@ -408,7 +408,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # The battery and the energy manager are one decision. A zero rooftop share can no longer reach

--- a/system_setups/household_electric_heating_building_sizer.py
+++ b/system_setups/household_electric_heating_building_sizer.py
@@ -311,7 +311,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # The battery and the energy manager are one decision. A zero rooftop share can no longer reach

--- a/system_setups/household_gas_building_sizer.py
+++ b/system_setups/household_gas_building_sizer.py
@@ -377,7 +377,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # Build Gas Meter

--- a/system_setups/household_gas_solar_thermal.py
+++ b/system_setups/household_gas_solar_thermal.py
@@ -238,7 +238,7 @@ def setup_function(
     # Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # Gas Meter

--- a/system_setups/household_gas_solar_thermal_building_sizer.py
+++ b/system_setups/household_gas_solar_thermal_building_sizer.py
@@ -416,7 +416,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # Build Gas Meter

--- a/system_setups/household_heatpump_building_sizer.py
+++ b/system_setups/household_heatpump_building_sizer.py
@@ -392,7 +392,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # The battery and the energy manager are one decision. A zero rooftop share can no longer reach

--- a/system_setups/household_heatpump_car_building_sizer.py
+++ b/system_setups/household_heatpump_car_building_sizer.py
@@ -458,7 +458,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # The battery and the energy manager are one decision. A zero rooftop share can no longer reach

--- a/system_setups/household_heatpump_solar_thermal_building_sizer.py
+++ b/system_setups/household_heatpump_solar_thermal_building_sizer.py
@@ -435,7 +435,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # The battery and the energy manager are one decision. A zero rooftop share can no longer reach

--- a/system_setups/household_hydrogen_boiler_building_sizer.py
+++ b/system_setups/household_hydrogen_boiler_building_sizer.py
@@ -364,7 +364,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # Build Gas Meter

--- a/system_setups/household_oil_building_sizer.py
+++ b/system_setups/household_oil_building_sizer.py
@@ -416,7 +416,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # The battery and the energy manager are one decision. A zero rooftop share can no longer reach

--- a/system_setups/household_pellets_building_sizer.py
+++ b/system_setups/household_pellets_building_sizer.py
@@ -389,7 +389,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # The battery and the energy manager are one decision. A zero rooftop share can no longer reach

--- a/system_setups/household_wood_chips_building_sizer.py
+++ b/system_setups/household_wood_chips_building_sizer.py
@@ -403,7 +403,7 @@ def setup_function(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # The battery and the energy manager are one decision. A zero rooftop share can no longer reach

--- a/tests/test_controller_l2_energy_management_system.py
+++ b/tests/test_controller_l2_energy_management_system.py
@@ -258,7 +258,7 @@ def test_house(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # Build EMS

--- a/tests/test_duplicate_component_feeds.py
+++ b/tests/test_duplicate_component_feeds.py
@@ -12,13 +12,10 @@ outputs of one source, and one output going to two different components, are bot
 
 # clean
 
-import dataclasses
-
 import pytest
 
 from hisim import loadtypes as lt
 from hisim.component import ComponentInput
-from hisim.config import ComponentID
 from hisim.dynamic_component import DuplicateComponentFeedError
 from hisim.components.electricity_meter import ElectricityMeter, ElectricityMeterConfig
 from hisim.simulationparameters import SimulationParameters
@@ -26,13 +23,9 @@ from hisim.simulationparameters import SimulationParameters
 
 def make_meter(name: str = "ElectricityMeter") -> ElectricityMeter:
     """Build an electricity meter to wire things into."""
-    config = dataclasses.replace(
-        ElectricityMeterConfig.get_electricity_meter_default_config(),
-        component_id=ComponentID(name=name),
-    )
     return ElectricityMeter(
         my_simulation_parameters=SimulationParameters.one_day_only(year=2021, seconds_per_timestep=60),
-        config=config,
+        config=ElectricityMeterConfig.preset_standard(name),
     )
 
 

--- a/tests/test_economics_bridge.py
+++ b/tests/test_economics_bridge.py
@@ -116,7 +116,7 @@ def test_lifecycle_cost_engine_runs_in_shadow_mode() -> None:
     )
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
     my_idealized_electric_heater = idealized_electric_heater.IdealizedElectricHeater(
         my_simulation_parameters=my_simulation_parameters,

--- a/tests/test_economics_data_and_integration.py
+++ b/tests/test_economics_data_and_integration.py
@@ -29,15 +29,18 @@ pytestmark = pytest.mark.base
 # staging area (#604), and its `get_cost_facts` adoption went with the module. The fleet's hplib
 # heat pump is MoreAdvancedHeatPumpHPLib, which declares PRICED and is priced through the adapter
 # table rather than the hook, so it has no declaration for this test to check.
+# The last element of each row is what the builder is called with: a legacy factory takes
+# nothing, a preset takes the instance name of the component it configures.
 ADOPTED_COMPONENTS = [
-    ("hisim.components.generic_pv_system", "PVSystem", "PVSystemConfig", "get_default_pv_system", "config"),
-    ("hisim.components.advanced_battery_bslib", "Battery", "BatteryConfig", "get_default_config", "battery_config"),
+    ("hisim.components.generic_pv_system", "PVSystem", "PVSystemConfig", "get_default_pv_system", "config", ()),
+    ("hisim.components.advanced_battery_bslib", "Battery", "BatteryConfig", "get_default_config", "battery_config",
+     ()),
     ("hisim.components.electricity_meter", "ElectricityMeter", "ElectricityMeterConfig",
-     "get_electricity_meter_default_config", "config"),
+     "preset_standard", "config", ("ElectricityMeter",)),
 ]
 
 
-def _facts_from_default_config(module_name, class_name, config_class_name, default_factory, config_attr):
+def _facts_from_default_config(module_name, class_name, config_class_name, default_factory, config_attr, builder_args):
     """Builds a component's cost facts from its own default config, without constructing it.
 
     `get_cost_facts` reads only the config, so a `SimpleNamespace` carrying that config under both
@@ -53,7 +56,7 @@ def _facts_from_default_config(module_name, class_name, config_class_name, defau
 
     module = importlib.import_module(module_name)
     component_class = getattr(module, class_name)
-    config = getattr(getattr(module, config_class_name), default_factory)()
+    config = getattr(getattr(module, config_class_name), default_factory)(*builder_args)
     dummy = types.SimpleNamespace(**{config_attr: config, "config": config})
     return component_class, config, component_class.get_cost_facts(dummy)
 
@@ -90,11 +93,11 @@ class TestCostFactsContract:
         """
         import importlib
 
-        module_name, class_name, config_class_name, default_factory, config_attr = spec
+        module_name, class_name, config_class_name, default_factory, config_attr, builder_args = spec
         module = importlib.import_module(module_name)
         component_class = getattr(module, class_name)
         config_class = getattr(module, config_class_name)
-        config = getattr(config_class, default_factory)()
+        config = getattr(config_class, default_factory)(*builder_args)
         capacity_fields = [
             data_field.name for data_field in dataclasses.fields(config_class) if data_field.metadata.get("capacity")
         ]

--- a/tests/test_electricity_meter.py
+++ b/tests/test_electricity_meter.py
@@ -80,7 +80,7 @@ def _build_system(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # Build Fake Heater

--- a/tests/test_electricity_meter_config.py
+++ b/tests/test_electricity_meter_config.py
@@ -1,4 +1,4 @@
-"""Tests for the ElectricityMeterConfig factory/classname classmethods and ElectricityMeterState.self_copy.
+"""Tests for the ElectricityMeterConfig preset/classname classmethods and ElectricityMeterState.self_copy.
 
 These tests pin down the pure, side-effect-free helpers on
 ``ElectricityMeterConfig`` and ``ElectricityMeterState`` that are otherwise
@@ -8,6 +8,8 @@ simulation, no I/O.
 """
 
 # clean
+
+import dataclasses
 
 import pytest
 
@@ -31,8 +33,8 @@ _OPTIONAL_FIELDS: tuple[str, ...] = (
 def _assert_all_optional_fields_are_none(config: ElectricityMeterConfig) -> None:
     """Assert every Optional cost/emission field on ``config`` is ``None``.
 
-    These are deliberately left unset by the default factory because capex and
-    device emissions are computed later in ``get_cost_capex``.
+    These are deliberately left unset by the preset because capex and device
+    emissions are computed later in ``get_cost_capex``.
     """
     for field_name in _OPTIONAL_FIELDS:
         assert getattr(config, field_name) is None, (
@@ -41,9 +43,9 @@ def _assert_all_optional_fields_are_none(config: ElectricityMeterConfig) -> None
 
 
 @pytest.mark.base
-def test_get_electricity_meter_default_config_defaults() -> None:
-    """``get_electricity_meter_default_config()`` returns the documented defaults."""
-    config: ElectricityMeterConfig = ElectricityMeterConfig.get_electricity_meter_default_config()
+def test_preset_standard_defaults() -> None:
+    """``preset_standard("ElectricityMeter")`` returns the documented defaults."""
+    config: ElectricityMeterConfig = ElectricityMeterConfig.preset_standard("ElectricityMeter")
     assert isinstance(config, ElectricityMeterConfig)
     assert config.component_id.name == "ElectricityMeter"
     assert config.component_id.building is None
@@ -51,24 +53,25 @@ def test_get_electricity_meter_default_config_defaults() -> None:
 
 
 @pytest.mark.base
-def test_get_electricity_meter_default_config_custom_name_and_building() -> None:
-    """Passing a full component_id sets name and building while keeping Optional fields ``None``."""
-    config: ElectricityMeterConfig = ElectricityMeterConfig.get_electricity_meter_default_config(
-        component_id=ComponentID(name="MyMeter", building="HouseA")
-    )
+def test_preset_standard_names_the_instance() -> None:
+    """The preset names the meter it builds; the name is the caller's, not a default."""
+    config: ElectricityMeterConfig = ElectricityMeterConfig.preset_standard("X")
     assert isinstance(config, ElectricityMeterConfig)
-    assert config.component_id.name == "MyMeter"
-    assert config.component_id.building == "HouseA"
+    assert config.component_id.name == "X"
+    assert config.component_id.building is None
     _assert_all_optional_fields_are_none(config)
 
 
 @pytest.mark.base
-def test_get_electricity_meter_default_config_name_only_defaults_building() -> None:
-    """Passing only ``name`` leaves the identity without a building."""
-    config: ElectricityMeterConfig = ElectricityMeterConfig.get_electricity_meter_default_config(name="X")
+def test_a_building_is_an_explicit_override_on_the_preset() -> None:
+    """A meter inside a named building is the preset plus an explicit identity override."""
+    config: ElectricityMeterConfig = dataclasses.replace(
+        ElectricityMeterConfig.preset_standard("MyMeter"),
+        component_id=ComponentID(name="MyMeter", building="HouseA"),
+    )
     assert isinstance(config, ElectricityMeterConfig)
-    assert config.component_id.name == "X"
-    assert config.component_id.building is None
+    assert config.component_id.name == "MyMeter"
+    assert config.component_id.building == "HouseA"
     _assert_all_optional_fields_are_none(config)
 
 

--- a/tests/test_electricity_meter_config.py
+++ b/tests/test_electricity_meter_config.py
@@ -9,8 +9,6 @@ simulation, no I/O.
 
 # clean
 
-import dataclasses
-
 import pytest
 
 from hisim.components.electricity_meter import (
@@ -18,7 +16,6 @@ from hisim.components.electricity_meter import (
     ElectricityMeterConfig,
     ElectricityMeterState,
 )
-from hisim.config import ComponentID
 
 
 _OPTIONAL_FIELDS: tuple[str, ...] = (
@@ -43,35 +40,17 @@ def _assert_all_optional_fields_are_none(config: ElectricityMeterConfig) -> None
 
 
 @pytest.mark.base
-def test_preset_standard_defaults() -> None:
-    """``preset_standard("ElectricityMeter")`` returns the documented defaults."""
-    config: ElectricityMeterConfig = ElectricityMeterConfig.preset_standard("ElectricityMeter")
-    assert isinstance(config, ElectricityMeterConfig)
-    assert config.component_id.name == "ElectricityMeter"
-    assert config.component_id.building is None
-    _assert_all_optional_fields_are_none(config)
-
-
-@pytest.mark.base
 def test_preset_standard_names_the_instance() -> None:
-    """The preset names the meter it builds; the name is the caller's, not a default."""
+    """The preset passes the caller's name through and leaves everything else unset.
+
+    Pins the whole of ``preset_standard``: the name is the caller's rather than a
+    built-in default, ``building`` stays ``None``, and every optional cost/emission
+    field stays ``None``.
+    """
     config: ElectricityMeterConfig = ElectricityMeterConfig.preset_standard("X")
     assert isinstance(config, ElectricityMeterConfig)
     assert config.component_id.name == "X"
     assert config.component_id.building is None
-    _assert_all_optional_fields_are_none(config)
-
-
-@pytest.mark.base
-def test_a_building_is_an_explicit_override_on_the_preset() -> None:
-    """A meter inside a named building is the preset plus an explicit identity override."""
-    config: ElectricityMeterConfig = dataclasses.replace(
-        ElectricityMeterConfig.preset_standard("MyMeter"),
-        component_id=ComponentID(name="MyMeter", building="HouseA"),
-    )
-    assert isinstance(config, ElectricityMeterConfig)
-    assert config.component_id.name == "MyMeter"
-    assert config.component_id.building == "HouseA"
     _assert_all_optional_fields_are_none(config)
 
 

--- a/tests/test_fuel_meter.py
+++ b/tests/test_fuel_meter.py
@@ -201,7 +201,7 @@ def test_house(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # Build Fuel Meter

--- a/tests/test_gas_meter.py
+++ b/tests/test_gas_meter.py
@@ -192,7 +192,7 @@ def test_house(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # Build Gas Meter

--- a/tests/test_heating_meter.py
+++ b/tests/test_heating_meter.py
@@ -207,7 +207,7 @@ def test_house(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # Build Gas Meter

--- a/tests/test_time_resolution.py
+++ b/tests/test_time_resolution.py
@@ -507,7 +507,7 @@ def run_cluster_house(
     # Build Electricity Meter
     my_electricity_meter = electricity_meter.ElectricityMeter(
         my_simulation_parameters=my_simulation_parameters,
-        config=electricity_meter.ElectricityMeterConfig.get_electricity_meter_default_config(),
+        config=electricity_meter.ElectricityMeterConfig.preset_standard("ElectricityMeter"),
     )
 
     # Build EMS


### PR DESCRIPTION
Deletes `ElectricityMeterConfig.get_electricity_meter_default_config` (17 setups, 10 test files); every caller uses `preset_standard`. The factory's only override user passes the name to the preset instead.

P4 batch B1, one converted component per PR, stacked. Golden-neutral and twin-neutral by construction: every removed twin line equals the preset's own value; no recorded value moved. Checks per branch: the class's tests, adapter contract, config contracts, two setup tests, one golden week pair, twin freshness (all 22 at the top of the stack), schema and grouping overview unchanged, pylint critical-only, prospector incl. system_setups/, flake8, mypy (both profiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)