### PR TITLE
The base marker is the fast edit loop again; full simulations split into extendedbase and extendedbase2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,8 @@ jobs:
             marker: "buildingtest"
           - name: extendedbase
             marker: "extendedbase"
+          - name: extendedbase2
+            marker: "extendedbase2"
           - name: postprocessingoptions
             marker: "postprocessingoptions"
             durations: "40"
@@ -50,7 +52,7 @@ jobs:
           - name: utsp
             marker: "utsp"
           - name: others
-            marker: "not base and not buildingtest and not system_setups and not extendedbase and not utsp and not postprocessingoptions"
+            marker: "not base and not buildingtest and not system_setups and not extendedbase and not extendedbase2 and not utsp and not postprocessingoptions"
             allow_empty: "true"
 
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,6 +175,12 @@ pytest-extendedbase:
     - cd tests
     - coverage run --parallel-mode --source=../hisim -m pytest -m "extendedbase" --durations=20 --junitxml=pytest-extendedbase.xml
 
+pytest-extendedbase2:
+  extends: .pytest_template
+  script:
+    - cd tests
+    - coverage run --parallel-mode --source=../hisim -m pytest -m "extendedbase2" --durations=20 --junitxml=pytest-extendedbase2.xml
+
 pytest-buildingtest:
   extends: .pytest_template
   script:
@@ -198,7 +204,7 @@ pytest-others:
   script:
     - cd tests
     - |
-      markers="not base and not buildingtest and not system_setups and not extendedbase"
+      markers="not base and not buildingtest and not system_setups and not extendedbase and not extendedbase2"
       markers="$markers and not utsp and not postprocessingoptions"
       coverage run --parallel-mode --source=../hisim -m pytest \
         -m "$markers" \
@@ -226,6 +232,8 @@ coverage:
     - job: pytest-base
       artifacts: true
     - job: pytest-extendedbase
+      artifacts: true
+    - job: pytest-extendedbase2
       artifacts: true
     - job: pytest-buildingtest
       artifacts: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,8 @@ ETHOS.HiSim (Household Infrastructure and Building Simulator) is a Python packag
 
 Markers are defined in `pytest.ini`:
 
-- `base` — fast core tests that must pass in any case. **Run these.**
+- `base` — unit-scale tests that must pass in any case: no full simulation of a system setup, a few seconds at most. **Run these.**
+- `extendedbase`, `extendedbase2` — the full-simulation tests, hand-balanced across two shards of roughly equal wall time. Slow. Avoid.
 - `buildingtest` — systematic sweep of the building component. Slow. Avoid.
 - `system_setups` — runs full system setups end to end. Slow. Avoid.
 - `mpc` — model-predictive-control system tests. Slow. Avoid.
@@ -36,7 +37,7 @@ Markers are defined in `pytest.ini`:
 
 Deselect the slow/networked ones explicitly when running a broader-than-base subset, e.g.:
 ```bash
-pytest -m "not buildingtest and not system_setups and not mpc and not utsp" -n 32 -q
+pytest -m "not extendedbase and not extendedbase2 and not buildingtest and not system_setups and not mpc and not utsp" -n 32 -q
 ```
 
 ## Do NOT touch

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ A bare component name such as `- Weather` says: connect this source through the 
 
 Running the tests
 -----------
-`pytest -m base` runs the fast suite. [TESTING.md](TESTING.md) lists what a change has to pass before it counts as done: the lint, `pytest -m "base or buildingtest"` and `python scripts/golden_check.py`, which compares simulation outputs with the golden references within a tolerance — references that a change never regenerates on its own. The test markers, including the slower `system_setups`, `mpc` and `utsp` suites, are declared in `pytest.ini`.
+`pytest -m base` runs the fast suite. [TESTING.md](TESTING.md) lists what a change has to pass before it counts as done: the lint, `pytest -m "base or extendedbase or extendedbase2 or buildingtest"` and `python scripts/golden_check.py`, which compares simulation outputs with the golden references within a tolerance — references that a change never regenerates on its own. The test markers are declared in `pytest.ini`. `base` is unit-scale only — nothing in it simulates a whole system setup — which is what keeps it the fast edit loop; the full-simulation tests live in the two hand-balanced shards `extendedbase` and `extendedbase2`, beside the slower `system_setups`, `mpc` and `utsp` suites.
 
 ## Contributions and Collaborations
 ETHOS.HiSim welcomes any kind of feedback, contributions, and collaborations.

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 Run all three; all must pass before a change is considered done.
 
 1. Lint:   `ruff check hisim/`                          — clean for files you touched.
-2. Tests:  `pytest -m "base or buildingtest"`           — must pass; add tests for new public functions.
+2. Tests:  `pytest -m "base or extendedbase or extendedbase2 or buildingtest"`           — must pass; add tests for new public functions.
 3. Golden: `python scripts/golden_check.py`             — simulation outputs must match within tolerance.
 
 Do NOT regenerate golden references. If a change is expected to alter outputs, say so

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,8 +10,9 @@ filterwarnings =
 # dependency is missing, say) appears by name and reason rather than a bare count.
 addopts = --strict-markers -rfEs
 markers =
-    base: base tests that have to run in any case
-    extendedbase: extended base tests that take up to 10 minutes to run (deselect with '-m "not extendedBase"')
+    base: unit-scale: no full simulation of a system setup, a few seconds at most - the fast edit loop (deselect with '-m "not base"')
+    extendedbase: full-simulation tests, hand-balanced with extendedbase2 so the two shards' wall times match; when adding one, run 'pytest -m extendedbase --durations=0' and 'pytest -m extendedbase2 --durations=0' and put it in the lighter shard (deselect with '-m "not extendedbase"')
+    extendedbase2: the second full-simulation shard, balanced against extendedbase by the same rule; a test carries exactly one of base, extendedbase and extendedbase2 (deselect with '-m "not extendedbase2"')
     buildingtest: systematic testing of the building component (deselect with '-m "not buildingtest"')
     system_setups: systematic testing of the system_setups (deselect with '-m "not system_setups"')
     mpc: systematic testing of the mpc controlled systems (deselect with '-m "not mpc"')

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -18,7 +18,9 @@ from hisim.config import ComponentID
 from tests import functions_for_testing as fft
 
 
-@pytest.mark.base
+# Builds a LoadProfileGenerator occupancy connector and a full year of weather before it
+# simulates, so it is a full-simulation test, not a unit-scale one; see pytest.ini.
+@pytest.mark.extendedbase
 @utils.measure_execution_time
 def test_building() -> None:
     """Verify the building thermal model cools at a bounded rate without heating.

--- a/tests/test_hisim_main_python.py
+++ b/tests/test_hisim_main_python.py
@@ -46,7 +46,11 @@ SIMULATION_PARAMS_OBJECT = SimulationParameters.one_day_only(2021, 60)
 # ---------------------------------------------------------------------------
 # initialize_from_python
 # ---------------------------------------------------------------------------
-@pytest.mark.base
+# The five initialize_from_python tests below each build a whole system setup through the
+# entry point, load profile and all: minutes, not the seconds `base` promises. They sit in
+# `extendedbase2` together because they share the LoadProfileGenerator cache warm-up; the two
+# argument-validation tests further down touch none of that and stay `base`. See pytest.ini.
+@pytest.mark.extendedbase2
 def test_initialize_from_python_without_optional_arguments():
     """Initialize from python with only python module."""
     simulator = hisim_main.initialize_from_python(PYTHON_SETUP)
@@ -54,7 +58,9 @@ def test_initialize_from_python_without_optional_arguments():
     assert simulator is not None
 
 
-@pytest.mark.base
+# Builds the whole basic household through the entry point like its neighbours, so it shares
+# their shard even though it never runs a timestep; see pytest.ini.
+@pytest.mark.extendedbase2
 def test_the_scenario_name_and_the_description_reach_post_processing(tmp_path):
     """The run's two pieces of metadata travel on the simulator, not through a global.
 
@@ -86,7 +92,7 @@ def test_the_scenario_name_and_the_description_reach_post_processing(tmp_path):
     assert ppdt.description == "Basic household system setup. Shows how to set up a standard system."
 
 
-@pytest.mark.base
+@pytest.mark.extendedbase2
 def test_initialize_from_python_with_module_config():
     """Initialize from python with python module and module config."""
     simulator = hisim_main.initialize_from_python(
@@ -97,7 +103,7 @@ def test_initialize_from_python_with_module_config():
     assert simulator is not None
 
 
-@pytest.mark.base
+@pytest.mark.extendedbase2
 def test_initialize_from_python_with_simulation_parameters():
     """Initialize from python with python module and simulation parameters object."""
     simulator = hisim_main.initialize_from_python(
@@ -108,7 +114,7 @@ def test_initialize_from_python_with_simulation_parameters():
     assert simulator.get_simulation_parameters() is SIMULATION_PARAMS_OBJECT
 
 
-@pytest.mark.base
+@pytest.mark.extendedbase2
 def test_initialize_from_python_with_simulation_parameters_json():
     """Initialize from python with python module and simulation parameters json."""
     simulator = hisim_main.initialize_from_python(
@@ -122,7 +128,7 @@ def test_initialize_from_python_with_simulation_parameters_json():
     assert simulation_parameters.end_date is not None
 
 
-@pytest.mark.base
+@pytest.mark.extendedbase2
 def test_initialize_from_python_with_all_inputs():
     """Initialize from python with all input arguments."""
     simulator = hisim_main.initialize_from_python(

--- a/tests/test_p3_parity.py
+++ b/tests/test_p3_parity.py
@@ -362,7 +362,8 @@ def test_the_renaming_table_declares_one_meaning_per_legacy_port() -> None:
     assert renaming.rename("ElectricityMeter", "SomethingNobodyDeclared") == "SomethingNobodyDeclared"
 
 
-@pytest.mark.base
+# Runs the `dynamic_components` setup for real, so it belongs to a full-simulation shard.
+@pytest.mark.extendedbase
 def test_the_table_still_spells_the_ports_the_dynamic_components_setup_actually_grows(tmp_path: Path) -> None:
     """Catches a renaming table whose dispatch counter no longer matches the controller's build.
 
@@ -378,8 +379,8 @@ def test_the_table_still_spells_the_ports_the_dynamic_components_setup_actually_
     This is the canary for the counter class of that failure. One setup is enough for it because
     the counter is the controller's: all twelve energy manager setups start their dispatch numbers
     from the same thirteen constructor-declared outputs, so a shift moves this setup's names
-    exactly as it moves every other's. This setup also needs no load profile, so it costs a base
-    test seconds instead of minutes. The per-setup insertion indices of the setups the canary does
+    exactly as it moves every other's. This setup also needs no load profile, so it costs its
+    shard seconds instead of minutes. The per-setup insertion indices of the setups the canary does
     not build are outside its net; those are cross-checked against the recorded scenario files by
     the next test and verified against live builds only by the fleet workflow. The canary asserts
     both halves: that every legacy name the table declares for this setup is a port the Python
@@ -480,7 +481,8 @@ def test_an_indicator_quoting_an_undeclared_port_still_fails_literally() -> None
     }
 
 
-@pytest.mark.base
+# Runs the `dynamic_components` setup for real, so it belongs to a full-simulation shard.
+@pytest.mark.extendedbase
 def test_a_kpi_broken_setup_gets_a_structural_verdict(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Catches a rig that turns a broken KPI layer into an exception instead of a verdict (T-21).
 
@@ -509,7 +511,8 @@ def test_a_kpi_broken_setup_gets_a_structural_verdict(tmp_path: Path, monkeypatc
     assert any("KPI stage unavailable" in note for note in verdict.notes)
 
 
-@pytest.mark.base
+# Runs the `dynamic_components` setup for real, so it belongs to a full-simulation shard.
+@pytest.mark.extendedbase
 def test_an_altered_recorded_file_fails_and_names_what_moved(tmp_path: Path) -> None:
     """Catches a rig that cannot tell a reproduced setup from a changed one (T-20).
 
@@ -535,7 +538,8 @@ def test_an_altered_recorded_file_fails_and_names_what_moved(tmp_path: Path) -> 
     assert Rig.ALTERED_COMPONENT in report
 
 
-@pytest.mark.base
+# Runs the `dynamic_components` setup for real, so it belongs to a full-simulation shard.
+@pytest.mark.extendedbase
 def test_a_structurally_changed_recorded_file_fails_the_wiring_comparison(tmp_path: Path) -> None:
     """Catches a wiring comparison that cannot tell a rewired system from a reproduced one.
 


### PR DESCRIPTION
`pytest -m base` had grown to ten minutes locally and eight in CI. Nine tests caused almost all of it: each runs a whole system setup through the entry point or the parity rig. This PR writes the criterion into `pytest.ini` rather than leaving it implied. `base` is unit-scale: no full simulation of a system setup, a few seconds at most. The full-simulation tests live in two hand-balanced shards, `extendedbase` and the new `extendedbase2`, and every test carries exactly one of the three markers. The marker descriptions say how to keep the shards balanced when a test is added.

**Moved out of `base`**

- `extendedbase2`: the five `initialize_from_python` tests in `tests/test_hisim_main_python.py`, kept together because they share one LoadProfileGenerator warm-up.
- `extendedbase`: the four live `dynamic_components` runs in `tests/test_p3_parity.py` and `test_building` in `tests/test_building.py`, which builds an occupancy connector before it simulates.

**Measured here, one pytest at a time, scratch cache**

| marker | before | after |
|---|---|---|
| `base` | 607.9 s, 2853 tests | 111.3 s, 2842 tests |
| `extendedbase` | | 128.5 s, 19 tests |
| `extendedbase2` | | 269.2 s, 5 tests (259 s of it two local-LPG failures that CI's LPG does not have; the three that pass take 7 s) |

The two shards are not within 20 % of each other under either accounting. With a healthy LPG the entry-point shard collapses to about 7 s and the imbalance flips, so a coherent one-file-per-shard split was kept over chasing a number that depends on the machine. The commit body carries both accountings.

**CI**: `tests.yml` gains an `extendedbase2` matrix entry and the catch-all excludes it; `.gitlab-ci.yml` gains the matching job so its `pytest-others` job does not silently absorb the shard. `TESTING.md`, `README.md` and `AGENTS.md` name the widened done-gate and the new rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)